### PR TITLE
Fix/update dxFeed symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   now also supports using metadata.
 - Coinlore now accepts an optional environment variable to set the default API endpoint
 - migrates @chainlink/ea-bootstrap and @chainlink/external-adapter packages to TS.
+- dxFeed now uses OTC feeds for FTSE and N225, rather than licensed data feeds
 
 ## [0.1.4] - 2020-10-30
 

--- a/dxfeed/adapter.js
+++ b/dxfeed/adapter.js
@@ -15,8 +15,8 @@ const customParams = {
 }
 
 const commonSymbols = {
-  N225: 'N225:JP',
-  FTSE: 'UKX:FTSE',
+  N225: 'NKY.IND:TEI',
+  FTSE: 'UKX.IND:TEI',
 }
 
 const execute = (input, callback) => {


### PR DESCRIPTION
- These symbols are for the OTC data rather than the licensed FTSE and N225 data (which is quite expensive). This is what node operators are using in production (Chainlayer, AlphaVantage)
- Their demo endpoint uses the licensed FTSE and N225 feeds, so you won't be able to use the develop against it after merging this
- We have a subscription that has these feeds, so you could mock a call for integration tests if necessary