### PR TITLE
additional fixes for RAI support on kaiko adapter

### DIFF
--- a/kaiko/src/adapter.ts
+++ b/kaiko/src/adapter.ts
@@ -29,13 +29,13 @@ export const execute: ExecuteWithConfig<Config> = async (request, config) => {
 
   let inverse = false
   let url = `/spot_exchange_rate/${base}/${quote}`
-  if (includes.length === 0 && quote === 'eth') {
-    url = `/spot_direct_exchange_rate/${base}/${quote}`
-  } else if (includes.length > 0 && base === 'digg' && includes[0].toLowerCase() === 'wbtc') {
+  if (includes.length > 0 && base === 'digg' && includes[0].toLowerCase() === 'wbtc') {
     inverse = true
     url = `/spot_direct_exchange_rate/wbtc/digg`
   } else if (includes.length > 0 && includes[0].toLowerCase() === 'weth') {
     url = `/spot_direct_exchange_rate/${base}/weth`
+  } else if (quote === 'eth') {
+    url = `/spot_direct_exchange_rate/${base}/${quote}`
   }
 
   // provide a reasonable interval to fetch only recent results

--- a/kaiko/src/adapter.ts
+++ b/kaiko/src/adapter.ts
@@ -29,11 +29,13 @@ export const execute: ExecuteWithConfig<Config> = async (request, config) => {
 
   let inverse = false
   let url = `/spot_exchange_rate/${base}/${quote}`
-  if (quote === 'eth') {
+  if (includes.length === 0 && quote === 'eth') {
     url = `/spot_direct_exchange_rate/${base}/${quote}`
   } else if (includes.length > 0 && base === 'digg' && includes[0].toLowerCase() === 'wbtc') {
     inverse = true
     url = `/spot_direct_exchange_rate/wbtc/digg`
+  } else if (includes.length > 0 && includes[0].toLowerCase() === 'weth') {
+    url = `/spot_direct_exchange_rate/${base}/weth`
   }
 
   // provide a reasonable interval to fetch only recent results


### PR DESCRIPTION
To run:
```json
{
    "id": "1",
    "data": {
        "coin": "rai",
        "to": "eth",
        "includes": ["weth"]
    }
}
```

**NOTE**: Volume for RAI/WETH seems pretty thin and the adapter may fail to get a price from the default past 30 minute window. It will throw an error like this:
```json
{
    "jobRunID": "1",
    "status": "errored",
    "statusCode": 500,
    "error": {
        "name": "AdapterError",
        "message": "Cannot read property 'price' of undefined"
    }
}
```