### PR TITLE
[Hotfix] LCX build script & makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ zip: deps build
 
 new:
 	mkdir $(adapter)
-	cp -r example/ $(adapter)
+	cp -r example/* $(adapter)
 	sed -i 's/example/$(adapter)/' $(adapter)/package.json
 	sed -i 's/Example/$(adapter)/' $(adapter)/README.md
 	sed -i 's/"workspaces": \[/"workspaces": \[\n    "$(adapter)",/' package.json

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ zip: deps build
 
 new:
 	mkdir $(adapter)
-	cp -r example/* $(adapter)
+	cp -rT example/ $(adapter)
 	sed -i 's/example/$(adapter)/' $(adapter)/package.json
 	sed -i 's/Example/$(adapter)/' $(adapter)/README.md
 	sed -i 's/"workspaces": \[/"workspaces": \[\n    "$(adapter)",/' package.json

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ zip: deps build
 
 new:
 	mkdir $(adapter)
-	cp -rT example/ $(adapter)
+	cp -R example/* $(adapter)
+	cp example/.eslintrc.js $(adapter)
 	sed -i 's/example/$(adapter)/' $(adapter)/package.json
 	sed -i 's/Example/$(adapter)/' $(adapter)/README.md
 	sed -i 's/"workspaces": \[/"workspaces": \[\n    "$(adapter)",/' package.json

--- a/lcx/package.json
+++ b/lcx/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "scripts": {
     "prepublishOnly": "yarn build && yarn test:unit",
-    "build": "yarn && tsc",
+    "build": "tsc",
     "lint": "eslint --ignore-path ../.eslintignore . --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "eslint --ignore-path ../.eslintignore . --ext .js,.jsx,.ts,.tsx --fix",
     "test": "mocha --exit --timeout 7000 -r ts-node/register 'test/**/*.test.ts'",

--- a/lcx/package.json
+++ b/lcx/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "scripts": {
     "prepublishOnly": "yarn build && yarn test:unit",
-    "build": "tsc",
+    "build": "yarn && tsc",
     "lint": "eslint --ignore-path ../.eslintignore . --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "eslint --ignore-path ../.eslintignore . --ext .js,.jsx,.ts,.tsx --fix",
     "test": "mocha --exit --timeout 7000 -r ts-node/register 'test/**/*.test.ts'",


### PR DESCRIPTION
### Description
Quick fix to LCX adapter's `build` script (which was built from the example adapter before Kristijan's recent change to run `yarn` first)

Also fix `make new adapter=...` that was incorrectly copying the example adapter and not adding to `package.json` workspaces.