### PR TITLE
Make sure response data is object, not array

### DIFF
--- a/fmpcloud/adapter.js
+++ b/fmpcloud/adapter.js
@@ -41,7 +41,8 @@ const createRequest = (input, callback) => {
 
   Requester.request(config, customError)
     .then(response => {
-      response.data.result = Requester.validateResultNumber(response.data, [0, 'price'])
+      response.data = response.data[0]
+      response.data.result = Requester.validateResultNumber(response.data, ['price'])
       callback(response.status, Requester.success(jobRunID, response))
     })
     .catch(error => {


### PR DESCRIPTION
When response data is an array (with a result key), tests seem to pass, though the Chainlink node will read an array and not the result key.