### PR TITLE
Bring in external-adapter package

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,19 @@
-name: Lint
+name: Actions
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
+  test-external-adapter:
+    name: Test @chainlink/external-adapter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: borales/actions-yarn@v2.0.0
+        with:
+          cmd: install
+      - uses: borales/actions-yarn@v2.0.0
+        with:
+          cmd: test
   run-linters:
     name: Run linters
     runs-on: ubuntu-latest

--- a/1forge/adapter.js
+++ b/1forge/adapter.js
@@ -1,4 +1,4 @@
-const { Requester, Validator } = require('external-adapter')
+const { Requester, Validator } = require('@chainlink/external-adapter')
 
 const customParams = {
   base: ['base', 'from'],

--- a/alphavantage/adapter.js
+++ b/alphavantage/adapter.js
@@ -1,4 +1,4 @@
-const { Requester, Validator } = require('external-adapter')
+const { Requester, Validator } = require('@chainlink/external-adapter')
 
 const customError = (data) => {
   if (data['Error Message']) return true

--- a/amberdata-gasprice/adapter.js
+++ b/amberdata-gasprice/adapter.js
@@ -1,4 +1,4 @@
-const { Requester, Validator } = require('external-adapter')
+const { Requester, Validator } = require('@chainlink/external-adapter')
 
 const customError = (data) => {
   return Object.keys(data.payload).length < 1

--- a/amberdata/adapter.js
+++ b/amberdata/adapter.js
@@ -1,4 +1,4 @@
-const { Requester, Validator } = require('external-adapter')
+const { Requester, Validator } = require('@chainlink/external-adapter')
 
 const customError = (data) => {
   return Object.keys(data.payload).length === 0

--- a/anyblock-gasprice/adapter.js
+++ b/anyblock-gasprice/adapter.js
@@ -1,4 +1,4 @@
-const { Requester, Validator } = require('external-adapter')
+const { Requester, Validator } = require('@chainlink/external-adapter')
 
 const customError = (data) => {
   if (Object.keys(data).length < 1) return true

--- a/bravenewcoin/adapter.js
+++ b/bravenewcoin/adapter.js
@@ -1,4 +1,4 @@
-const { Requester, Validator } = require('external-adapter')
+const { Requester, Validator } = require('@chainlink/external-adapter')
 
 const customParams = {
   from: ['base', 'from', 'coin'],

--- a/coinapi/adapter.js
+++ b/coinapi/adapter.js
@@ -1,4 +1,4 @@
-const { Requester, Validator } = require('external-adapter')
+const { Requester, Validator } = require('@chainlink/external-adapter')
 
 const customParams = {
   base: ['base', 'from', 'coin'],

--- a/coingecko/adapter.js
+++ b/coingecko/adapter.js
@@ -1,4 +1,4 @@
-const { Requester, Validator } = require('external-adapter')
+const { Requester, Validator } = require('@chainlink/external-adapter')
 
 const customError = (data) => {
   if (Object.keys(data).length === 0) return true

--- a/coinmarketcap/adapter.js
+++ b/coinmarketcap/adapter.js
@@ -1,4 +1,4 @@
-const { Requester, Validator } = require('external-adapter')
+const { Requester, Validator } = require('@chainlink/external-adapter')
 
 const customParams = {
   symbol: ['base', 'from', 'coin', 'sym', 'symbol'],

--- a/coinpaprika/adapter.js
+++ b/coinpaprika/adapter.js
@@ -1,4 +1,4 @@
-const { Requester, Validator } = require('external-adapter')
+const { Requester, Validator } = require('@chainlink/external-adapter')
 
 const customParams = {
   base: ['base', 'from', 'coin'],

--- a/cryptoapis/adapter.js
+++ b/cryptoapis/adapter.js
@@ -1,4 +1,4 @@
-const { Requester, Validator } = require('external-adapter')
+const { Requester, Validator } = require('@chainlink/external-adapter')
 
 const customParams = {
   base: ['base', 'from', 'coin'],

--- a/cryptocompare/adapter.js
+++ b/cryptocompare/adapter.js
@@ -1,4 +1,4 @@
-const { Requester, Validator } = require('external-adapter')
+const { Requester, Validator } = require('@chainlink/external-adapter')
 
 const customError = (data) => {
   if (data.Response === 'Error') return true

--- a/currencylayer/adapter.js
+++ b/currencylayer/adapter.js
@@ -1,4 +1,4 @@
-const { Requester, Validator } = require('external-adapter')
+const { Requester, Validator } = require('@chainlink/external-adapter')
 
 const customParams = {
   base: ['base', 'from'],

--- a/eodhistoricaldata/adapter.js
+++ b/eodhistoricaldata/adapter.js
@@ -1,4 +1,4 @@
-const { Requester, Validator } = require('external-adapter')
+const { Requester, Validator } = require('@chainlink/external-adapter')
 
 const commonKeys = {
   N225: 'N225.INDX',

--- a/etherchain/adapter.js
+++ b/etherchain/adapter.js
@@ -1,4 +1,4 @@
-const { Requester, Validator } = require('external-adapter')
+const { Requester, Validator } = require('@chainlink/external-adapter')
 
 const customError = (data) => {
   if (Object.keys(data).length < 1) return true

--- a/ethgasstation/adapter.js
+++ b/ethgasstation/adapter.js
@@ -1,4 +1,4 @@
-const { Requester, Validator } = require('external-adapter')
+const { Requester, Validator } = require('@chainlink/external-adapter')
 
 const customError = (data) => {
   if (Object.keys(data).length < 1) return true

--- a/external-adapter/README.md
+++ b/external-adapter/README.md
@@ -1,11 +1,11 @@
 # External Adapter Helper
 
-This repo helps with creating Chainlink external adapters in NodeJS.
+This package helps with creating Chainlink external adapters in NodeJS.
 
 ## Adding to your project
 
 ```
-yarn add external-adapter
+yarn add @chainlink/external-adapter
 ```
 
 ## Usage

--- a/external-adapter/README.md
+++ b/external-adapter/README.md
@@ -1,0 +1,161 @@
+# External Adapter Helper
+
+This repo helps with creating Chainlink external adapters in NodeJS.
+
+## Adding to your project
+
+```
+yarn add external-adapter
+```
+
+## Usage
+
+```javascript
+const { Requester, Validator } = require('@chainlink/external-adapter')
+```
+
+## Validator
+
+Custom parameters can be given to the Validator in order to ensure that the requester supplied parameters which are expected by the endpoint.
+
+```javascript
+const customParams = {
+  // An array of strings can be used to indicate that one of
+  // the following keys must be supplied by the requester
+  base: ['base', 'from', 'coin'],
+  quote: ['quote', 'to', 'market'],
+  // Specific keys can be given a Boolean flag to indicate
+  // whether or not the requester is required to provide
+  // a value
+  endpoint: false
+}
+```
+
+### Validator
+
+The Validator relies on the data supplied in the customParams object to ensure that a requester supplied the expected parameters.
+
+#### Arguments
+
+- `callback` (Function): The callback function to execute if validation fails
+- `input` (Object): The request payload from the Chainlink node
+- `customParams` (Object): A customParams object as shown above
+
+Validation of the requester's input parameters can be done by creating an instance of the Validator.
+
+```javascript
+// The input data is validated upon instantiating the Validator
+// If input validation fails, the callback is called with an error
+const validator = new Validator(callback, input, customParams)
+```
+
+Validated params can be obtained from the `validator.validated` object.
+
+```javascript
+// The jobRunID is always supplied by the Chainlink node, but in case
+// it's not supplied upon invoking the external adapter, it will default
+// to '1'
+const jobRunID = validator.validated.id
+// Since endpoint doesn't need to be supplied by the requester, we can
+// assign a default value
+const endpoint = validator.validated.data.endpoint || 'price'
+// We specified that one of the values in the base array should be a
+// parameter in use, that value is stored in the name of the key you
+// specified for the array
+const base = validator.validated.data.base
+const quote = validator.validated.data.quote
+```
+
+## Requester
+
+The Requester is a wrapper around a retryable pattern for reaching out to an endpoint. It can be supplied with a customError object to describe the custom error cases which the adapter should retry fetching data even if the response was successful.
+
+```javascript
+const customError = (data) => {
+  // Error cases should return true
+  if (Object.keys(data).length === 0) return true
+  // If no error case is caught, return false
+  return false
+}
+```
+
+### request
+
+#### Arguments
+
+- `config` (Object): An [axios](https://www.npmjs.com/package/axios) config object
+- `customError` (Object): A customError object as shown above
+- `retries` (Number): The number of retries the adapter should attempt to call the API
+- `delay` (Number): The delay between retries (value in ms)
+
+Call `Requester.request` to have the adapter retry failed connection attempts (along with any customError cases) for the given URL within the config.
+
+```javascript
+Requester.request(config, customError, retries, delay)
+  .then(response => {
+    // Optionally store the desired result at data.result
+    response.data.result = Requester.validateResultNumber(response.data,
+                                                          ['eth', 'usd'])
+    // Return the successful response back to the Chainlink node
+    callback(response.statusCode, Requester.success(jobRunID, response))
+  })
+  .catch(error => {
+    callback(500, Requester.errored(jobRunID, error))
+  })
+```
+
+### validateResultNumber
+
+#### Arguments
+
+- `data` (Object): The response's data object
+- `path` (Array): An array of strings (or values of strings) or numbers for indicies to walk the JSON path
+
+You can use `validateResultNumber` to obtain the value at the given path and receive a number. It takes the response data's object and an array representing the JSON path to return. If the value at the given path is `undefined` or `0`, an error will be thrown.
+
+```javascript
+const result = Requester.validateResultNumber(response.data, ['eth', 'usd'])
+```
+
+### getResult
+
+#### Arguments
+
+- `data` (Object): The response's data object
+- `path` (Array): An array of strings (or values of strings) or numbers for indicies to walk the JSON path
+
+The `getResult` function is similar to `validateResultNumber` but if the value at the given path is not found, no error will be thrown.
+
+```javascript
+const result = Requester.getResult(response.data, ['eth', 'usd'])
+```
+
+### errored
+
+Returns the error object formatted in a way which is expected by the Chainlink node.
+
+#### Arguments
+
+- `jobRunID` (String): The job's run ID
+- `error` (Object): The error object
+
+```javascript
+.catch(error => {
+  callback(500, Requester.errored(jobRunID, error))
+})
+```
+
+### success
+
+Returns the response object formatted in a way which is expected by the Chainlink node.
+
+#### Arguments
+
+- `jobRunID` (String): The job's run ID
+- `response` (Object): The response object
+
+```javascript
+.then(response => {
+  callback(response.statusCode, Requester.success(jobRunID, response))
+})
+```

--- a/external-adapter/index.js
+++ b/external-adapter/index.js
@@ -1,0 +1,7 @@
+const { Requester } = require('./src/requester')
+const { Validator } = require('./src/validator')
+const { AdapterError } = require('./src/adapterError')
+
+exports.Requester = Requester
+exports.Validator = Validator
+exports.AdapterError = AdapterError

--- a/external-adapter/package.json
+++ b/external-adapter/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@chainlink/external-adapter",
+  "version": "0.2.3",
+  "description": "Helpers for creating Chainlink External Adapters",
+  "main": "index.js",
+  "scripts": {
+    "test": "yarn mocha --exit --timeout 0"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "axios": "^0.19.2",
+    "winston": "^3.2.1"
+  },
+  "devDependencies": {
+    "express": "^4.17.1"
+  }
+}

--- a/external-adapter/src/adapterError.js
+++ b/external-adapter/src/adapterError.js
@@ -1,0 +1,18 @@
+class AdapterError extends Error {
+  constructor (message) {
+    super(message)
+    this.name = 'AdapterError'
+    this.message = message
+  }
+
+  toJSON () {
+    return {
+      error: {
+        name: this.name,
+        message: this.message
+      }
+    }
+  }
+}
+
+exports.AdapterError = AdapterError

--- a/external-adapter/src/logger.js
+++ b/external-adapter/src/logger.js
@@ -1,0 +1,13 @@
+const { createLogger, format, transports } = require('winston')
+const { combine, json, timestamp } = format
+
+const logger = createLogger({
+  level: process.env.LOG_LEVEL || 'info',
+  format: combine(
+    timestamp(),
+    json()
+  ),
+  transports: [new transports.Console()]
+})
+
+exports.logger = logger

--- a/external-adapter/src/requester.js
+++ b/external-adapter/src/requester.js
@@ -1,0 +1,108 @@
+const axios = require('axios')
+const { AdapterError } = require('./adapterError')
+const { logger } = require('./logger')
+
+class Requester {
+  static request (config, customError, retries = 3, delay = 1000) {
+    if (typeof config === 'string') config = { url: config }
+    if (typeof config.timeout === 'undefined') {
+      const timeout = Number(process.env.TIMEOUT)
+      config.timeout = !isNaN(timeout) ? timeout : 3000
+    }
+    if (typeof customError === 'undefined') {
+      customError = function _customError(data) {
+        return false
+      }
+    }
+    if (typeof customError !== 'function') {
+      delay = retries
+      retries = customError
+      customError = function _customError(data) {
+        return false
+      }
+    }
+
+    return new Promise((resolve, reject) => {
+      const retry = (config, n) => {
+        return axios(config)
+          .then(response => {
+            if (response.data.error || customError(response.data)) {
+              if (n === 1) {
+                const error = `Could not retrieve valid data: ${JSON.stringify(response.data)}`
+                logger.error(error)
+                reject(new AdapterError(error))
+              } else {
+                setTimeout(() => {
+                  retries--
+                  logger.warn(`Error in response. Retrying: ${JSON.stringify(response.data)}`)
+                  retry(config, retries)
+                }, delay)
+              }
+            } else {
+              logger.info(`Received response: ${JSON.stringify(response.data)}`)
+              return resolve(response)
+            }
+          })
+          .catch(error => {
+            if (n === 1) {
+              logger.error(`Could not reach endpoint: ${JSON.stringify(error.message)}`)
+              reject(new AdapterError(error.message))
+            } else {
+              setTimeout(() => {
+                retries--
+                logger.warn(`Caught error. Retrying: ${JSON.stringify(error.message)}`)
+                retry(config, retries)
+              }, delay)
+            }
+          })
+      }
+      return retry(config, retries)
+    })
+  }
+
+  static validateResultNumber (data, path) {
+    const result = this.getResult(data, path)
+    if (typeof result === 'undefined') {
+      const error = 'Result could not be found in path'
+      logger.error(error)
+      throw new AdapterError(error)
+    }
+    if (Number(result) === 0 || isNaN(Number(result))) {
+      const error = 'Invalid result'
+      logger.error(error)
+      throw new AdapterError(error)
+    }
+    return Number(result)
+  }
+
+  static getResult (data, path) {
+    return path.reduce((o, n) => o[n], data)
+  }
+
+  static adapterErrorCallback (jobRunID, error, callback) {
+    setTimeout(callback(500, Requester.errored(jobRunID, error)), 0)
+  }
+
+  static errored (jobRunID = '1', error = 'An error occurred') {
+    return {
+      jobRunID,
+      status: 'errored',
+      error: new AdapterError(error),
+      statusCode: 500
+    }
+  }
+
+  static success (jobRunID = '1', response) {
+    if (!response.data.hasOwnProperty('result')) {
+      response.data.result = null
+    }
+    return {
+      jobRunID,
+      data: response.data,
+      result: response.data.result,
+      statusCode: response.status
+    }
+  }
+}
+
+exports.Requester = Requester

--- a/external-adapter/src/requester.js
+++ b/external-adapter/src/requester.js
@@ -10,14 +10,14 @@ class Requester {
       config.timeout = !isNaN(timeout) ? timeout : 3000
     }
     if (typeof customError === 'undefined') {
-      customError = function _customError(data) {
+      customError = function _customError (data) {
         return false
       }
     }
     if (typeof customError !== 'function') {
       delay = retries
       retries = customError
-      customError = function _customError(data) {
+      customError = function _customError (data) {
         return false
       }
     }
@@ -93,7 +93,7 @@ class Requester {
   }
 
   static success (jobRunID = '1', response) {
-    if (!response.data.hasOwnProperty('result')) {
+    if (!('result' in response.data)) {
       response.data.result = null
     }
     return {

--- a/external-adapter/src/validator.js
+++ b/external-adapter/src/validator.js
@@ -1,0 +1,57 @@
+const { AdapterError } = require('./adapterError')
+const { Requester } = require('./requester')
+const { logger } = require('./logger')
+
+class Validator {
+  constructor (callback, input = {}, customParams = {}) {
+    this.callback = callback
+    this.input = input
+    this.customParams = customParams
+    this.validated = { data: { } }
+    this.validateInput(this.callback)
+  }
+
+  validateInput (callback) {
+    if (typeof this.input.id === 'undefined') {
+      this.input.id = '1'
+    }
+    this.validated.id = this.input.id
+
+    try {
+      for (const key in this.customParams) {
+        if (Array.isArray(this.customParams[key])) {
+          this.validateRequiredParam(this.getRequiredArrayParam(this.customParams[key]), key)
+        } else if (this.customParams[key] === true) {
+          this.validateRequiredParam(this.input.data[key], key, callback)
+        } else {
+          if (typeof this.input.data[key] !== 'undefined') {
+            this.validated.data[key] = this.input.data[key]
+          }
+        }
+      }
+    } catch (error) {
+      logger.error(`Error validating input: ${error}`)
+      Requester.adapterErrorCallback(this.input.id, error, callback)
+    }
+  }
+
+  validateRequiredParam (param, key, callback) {
+    if (typeof param === 'undefined') {
+      const error = `Required parameter not supplied: ${key}`
+      logger.error(error)
+      throw new AdapterError(error)
+    } else {
+      this.validated.data[key] = param
+    }
+  }
+
+  getRequiredArrayParam (keyArray) {
+    for (const param of keyArray) {
+      if (typeof this.input.data[param] !== 'undefined') {
+        return this.input.data[param]
+      }
+    }
+  }
+}
+
+exports.Validator = Validator

--- a/external-adapter/test/helpers/server.js
+++ b/external-adapter/test/helpers/server.js
@@ -1,0 +1,56 @@
+const express = require('express')
+
+class Server {
+  constructor () {
+    this.app = express()
+    this.start()
+    this.port = 18080
+    this.errorCount = 0
+  }
+
+  start () {
+    this.app.get('/', (req, res) => {
+      res.status(200).json({
+        result: 'success',
+        value: 1
+      })
+    })
+
+    this.app.get('/error', (req, res) => {
+      this.errorCount++
+      res.status(500).send('There was an error')
+    })
+
+    this.app.get('/errorsTwice', (req, res) => {
+      if (this.errorCount >= 2) {
+        res.status(200).json({
+          result: 'success',
+          value: 1
+        })
+      } else {
+        this.errorCount++
+        res.status(500).send('There was an error')
+      }
+    })
+
+    this.app.get('/customError', (req, res) => {
+      this.errorCount++
+      res.status(200).json({
+        result: 'error',
+        value: 1
+      })
+    })
+
+    this.server = this.app.listen(this.port, () => {})
+  }
+
+  stop () {
+    this.server.close()
+  }
+
+  reset () {
+    this.errorCount = 0
+  }
+}
+
+exports.Server = Server

--- a/external-adapter/test/requester.test.js
+++ b/external-adapter/test/requester.test.js
@@ -1,0 +1,210 @@
+const { assert } = require('chai')
+const { Requester } = require('../src/requester')
+const { Server } = require('./helpers/server')
+
+describe('Requester', () => {
+  const errorMessage = 'Request failed with status code 500'
+  const customErrorMessage = 'Could not retrieve valid data: {"result":"error","value":1}'
+  const successUrl = 'http://localhost:18080'
+  const errorUrl = 'http://localhost:18080/error'
+  const errorTwiceUrl = 'http://localhost:18080/errorsTwice'
+  const customErrorUrl = 'http://localhost:18080/customError'
+  const options = {
+    timeout: 100
+  }
+  const customError = (data) => {
+    return data.result !== 'success'
+  }
+
+  const server = new Server()
+
+  before(() => {
+    server.start()
+  })
+
+  beforeEach(() => {
+    server.reset()
+    assert.equal(server.errorCount, 0)
+  })
+
+  describe('Requester.request', () => {
+    it('returns an error from an endpoint', async () => {
+      options.url = errorUrl
+      try {
+        await Requester.request(options, 1, 0)
+        assert.fail('expected error')
+      } catch (error) {
+        assert.equal(server.errorCount, 1)
+        assert.equal(error.message, errorMessage)
+      }
+    })
+
+    it('accepts custom retry amounts', async () => {
+      options.url = errorUrl
+      try {
+        await Requester.request(options, 9, 0)
+        assert.fail('expected error')
+      } catch (error) {
+        assert.equal(server.errorCount, 9)
+        assert.equal(error.message, errorMessage)
+      }
+    })
+
+    it('retries errored statuses', async () => {
+      options.url = errorTwiceUrl
+      const { data } = await Requester.request(options, 3, 0)
+      assert.equal(server.errorCount, 2)
+      assert.equal(data.result, 'success')
+      assert.equal(data.value, 1)
+    })
+
+    it('retries custom errors', async () => {
+      options.url = customErrorUrl
+      try {
+        await Requester.request(options, customError, 3, 0)
+        assert.fail('expected error')
+      } catch (error) {
+        assert.equal(server.errorCount, 3)
+        assert.equal(error.message, customErrorMessage)
+      }
+    })
+
+    it('returns the result from an endpoint', async () => {
+      options.url = successUrl
+      const { data } = await Requester.request(options)
+      assert.equal(server.errorCount, 0)
+      assert.equal(data.result, 'success')
+      assert.equal(data.value, 1)
+    })
+
+    it('accepts optional customError param', async () => {
+      options.url = successUrl
+      const { data } = await Requester.request(options, customError)
+      assert.equal(server.errorCount, 0)
+      assert.equal(data.result, 'success')
+      assert.equal(data.value, 1)
+    })
+
+    it('accepts optional retries param with customError', async () => {
+      options.url = successUrl
+      const { data } = await Requester.request(options, customError, 1)
+      assert.equal(server.errorCount, 0)
+      assert.equal(data.result, 'success')
+      assert.equal(data.value, 1)
+    })
+
+    it('accepts optional retries param without customError', async () => {
+      options.url = successUrl
+      const { data } = await Requester.request(options, 1)
+      assert.equal(server.errorCount, 0)
+      assert.equal(data.result, 'success')
+      assert.equal(data.value, 1)
+    })
+
+    it('accepts optional delay param with customError', async () => {
+      options.url = successUrl
+      const { data } = await Requester.request(options, customError, 1, 0)
+      assert.equal(server.errorCount, 0)
+      assert.equal(data.result, 'success')
+      assert.equal(data.value, 1)
+    })
+
+    it('accepts optional delay param without customError', async () => {
+      options.url = successUrl
+      const { data } = await Requester.request(options, 1, 0)
+      assert.equal(server.errorCount, 0)
+      assert.equal(data.result, 'success')
+      assert.equal(data.value, 1)
+    })
+  })
+
+  describe('Requester.validateResultNumber', () => {
+    it('returns the desired value', async () => {
+      options.url = successUrl
+      const { data } = await Requester.request(options, 1, 0)
+      assert.equal(server.errorCount, 0)
+      assert.equal(data.result, 'success')
+      assert.equal(data.value, 1)
+      const result = Requester.validateResultNumber(data, ['value'])
+      assert.equal(result, 1)
+    })
+
+    it('errors if the value is not a number', async () => {
+      options.url = successUrl
+      const { data } = await Requester.request(options, 1, 0)
+      assert.equal(server.errorCount, 0)
+      assert.equal(data.result, 'success')
+      assert.equal(data.value, 1)
+      try {
+        Requester.validateResultNumber(data, ['result'])
+        assert.fail('expected error')
+      } catch (error) {
+        assert.equal(error.message, 'Invalid result')
+      }
+    })
+  })
+
+  describe('Requester.getResult', () => {
+    it('returns the desired value', async () => {
+      options.url = successUrl
+      const { data } = await Requester.request(options, 1, 0)
+      assert.equal(server.errorCount, 0)
+      assert.equal(data.result, 'success')
+      assert.equal(data.value, 1)
+      const result = Requester.getResult(data, ['value'])
+      assert.equal(result, 1)
+    })
+
+    it('does not error if the value is not a number', async () => {
+      options.url = successUrl
+      const { data } = await Requester.request(options, 1, 0)
+      assert.equal(server.errorCount, 0)
+      assert.equal(data.result, 'success')
+      assert.equal(data.value, 1)
+      const result = Requester.getResult(data, ['result'])
+      assert.equal(result, 'success')
+    })
+
+    it('returns undefined if the input is not data', async () => {
+      options.url = successUrl
+      const response = await Requester.request(options, 1, 0)
+      assert.equal(server.errorCount, 0)
+      assert.equal(response.data.result, 'success')
+      assert.equal(response.data.value, 1)
+      const result = Requester.getResult(response, ['result'])
+      assert.equal(typeof(result), 'undefined')
+    })
+  })
+
+  describe('Requester.errored', () => {
+    it('returns a Chainlink error when no params are supplied', () => {
+      const error = Requester.errored()
+      assert.equal(error.jobRunID, '1')
+      assert.equal(error.status, 'errored')
+      assert.equal(error.error.message, 'An error occurred')
+    })
+
+    it('returns a Chainlink error when no data is supplied', () => {
+      const error = Requester.errored('abc123')
+      assert.equal(error.jobRunID, 'abc123')
+      assert.equal(error.status, 'errored')
+      assert.equal(error.error.message, 'An error occurred')
+    })
+  })
+
+  describe('Requester.success', () => {
+    it('returns a Chainlink result', async () => {
+      options.url = successUrl
+      const response = await Requester.request(options, 1, 0)
+      const result = Requester.success('1', response)
+      assert.equal(result.jobRunID, '1')
+      assert.equal(result.result, 'success')
+      assert.equal(result.data.result, 'success')
+      assert.equal(result.statusCode, 200)
+    })
+  })
+
+  after(() => {
+    server.stop()
+  })
+})

--- a/external-adapter/test/requester.test.js
+++ b/external-adapter/test/requester.test.js
@@ -172,7 +172,7 @@ describe('Requester', () => {
       assert.equal(response.data.result, 'success')
       assert.equal(response.data.value, 1)
       const result = Requester.getResult(response, ['result'])
-      assert.equal(typeof(result), 'undefined')
+      assert.equal(typeof result, 'undefined')
     })
   })
 

--- a/external-adapter/test/validator.test.js
+++ b/external-adapter/test/validator.test.js
@@ -1,0 +1,133 @@
+const { assert } = require('chai')
+const { Validator } = require('../src/validator')
+
+describe('Validator', () => {
+  let called = false
+
+  beforeEach(() => {
+    called = false
+  })
+
+  // If the callback gets called by the Validator, that
+  // means an error occurred
+  const callback = (statusCode, data) => {
+    called = true
+    return () => {
+      assert.equal(statusCode, 500)
+      assert.equal(data.status, 'errored')
+    }
+  }
+
+  describe('without required params', () => {
+    const params = {
+      endpoint: false
+    }
+
+    it('errors if no input data is supplied', () => {
+      const validator = new Validator(callback, {}, params)
+      assert.equal(validator.validated.id, '1')
+      assert.isEmpty(validator.validated.data)
+      assert.isTrue(called)
+    })
+
+    it('does not error if optional params are included', () => {
+      const input = {
+        id: 'abc123',
+        data: {
+          endpoint: 'test'
+        }
+      }
+
+      const validator = new Validator(callback, input, params)
+      assert.equal(validator.validated.id, input.id)
+      assert.equal(validator.validated.data.endpoint, input.data.endpoint)
+      assert.isFalse(called)
+    })
+
+    it('does not error if input data is excluded', () => {
+      const input = {
+        id: 'abc123'
+      }
+
+      const validator = new Validator(callback, input)
+      assert.equal(validator.validated.id, input.id)
+      assert.isFalse(called)
+    })
+
+    it('does not error if input data and params are excluded', () => {
+      const validator = new Validator(callback)
+      assert.equal(validator.validated.id, '1')
+      assert.isFalse(called)
+    })
+  })
+
+  describe('with required params', () => {
+    const params = {
+      keys: ['one', 'two'],
+      endpoint: true
+    }
+
+    it('errors if no input is provided', () => {
+      const validator = new Validator(callback, {}, params)
+      assert.equal(validator.validated.id, '1')
+      assert.isEmpty(validator.validated.data)
+      assert.isTrue(called)
+    })
+
+    it('errors if an array param is not provided', () => {
+      const input = {
+        id: 'abc123',
+        data: {
+          endpoint: 'test'
+        }
+      }
+
+      const validator = new Validator(callback, input, params)
+      assert.equal(validator.validated.id, input.id)
+      assert.isEmpty(validator.validated.data)
+      assert.isTrue(called)
+    })
+
+    it('errors if a boolean param is not provided', () => {
+      const input = {
+        id: 'abc123',
+        data: {
+          one: 'test'
+        }
+      }
+
+      const validator = new Validator(callback, input, params)
+      assert.equal(validator.validated.id, input.id)
+      assert.isTrue(called)
+    })
+
+    it('does not error if required params are included', () => {
+      const input = {
+        id: 'abc123',
+        data: {
+          endpoint: 'test',
+          one: 'test'
+        }
+      }
+
+      const validator = new Validator(callback, input, params)
+      assert.equal(validator.validated.id, input.id)
+      assert.equal(validator.validated.data.endpoint, input.data.endpoint)
+      assert.equal(validator.validated.data.keys, input.data.one)
+      assert.isFalse(called)
+    })
+  })
+
+  it('accepts input without customParams', () => {
+    const input = {
+      id: 'abc123',
+      data: {
+        endpoint: 'test',
+        one: 'test'
+      }
+    }
+    const validator = new Validator(callback, input)
+    assert.equal(validator.validated.id, input.id)
+    assert.isFalse(called)
+  })
+})

--- a/fcsapi/adapter.js
+++ b/fcsapi/adapter.js
@@ -1,4 +1,4 @@
-const { Requester, Validator } = require('external-adapter')
+const { Requester, Validator } = require('@chainlink/external-adapter')
 
 const customError = (data) => {
   if (data.msg !== 'Successfully') return true

--- a/finnhub/adapter.js
+++ b/finnhub/adapter.js
@@ -1,4 +1,4 @@
-const { Requester, Validator } = require('external-adapter')
+const { Requester, Validator } = require('@chainlink/external-adapter')
 
 const commonKeys = {
   N225: '^N225',

--- a/fixer/adapter.js
+++ b/fixer/adapter.js
@@ -1,4 +1,4 @@
-const { Requester, Validator } = require('external-adapter')
+const { Requester, Validator } = require('@chainlink/external-adapter')
 
 const customParams = {
   base: ['base', 'from'],

--- a/fmpcloud/adapter.js
+++ b/fmpcloud/adapter.js
@@ -1,4 +1,4 @@
-const { Requester, Validator } = require('external-adapter')
+const { Requester, Validator } = require('@chainlink/external-adapter')
 
 const commonKeys = {
   N225: '^N225',

--- a/google-finance/adapter.js
+++ b/google-finance/adapter.js
@@ -1,4 +1,4 @@
-const { Requester, Validator } = require('external-adapter')
+const { Requester, Validator } = require('@chainlink/external-adapter')
 const google = require('boxhock_google-finance-data')
 
 const commonKeys = {

--- a/kaiko/adapter.js
+++ b/kaiko/adapter.js
@@ -1,4 +1,4 @@
-const { Requester, Validator } = require('external-adapter')
+const { Requester, Validator } = require('@chainlink/external-adapter')
 
 const customError = (data) => {
   if (data.result === 'error') return true

--- a/market-closure/adapter.js
+++ b/market-closure/adapter.js
@@ -1,4 +1,4 @@
-const { Requester, Validator } = require('external-adapter')
+const { Requester, Validator } = require('@chainlink/external-adapter')
 const { MarketClosure } = require('market-closure')
 const { tradingHalted } = require('./marketCheck')
 const { getContractPrice } = require('./readReferenceContract')

--- a/market-closure/tradinghours/marketCheck.js
+++ b/market-closure/tradinghours/marketCheck.js
@@ -1,4 +1,4 @@
-const { Requester } = require('external-adapter')
+const { Requester } = require('@chainlink/external-adapter')
 
 const commonMICs = {
   FTSE: 'xlon',

--- a/oilpriceapi/adapter.js
+++ b/oilpriceapi/adapter.js
@@ -1,4 +1,4 @@
-const { Requester, Validator } = require('external-adapter')
+const { Requester, Validator } = require('@chainlink/external-adapter')
 
 const commonKeys = {
   BZ: 'BRENT_CRUDE_USD'

--- a/openexchangerates/adapter.js
+++ b/openexchangerates/adapter.js
@@ -1,4 +1,4 @@
-const { Requester, Validator } = require('external-adapter')
+const { Requester, Validator } = require('@chainlink/external-adapter')
 
 const customParams = {
   base: ['base', 'from'],

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "amberdata-gasprice"
   ],
   "scripts": {
-    "lint": "yarn eslint ."
+    "lint": "yarn eslint .",
+    "test": "yarn workspace @chainlink/external-adapter test"
   },
   "dependencies": {
     "@zeit/ncc": "^0.22.1",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "private": true,
   "workspaces": [
+    "external-adapter",
     "1forge",
     "alphavantage",
     "amberdata",
@@ -44,7 +45,6 @@
     "boxhock_google-finance-data": "^0.1.0",
     "ethers": "^4.0.47",
     "express": "^4.17.0",
-    "external-adapter": "^0.2.3",
     "market-closure": "^0.1.2",
     "web3": "^1.2.7",
     "yahoo-finance": "^0.3.6"

--- a/poa-gasprice/adapter.js
+++ b/poa-gasprice/adapter.js
@@ -1,4 +1,4 @@
-const { Requester, Validator } = require('external-adapter')
+const { Requester, Validator } = require('@chainlink/external-adapter')
 
 const customError = (data) => {
   if (Object.keys(data).length < 1) return true

--- a/polygon/adapter.js
+++ b/polygon/adapter.js
@@ -1,4 +1,4 @@
-const { Requester, Validator } = require('external-adapter')
+const { Requester, Validator } = require('@chainlink/external-adapter')
 
 const customError = (data) => {
   return data.status === 'ERROR'

--- a/yahoo-finance/adapter.js
+++ b/yahoo-finance/adapter.js
@@ -1,4 +1,4 @@
-const { Requester, Validator } = require('external-adapter')
+const { Requester, Validator } = require('@chainlink/external-adapter')
 const yahooFinance = require('yahoo-finance')
 
 const commonKeys = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1409,7 +1409,7 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
 
-express@^4.14.0, express@^4.17.0:
+express@^4.14.0, express@^4.17.0, express@^4.17.1:
   version "4.17.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"
   integrity sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==
@@ -1456,14 +1456,6 @@ extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
-
-external-adapter@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/external-adapter/-/external-adapter-0.2.3.tgz#be93a31661d0e6788fc3b3136721242da4586933"
-  integrity sha512-o3WS7kDK7R6IIc9813xxSnijoLUTeNrWJdbuZhaN1DNkdCX8kYSyBI5xUrM6sDwYbPC4Xtcaa45SwkQupKY2jw==
-  dependencies:
-    axios "^0.19.2"
-    winston "^3.2.1"
 
 external-editor@^3.0.3:
   version "3.1.0"


### PR DESCRIPTION
Local development and builds use the package on the filesystem. Developers creating their own external adapters can import/require `@chainlink/external-adapter`.