### PR TITLE
Dxfeed endpoint falls back to price endpoint

### DIFF
--- a/dxfeed-secondary/README.md
+++ b/dxfeed-secondary/README.md
@@ -17,7 +17,7 @@ This adapter supports the following environment variables:
 ## Input Params
 
 - `base`, `from`, or `asset`: The symbol of the asset to query
-- `endpoint`: Optional endpoint param
+- `endpoint`: Optional endpoint param, defaults to using the price endpoint
 
 ## Output
 

--- a/dxfeed-secondary/src/adapter.ts
+++ b/dxfeed-secondary/src/adapter.ts
@@ -1,4 +1,4 @@
-import { Requester, Validator, AdapterError } from '@chainlink/external-adapter'
+import { Requester, Validator } from '@chainlink/external-adapter'
 import { ExecuteWithConfig, ExecuteFactory, Config } from '@chainlink/types'
 import { makeConfig, DEFAULT_ENDPOINT } from './config'
 import { price } from './endpoint'
@@ -13,20 +13,11 @@ export const execute: ExecuteWithConfig<Config> = async (request, config) => {
 
   Requester.logConfig(config)
 
-  const jobRunID = validator.validated.id
   const endpoint = validator.validated.data.endpoint || DEFAULT_ENDPOINT
 
   switch (endpoint) {
-    case price.NAME: {
-      return await price.execute(request, config)
-      break
-    }
     default: {
-      throw new AdapterError({
-        jobRunID,
-        message: `Endpoint ${endpoint} not supported.`,
-        statusCode: 400,
-      })
+      return await price.execute(request, config)
     }
   }
 }

--- a/dxfeed/README.md
+++ b/dxfeed/README.md
@@ -11,7 +11,7 @@ This adapter supports the following environment variables:
 ## Input Params
 
 - `base`, `from`, or `asset`: The symbol of the asset to query
-- `endpoint`: Optional endpoint param
+- `endpoint`: Optional endpoint param, defaults to using the price endpoint
 
 The `base` param handles the following symbol conversions:
 

--- a/dxfeed/src/adapter.ts
+++ b/dxfeed/src/adapter.ts
@@ -1,4 +1,4 @@
-import { Requester, Validator, AdapterError } from '@chainlink/external-adapter'
+import { Requester, Validator } from '@chainlink/external-adapter'
 import { ExecuteWithConfig, ExecuteFactory, Config } from '@chainlink/types'
 import { makeConfig, DEFAULT_ENDPOINT } from './config'
 import { price } from './endpoint'
@@ -13,20 +13,11 @@ export const execute: ExecuteWithConfig<Config> = async (request, config) => {
 
   Requester.logConfig(config)
 
-  const jobRunID = validator.validated.id
   const endpoint = validator.validated.data.endpoint || DEFAULT_ENDPOINT
 
   switch (endpoint) {
-    case price.NAME: {
-      return await price.execute(request, config)
-      break
-    }
     default: {
-      throw new AdapterError({
-        jobRunID,
-        message: `Endpoint ${endpoint} not supported.`,
-        statusCode: 400,
-      })
+      return await price.execute(request, config)
     }
   }
 }


### PR DESCRIPTION
A hotfix to allow Dxfeeds to be used as `price` adapters with a mismatched `endpoint` param.