### PR TITLE
Cache and Rate limit metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - CMC now uses preset IDs instead of preset slugs
 - Added support for `tradermade` in `outlier-detection` composite adapter
 - Added a per-provider ratelimit reference
+- Added Prometheus metrics
 
 ### Fixed
 

--- a/packages/composites/token-allocation/src/adapter.ts
+++ b/packages/composites/token-allocation/src/adapter.ts
@@ -5,6 +5,7 @@ import { TokenAllocations, Config, ResponsePayload, GetPrices } from './types'
 import { Decimal } from 'decimal.js'
 import { AdapterError } from '@chainlink/ea-bootstrap'
 import { BigNumber } from 'ethers'
+import { getPriceProvider } from './dataProvider'
 
 export const priceTotalValue = (
   allocations: TokenAllocations,
@@ -112,7 +113,7 @@ export const execute = async (input: AdapterRequest, config: Config): Promise<Ad
       data: { sources: [], payload, result },
     })
 
-  const getPrices = config.priceAdapter.getPrices(jobRunID)
+  const getPrices = getPriceProvider(config.providerConfig.api, jobRunID)
   switch (method.toLowerCase()) {
     case 'price':
       // eslint-disable-next-line no-case-declarations

--- a/packages/composites/token-allocation/src/adapter.ts
+++ b/packages/composites/token-allocation/src/adapter.ts
@@ -1,9 +1,8 @@
 import { AdapterResponse, Execute, AdapterRequest } from '@chainlink/types'
-import { Requester, Validator } from '@chainlink/external-adapter'
-import { DEFAULT_TOKEN_BALANCE, DEFAULT_TOKEN_DECIMALS, makeConfig } from './config'
+import { DEFAULT_TOKEN_BALANCE, DEFAULT_TOKEN_DECIMALS, makeConfig, makeOptions } from './config'
 import { TokenAllocations, Config, ResponsePayload, GetPrices } from './types'
 import { Decimal } from 'decimal.js'
-import { AdapterError } from '@chainlink/ea-bootstrap'
+import { AdapterError, Requester, Validator } from '@chainlink/ea-bootstrap'
 import { BigNumber } from 'ethers'
 import { getPriceProvider } from './dataProvider'
 
@@ -113,7 +112,7 @@ export const execute = async (input: AdapterRequest, config: Config): Promise<Ad
       data: { sources: [], payload, result },
     })
 
-  const getPrices = getPriceProvider(config.providerConfig.api, jobRunID)
+  const getPrices = getPriceProvider(sourceConfig.api, jobRunID)
   switch (method.toLowerCase()) {
     case 'price':
       // eslint-disable-next-line no-case-declarations

--- a/packages/composites/token-allocation/src/adapter.ts
+++ b/packages/composites/token-allocation/src/adapter.ts
@@ -68,7 +68,12 @@ const toValidAllocations = (allocations: any[]): TokenAllocations => {
   })
 }
 
