### PR TITLE
ethgasstation add api key

### DIFF
--- a/ethgasstation/adapter.js
+++ b/ethgasstation/adapter.js
@@ -15,7 +15,7 @@ const createRequest = (input, callback) => {
   const jobRunID = validator.validated.id
   const endpoint = validator.validated.data.endpoint || 'ethgasAPI'
   const speed = validator.validated.data.speed
-  const url = `https://ethgasstation.info/json/${endpoint}.json`
+  const url = `https://ethgasstation.info/api/${endpoint}.json?api-key=${process.env.API_KEY}`
 
   Requester.request(url, customError)
     .then(response => {


### PR DESCRIPTION
https://ethgasstation.info/blog/eth-gas-station-api-will-require-an-api-key-starting-july-1st-2020/

Starting July 1st, ethgasstation will now require an API key