### PR TITLE
Improve Redis connection cleanup

### DIFF
--- a/bootstrap/src/lib/cache/index.ts
+++ b/bootstrap/src/lib/cache/index.ts
@@ -63,7 +63,7 @@ const defaultCacheBuilder = () => {
   }
 }
 // Options without sensitive data
-export const redactOptions = (options: CacheOptions) => ({
+export const redactOptions = (options: CacheOptions): CacheOptions => ({
   ...options,
   cacheOptions:
     options.cacheOptions.type === 'redis'
@@ -169,9 +169,11 @@ export const withCache: Middleware<CacheOptions> = async (execute, options = def
 
   // Middleware wrapped execute fn which cleans up after
   return async (input) => {
-    const result = await _executeWithCache(input)
-    // Clean the connection
-    await cache.close()
-    return result
+    try {
+      return await _executeWithCache(input)
+    } finally {
+      // Close the cache connection in any case
+      await cache.close()
+    }
   }
 }


### PR DESCRIPTION
Redis connections are left hanging when adapter errors. Those hanging connections can slow down or crash the Redis node. This PR addresses this issue by improving the Redis connection cleanup.

Thanks @saschagoebel for making the [original PR](https://github.com/smartcontractkit/external-adapters-js/pull/360).