### PR TITLE
fix: unsubscription metric happens only if the subs was active

### DIFF
--- a/packages/core/bootstrap/src/lib/ws/reducer.ts
+++ b/packages/core/bootstrap/src/lib/ws/reducer.ts
@@ -60,6 +60,8 @@ export interface SubscriptionsState {
   /** Map of all subscriptions by key */
   [key: string]: {
     active: boolean
+    wasEverActive?: boolean
+    unsubscribed?: boolean
     subscribing: number
     input: AdapterRequest
   }
@@ -75,6 +77,8 @@ export const subscriptionsReducer = createReducer<SubscriptionsState>(
       const key = getSubsId(action.payload.subscriptionMsg)
       state[key] = {
         active: true,
+        wasEverActive: true,
+        unsubscribed: false,
         subscribing: 0,
         input: { ...action.payload.input },
       }
@@ -96,7 +100,9 @@ export const subscriptionsReducer = createReducer<SubscriptionsState>(
     builder.addCase(actions.unsubscribed, (state, action) => {
       // Remove subscription
       const key = getSubsId(action.payload.subscriptionMsg)
-      delete state[key]
+      
+      state[key].active = false
+      state[key].unsubscribed = true
     })
 
     builder.addCase(actions.disconnected, (state) => {


### PR DESCRIPTION
- **Fix 1**: Invalid subscriptions could remain on subscribing state forever. Unresponsive timeout will take them in account now.
- **Fix 2**: Subscriptions that never were active were included into the unsubscription metric. `wasEverActive` check is included on the state, getting track of the timeline of the subscription. (Thanks @aalu1418) 