### PR TITLE
[Feature] COVID tracker adapter

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,10 @@ jobs:
             blockcypher,
             wbtc-address-set,
             renvm-address-set,
+            messari,
+            coinlore,
+            trueusd,
+            covid-tracker,
           ]
     steps:
       - uses: actions/checkout@v2

--- a/covid-tracker/README.md
+++ b/covid-tracker/README.md
@@ -1,0 +1,57 @@
+# Chainlink COVID Tracker External Adapter
+
+## US Data API (default)
+
+### Endpoint
+
+https://api.covidtracking.com/v1/us/current.json
+
+### Input Params
+
+- `field`: The data field to return. Must be in camel case style. (required, see Current US Values on https://covidtracking.com/data/api for a full list)
+- `date`: The date to query formatted by `[YEAR][month][DAY]` e.g. `20201012`, if not given defaults to the most recent date with available data (optional)
+- `endpoint`: The endpoint to use (defaults to "us", one of "us")
+
+### Example Usage
+
+```json
+{ "field": "death" }
+```
+
+#### Output
+
+```json
+{
+  "jobRunID": "1",
+  "data": {
+    "date": 20201022,
+    "states": 56,
+    "positive": 8366221,
+    "negative": 111569861,
+    "pending": 12222,
+    "hospitalizedCurrently": 41010,
+    "hospitalizedCumulative": 443777,
+    "inIcuCurrently": 8086,
+    "inIcuCumulative": 23018,
+    "onVentilatorCurrently": 2147,
+    "onVentilatorCumulative": 2641,
+    "recovered": 3353056,
+    "dateChecked": "2020-10-22T00:00:00Z",
+    "death": 214845,
+    "hospitalized": 443777,
+    "totalTestResults": 128964596,
+    "lastModified": "2020-10-22T00:00:00Z",
+    "total": 0,
+    "posNeg": 0,
+    "deathIncrease": 1173,
+    "hospitalizedIncrease": 2706,
+    "negativeIncrease": 923136,
+    "positiveIncrease": 76560,
+    "totalTestResultsIncrease": 1139419,
+    "hash": "a487345726650f5e4fc102ef1e42b6378fee3493",
+    "result": 1139419
+  },
+  "result": 1139419,
+  "statusCode": 200
+}
+```

--- a/covid-tracker/README.md
+++ b/covid-tracker/README.md
@@ -8,7 +8,7 @@ https://api.covidtracking.com/v1/us/current.json
 
 ### Input Params
 
-- `location`: The location to retrieve data on (required, one of "USA")
+- `location`: The location to retrieve data on (required, one of "usa")
 - `field`: The data field to return. Must be in camel case style. (required, see Current US Values on https://covidtracking.com/data/api for a full list)
 - `date`: The date to query formatted by `[YEAR][MONTH][DAY]` e.g. `20201012`, if not given defaults to the most recent date with available data (optional)
 - `endpoint`: The endpoint to use (optional, defaults to "country", one of "country")
@@ -16,7 +16,7 @@ https://api.covidtracking.com/v1/us/current.json
 ### Example Usage
 
 ```json
-{ "field": "death" }
+{ "field": "death", "location": "usa" }
 ```
 
 #### Output

--- a/covid-tracker/README.md
+++ b/covid-tracker/README.md
@@ -1,6 +1,6 @@
 # Chainlink COVID Tracker External Adapter
 
-## US Data API (default)
+## Country Data API (default)
 
 ### Endpoint
 
@@ -8,9 +8,10 @@ https://api.covidtracking.com/v1/us/current.json
 
 ### Input Params
 
+- `location`: The location to retrieve data on (required, one of "USA")
 - `field`: The data field to return. Must be in camel case style. (required, see Current US Values on https://covidtracking.com/data/api for a full list)
-- `date`: The date to query formatted by `[YEAR][month][DAY]` e.g. `20201012`, if not given defaults to the most recent date with available data (optional)
-- `endpoint`: The endpoint to use (defaults to "us", one of "us")
+- `date`: The date to query formatted by `[YEAR][MONTH][DAY]` e.g. `20201012`, if not given defaults to the most recent date with available data (optional)
+- `endpoint`: The endpoint to use (optional, defaults to "country", one of "country")
 
 ### Example Usage
 

--- a/covid-tracker/adapter.js
+++ b/covid-tracker/adapter.js
@@ -1,10 +1,11 @@
 const { Requester, Validator } = require('@chainlink/external-adapter')
 
-const ENDPOINT_US = 'us'
+const ENDPOINT_COUNTRY = 'country'
 
-const DEFAULT_ENDPOINT = ENDPOINT_US
+const DEFAULT_ENDPOINT = ENDPOINT_COUNTRY
 
-const usParams = {
+const countryParams = {
+  location: ['location'],
   field: ['field'],
   date: false,
 }
@@ -32,8 +33,8 @@ const findDay = (payload, date) => {
   return null
 }
 
-const us = (jobRunID, input, callback) => {
-  const validator = new Validator(input, usParams)
+const country = (jobRunID, input, callback) => {
+  const validator = new Validator(input, countryParams)
   if (validator.error) return callback(validator.error.statusCode, validator.error)
 
   const field = validator.validated.data.field
@@ -67,8 +68,8 @@ const execute = (input, callback) => {
   const jobRunID = validator.validated.id
   const endpoint = validator.validated.data.endpoint || DEFAULT_ENDPOINT
   switch (endpoint.toLowerCase()) {
-    case ENDPOINT_US:
-      return us(jobRunID, input, callback)
+    case ENDPOINT_COUNTRY:
+      return country(jobRunID, input, callback)
     default:
       callback(500, Requester.errored(jobRunID, 'invalid endpoint provided'))
   }

--- a/covid-tracker/adapter.js
+++ b/covid-tracker/adapter.js
@@ -1,0 +1,77 @@
+const { Requester, Validator } = require('@chainlink/external-adapter')
+
+const ENDPOINT_US = 'us'
+
+const DEFAULT_ENDPOINT = ENDPOINT_US
+
+const usParams = {
+  field: ['field'],
+  date: false,
+}
+
+const validDate = (date) => {
+  if (date) {
+    if (isNaN(Number(date))) return false
+    if (date.length != 8) return false
+  }
+  return true
+}
+
+const findDay = (payload, date) => {
+  if (!date) return payload[0]
+  // All historical dates are given, find the the correct one
+  for (const index in payload) {
+    if (payload[index].date === Number(date)) {
+      return payload[index]
+    }
+    // Response body is sorted by descending data. If we see an earlier date we know our result doesn't exist.
+    if (payload[index].date < Number(date)) {
+      return null
+    }
+  }
+  return null
+}
+
+const us = (jobRunID, input, callback) => {
+  const validator = new Validator(input, usParams)
+  if (validator.error) return callback(validator.error.statusCode, validator.error)
+
+  const field = validator.validated.data.field
+  const date = validator.validated.data.date
+  if (!validDate(date)) return callback(400, Requester.errored(jobRunID, 'Invalid date format'))
+
+  const suffix = date ? 'daily' : 'current'
+  const url = `https://api.covidtracking.com/v1/us/${suffix}.json`
+  const config = { url }
+
+  const _handleResponse = (response) => {
+    response.data = findDay(response.data, date)
+    if (!response.data) return callback(400, Requester.errored(jobRunID, 'Date not found'))
+    response.data.result = Requester.validateResultNumber(response.data, [`${field}`])
+    callback(response.status, Requester.success(jobRunID, response))
+  }
+
+  const _handleError = (error) => callback(500, Requester.errored(jobRunID, error))
+
+  Requester.request(config).then(_handleResponse).catch(_handleError)
+}
+
+const customParams = {
+  endpoint: false,
+}
+
+const execute = (input, callback) => {
+  const validator = new Validator(input, customParams)
+  if (validator.error) return callback(validator.error.statusCode, validator.error)
+
+  const jobRunID = validator.validated.id
+  const endpoint = validator.validated.data.endpoint || DEFAULT_ENDPOINT
+  switch (endpoint.toLowerCase()) {
+    case ENDPOINT_US:
+      return us(jobRunID, input, callback)
+    default:
+      callback(500, Requester.errored(jobRunID, 'invalid endpoint provided'))
+  }
+}
+
+module.exports.execute = execute

--- a/covid-tracker/index.js
+++ b/covid-tracker/index.js
@@ -1,0 +1,4 @@
+const { expose } = require('@chainlink/ea-bootstrap')
+const { execute } = require('./adapter')
+
+module.exports = expose(execute)

--- a/covid-tracker/package.json
+++ b/covid-tracker/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "covid-tracker",
+  "version": "0.1.0",
+  "license": "MIT",
+  "main": "index.js",
+  "scripts": {
+    "server": "node -e 'require(\"./index.js\").server()'",
+    "lint": "eslint --ignore-path ../.eslintignore . --ext .js,.jsx,.ts,.tsx",
+    "lint:fix": "eslint --ignore-path ../.eslintignore . --ext .js,.jsx,.ts,.tsx --fix",
+    "test": "yarn _mocha --timeout 0",
+    "test:unit": "yarn _mocha --grep @integration --invert --timeout 0",
+    "test:integration": "yarn _mocha --grep @integration --timeout 0"
+  },
+  "dependencies": {}
+}

--- a/covid-tracker/test/adapter_test.js
+++ b/covid-tracker/test/adapter_test.js
@@ -1,0 +1,85 @@
+const { assert } = require('chai')
+const { assertSuccess, assertError } = require('@chainlink/external-adapter')
+const { execute } = require('../adapter')
+
+describe('execute', () => {
+  const jobID = '1'
+
+  context('successful calls @integration', () => {
+    const requests = [
+      {
+        name: 'id not supplied',
+        testData: { data: { field: 'totalTestResults' } },
+      },
+      {
+        name: 'without date',
+        testData: { id: jobID, data: { field: 'totalTestResultsIncrease' } },
+      },
+      {
+        name: 'with date',
+        testData: { id: jobID, data: { field: 'death', date: '20201010' } },
+      },
+    ]
+
+    requests.forEach((req) => {
+      it(`${req.name}`, (done) => {
+        execute(req.testData, (statusCode, data) => {
+          assertSuccess({ expected: 200, actual: statusCode }, data, jobID)
+          assert.isAbove(data.result, 0)
+          assert.isAbove(data.data.result, 0)
+          done()
+        })
+      })
+    })
+  })
+
+  context('validation error', () => {
+    const requests = [
+      { name: 'empty body', testData: {} },
+      { name: 'empty data', testData: { data: {} } },
+      {
+        name: 'field not supplied',
+        testData: { id: jobID, data: {} },
+      },
+      {
+        name: 'unknown date format',
+        testData: { id: jobID, data: { field: 'deaths', date: 'not_real' } },
+      },
+      {
+        name: 'unknown date format 2',
+        testData: { id: jobID, data: { field: 'deaths', date: '2020111' } },
+      },
+      {
+        name: 'date not found',
+        testData: { id: jobID, data: { field: 'deaths', date: '17601010' } },
+      },
+    ]
+
+    requests.forEach((req) => {
+      it(`${req.name}`, (done) => {
+        execute(req.testData, (statusCode, data) => {
+          assertError({ expected: 400, actual: statusCode }, data, jobID)
+          done()
+        })
+      })
+    })
+  })
+
+  context('error calls @integration', () => {
+    const requests = [
+      {
+        name: 'unknown field',
+        testData: { id: jobID, data: { field: 'not_real' } },
+      },
+    ]
+
+    requests.forEach((req) => {
+      it(`${req.name}`, (done) => {
+        execute(req.testData, (statusCode, data) => {
+          assertError({ expected: 500, actual: statusCode }, data, jobID)
+          done()
+        })
+      })
+    })
+  })
+})

--- a/covid-tracker/test/adapter_test.js
+++ b/covid-tracker/test/adapter_test.js
@@ -9,15 +9,15 @@ describe('execute', () => {
     const requests = [
       {
         name: 'id not supplied',
-        testData: { data: { field: 'totalTestResults' } },
+        testData: { data: { field: 'totalTestResults', location: 'USA' } },
       },
       {
         name: 'without date',
-        testData: { id: jobID, data: { field: 'totalTestResultsIncrease' } },
+        testData: { id: jobID, data: { field: 'totalTestResultsIncrease', location: 'USA' } },
       },
       {
         name: 'with date',
-        testData: { id: jobID, data: { field: 'death', date: '20201010' } },
+        testData: { id: jobID, data: { field: 'death', date: '20201010', location: 'USA' } },
       },
     ]
 
@@ -39,19 +39,23 @@ describe('execute', () => {
       { name: 'empty data', testData: { data: {} } },
       {
         name: 'field not supplied',
-        testData: { id: jobID, data: {} },
+        testData: { id: jobID, data: { location: 'USA' } },
+      },
+      {
+        name: 'location not supplied',
+        testData: { id: jobID, data: { field: 'deaths' } },
       },
       {
         name: 'unknown date format',
-        testData: { id: jobID, data: { field: 'deaths', date: 'not_real' } },
+        testData: { id: jobID, data: { field: 'deaths', date: 'not_real', location: 'USA' } },
       },
       {
         name: 'unknown date format 2',
-        testData: { id: jobID, data: { field: 'deaths', date: '2020111' } },
+        testData: { id: jobID, data: { field: 'deaths', date: '2020111', location: 'USA' } },
       },
       {
         name: 'date not found',
-        testData: { id: jobID, data: { field: 'deaths', date: '17601010' } },
+        testData: { id: jobID, data: { field: 'deaths', date: '17601010', location: 'USA' } },
       },
     ]
 
@@ -69,7 +73,7 @@ describe('execute', () => {
     const requests = [
       {
         name: 'unknown field',
-        testData: { id: jobID, data: { field: 'not_real' } },
+        testData: { id: jobID, data: { field: 'not_real', location: 'USA' } },
       },
     ]
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "private": true,
   "workspaces": [
+    "covid-tracker",
     "messari",
     "coinlore",
     "trueusd",


### PR DESCRIPTION
### Description
Adds a new adapter for COVID tracker's API (https://covidtracking.com/data/api)

This adapter is dynamic in that it takes in a `field` param for the data field to return and an optional `date` field for accessing historical COVID data.

### Caveats
While testing validation I noticed that a test that returns a `400` error that is put in the `'error calls @integration'` group still passes. Not sure if this is a repository wide issue - needs further testing.

### Ticket
https://www.pivotaltracker.com/story/show/175417790