-const computePrice = async (sourceConfig: any, allocations: TokenAllocations, quote: string) => {
+const computePrice = async (
+  jobRunID: string,
+  config: Config,
+  allocations: TokenAllocations,
+  quote: string,
+) => {
   const symbols = (allocations as TokenAllocations).map((t) => t.symbol)
   const payload = await sourceConfig.getPrices(symbols, quote)
 
@@ -77,7 +82,8 @@ const computePrice = async (sourceConfig: any, allocations: TokenAllocations, qu
 }
 
 const computeMarketCap = async (
-  sourceConfig: any,
+  jobRunID: string,
+  config: Config,
   allocations: TokenAllocations,
   quote: string,
 ) => {

--- a/packages/composites/token-allocation/src/adapter.ts
+++ b/packages/composites/token-allocation/src/adapter.ts
@@ -1,7 +1,7 @@
 import { AdapterResponse, Execute, AdapterRequest } from '@chainlink/types'
-import { Requester, Validator } from '@chainlink/ea-bootstrap'
-import { DEFAULT_TOKEN_BALANCE, DEFAULT_TOKEN_DECIMALS, makeConfig, makeOptions } from './config'
-import { TokenAllocations, Config, ResponsePayload, PriceAdapter } from './types'
+import { Requester, Validator } from '@chainlink/external-adapter'
+import { DEFAULT_TOKEN_BALANCE, DEFAULT_TOKEN_DECIMALS, makeConfig } from './config'
+import { TokenAllocations, Config, ResponsePayload, GetPrices } from './types'
 import { Decimal } from 'decimal.js'
 import { AdapterError } from '@chainlink/ea-bootstrap'
 import { BigNumber } from 'ethers'
@@ -68,27 +68,21 @@ const toValidAllocations = (allocations: any[]): TokenAllocations => {
   })
 }
 
-const computePrice = async (
-  jobRunID: string,
-  config: Config,
-  allocations: TokenAllocations,
-  quote: string,
-) => {
+const computePrice = async (getPrices: GetPrices, allocations: TokenAllocations, quote: string) => {
   const symbols = (allocations as TokenAllocations).map((t) => t.symbol)
-  const payload = await sourceConfig.getPrices(symbols, quote)
+  const payload = await getPrices(symbols, quote)
 
   const result = priceTotalValue(allocations, quote, payload)
   return { payload, result }
 }
 
 const computeMarketCap = async (
-  jobRunID: string,
-  config: Config,
+  getPrices: GetPrices,
   allocations: TokenAllocations,
   quote: string,
 ) => {
   const symbols = (allocations as TokenAllocations).map((t) => t.symbol)
-  const payload = await sourceConfig.getPrices(symbols, quote, true)
+  const payload = await getPrices(symbols, quote, true)
 
   const result = marketCapTotalValue(allocations, quote, payload)
   return { payload, result }
@@ -118,14 +112,15 @@ export const execute = async (input: AdapterRequest, config: Config): Promise<Ad
       data: { sources: [], payload, result },
     })
 
+  const getPrices = config.priceAdapter.getPrices(jobRunID)
   switch (method.toLowerCase()) {
     case 'price':
       // eslint-disable-next-line no-case-declarations
-      const price = await computePrice(sourceConfig, allocations, quote)
+      const price = await computePrice(getPrices, allocations, quote)
       return _success(price.payload, price.result)
     case 'marketcap':
       // eslint-disable-next-line no-case-declarations
-      const marketCap = await computeMarketCap(sourceConfig, allocations, quote)
+      const marketCap = await computeMarketCap(getPrices, allocations, quote)
       return _success(marketCap.payload, marketCap.result)
     default:
       throw new AdapterError({

--- a/packages/composites/token-allocation/src/config.ts
+++ b/packages/composites/token-allocation/src/config.ts
@@ -1,6 +1,27 @@
 import { util, Requester } from '@chainlink/ea-bootstrap'
+import { AdapterImplementation } from '@chainlink/types'
+import Amberdata from '@chainlink/amberdata-adapter'
+import CoinApi from '@chainlink/coinapi-adapter'
+import CoinGecko from '@chainlink/coingecko-adapter'
+import CoinMarketCap from '@chainlink/coinmarketcap-adapter'
+import CoinPaprika from '@chainlink/coinpaprika-adapter'
+import CryptoCompare from '@chainlink/cryptocompare-adapter'
+import Kaiko from '@chainlink/kaiko-adapter'
+import Nomics from '@chainlink/nomics-adapter'
 import { Config, SourceRequestOptions } from './types'
-import { adapters } from './dataProvider'
+
+export const adapters: AdapterImplementation[] = [
+  Amberdata,
+  CoinApi,
+  CoinGecko,
+  CoinMarketCap,
+  CoinPaprika,
+  CryptoCompare,
+  Kaiko,
+  Nomics,
+]
+
+export type Source = typeof adapters[number]['NAME']
 
 export const DEFAULT_TOKEN_DECIMALS = 18
 export const DEFAULT_TOKEN_BALANCE = 1
@@ -16,19 +37,18 @@ export const makeConfig = (prefix = ''): Config => {
   const sources: SourceRequestOptions = {}
 
   for (const a of adapters) {
-    const name = a.NAME.toLowerCase()
-    const url = getURL(name)
+    const name = a.NAME
+    const url = getURL(name.toUpperCase())
     if (url) {
       const defaultConfig = Requester.getDefaultConfig(prefix)
       defaultConfig.api.baseURL = url
       defaultConfig.api.method = 'post'
-      sources[name] = getDataProvider(defaultConfig.api)
+      sources[name.toLowerCase()] = defaultConfig
     }
   }
 
   return {
     sources,
-    providerConfig: defaultConfig,
     defaultMethod: util.getEnv('DEFAULT_METHOD', prefix) || 'price',
     defaultQuote: util.getEnv('DEFAULT_QUOTE') || 'USD',
   }

--- a/packages/composites/token-allocation/src/config.ts
+++ b/packages/composites/token-allocation/src/config.ts
@@ -1,6 +1,4 @@
-import { util } from '@chainlink/ea-bootstrap'
-import { Requester } from '@chainlink/ea-bootstrap'
-import { getDataProvider } from './dataProvider'
+import { util, Requester } from '@chainlink/ea-bootstrap'
 import { Config, SourceRequestOptions } from './types'
 import { adapters } from './dataProvider'
 
@@ -30,6 +28,7 @@ export const makeConfig = (prefix = ''): Config => {
 
   return {
     sources,
+    providerConfig: defaultConfig,
     defaultMethod: util.getEnv('DEFAULT_METHOD', prefix) || 'price',
     defaultQuote: util.getEnv('DEFAULT_QUOTE') || 'USD',
   }

--- a/packages/composites/token-allocation/src/dataProvider.ts
+++ b/packages/composites/token-allocation/src/dataProvider.ts
@@ -24,8 +24,7 @@ export const adapters: AdapterImplementation[] = [
 
 export type Source = typeof adapters[number]['NAME']
 
-const getPrices = (apiConfig: any) => async (
-  jobRunID: string,
+const getPrices = (apiConfig: any) => (jobRunID: string) => async (
   symbols: string[],
   quote: string,
   withMarketCap = false,

--- a/packages/composites/token-allocation/src/dataProvider.ts
+++ b/packages/composites/token-allocation/src/dataProvider.ts
@@ -1,28 +1,6 @@
 import { Requester } from '@chainlink/ea-bootstrap'
-import { PriceAdapter, ResponsePayload } from './types'
-import { AdapterImplementation, RequestConfig } from '@chainlink/types'
-// data provider external adapters
-import Amberdata from '@chainlink/amberdata-adapter'
-import CoinApi from '@chainlink/coinapi-adapter'
-import CoinGecko from '@chainlink/coingecko-adapter'
-import CoinMarketCap from '@chainlink/coinmarketcap-adapter'
-import CoinPaprika from '@chainlink/coinpaprika-adapter'
-import CryptoCompare from '@chainlink/cryptocompare-adapter'
-import Kaiko from '@chainlink/kaiko-adapter'
-import Nomics from '@chainlink/nomics-adapter'
-
-export const adapters: AdapterImplementation[] = [
-  Amberdata,
-  CoinApi,
-  CoinGecko,
-  CoinMarketCap,
-  CoinPaprika,
-  CryptoCompare,
-  Kaiko,
-  Nomics,
-]
-
-export type Source = typeof adapters[number]['NAME']
+import { RequestConfig } from '@chainlink/types'
+import { ResponsePayload } from './types'
 
 export const getPriceProvider = (apiConfig: RequestConfig, jobRunID: string) => async (
   symbols: string[],

--- a/packages/composites/token-allocation/src/dataProvider.ts
+++ b/packages/composites/token-allocation/src/dataProvider.ts
@@ -32,7 +32,10 @@ const getPrices = (apiConfig: any) => async (
 ): Promise<ResponsePayload> => {
   const results = await Promise.all(
     symbols.map(async (base) => {
-      const data = { id: jobRunID, data: { base, quote, endpoint: withMarketCap ? 'marketcap' : 'price' } }
+      const data = {
+        id: jobRunID,
+        data: { base, quote, endpoint: withMarketCap ? 'marketcap' : 'price' },
+      }
       const response = await Requester.request({ ...apiConfig, data: data })
       return response.data.result
     }),

--- a/packages/composites/token-allocation/src/dataProvider.ts
+++ b/packages/composites/token-allocation/src/dataProvider.ts
@@ -25,13 +25,14 @@ export const adapters: AdapterImplementation[] = [
 export type Source = typeof adapters[number]['NAME']
 
 const getPrices = (apiConfig: any) => async (
+  jobRunID: string,
   symbols: string[],
   quote: string,
   withMarketCap = false,
 ): Promise<ResponsePayload> => {
   const results = await Promise.all(
     symbols.map(async (base) => {
-      const data = { data: { base, quote, endpoint: withMarketCap ? 'marketcap' : 'price' } }
+      const data = { id: jobRunID, data: { base, quote, endpoint: withMarketCap ? 'marketcap' : 'price' } }
       const response = await Requester.request({ ...apiConfig, data: data })
       return response.data.result
     }),

--- a/packages/composites/token-allocation/src/dataProvider.ts
+++ b/packages/composites/token-allocation/src/dataProvider.ts
@@ -1,6 +1,6 @@
 import { Requester } from '@chainlink/ea-bootstrap'
 import { PriceAdapter, ResponsePayload } from './types'
-import { AdapterImplementation } from '@chainlink/types'
+import { AdapterImplementation, RequestConfig } from '@chainlink/types'
 // data provider external adapters
 import Amberdata from '@chainlink/amberdata-adapter'
 import CoinApi from '@chainlink/coinapi-adapter'
@@ -24,7 +24,7 @@ export const adapters: AdapterImplementation[] = [
 
 export type Source = typeof adapters[number]['NAME']
 
-const getPrices = (apiConfig: any) => (jobRunID: string) => async (
+export const getPriceProvider = (apiConfig: RequestConfig, jobRunID: string) => async (
   symbols: string[],
   quote: string,
   withMarketCap = false,
@@ -50,10 +50,4 @@ const getPrices = (apiConfig: any) => (jobRunID: string) => async (
   })
 
   return Object.fromEntries(payloadEntries)
-}
-
-export const getDataProvider = (apiConfig: any): PriceAdapter => {
-  return {
-    getPrices: getPrices(apiConfig),
-  }
 }

--- a/packages/composites/token-allocation/src/types.ts
+++ b/packages/composites/token-allocation/src/types.ts
@@ -26,15 +26,10 @@ export type GetPrices = (
   withMarketCap?: boolean,
 ) => Promise<ResponsePayload>
 
-export type PriceAdapter = {
-  getPrices: (jobRunId: string) => GetPrices
-}
-
-export type SourceRequestOptions = { [source: string]: PriceAdapter }
+export type SourceRequestOptions = { [source: string]: DefaultConfig }
 
 export type Config = {
   sources: SourceRequestOptions
-  providerConfig: DefaultConfig
   defaultMethod: string
   defaultQuote: string
 }

--- a/packages/composites/token-allocation/src/types.ts
+++ b/packages/composites/token-allocation/src/types.ts
@@ -1,3 +1,4 @@
+import { Config as DefaultConfig } from '@chainlink/types'
 import { BigNumberish } from 'ethers'
 
 export type TokenAllocation = {
@@ -33,6 +34,7 @@ export type SourceRequestOptions = { [source: string]: PriceAdapter }
 
 export type Config = {
   sources: SourceRequestOptions
+  providerConfig: DefaultConfig
   defaultMethod: string
   defaultQuote: string
 }

--- a/packages/composites/token-allocation/src/types.ts
+++ b/packages/composites/token-allocation/src/types.ts
@@ -19,13 +19,14 @@ export type ResponsePayload = {
 
 export type TokenAllocations = TokenAllocation[]
 
+export type GetPrices = (
+  baseSymbols: string[],
+  quote: string,
+  withMarketCap?: boolean,
+) => Promise<ResponsePayload>
+
 export type PriceAdapter = {
-  getPrices: (
-    jobRunID: string,
-    baseSymbols: string[],
-    quote: string,
-    withMarketCap?: boolean,
-  ) => Promise<ResponsePayload>
+  getPrices: (jobRunId: string) => GetPrices
 }
 
 export type SourceRequestOptions = { [source: string]: PriceAdapter }

--- a/packages/composites/token-allocation/src/types.ts
+++ b/packages/composites/token-allocation/src/types.ts
@@ -21,6 +21,7 @@ export type TokenAllocations = TokenAllocation[]
 
 export type PriceAdapter = {
   getPrices: (
+    jobRunID: string,
     baseSymbols: string[],
     quote: string,
     withMarketCap?: boolean,

--- a/packages/core/bootstrap/README.md
+++ b/packages/core/bootstrap/README.md
@@ -11,6 +11,12 @@ A metrics server can be exposed which returns prometheus compatible data on the 
 - `METRICS_PORT`: Optional number, defaults to `9080`, set to change the port the `/metrics` endpoint is served on
 - `METRICS_NAME`: Optional string, defaults to 'N/A', set to apply a label of `NAME` to each metric
 
+### Development
+
+To run Prometheus and Grafana with development setup:
+```
+yarn dev:metrics
+```
 ## Caching
 
 To cache data, every adapter using the `bootstrap` package, has access to a simple LRU cache that will cache successful 200 responses using SHA1 hash of input as a key.

--- a/packages/core/bootstrap/docker-compose.yml
+++ b/packages/core/bootstrap/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3.7"
+
+volumes:
+  prometheus_data: {}
+  grafana_data: {}
+
+services:
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    ports:
+      - "9090:9090"
+  grafana:
+    image: grafana/grafana
+    volumes:
+      - grafana_data:/var/lib/grafana
+    depends_on:
+      - prometheus
+    ports:
+      - "3000:3000"
+    links: 
+      - prometheus

--- a/packages/core/bootstrap/package.json
+++ b/packages/core/bootstrap/package.json
@@ -14,6 +14,7 @@
     "setup": "yarn clean && yarn build",
     "build": "tsc -b",
     "dev:remotedev": "node ./scripts/remotedev.js",
+    "dev:metrics": "docker-compose up -d",
     "lint": "eslint --ignore-path ../../../.eslintignore . --ext .ts,.tsx",
     "lint:fix": "eslint --ignore-path ../../../.eslintignore . --ext .js,.jsx,.ts,.tsx --fix",
     "test": "yarn run mocha --exit --timeout 0 -r ts-node/register 'test/**/*.test.ts'",

--- a/packages/core/bootstrap/prometheus.yml
+++ b/packages/core/bootstrap/prometheus.yml
@@ -1,0 +1,22 @@
+# my global config
+global:
+  scrape_interval:     15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
+  evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
+
+# A scrape configuration containing exactly one endpoint to scrape:
+# Here it's Prometheus itself.
+scrape_configs:
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  - job_name: 'ea-prometheus'
+
+    # metrics_path defaults to '/metrics'
+    # scheme defaults to 'http'.
+
+    static_configs:
+    ## Development only
+    # Linux
+    # - targets: ['localhost:9080']
+    # Windows
+    # - targets: ['docker.for.win.host.internal:9080']
+    # Mac
+    - targets: ['docker.for.mac.host.internal:9080']

--- a/packages/core/bootstrap/src/index.ts
+++ b/packages/core/bootstrap/src/index.ts
@@ -144,7 +144,8 @@ const executeSync = (execute: Execute): ExecuteSync => {
         store.dispatch(
           cacheWarmer.actions.warmupSubscribed({
             id: data.id,
-            executeFn: executeWithMiddleware,
+            // We need to initilialize the middleware on every beat to open a connection with the cache
+            executeFn: async (input) => await (await withMiddleware(execute))(input),
             data,
           }),
         )

--- a/packages/core/bootstrap/src/index.ts
+++ b/packages/core/bootstrap/src/index.ts
@@ -98,6 +98,15 @@ const withMetrics: Middleware = async (execute) => async (input: AdapterRequest)
   }
 }
 
+const withDebug: Middleware = async (execute) => async (input: AdapterRequest) => {
+  const result = await execute(input)
+  if (!util.isDebug()) {
+    const { debug, ...rest } = result
+    return rest
+  }
+  return result
+}
+
 const middleware = [
   withLogger,
   skipOnError(withCache),
@@ -106,6 +115,7 @@ const middleware = [
     dispatch: (a) => store.dispatch(a),
   } as Store),
   withStatusCode,
+  withDebug,
 ].concat(metrics.METRICS_ENABLED ? [withMetrics] : [])
 
 // Init all middleware, and return a wrapped execute fn

--- a/packages/core/bootstrap/src/lib/cache/index.ts
+++ b/packages/core/bootstrap/src/lib/cache/index.ts
@@ -188,7 +188,10 @@ export const withCache: Middleware = async (execute, options = defaultOptions())
         return {
           jobRunID: data.id,
           ...entry,
-          debug,
+          debug: {
+            ...(entry.debug || {}),
+            ...debug,
+          },
         }
       }
       logger.debug(`Cache: SKIP(maxAge < 0)`)

--- a/packages/core/bootstrap/src/lib/cache/index.ts
+++ b/packages/core/bootstrap/src/lib/cache/index.ts
@@ -182,7 +182,7 @@ export const withCache: Middleware = async (execute, options = defaultOptions())
         const debug = {
           cacheHit: true,
           staleness,
-          cachePerformance: endMetrics(staleness),
+          performance: endMetrics(true, staleness),
           providerCost: 0,
         }
         return {
@@ -201,7 +201,7 @@ export const withCache: Middleware = async (execute, options = defaultOptions())
     await _cacheOnSuccess(result)
     const debug = {
       staleness: 0,
-      cachePerformance: endMetrics(),
+      performance: endMetrics(false, 0),
       providerCost: result.data.cost || 1,
     }
     return { ...result, debug }

--- a/packages/core/bootstrap/src/lib/cache/index.ts
+++ b/packages/core/bootstrap/src/lib/cache/index.ts
@@ -211,7 +211,7 @@ export const withCache: Middleware = async (execute, options = defaultOptions())
   return async (input) => {
     const result = await _executeWithCache(input)
     // Clean the connection
-    // await cache.close()
+    await cache.close()
     return result
   }
 }

--- a/packages/core/bootstrap/src/lib/cache/index.ts
+++ b/packages/core/bootstrap/src/lib/cache/index.ts
@@ -177,7 +177,7 @@ export const withCache: Middleware = async (execute, options = defaultOptions())
         logger.debug(`Cache: GET ${key}`, entry)
         const reqMaxAge = _getRequestMaxAge(data)
         if (reqMaxAge && reqMaxAge !== entry.maxAge) await _cacheOnSuccess(entry)
-        const ttl = await cache.pttl(key)
+        const ttl = await cache.ttl(key)
         const staleness = entry.maxAge - ttl
         const debug = {
           cacheHit: true,

--- a/packages/core/bootstrap/src/lib/cache/index.ts
+++ b/packages/core/bootstrap/src/lib/cache/index.ts
@@ -14,7 +14,7 @@ const DEFAULT_RC_INTERVAL_MAX = 1000
 const DEFAULT_RC_INTERVAL_COEFFICIENT = 2
 const DEFAULT_RC_ENTROPY_MAX = 0
 
-const MAXIMUM_MAX_AGE = 1000 * 60 * 2
+export const MAXIMUM_MAX_AGE = 1000 * 60 * 2
 const ERROR_MAX_AGE = 1000 * 60
 
 const env = process.env
@@ -175,7 +175,8 @@ export const withCache: Middleware = async (execute, options = defaultOptions())
         logger.debug(`Cache: GET ${key}`, entry)
         const reqMaxAge = _getRequestMaxAge(data)
         if (reqMaxAge && reqMaxAge !== entry.maxAge) await _cacheOnSuccess(entry)
-        return { jobRunID: data.id, ...entry }
+        const ttl = await cache.ttl(key)
+        return { jobRunID: data.id, ...entry, ttl }
       }
       logger.debug(`Cache: SKIP(maxAge < 0)`)
     }
@@ -192,7 +193,7 @@ export const withCache: Middleware = async (execute, options = defaultOptions())
   return async (input) => {
     const result = await _executeWithCache(input)
     // Clean the connection
-    await cache.close()
+    // await cache.close()
     return result
   }
 }

--- a/packages/core/bootstrap/src/lib/cache/index.ts
+++ b/packages/core/bootstrap/src/lib/cache/index.ts
@@ -204,7 +204,7 @@ export const withCache: Middleware = async (execute, options = defaultOptions())
       performance: endMetrics(false, 0),
       providerCost: result.data.cost || 1,
     }
-    return { ...result, debug }
+    return { ...result, debug: { ...debug, ...result.debug } }
   }
 
   // Middleware wrapped execute fn which cleans up after

--- a/packages/core/bootstrap/src/lib/cache/local.ts
+++ b/packages/core/bootstrap/src/lib/cache/local.ts
@@ -36,7 +36,7 @@ export class LocalLRUCache {
     return this.client.del(key)
   }
 
-  pttl(key: string) {
+  ttl(key: string) {
     // Get LRU internal 'cache' symbol
     const _isCacheSymbol = (sym: symbol) => sym.toString().includes('cache')
     const cacheSymbol = Object.getOwnPropertySymbols(this.client).find(_isCacheSymbol)

--- a/packages/core/bootstrap/src/lib/cache/local.ts
+++ b/packages/core/bootstrap/src/lib/cache/local.ts
@@ -36,7 +36,7 @@ export class LocalLRUCache {
     return this.client.del(key)
   }
 
-  ttl(key: string) {
+  pttl(key: string) {
     // Get LRU internal 'cache' symbol
     const _isCacheSymbol = (sym: symbol) => sym.toString().includes('cache')
     const cacheSymbol = Object.getOwnPropertySymbols(this.client).find(_isCacheSymbol)
@@ -48,7 +48,7 @@ export class LocalLRUCache {
     if (!hit) return 0
 
     // Return ttl >= 0
-    const ttl = hit.now + (hit.maxAge || 0) - Date.now()
+    const ttl = hit.value?.now + (hit.value?.maxAge || 0) - Date.now()
     return ttl < 0 ? 0 : ttl
   }
 

--- a/packages/core/bootstrap/src/lib/cache/local.ts
+++ b/packages/core/bootstrap/src/lib/cache/local.ts
@@ -36,6 +36,12 @@ export class LocalLRUCache {
     return this.client.del(key)
   }
 
+  ttl(key: string) {
+    const exists = this.client.get(key)
+    if (exists) return 1
+    return undefined
+  }
+
   close() {
     // noop
   }

--- a/packages/core/bootstrap/src/lib/cache/metrics.ts
+++ b/packages/core/bootstrap/src/lib/cache/metrics.ts
@@ -1,0 +1,33 @@
+import * as client from 'prom-client'
+import { MAXIMUM_MAX_AGE } from './index'
+
+enum CacheTypes {
+  Redis = 'redis',
+  Local = 'local',
+}
+
+export const cacheExecutionDurationSeconds = new client.Histogram({
+  name: 'cache_execution_duration_seconds',
+  help: 'A histogram bucket of the distribution of cache execution durations',
+  // we should tune these as we collect data, this is the default
+  // bucket distribution that prom comes with
+  buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+})
+
+export const cacheDataStaleness = new client.Histogram({
+  name: 'cache_data_staleness',
+  help: 'Observes the staleness of the data returned',
+  labelNames: ['job_run_id', 'participant_id', 'cache_type', 'experimental'] as const,
+  buckets: [0, 1000, 5000, 10000, 30000, 60000, 90000, MAXIMUM_MAX_AGE], // ms
+})
+
+export const observeMetrics = (id: string, participantId: string) => {
+  const cacheType = process.env.CACHE_TYPE === 'redis' ? CacheTypes.Redis : CacheTypes.Local
+  const defaultLabels = { job_run_id: id, participant_id: participantId, experimental: 'true' }
+
+  const end = cacheExecutionDurationSeconds.startTimer()
+  return (staleness = 0): number => {
+    cacheDataStaleness.labels({ ...defaultLabels, cache_type: cacheType }).observe(staleness)
+    return end()
+  }
+}

--- a/packages/core/bootstrap/src/lib/cache/redis.ts
+++ b/packages/core/bootstrap/src/lib/cache/redis.ts
@@ -104,7 +104,7 @@ export class RedisCache {
     return timeout(this._del(key), this.options.timeout)
   }
 
-  async pttl(key: string) {
+  async ttl(key: string) {
     // TTL in ms
     return timeout(this._pttl(key), this.options.timeout)
   }

--- a/packages/core/bootstrap/src/lib/cache/redis.ts
+++ b/packages/core/bootstrap/src/lib/cache/redis.ts
@@ -62,7 +62,7 @@ export class RedisCache {
   _set: any
   _del: any
   _quit: any
-  _ttl: any
+  _pttl: any
 
   constructor(options: RedisOptions) {
     this.options = options
@@ -75,7 +75,7 @@ export class RedisCache {
     this._set = promisify(client.set).bind(client)
     this._del = promisify(client.del).bind(client)
     this._quit = promisify(client.quit).bind(client)
-    this._ttl = promisify(client.ttl).bind(client)
+    this._pttl = promisify(client.pttl).bind(client)
     this.client = client
   }
 
@@ -104,8 +104,9 @@ export class RedisCache {
     return timeout(this._del(key), this.options.timeout)
   }
 
-  async ttl(key: string) {
-    return timeout(this._ttl(key), this.options.timeout)
+  async pttl(key: string) {
+    // TTL in ms
+    return timeout(this._pttl(key), this.options.timeout)
   }
 
   /**

--- a/packages/core/bootstrap/src/lib/rate-limit/index.ts
+++ b/packages/core/bootstrap/src/lib/rate-limit/index.ts
@@ -50,11 +50,11 @@ const logRemainingCapacity = (state: Heartbeats, interval: IntervalNames): void 
   const capacity = config.get().totalCapacity / cost
   const remainingCapacity = capacity - dataProviderRequests.length
   if (remainingCapacity <= 0) {
-    logger.error('Rate Limit: Data Provider tokens not available')
+    logger.debug('Rate Limit: Data Provider tokens not available')
     return
   }
   if (remainingCapacity <= 0.1 * capacity) {
-    logger.warn('Rate Limit: Data Provider tokens about to run out')
+    logger.debug('Rate Limit: Data Provider tokens about to run out')
     return
   }
 }
@@ -95,12 +95,7 @@ export const withRateLimit = (store: Store<RootState>): Middleware => async (exe
   state = store.getState()
   logRemainingCapacity(state.heartbeats, IntervalNames.MINUTE)
 
-  const isCacheHit = !!result.maxAge
-  if (!isCacheHit) {
-    metrics.rateLimitCreditsSpentTotal
-      .labels({ id: input.id, participantId: requestTypeId, experimental: 'true' })
-      .inc(result.data.cost || 1)
-  }
+  metrics.observeMetrics(input.id, requestTypeId, result)
 
   return result
 }

--- a/packages/core/bootstrap/src/lib/rate-limit/index.ts
+++ b/packages/core/bootstrap/src/lib/rate-limit/index.ts
@@ -97,7 +97,16 @@ export const withRateLimit = (store: Store<RootState>): Middleware => async (exe
   state = store.getState()
   logRemainingCapacity(state.heartbeats, IntervalNames.MINUTE)
 
-  metrics.observeMetrics(input.id, requestTypeId, result)
+  const defaultLabels = {
+    job_run_id: input.id,
+    participant_id: requestTypeId,
+    experimental: 'true',
+  }
+  let cost = Number(result.debug?.providerCost)
+  if (isNaN(cost)) {
+    cost = 1
+  }
+  metrics.rateLimitCreditsSpentTotal.labels(defaultLabels).inc(cost)
 
   return result
 }

--- a/packages/core/bootstrap/src/lib/rate-limit/index.ts
+++ b/packages/core/bootstrap/src/lib/rate-limit/index.ts
@@ -102,10 +102,7 @@ export const withRateLimit = (store: Store<RootState>): Middleware => async (exe
     participant_id: requestTypeId,
     experimental: 'true',
   }
-  let cost = Number(result.debug?.providerCost)
-  if (isNaN(cost)) {
-    cost = 1
-  }
+  const cost = Number(result.debug?.providerCost) || 1
   metrics.rateLimitCreditsSpentTotal.labels(defaultLabels).inc(cost)
 
   return result

--- a/packages/core/bootstrap/src/lib/rate-limit/metrics.ts
+++ b/packages/core/bootstrap/src/lib/rate-limit/metrics.ts
@@ -1,38 +1,18 @@
 import { AdapterResponse } from '@chainlink/types'
 import * as client from 'prom-client'
-import { MAXIMUM_MAX_AGE } from '../cache'
-
-enum CacheTypes {
-  Redis = 'redis',
-  Local = 'local',
-}
 
 export const rateLimitCreditsSpentTotal = new client.Counter({
   name: 'rate_limit_credits_spent_total',
   help: 'The number of data provider credits the adapter is consuming',
-  labelNames: ['job_run_id', 'experimental'] as const,
+  labelNames: ['job_run_id', 'participant_id', 'experimental'] as const,
 })
 
-export const rateLimitDataStaleness = new client.Histogram({
-  name: 'rate_limit_data_staleness',
-  help: 'Observes the staleness of the data returned',
-  labelNames: ['job_run_id', 'experimental', 'cache_type'] as const,
-  buckets: [0, 1000, 5000, 10000, 30000, 60000, 90000, MAXIMUM_MAX_AGE], // ms
-})
+export const observeMetrics = (
+  id: string,
+  requestTypeId: string,
+  result: AdapterResponse,
+): void => {
+  const defaultLabels = { job_run_id: id, participant_id: requestTypeId, experimental: 'true' }
 
-export const observeMetrics = (id: string, requestTypeId: string, result: AdapterResponse) => {
-  const cacheType = process.env.CACHE_TYPE === 'redis' ? CacheTypes.Redis : CacheTypes.Local
-  const defaultLabels = { job_run_id: id, participantId: requestTypeId, experimental: 'true' }
-
-  const isCacheHit = !!result.maxAge
-  if (!isCacheHit) {
-    rateLimitCreditsSpentTotal.labels(defaultLabels).inc(result.data.cost || 1)
-  }
-
-  const ttl = Number((result as any).ttl)
-  let staleness = 0
-  if (result.maxAge && ttl) {
-    staleness = result.maxAge - ttl * 1000
-  }
-  rateLimitDataStaleness.labels({ ...defaultLabels, cache_type: cacheType }).observe(staleness)
+  rateLimitCreditsSpentTotal.labels(defaultLabels).inc(result.debug.providerCost || 1)
 }

--- a/packages/core/bootstrap/src/lib/rate-limit/metrics.ts
+++ b/packages/core/bootstrap/src/lib/rate-limit/metrics.ts
@@ -1,13 +1,40 @@
+import { AdapterResponse } from '@chainlink/types'
 import * as client from 'prom-client'
+import { MAXIMUM_MAX_AGE } from '../cache'
+
+enum CacheTypes {
+  Redis = 'redis',
+  Local = 'local'
+}
 
 export const rateLimitCreditsSpentTotal = new client.Counter({
   name: 'rate_limit_credits_spent_total',
   help: 'The number of data provider credits the adapter is consuming',
-  labelNames: ['id', 'participantId', 'experimental'] as const,
+  labelNames: ['job_run_id', 'experimental'] as const,
 })
 
-export const rateLimitDataStaleness = new client.Counter({
+export const rateLimitDataStaleness = new client.Histogram({
   name: 'rate_limit_data_staleness',
-  help: 'The number of data provider credits the adapter is consuming',
-  labelNames: ['id', 'participantId', 'experimental'] as const,
+  help: 'Observes the staleness of the data returned',
+  labelNames: ['job_run_id', 'experimental', 'cache_type'] as const,
+  buckets: [0, 1000, 5000, 10000, 30000, 60000, 90000, MAXIMUM_MAX_AGE] // ms
 })
+
+export const observeMetrics = (id: string, requestTypeId: string, result: AdapterResponse) => {
+  const cacheType = process.env.CACHE_TYPE === 'redis' ? CacheTypes.Redis : CacheTypes.Local
+  const defaultLabels = { job_run_id: id, participantId: requestTypeId, experimental: 'true' }
+
+  const isCacheHit = !!result.maxAge
+  if (!isCacheHit) {
+    rateLimitCreditsSpentTotal
+      .labels(defaultLabels)
+      .inc(result.data.cost || 1)
+  }
+
+  const ttl = Number((result as any).ttl)
+  let staleness = 0
+  if (result.maxAge && ttl) {
+    staleness = result.maxAge - (ttl * 1000)
+  }
+  rateLimitDataStaleness.labels({ ...defaultLabels, cache_type: cacheType }).observe(staleness)
+}

--- a/packages/core/bootstrap/src/lib/rate-limit/metrics.ts
+++ b/packages/core/bootstrap/src/lib/rate-limit/metrics.ts
@@ -14,5 +14,9 @@ export const observeMetrics = (
 ): void => {
   const defaultLabels = { job_run_id: id, participant_id: requestTypeId, experimental: 'true' }
 
-  rateLimitCreditsSpentTotal.labels(defaultLabels).inc(result.debug.providerCost)
+  let cost = Number(result.debug?.providerCost)
+  if (isNaN(cost)) {
+    cost = 1
+  }
+  rateLimitCreditsSpentTotal.labels(defaultLabels).inc(cost)
 }

--- a/packages/core/bootstrap/src/lib/rate-limit/metrics.ts
+++ b/packages/core/bootstrap/src/lib/rate-limit/metrics.ts
@@ -14,5 +14,5 @@ export const observeMetrics = (
 ): void => {
   const defaultLabels = { job_run_id: id, participant_id: requestTypeId, experimental: 'true' }
 
-  rateLimitCreditsSpentTotal.labels(defaultLabels).inc(result.debug.providerCost || 1)
+  rateLimitCreditsSpentTotal.labels(defaultLabels).inc(result.debug.providerCost)
 }

--- a/packages/core/bootstrap/src/lib/rate-limit/metrics.ts
+++ b/packages/core/bootstrap/src/lib/rate-limit/metrics.ts
@@ -1,4 +1,3 @@
-import { AdapterResponse } from '@chainlink/types'
 import * as client from 'prom-client'
 
 export const rateLimitCreditsSpentTotal = new client.Counter({
@@ -6,17 +5,3 @@ export const rateLimitCreditsSpentTotal = new client.Counter({
   help: 'The number of data provider credits the adapter is consuming',
   labelNames: ['job_run_id', 'participant_id', 'experimental'] as const,
 })
-
-export const observeMetrics = (
-  id: string,
-  requestTypeId: string,
-  result: AdapterResponse,
-): void => {
-  const defaultLabels = { job_run_id: id, participant_id: requestTypeId, experimental: 'true' }
-
-  let cost = Number(result.debug?.providerCost)
-  if (isNaN(cost)) {
-    cost = 1
-  }
-  rateLimitCreditsSpentTotal.labels(defaultLabels).inc(cost)
-}

--- a/packages/core/bootstrap/src/lib/store/index.ts
+++ b/packages/core/bootstrap/src/lib/store/index.ts
@@ -12,7 +12,7 @@ import {
 import logger from 'redux-logger'
 import { nanoid } from '@reduxjs/toolkit'
 import { composeWithDevTools } from 'remote-redux-devtools'
-import { isDebug } from '../util'
+import { isDebug, isDebugLogLevel } from '../util'
 
 export const toActionPayload = <A extends ActionBase>(data: any): A => ({
   id: nanoid(),
@@ -30,7 +30,7 @@ export function configureStore(
   preloadedState: PreloadedState<any> = {},
   middleware: Middleware<unknown, any, Dispatch<AnyAction>>[] = [],
 ): Store {
-  if (isDebug()) middleware.push(logger)
+  if (isDebug() || isDebugLogLevel()) middleware.push(logger)
   const middlewareEnhancer = applyMiddleware(...middleware)
 
   const enhancers = [middlewareEnhancer]

--- a/packages/core/bootstrap/src/lib/store/index.ts
+++ b/packages/core/bootstrap/src/lib/store/index.ts
@@ -12,6 +12,7 @@ import {
 import logger from 'redux-logger'
 import { nanoid } from '@reduxjs/toolkit'
 import { composeWithDevTools } from 'remote-redux-devtools'
+import { isDebug } from '../util'
 
 export const toActionPayload = <A extends ActionBase>(data: any): A => ({
   id: nanoid(),
@@ -29,10 +30,7 @@ export function configureStore(
   preloadedState: PreloadedState<any> = {},
   middleware: Middleware<unknown, any, Dispatch<AnyAction>>[] = [],
 ): Store {
-  const isDebug =
-    process.env.DEBUG || process.env.NODE_ENV === 'development' || process.env.LOG_LEVEL === 'debug'
-  if (isDebug) middleware.push(logger)
-
+  if (isDebug()) middleware.push(logger)
   const middlewareEnhancer = applyMiddleware(...middleware)
 
   const enhancers = [middlewareEnhancer]

--- a/packages/core/bootstrap/src/lib/util.ts
+++ b/packages/core/bootstrap/src/lib/util.ts
@@ -175,6 +175,14 @@ export const getHashOpts = (): Required<Parameters<typeof objectHash>>['1'] => (
       .includes(props),
 })
 
+export const isDebug = (): boolean => {
+  return (
+    parseBool(process.env.DEBUG) ||
+    process.env.NODE_ENV === 'development' ||
+    process.env.LOG_LEVEL === 'debug'
+  )
+}
+
 /**
  * @description Calculates all possible permutations without repetition of a certain size.
  *
@@ -214,7 +222,7 @@ const permutations = (collection: any, n: any) => {
  * @returns Array of permutations
  */
 export const permutator = (options: string[], delimiter?: string): string[] | string[][] => {
-  const output: string[][] = flatMap(options, (v, i, a) => permutations(a, i + 1))
+  const output: string[][] = flatMap(options, (v: any, i: any, a: any) => permutations(a, i + 1))
   const join = (combos: string[][]) => combos.map((p) => p.join(delimiter))
   return typeof delimiter === 'string' ? join(output) : output
 }

--- a/packages/core/bootstrap/src/lib/util.ts
+++ b/packages/core/bootstrap/src/lib/util.ts
@@ -175,12 +175,14 @@ export const getHashOpts = (): Required<Parameters<typeof objectHash>>['1'] => (
       .includes(props),
 })
 
+// Helper to identify if debug mode is running
 export const isDebug = (): boolean => {
-  return (
-    parseBool(process.env.DEBUG) ||
-    process.env.NODE_ENV === 'development' ||
-    process.env.LOG_LEVEL === 'debug'
-  )
+  return parseBool(process.env.DEBUG) || process.env.NODE_ENV === 'development'
+}
+
+// Helper to identify if debug log level is set
+export const isDebugLogLevel = (): boolean => {
+  return process.env.LOG_LEVEL === 'debug'
 }
 
 /**

--- a/packages/core/types/@chainlink/index.d.ts
+++ b/packages/core/types/@chainlink/index.d.ts
@@ -34,6 +34,7 @@ declare module '@chainlink/types' {
     data: any // Response data, holds "result" for Flux Monitor. Correct way.
     result: any // Result for OCR
     maxAge?: number
+    debug?: any
   }
 
   /* ERRORS */


### PR DESCRIPTION
## Cache and RL Metrics

- 3 new metrics added:
  - `rate_limit_credits_spent_total`: Counter that gets track of the number of requests the adapter is making to the provider
  - `cache_execution_duration_seconds`: Histogram that observes the duration of the cache module execution.
  - `cache_data_staleness`: Histogram that observes how old is the data returned
- Added `docker-compose.yml` to setup prometheus and grafana for a dev environment
- Token allocations sends the jobRunId into the adapter. Needed for metrics