### PR TITLE
Clean Redis Shutdown

### DIFF
--- a/bootstrap/src/lib/cache/index.ts
+++ b/bootstrap/src/lib/cache/index.ts
@@ -169,9 +169,19 @@ export const withCache: Middleware<CacheOptions> = async (execute, options = def
 
   // Middleware wrapped execute fn which cleans up after
   return async (input) => {
-    const result = await _executeWithCache(input)
-    // Clean the connection
-    await cache.close()
-    return result
+    try {
+        const result = await _executeWithCache(input)    
+        
+        // Clean the connection
+        await cache.close()
+        
+        return result
+    }
+    catch (err) {
+        // Close the cache connection in any case
+        await cache.close()
+        // Re-Throw Error
+        throw err
+    }
   }
 }

--- a/bootstrap/src/lib/cache/redis.ts
+++ b/bootstrap/src/lib/cache/redis.ts
@@ -107,8 +107,21 @@ export class RedisCache {
    *
    * The alternative is to use: `context.callbackWaitsForEmtpyEventLoop = false`
    */
-  async close() {
-    // No further commands will be processed
-    this.client.end(true)
+  close() {
+    if (!this.client) {
+        return Promise.resolve()
+    }
+
+    return new Promise(resolve => {
+        setTimeout(resolve, 5000) // Force quit after 5 seconds
+
+        // The quit method does not reliably resolve, so we have to resort to the `end´ event
+        this.client.once('end', () => {
+            logger.debug('Redis cache shutdown complete')
+            resolve()
+        })
+
+        this.client.quit()
+    })
   }
 }


### PR DESCRIPTION
This has not been tested, but it's mostly copypasta from one of my projects where I use Redis for caching as well. Fixes these issues:

- client.end should not be used in production and will sometimes lose data

- Close the Redis connection even when the request failed. Otherwise the open connections will stack until the adapter is restarted. 