### PR TITLE
dYdX write adapter result path

### DIFF
--- a/dydx-stark/package.json
+++ b/dydx-stark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/dydx-stark-adapter",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Chainlink dydx-stark adapter.",
   "keywords": [
     "Chainlink",

--- a/dydx-stark/src/endpoint/send.ts
+++ b/dydx-stark/src/endpoint/send.ts
@@ -20,7 +20,11 @@ export const execute: ExecuteWithConfig<Config> = async (request, config) => {
   const { asset, ...data } = validator.validated.data
 
   const dataPath = data.dataPath || DEFAULT_DATA_PATH
-  const price = <number | string>objectPath.get(data, dataPath)
+  let price = <number | string>objectPath.get(data, dataPath)
+
+  /* Remove me May 10th 2021 */
+  if (!price) price = <number | string>objectPath.get(request, dataPath)
+  /**************************/
 
   const priceData: PriceDataPoint = {
     oracleName: config.oracleName,


### PR DESCRIPTION
### Description
A feature was requested to write a medianized response from multiple data sources for dYdX.
 
Core recently added a feature to their job pipeline that allows for a single `medianized` answer from multiple EA responses.

One limitation is that the core node is currently sending the input to the `dYdX starkware` write adapter as:
```
{"data": {"asset": "LINKUSD"}, "result": 12345} <---- notice "result" is outside of "data"
```

The change will be going into Core's release on Monday May 10th, but for time sensitivity we can add a hack into the EA to read from outside of the input parameters' `data` object.

NOTE: this should be removed on Monday May 10th