### PR TITLE
Missing params on response

### DIFF
--- a/bootstrap/src/index.ts
+++ b/bootstrap/src/index.ts
@@ -4,14 +4,7 @@ import * as util from './lib/util'
 import * as server from './lib/server'
 import * as gcp from './lib/gcp'
 import * as aws from './lib/aws'
-import {
-  ExecuteSync,
-  AdapterRequest,
-  Execute,
-  AdapterHealthCheck,
-  AdapterResponse,
-  AdapterErrorResponse,
-} from '@chainlink/types'
+import { ExecuteSync, AdapterRequest, Execute, AdapterHealthCheck } from '@chainlink/types'
 
 export type Middleware<O = any> = (execute: Execute, options?: O) => Promise<Execute>
 

--- a/bootstrap/src/index.ts
+++ b/bootstrap/src/index.ts
@@ -66,13 +66,6 @@ const withMiddleware = async (execute: Execute) => {
   return execute
 }
 
-const wrapResponse = (response: AdapterResponse | AdapterErrorResponse) => {
-  return {
-    statusCode: response.statusCode,
-    data: response,
-  }
-}
-
 // Execution helper async => sync
 const executeSync = (execute: Execute): ExecuteSync => {
   // TODO: Try to init middleware only once
@@ -83,8 +76,7 @@ const executeSync = (execute: Execute): ExecuteSync => {
     // We init on every call because of cache connection broken state issue
     return withMiddleware(execute)
       .then((executeWithMiddleware) => executeWithMiddleware(data))
-      .then(wrapResponse)
-      .then((result) => callback(result.statusCode, result.data))
+      .then((result) => callback(result.statusCode, result))
       .catch((error) => callback(error.statusCode || 500, Requester.errored(data.id, error)))
   }
 }


### PR DESCRIPTION
After removing `utils.wrapAdapter`, we just need to pass the response on the callback
