### PR TITLE
Query string params (post-typescript)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   - `coinranking` to get crypto prices from Coinranking
 - Added support for metadata in requests. This gives adapters access to the FM on-chain round state.
 - Moves re-usable test behaviors & testing utils to a new package - `@chainlink/adapter-test-helpers`
-
+- Added support for using query string parameters as input to adapters.
 ### Changed
 
 - Oilprice adapters now accept a common request for Brent crude oil: `{"market":"brent"}`

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ This is an example, a JSON body the adapter will receive when plugged into the C
 
 When the FluxMonitor posts to External Adapters, it will include the `RoundState` as the "meta" field in the request, serialized to a JSON object with lower camelCase keys.
 
+Optionally `data` parameters can also be passed via a query string like: `{ENDPOINT}?from=ETH&to=USD`
 ## Docker
 
 To build a Docker container for a specific `$adapter`, use the following example:
@@ -137,6 +138,15 @@ If using a REST API Gateway, you will need to disable the Lambda proxy integrati
 - Click Integration Request
 - Uncheck Use Lamba Proxy integration
 - Click OK on the two dialogs
+- Click the Mapping Templates dropdown
+- Check "When there are no templates defined (recommended)"
+- Add new Content-Type `application/json`
+- Use Mapping Template: 
+```
+#set($input.path("$").queryStringParameters = $input.params().querystring)
+$input.json('$')
+```
+- Click Save
 - Return to your function
 - Remove the API Gateway and Save
 - Click Add Trigger and use the same API Gateway

