### PR TITLE
Fix location of eth helper in market closure adapters

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,12 +1,6 @@
 name: Actions
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+on: [push, pull_request]
 
 jobs:
   test-external-adapter:

--- a/market-closure/adapter.js
+++ b/market-closure/adapter.js
@@ -1,7 +1,7 @@
 const { Requester, Validator } = require('@chainlink/external-adapter')
 const { MarketClosure } = require('market-closure')
 const { tradingHalted } = require('./marketCheck')
-const { getContractPrice } = require('./helpers/eth/readReferenceContract')
+const { getContractPrice } = require('../helpers/eth/readReferenceContract')
 const adapterCreateRequest = require('./priceAdapter').createRequest
 
 const customParams = {


### PR DESCRIPTION
The context of this `adapter.js` changes to be within the `$(check)` directory.