### PR TITLE
fix: CMC api key

### DIFF
--- a/composite/token-allocation/src/data-providers/amberdata.ts
+++ b/composite/token-allocation/src/data-providers/amberdata.ts
@@ -4,7 +4,7 @@ import { util } from '@chainlink/ea-bootstrap'
 const getPriceData = async (symbol: string) => {
   const url = `https://web3api.io/api/v2/market/tokens/prices/${symbol.toLowerCase()}/latest`
   const headers = {
-    'X-API-KEY': util.getRequiredEnv('API_KEY'),
+    'X-API-KEY': util.getRandomRequiredEnv('API_KEY'),
   }
   const config = {
     url,

--- a/composite/token-allocation/src/data-providers/coinapi.ts
+++ b/composite/token-allocation/src/data-providers/coinapi.ts
@@ -6,7 +6,7 @@ const getPriceData = async (symbol: string, currency: string) => {
   const config = {
     url,
     params: {
-      apikey: util.getRequiredEnv('API_KEY'),
+      apikey: util.getRandomRequiredEnv('API_KEY'),
     },
   }
   const response = await Requester.request(config)

--- a/composite/token-allocation/src/data-providers/coinmarketcap.ts
+++ b/composite/token-allocation/src/data-providers/coinmarketcap.ts
@@ -1,4 +1,5 @@
 import { Requester } from '@chainlink/external-adapter'
+import { util } from '@chainlink/ea-bootstrap'
 
 // Coin IDs fetched from the ID map: https://coinmarketcap.com/api/documentation/v1/#operation/getV1CryptocurrencyMap
 const presetIds: { [symbol: string]: number } = {
@@ -37,7 +38,7 @@ const getPriceData = async (assets: string[], convert: string) => {
   const _getPriceData = async (params: any): Promise<any> => {
     const url = 'https://pro-api.coinmarketcap.com/v1/cryptocurrency/quotes/latest'
     const headers = {
-      'X-CMC_PRO_API_KEY': process.env.API_KEY,
+      'X-CMC_PRO_API_KEY': util.getRandomRequiredEnv('API_KEY'),
     }
     const config = {
       url,

--- a/composite/token-allocation/src/data-providers/cryptocompare.ts
+++ b/composite/token-allocation/src/data-providers/cryptocompare.ts
@@ -6,7 +6,7 @@ const getPriceData = async (symbols: string, currency: string) => {
   const params = {
     tsyms: currency.toUpperCase(),
     fsyms: symbols,
-    api_key: util.getRequiredEnv('API_KEY'),
+    api_key: util.getRandomRequiredEnv('API_KEY'),
   }
   const config = {
     url,

--- a/composite/token-allocation/src/data-providers/kaiko.ts
+++ b/composite/token-allocation/src/data-providers/kaiko.ts
@@ -10,7 +10,7 @@ const getPriceData = async (symbol: string, currency: string) => {
     interval: '1m',
   }
   const headers = {
-    'X-Api-Key': util.getRequiredEnv('API_KEY'),
+    'X-Api-Key': util.getRandomRequiredEnv('API_KEY'),
     'User-Agent': 'Chainlink',
   }
   const timeout = 5000

--- a/composite/token-allocation/src/data-providers/nomics.ts
+++ b/composite/token-allocation/src/data-providers/nomics.ts
@@ -10,7 +10,7 @@ const getPriceData = async (symbols: string, currency: string) => {
   const params = {
     ids: symbols,
     convert: currency.toUpperCase(),
-    key: util.getRequiredEnv('API_KEY'),
+    key: util.getRandomRequiredEnv('API_KEY'),
   }
   const config = {
     url,


### PR DESCRIPTION
token-allocation uses getRandomRequiredEnv for multiple keys