### PR TITLE
fix(tradingeconomics): fix missing overrides for websocket

### DIFF
--- a/packages/core/bootstrap/src/lib/external-adapter/overrides/presetSymbols.json
+++ b/packages/core/bootstrap/src/lib/external-adapter/overrides/presetSymbols.json
@@ -52,5 +52,9 @@
     "N225": "JPN225",
     "WTI": "OIL",
     "BRENT": "UKOIL"
+  },
+  "tradingeconomics": {
+    "N225": "NKY:IND",
+    "FTSE": "UKX:IND"
   }
 }

--- a/packages/sources/tradingeconomics/src/adapter.ts
+++ b/packages/sources/tradingeconomics/src/adapter.ts
@@ -6,20 +6,12 @@ export const customParams = {
   base: ['base', 'from', 'asset'],
 }
 
-const commonSymbols: { [symbol: string]: string } = {
-  N225: 'NKY:IND',
-  FTSE: 'UKX:IND',
-}
-
 export const execute = async (input: AdapterRequest, config: Config) => {
   const validator = new Validator(input, customParams)
   if (validator.error) throw validator.error
 
   const jobRunID = validator.validated.id
-  let symbol = validator.validated.data.base.toUpperCase()
-  if (symbol in commonSymbols) {
-    symbol = commonSymbols[symbol]
-  }
+  const symbol = validator.overrideSymbol(NAME).toUpperCase()
 
   // Fall back to getting the data from HTTP endpoint
   const url = `/symbol/${symbol}`


### PR DESCRIPTION
WS for tradingeconomics was not reading overrides because they were originally hard coded into the `adapter.js` file. Now the overrides are moved to the `presetSymbols.json` file, and the REST API endpoint is fixed accordingly.