### PR TITLE
Fixes for Websocket acceptance testing

### DIFF
--- a/packages/sources/cryptocompare/src/config.ts
+++ b/packages/sources/cryptocompare/src/config.ts
@@ -60,7 +60,8 @@ export const WSHandlerFactory = (config?: Config): MakeWSHandler => {
       filter: (message) => {
         // Ignore everything is not from the wanted channels
         const code = Number(message.TYPE)
-        return code === subscriptions.ticker || code === subscriptions.aggregate
+        const flag = Number(message.FLAGS) // flags = 4 (means price unchanged, PRICE parameter not included)
+        return (code === subscriptions.ticker || code === subscriptions.aggregate) && flag !== 4
       },
       toResponse: (message: any) => {
         const result = Requester.validateResultNumber(message, ['PRICE'])


### PR DESCRIPTION
Cryptocompare
- Prevent validator error while checking for `PRICE` (use provided `FLAGS` parameter to filter out price unchanged messages)