### PR TITLE
fix: Intrinio needs all handlers, not just server

### DIFF
--- a/intrinio/src/adapter.ts
+++ b/intrinio/src/adapter.ts
@@ -39,11 +39,16 @@ const subscribe = (assets: string[], config: Config) => {
         break
     }
   })
+  return client
 }
 
-export const startService = (config: Config): void => {
+export const startService = (config: Config) => {
   const symbols = config.symbols.toUpperCase().split(',')
-  subscribe(symbols, config)
+  return subscribe(symbols, config)
+}
+
+export const stopService = (client: any): void => {
+  client.destroy()
 }
 
 const customParams = {

--- a/intrinio/src/index.ts
+++ b/intrinio/src/index.ts
@@ -1,10 +1,12 @@
 import { expose } from '@chainlink/ea-bootstrap'
-import { makeExecute, startService } from './adapter'
+import { makeExecute, startService, stopService } from './adapter'
 import { makeConfig, NAME } from './config'
 
 const makeExecuteWS = () => {
-  startService(makeConfig())
-  return makeExecute()
+  const service = startService(makeConfig())
+  const response = makeExecute()
+  stopService(service)
+  return response
 }
 
 export = { NAME, makeExecute, makeConfig, ...expose(makeExecuteWS()) }

--- a/intrinio/src/index.ts
+++ b/intrinio/src/index.ts
@@ -1,19 +1,10 @@
-import * as bootstrap from '@chainlink/ea-bootstrap'
+import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute, startService } from './adapter'
-import { AdapterRequest, Execute, ExecuteSync } from '@chainlink/types'
-import { Requester } from '@chainlink/external-adapter'
-import { makeConfig } from './config'
+import { makeConfig, NAME } from './config'
 
-// Execution helper async => sync
-const executeSync = (execute: Execute): ExecuteSync => {
-  return (data: AdapterRequest, callback: any) => {
-    return execute(data)
-      .then((result) => callback(result.statusCode, result))
-      .catch((error) => callback(error.statusCode || 500, Requester.errored(data.id, error)))
-  }
-}
-
-export const server = (): void => {
+const makeExecuteWS = () => {
   startService(makeConfig())
-  bootstrap.server.initHandler(executeSync(makeExecute()))()
+  return makeExecute()
 }
+
+export = { NAME, makeExecute, makeConfig, ...expose(makeExecuteWS()) }


### PR DESCRIPTION
### Description
Intrinio EA needs to have handlers to work with AWS Lambda.

It is a WS adapter, so connections need to be cleaned up.