### PR TITLE
Small fix for running metrics locally + ubuntu

### DIFF
--- a/packages/core/bootstrap/prometheus.yml
+++ b/packages/core/bootstrap/prometheus.yml
@@ -15,6 +15,7 @@ scrape_configs:
     static_configs:
     ## Development only
     # Linux
+    # In the case of the `bridge` network, Docker subnet is 172.17.0.0/16, and 172.17.0.1 is allocated for the gateway.
     # - targets: ['172.17.0.1:9080']
     # Windows
     # - targets: ['docker.for.win.host.internal:9080']

--- a/packages/core/bootstrap/prometheus.yml
+++ b/packages/core/bootstrap/prometheus.yml
@@ -15,7 +15,7 @@ scrape_configs:
     static_configs:
     ## Development only
     # Linux
-    # - targets: ['localhost:9080']
+    # - targets: ['172.17.0.1:9080']
     # Windows
     # - targets: ['docker.for.win.host.internal:9080']
     # Mac


### PR DESCRIPTION
Small modification to `prometheus.yml` to allow prometheus docker container to read the correct EA metrics endpoint. (using the docker gateway IP for linux/ubuntu)