### PR TITLE
Query string params

### DIFF
--- a/bootstrap/lib/aws.js
+++ b/bootstrap/lib/aws.js
@@ -49,7 +49,10 @@ exports.initHandlerREST = (execute) => (event, _context, callback) => {
     return callback(null, UNSUPPORTED_MEDIA_TYPE_RESPONSE)
   }
   let newBody = event.requestBody
-  newBody.data = Object.assign(event.requestBody.data === undefined ? {} : event.requestBody.data, parseQueryString(event.queryStringParameters))
+  newBody.data = Object.assign(
+    event.requestBody.data === undefined ? {} : event.requestBody.data,
+    parseQueryString(event.queryStringParameters),
+  )
   execute(newBody, (_, data) => {
     callback(null, data)
   })
@@ -62,7 +65,10 @@ exports.initHandlerHTTP = (execute) => (event, _context, callback) => {
   }
   const body = JSON.parse(event.body)
   let newBody = body.requestBody
-  newBody.data = Object.assign(event.requestBody.data === undefined ? {} : event.requestBody.data, parseQueryString(event.queryStringParameters))
+  newBody.data = Object.assign(
+    event.requestBody.data === undefined ? {} : event.requestBody.data,
+    parseQueryString(event.queryStringParameters),
+  )
   execute(newBody, (statusCode, data) => {
     callback(null, {
       statusCode: statusCode,

--- a/bootstrap/lib/server.js
+++ b/bootstrap/lib/server.js
@@ -17,7 +17,6 @@ const CONTENT_TYPE_TEXT_PLAIN = 'text/plain'
 
 const notImplementedHealthCheck = (callback) => callback(HTTP_ERROR_NOT_IMPLEMENTED)
 
-
 const initHandler = (execute, checkHealth = notImplementedHealthCheck) => () => {
   app.use(express.json())
 
@@ -27,7 +26,10 @@ const initHandler = (execute, checkHealth = notImplementedHealthCheck) => () => 
         .status(HTTP_ERROR_UNSUPPORTED_MEDIA_TYPE)
         .send(HTTP_ERROR_UNSUPPORTED_MEDIA_TYPE_MESSAGE)
     }
-    req.body.data = Object.assign(req.body.data === undefined ? {} : req.body.data, parseQueryString(req.query))
+    req.body.data = Object.assign(
+      req.body.data === undefined ? {} : req.body.data,
+      parseQueryString(req.query),
+    )
     execute(req.body, (status, result) => {
       res.status(status).json(result)
     })

--- a/bootstrap/lib/server.js
+++ b/bootstrap/lib/server.js
@@ -15,6 +15,26 @@ const CONTENT_TYPE_TEXT_PLAIN = 'text/plain'
 
 const notImplementedHealthCheck = (callback) => callback(HTTP_ERROR_NOT_IMPLEMENTED)
 
+const formatQueryStringValue = (val) => {
+  if (typeof val === 'object') {
+    return formatObj(val)
+  } else if (Array.isArray(val)) {
+    return val.map(formatQueryStringValue)
+  } else if (isNaN(val)) { // if it's not a number it's a string
+    return val
+  } else {
+    return Number(val)
+  }
+}
+
+const formatObj = (query) => {
+  let formatted = {}
+  for (const [key, val] of Object.entries(query)) {
+    formatted[formatQueryStringValue(key)] = formatQueryStringValue(val)
+  }
+  return formatted
+}
+
 const initHandler = (execute, checkHealth = notImplementedHealthCheck) => () => {
   app.use(express.json())
 
@@ -24,7 +44,7 @@ const initHandler = (execute, checkHealth = notImplementedHealthCheck) => () => 
         .status(HTTP_ERROR_UNSUPPORTED_MEDIA_TYPE)
         .send(HTTP_ERROR_UNSUPPORTED_MEDIA_TYPE_MESSAGE)
     }
-
+    Object.assign(req.body.data, formatObj(req.query))
     execute(req.body, (status, result) => {
       res.status(status).json(result)
     })

--- a/bootstrap/lib/util.js
+++ b/bootstrap/lib/util.js
@@ -8,6 +8,15 @@ const parseBool = (value) => {
   return (_val === 'true' || _val === 'false') && _val === 'true'
 }
 
+// parse incoming query string, strings into Numbers where possible
+const parseQueryString = (query) => {
+  let formatted = {}
+  for (const [key, val] of Object.entries(query)) {
+    formatted[key] = isNaN(val) ? val : Number(val)
+  }
+  return formatted
+}
+
 // We generate an UUID per instance
 const uuid = () => {
   if (!process.env.UUID) process.env.UUID = uuidv4()
@@ -102,4 +111,5 @@ module.exports = {
   exponentialBackOffMs,
   getWithCoalescing,
   wrapExecute,
+  parseQueryString,
 }


### PR DESCRIPTION
Will need to be merged alongside [this PR](https://github.com/smartcontractkit/infra-modules/pull/286). This allows us to pass arbitrary query string parameters to external adapters, useful for specifying a single external adapter as multiple data sources. For [this story](https://www.pivotaltracker.com/story/show/175901421)