### PR TITLE
[Fix] Coinlore test

### DIFF
--- a/coinlore/README.md
+++ b/coinlore/README.md
@@ -18,7 +18,7 @@ The default is to use the Chainlink `dominance` behavior.
 | Required? |  Name   |                                   Description                                   |   Options    | Defaults to |
 | :-------: | :-----: | :-----------------------------------------------------------------------------: | :----------: | :---------: |
 |           | `field` |     The object path to access the value that will be returned as the result     |              |     `d`     |
-|           | `base`  | When using a field of `d`, the currency to prefix the field with (e.g. `btc_d`) | `btc`, `eth` |    `btc`    |
+|           | `base`  | When using a field of `d`, the currency to prefix the field with (e.g. `usd_d`) | `btc`, `eth` |    `btc`    |
 
 ### Sample Input
 

--- a/coinlore/test/global.test.ts
+++ b/coinlore/test/global.test.ts
@@ -4,7 +4,7 @@ import { AdapterRequest } from '@chainlink/types'
 import { assert } from 'chai'
 import { makeExecute } from '../src/adapter'
 
-xdescribe('execute', () => {
+describe('execute', () => {
   const jobID = '1'
   const execute = makeExecute()
 
@@ -12,23 +12,15 @@ xdescribe('execute', () => {
     const requests = [
       {
         name: 'id not supplied',
-        testData: { data: { market: 'BTC' } },
+        testData: { data: { base: 'BTC' } },
       },
       {
         name: 'id is supplied',
-        testData: { id: jobID, data: { market: 'ETH' } },
-      },
-      {
-        name: 'to',
-        testData: { id: jobID, data: { to: 'BTC' } },
-      },
-      {
-        name: 'quote',
-        testData: { id: jobID, data: { quote: 'BTC' } },
+        testData: { id: jobID, data: { base: 'ETH' } },
       },
       {
         name: 'global marketcap',
-        testData: { id: jobID, data: { endpoint: 'globalmarketcap', quote: 'USD' } },
+        testData: { id: jobID, data: { endpoint: 'globalmarketcap', base: 'USD' } },
       },
     ]
 
@@ -42,30 +34,11 @@ xdescribe('execute', () => {
     })
   })
 
-  context('validation error', () => {
-    const requests = [
-      {
-        name: 'market not supplied',
-        testData: { id: jobID, data: {} },
-      },
-    ]
-    requests.forEach((req) => {
-      it(`${req.name}`, async () => {
-        try {
-          await execute(req.testData as AdapterRequest)
-        } catch (error) {
-          const errorResp = Requester.errored(jobID, error)
-          assertError({ expected: 400, actual: errorResp.statusCode }, errorResp, jobID)
-        }
-      })
-    })
-  })
-
   context('error calls @integration', () => {
     const requests = [
       {
         name: 'unknown market',
-        testData: { id: jobID, data: { market: 'not_real' } },
+        testData: { id: jobID, data: { base: 'not_real' } },
       },
     ]
 


### PR DESCRIPTION
### Description
We were seeing a failing test on `Coinlore`.

Currently in CI we run only unit tests, which in reality ends up being just checking for validation errors.
In the TS refactor `Coinlore` had a param that was made optional. Meaning there was no more validation check. So it passed through to hitting the API.

Coinlore seems to have gone dark, seemingly their domain expired, so this test was then throwing not found errors when trying to hit the endpoint.