### PR TITLE
adds API_KEY for cryptocompare

### DIFF
--- a/cryptocompare/adapter.js
+++ b/cryptocompare/adapter.js
@@ -29,6 +29,12 @@ const createRequest = (input, callback) => {
     params
   }
 
+  if (process.env.API_KEY) {
+    config.headers = {
+      authorization: `Apikey ${process.env.API_KEY}`
+    }
+  }
+
   Requester.request(config, customError)
     .then(response => {
       response.data.result = Requester.validateResultNumber(response.data, [tsyms])


### PR DESCRIPTION
Current version of the cryptocompare adapter silently ignores API_KEY. 

https://github.com/smartcontractkit/external-adapters-js/blob/7f1b65734efa651cebe8d7dcca1f537f257d6485/cryptocompare/adapter.js#L27-L30

This PR adds the proper API_KEY handling.