### PR TITLE
[FEATURE] Coingecko OpenWhisk integration with Serverless Framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 *.zip
 dist
 .DS_Store
+.serverless
+.env

--- a/coingecko/index.js
+++ b/coingecko/index.js
@@ -3,11 +3,10 @@ const { createRequest } = require('./adapter')
 
 const { openwhiskWrap } = require('./openwhisk')
 
-
 module.exports = {
-    server: bootstrap.server.init(createRequest),
-    gcpservice: bootstrap.serverless.initGcpService(createRequest),
-    handler: bootstrap.serverless.initHandler(createRequest),
-    handlerv2: bootstrap.serverless.initHandlerV2(createRequest),
-    openwhisk: openwhiskWrap(createRequest)
+  server: bootstrap.server.init(createRequest),
+  gcpservice: bootstrap.serverless.initGcpService(createRequest),
+  handler: bootstrap.serverless.initHandler(createRequest),
+  handlerv2: bootstrap.serverless.initHandlerV2(createRequest),
+  openwhisk: openwhiskWrap(createRequest)
 }

--- a/coingecko/index.js
+++ b/coingecko/index.js
@@ -1,10 +1,13 @@
 const bootstrap = require('@chainlink/ea-bootstrap')
 const { createRequest } = require('./adapter')
 
-module.exports = {
-  server: bootstrap.server.init(createRequest),
+const { openwhiskWrap } = require('./openwhisk')
 
-  gcpservice: bootstrap.serverless.initGcpService(createRequest),
-  handler: bootstrap.serverless.initHandler(createRequest),
-  handlerv2: bootstrap.serverless.initHandlerV2(createRequest)
+
+module.exports = {
+    server: bootstrap.server.init(createRequest),
+    gcpservice: bootstrap.serverless.initGcpService(createRequest),
+    handler: bootstrap.serverless.initHandler(createRequest),
+    handlerv2: bootstrap.serverless.initHandlerV2(createRequest),
+    openwhisk: openwhiskWrap(createRequest)
 }

--- a/coingecko/openwhisk.js
+++ b/coingecko/openwhisk.js
@@ -1,17 +1,17 @@
 const openwhiskCallback = (resolve) => (statusCode, data) => {
-    resolve({
-        statusCode,
-        body: JSON.stringify(data),
-        isBase64Encoded: false
-    })
+  resolve({
+    statusCode,
+    body: JSON.stringify(data),
+    isBase64Encoded: false
+  })
 }
 const openwhiskWrap = (createRequest) => async (params) => {
-    return new Promise((resolve) => {
-        createRequest(params, openwhiskCallback(resolve))
-    })
+  return new Promise((resolve) => {
+    createRequest(params, openwhiskCallback(resolve))
+  })
 }
 
 module.exports = {
-    openwhiskCallback,
-    openwhiskWrap
+  openwhiskCallback,
+  openwhiskWrap
 }

--- a/coingecko/openwhisk.js
+++ b/coingecko/openwhisk.js
@@ -1,0 +1,17 @@
+const openwhiskCallback = (resolve) => (statusCode, data) => {
+    resolve({
+        statusCode,
+        body: JSON.stringify(data),
+        isBase64Encoded: false
+    })
+}
+const openwhiskWrap = (createRequest) => async (params) => {
+    return new Promise((resolve) => {
+        createRequest(params, openwhiskCallback(resolve))
+    })
+}
+
+module.exports = {
+    openwhiskCallback,
+    openwhiskWrap
+}

--- a/coingecko/openwhisk.yml
+++ b/coingecko/openwhisk.yml
@@ -1,0 +1,18 @@
+configValidationMode: off
+service: ea
+
+provider:
+  name: openwhisk
+  environment: ${file(./.env.yml)}
+
+functions:
+  coingecko:
+    handler: index.openwhisk
+    events:
+      - http: POST /coingecko
+    annotations:
+      web-export: true
+      require-whisk-auth: false
+
+plugins:
+  - serverless-openwhisk

--- a/coingecko/package.json
+++ b/coingecko/package.json
@@ -1,14 +1,17 @@
 {
-  "name": "coingecko",
-  "version": "0.1.0",
-  "license": "MIT",
-  "main": "index.js",
-  "scripts": {
-    "server": "node -e 'require(\"./index.js\").server()'",
-    "test": "yarn _mocha --timeout 0"
-  },
-  "dependencies": {
-    "@chainlink/ea-bootstrap": "0.0.1",
-    "@chainlink/external-adapter": "^0.2.3"
-  }
+    "name": "coingecko",
+    "version": "0.1.0",
+    "license": "MIT",
+    "main": "index.js",
+    "scripts": {
+        "server": "node -e 'require(\"./index.js\").server()'",
+        "test": "yarn _mocha --timeout 0"
+    },
+    "dependencies": {
+        "@chainlink/ea-bootstrap": "0.0.1",
+        "@chainlink/external-adapter": "^0.2.3"
+    },
+    "devDependencies": {
+        "serverless-openwhisk": ">=0.13.0"
+    }
 }


### PR DESCRIPTION
This pull requests provides an example of using [Serverless Framework](https://serverless.com) and [Apache Openwhisk](https://openwhisk.apache.org/) to deploy the coingecko adapter.
I recommend checking out https://github.com/serverless/serverless-openwhisk for more info on specific deployment.

```
cd coingecko
sls deploy -c openwhisk.yml
```