--- a/bootstrap/src/lib/aws.ts
+++ b/bootstrap/src/lib/aws.ts
@@ -70,12 +70,12 @@ export const initHandlerHTTP = (execute: ExecuteSync) => (
   if (!isContentTypeSupported(event)) {
     return callback(null, UNSUPPORTED_MEDIA_TYPE_RESPONSE)
   }
-  const bodyIncludingQuery = JSON.parse(event.body)
-  bodyIncludingQuery.data = {
-    ...bodyIncludingQuery.data,
-    ...toObjectWithNumbers(bodyIncludingQuery.queryStringParameters || {}),
+  const body = JSON.parse(event.body)
+  body.data = {
+    ...body.data,
+    ...toObjectWithNumbers(body.queryStringParameters || {}),
   }
-  execute(bodyIncludingQuery, (statusCode, data) => {
+  execute(body, (statusCode, data) => {
     callback(null, {
       statusCode: statusCode,
       body: JSON.stringify(data),

--- a/bootstrap/src/lib/aws.ts
+++ b/bootstrap/src/lib/aws.ts
@@ -8,6 +8,7 @@ import {
   HTTP_ERROR_UNSUPPORTED_MEDIA_TYPE,
   HTTP_ERROR_UNSUPPORTED_MEDIA_TYPE_MESSAGE,
 } from './errors'
+import {toObjectWithNumbers} from "./util";
 
 const awsGetRequestHeaders = (event: any) => {
   if (!event || !event.headers) return {}
@@ -51,7 +52,10 @@ export const initHandlerREST = (execute: ExecuteSync) => (
   if (!isContentTypeSupported(event)) {
     return callback(null, UNSUPPORTED_MEDIA_TYPE_RESPONSE)
   }
-
+  event.data = {
+    ...event.data,
+    ...toObjectWithNumbers(event.queryStringParameters || {})
+  }
   execute(event, (_, data) => {
     callback(null, data)
   })

--- a/bootstrap/src/lib/aws.ts
+++ b/bootstrap/src/lib/aws.ts
@@ -8,7 +8,7 @@ import {
   HTTP_ERROR_UNSUPPORTED_MEDIA_TYPE,
   HTTP_ERROR_UNSUPPORTED_MEDIA_TYPE_MESSAGE,
 } from './errors'
-import {toObjectWithNumbers} from "./util";
+import { toObjectWithNumbers } from './util'
 
 const awsGetRequestHeaders = (event: any) => {
   if (!event || !event.headers) return {}
@@ -54,7 +54,7 @@ export const initHandlerREST = (execute: ExecuteSync) => (
   }
   event.data = {
     ...event.data,
-    ...toObjectWithNumbers(event.queryStringParameters || {})
+    ...toObjectWithNumbers(event.queryStringParameters || {}),
   }
   execute(event, (_, data) => {
     callback(null, data)
@@ -70,10 +70,10 @@ export const initHandlerHTTP = (execute: ExecuteSync) => (
   if (!isContentTypeSupported(event)) {
     return callback(null, UNSUPPORTED_MEDIA_TYPE_RESPONSE)
   }
-  let bodyIncludingQuery = JSON.parse(event.body)
+  const bodyIncludingQuery = JSON.parse(event.body)
   bodyIncludingQuery.data = {
     ...bodyIncludingQuery.data,
-    ...toObjectWithNumbers(bodyIncludingQuery.queryStringParameters || {})
+    ...toObjectWithNumbers(bodyIncludingQuery.queryStringParameters || {}),
   }
   execute(bodyIncludingQuery, (statusCode, data) => {
     callback(null, {

--- a/bootstrap/src/lib/aws.ts
+++ b/bootstrap/src/lib/aws.ts
@@ -70,12 +70,12 @@ export const initHandlerHTTP = (execute: ExecuteSync) => (
   if (!isContentTypeSupported(event)) {
     return callback(null, UNSUPPORTED_MEDIA_TYPE_RESPONSE)
   }
-  let newBody = JSON.parse(event.body)
-  newBody.data = {
-    ...newBody.data,
-    ...toObjectWithNumbers(newBody.queryStringParameters || {})
+  let bodyIncludingQuery = JSON.parse(event.body)
+  bodyIncludingQuery.data = {
+    ...bodyIncludingQuery.data,
+    ...toObjectWithNumbers(bodyIncludingQuery.queryStringParameters || {})
   }
-  execute(newBody, (statusCode, data) => {
+  execute(bodyIncludingQuery, (statusCode, data) => {
     callback(null, {
       statusCode: statusCode,
       body: JSON.stringify(data),

--- a/bootstrap/src/lib/aws.ts
+++ b/bootstrap/src/lib/aws.ts
@@ -70,8 +70,12 @@ export const initHandlerHTTP = (execute: ExecuteSync) => (
   if (!isContentTypeSupported(event)) {
     return callback(null, UNSUPPORTED_MEDIA_TYPE_RESPONSE)
   }
-
-  execute(JSON.parse(event.body), (statusCode, data) => {
+  let newBody = JSON.parse(event.body)
+  newBody.data = {
+    ...newBody.data,
+    ...toObjectWithNumbers(newBody.queryStringParameters || {})
+  }
+  execute(newBody, (statusCode, data) => {
     callback(null, {
       statusCode: statusCode,
       body: JSON.stringify(data),

--- a/bootstrap/src/lib/gcp.ts
+++ b/bootstrap/src/lib/gcp.ts
@@ -4,6 +4,7 @@ import {
   HTTP_ERROR_UNSUPPORTED_MEDIA_TYPE_MESSAGE,
 } from './errors'
 import { ExecuteSync } from '@chainlink/types'
+import { toObjectWithNumbers } from "./util";
 
 export const initHandler = (execute: ExecuteSync) => (req: any, res: any) => {
   if (!req.is(CONTENT_TYPE_APPLICATION_JSON)) {
@@ -12,7 +13,10 @@ export const initHandler = (execute: ExecuteSync) => (req: any, res: any) => {
       .status(HTTP_ERROR_UNSUPPORTED_MEDIA_TYPE)
       .send(HTTP_ERROR_UNSUPPORTED_MEDIA_TYPE_MESSAGE)
   }
-
+  req.body.data = {
+    ...req.body.data || {},
+    ...toObjectWithNumbers(req.query)
+  }
   execute(req.body, (statusCode, data) => {
     res.type('json').status(statusCode).send(data)
   })

--- a/bootstrap/src/lib/gcp.ts
+++ b/bootstrap/src/lib/gcp.ts
@@ -4,7 +4,7 @@ import {
   HTTP_ERROR_UNSUPPORTED_MEDIA_TYPE_MESSAGE,
 } from './errors'
 import { ExecuteSync } from '@chainlink/types'
-import { toObjectWithNumbers } from "./util";
+import { toObjectWithNumbers } from './util'
 
 export const initHandler = (execute: ExecuteSync) => (req: any, res: any) => {
   if (!req.is(CONTENT_TYPE_APPLICATION_JSON)) {
@@ -14,8 +14,8 @@ export const initHandler = (execute: ExecuteSync) => (req: any, res: any) => {
       .send(HTTP_ERROR_UNSUPPORTED_MEDIA_TYPE_MESSAGE)
   }
   req.body.data = {
-    ...req.body.data || {},
-    ...toObjectWithNumbers(req.query)
+    ...(req.body.data || {}),
+    ...toObjectWithNumbers(req.query),
   }
   execute(req.body, (statusCode, data) => {
     res.type('json').status(statusCode).send(data)

--- a/bootstrap/src/lib/server.ts
+++ b/bootstrap/src/lib/server.ts
@@ -1,4 +1,5 @@
 import { logger } from '@chainlink/external-adapter'
+import { toObjectWithNumbers } from "./util";
 import express from 'express'
 import {
   HTTP_ERROR_NOT_IMPLEMENTED,
@@ -29,7 +30,10 @@ export const initHandler = (
         .status(HTTP_ERROR_UNSUPPORTED_MEDIA_TYPE)
         .send(HTTP_ERROR_UNSUPPORTED_MEDIA_TYPE_MESSAGE)
     }
-
+    req.body.data = {
+      ...req.body.data || {},
+      ...toObjectWithNumbers(req.query)
+    }
     execute(req.body, (status, result) => {
       res.status(status).json(result)
     })

--- a/bootstrap/src/lib/server.ts
+++ b/bootstrap/src/lib/server.ts
@@ -1,5 +1,5 @@
 import { logger } from '@chainlink/external-adapter'
-import { toObjectWithNumbers } from "./util";
+import { toObjectWithNumbers } from './util'
 import express from 'express'
 import {
   HTTP_ERROR_NOT_IMPLEMENTED,
@@ -31,8 +31,8 @@ export const initHandler = (
         .send(HTTP_ERROR_UNSUPPORTED_MEDIA_TYPE_MESSAGE)
     }
     req.body.data = {
-      ...req.body.data || {},
-      ...toObjectWithNumbers(req.query)
+      ...(req.body.data || {}),
+      ...toObjectWithNumbers(req.query),
     }
     execute(req.body, (status, result) => {
       res.status(status).json(result)

--- a/bootstrap/src/lib/util.ts
+++ b/bootstrap/src/lib/util.ts
@@ -16,6 +16,12 @@ export const parseBool = (value: any): boolean => {
   return (_val === 'true' || _val === 'false') && _val === 'true'
 }
 
+// convert string values into Numbers where possible (for incoming query strings)
+export const toObjectWithNumbers = (obj: any): object => {
+  const toNumber = (v: any) => isNaN(v) ? v : Number(v)
+  return Object.fromEntries(Object.entries(obj).map(([k, v]) => [k, toNumber(v)]))
+}
+
 // We generate an UUID per instance
 export const uuid = (): string => {
   if (!process.env.UUID) process.env.UUID = uuidv4()

--- a/bootstrap/src/lib/util.ts
+++ b/bootstrap/src/lib/util.ts
@@ -17,8 +17,8 @@ export const parseBool = (value: any): boolean => {
 }
 
 // convert string values into Numbers where possible (for incoming query strings)
-export const toObjectWithNumbers = (obj: any): object => {
-  const toNumber = (v: any) => isNaN(v) ? v : Number(v)
+export const toObjectWithNumbers = (obj: any) => {
+  const toNumber = (v: any) => (isNaN(v) ? v : Number(v))
   return Object.fromEntries(Object.entries(obj).map(([k, v]) => [k, toNumber(v)]))
 }
 


### PR DESCRIPTION
Moving [this PR](https://github.com/smartcontractkit/external-adapters-js/pull/173) here to avoid the ugly merge after typescript changes (my git-fu could use some improvement)
This allows us to pass arbitrary query string parameters to external adapters, useful for specifying a single external adapter as multiple data sources. For [this story](https://www.pivotaltracker.com/story/show/175901421)

Querystrings won't be enabled for us until https://github.com/smartcontractkit/infra-modules/pull/286 is merged, but the two PRs are independent in that they won't break anything if one is merged before the other.