### PR TITLE
[DRAFT] EAs with Context

### DIFF
--- a/bootstrap/src/lib/cache/index.ts
+++ b/bootstrap/src/lib/cache/index.ts
@@ -76,7 +76,6 @@ export const withCache = async (
 ) => {
   // If disabled noop
   if (!options.enabled) return (data: AdapterRequest) => execute(data)
-
   const cache = await options.cacheBuilder(options.cacheOptions)
 
   // Algorithm we use to derive entry key


### PR DESCRIPTION
### Description
Remanent from moving individual request caching toward using a `Context`, away from using `withCache` middleware inside `Requester`.