### PR TITLE
feat: warmer and ws play together

### DIFF
--- a/packages/core/bootstrap/src/index.ts
+++ b/packages/core/bootstrap/src/index.ts
@@ -123,7 +123,7 @@ export const withDebug: Middleware = async (execute) => async (input: AdapterReq
 }
 
 // Init all middleware, and return a wrapped execute fn
-const withMiddleware = async (execute: Execute, middleware: Middleware[]) => {
+export const withMiddleware = async (execute: Execute, middleware: Middleware[]) => {
   // Init and wrap middleware one by one
   for (let i = 0; i < middleware.length; i++) {
     execute = await middleware[i](execute)
@@ -135,9 +135,17 @@ const withMiddleware = async (execute: Execute, middleware: Middleware[]) => {
 const executeSync = (execute: Execute, makeWsHandler?: MakeWSHandler): ExecuteSync => {
   // TODO: Try to init middleware only once
   // const initMiddleware = withMiddleware(execute)
+  const warmerMiddleware = [
+    withLogger,
+    skipOnError(withCache),
+    rateLimit.withRateLimit(storeSlice('rateLimit')),
+    withStatusCode,
+  ].concat(metrics.METRICS_ENABLED ? [withMetrics, withDebug] : [withDebug])
+
   const middleware = [
     withLogger,
     skipOnError(withCache),
+    cacheWarmer.withCacheWarmer(storeSlice('cacheWarmer'), warmerMiddleware, { store: storeSlice('ws'), makeWSHandler: makeWsHandler }),
     ws.withWebSockets(storeSlice('ws'), makeWsHandler),
     rateLimit.withRateLimit(storeSlice('rateLimit')),
     withStatusCode,
@@ -149,21 +157,7 @@ const executeSync = (execute: Execute, makeWsHandler?: MakeWSHandler): ExecuteSy
     try {
       const executeWithMiddleware = await withMiddleware(execute, middleware)
       const result = await executeWithMiddleware(data)
-      // only consider registering a warmup request if the original one was successful
-      // and we have caching enabled
-      if (
-        util.parseBool(process.env.CACHE_ENABLED) &&
-        util.parseBool(process.env.EXPERIMENTAL_WARMUP_ENABLED)
-      ) {
-        store.dispatch(
-          cacheWarmer.actions.warmupSubscribed({
-            id: data.id,
-            // We need to initilialize the middleware on every beat to open a connection with the cache
-            executeFn: async (input) => await (await withMiddleware(execute, middleware))(input),
-            data,
-          }),
-        )
-      }
+
       return callback(result.statusCode, result)
     } catch (error) {
       return callback(error.statusCode || 500, Requester.errored(data.id, error))

--- a/packages/core/bootstrap/src/index.ts
+++ b/packages/core/bootstrap/src/index.ts
@@ -136,16 +136,15 @@ const executeSync = (execute: Execute, makeWsHandler?: MakeWSHandler): ExecuteSy
   // TODO: Try to init middleware only once
   // const initMiddleware = withMiddleware(execute)
   const warmerMiddleware = [
-    withLogger,
     skipOnError(withCache),
     rateLimit.withRateLimit(storeSlice('rateLimit')),
     withStatusCode,
-  ].concat(metrics.METRICS_ENABLED ? [withMetrics, withDebug] : [withDebug])
+  ].concat(metrics.METRICS_ENABLED ? [withMetrics] : [])
 
   const middleware = [
     withLogger,
     skipOnError(withCache),
-    cacheWarmer.withCacheWarmer(storeSlice('cacheWarmer'), warmerMiddleware, { store: storeSlice('ws'), makeWSHandler: makeWsHandler }),
+    cacheWarmer.withCacheWarmer(storeSlice('cacheWarmer'), warmerMiddleware, { store: storeSlice('ws'), makeWSHandler: makeWsHandler })(execute),
     ws.withWebSockets(storeSlice('ws'), makeWsHandler),
     rateLimit.withRateLimit(storeSlice('rateLimit')),
     withStatusCode,

--- a/packages/core/bootstrap/src/lib/cache-warmer/index.ts
+++ b/packages/core/bootstrap/src/lib/cache-warmer/index.ts
@@ -1,3 +1,49 @@
+
+import { AdapterRequest, MakeWSHandler, Middleware } from '@chainlink/types'
+import { Store } from 'redux'
+import { RootState } from './reducer'
+import * as actions from './actions'
+import { getSubscriptionKey } from './util'
+import { getSubsId, RootState as WSState } from '../ws/reducer'
+import { withMiddleware } from '../../index'
+import * as util from '../util'
+
 export * as actions from './actions'
 export * as reducer from './reducer'
 export * as epics from './epics'
+
+interface WSInput {
+  store: Store<WSState>
+  makeWSHandler?: MakeWSHandler
+}
+
+export const withCacheWarmer = (warmerStore: Store<RootState>, middleware: Middleware[], ws: WSInput): Middleware => async (execute) => async (input: AdapterRequest) => {
+  const isWarmerActive = util.parseBool(process.env.CACHE_ENABLED) && util.parseBool(process.env.EXPERIMENTAL_WARMUP_ENABLED)
+  if (!isWarmerActive) return await execute(input)
+
+  if (ws.makeWSHandler) {
+    // If WS is available, and there is an active subscription, warmer should not be active
+    const wsHandler = await ws.makeWSHandler()
+    const subscriptionKey = getSubsId(wsHandler.subscribe(input))
+    // TODO: Could happen that a subscription is still loading. If that's the case, warmer will open a subscription. If the WS becomes active, on next requests warmer will be unsubscribed
+    const isActiveSubscription = ws.store.getState().subscriptions[subscriptionKey]?.active
+    // If there is a WS subscription active, warmup subscription (if exists) should be removed, and not play for the moment
+    if (isActiveSubscription) {
+      warmerStore.dispatch(actions.warmupUnsubscribed({ key: getSubscriptionKey(input) }))
+      return await execute(input)
+    }
+  }
+
+  // In case WS is not available, or WS has no active subscription, warmer should be active
+  const result = await execute(input)
+  // Dispatch subscription only if execute was succesful
+  warmerStore.dispatch(
+    actions.warmupSubscribed({
+      id: input.id,
+      // We need to initilialize the middleware on every beat to open a connection with the cache
+      executeFn: async (input) => await (await withMiddleware(execute, middleware))(input),
+      data: input,
+    }),
+  )
+  return result
+}

--- a/packages/core/bootstrap/src/lib/cache-warmer/index.ts
+++ b/packages/core/bootstrap/src/lib/cache-warmer/index.ts
@@ -1,5 +1,5 @@
 
-import { AdapterRequest, MakeWSHandler, Middleware } from '@chainlink/types'
+import { AdapterRequest, Execute, MakeWSHandler, Middleware } from '@chainlink/types'
 import { Store } from 'redux'
 import { RootState } from './reducer'
 import * as actions from './actions'
@@ -17,18 +17,18 @@ interface WSInput {
   makeWSHandler?: MakeWSHandler
 }
 
-export const withCacheWarmer = (warmerStore: Store<RootState>, middleware: Middleware[], ws: WSInput): Middleware => async (execute) => async (input: AdapterRequest) => {
+export const withCacheWarmer = (warmerStore: Store<RootState>, middleware: Middleware[], ws: WSInput) => (rawExecute: Execute): Middleware => async (execute) => async (input: AdapterRequest) => {
   const isWarmerActive = util.parseBool(process.env.CACHE_ENABLED) && util.parseBool(process.env.EXPERIMENTAL_WARMUP_ENABLED)
   if (!isWarmerActive) return await execute(input)
 
   if (ws.makeWSHandler) {
     // If WS is available, and there is an active subscription, warmer should not be active
     const wsHandler = await ws.makeWSHandler()
-    const subscriptionKey = getSubsId(wsHandler.subscribe(input))
-    // TODO: Could happen that a subscription is still loading. If that's the case, warmer will open a subscription. If the WS becomes active, on next requests warmer will be unsubscribed
-    const isActiveSubscription = ws.store.getState().subscriptions[subscriptionKey]?.active
+    const wsSubscriptionKey = getSubsId(wsHandler.subscribe(input))
+    // Could happen that a subscription is still loading. If that's the case, warmer will open a subscription. If the WS becomes active, on next requests warmer will be unsubscribed
+    const isActiveWSSubscription = ws.store.getState().subscriptions[wsSubscriptionKey]?.active
     // If there is a WS subscription active, warmup subscription (if exists) should be removed, and not play for the moment
-    if (isActiveSubscription) {
+    if (isActiveWSSubscription) {
       warmerStore.dispatch(actions.warmupUnsubscribed({ key: getSubscriptionKey(input) }))
       return await execute(input)
     }
@@ -41,7 +41,8 @@ export const withCacheWarmer = (warmerStore: Store<RootState>, middleware: Middl
     actions.warmupSubscribed({
       id: input.id,
       // We need to initilialize the middleware on every beat to open a connection with the cache
-      executeFn: async (input) => await (await withMiddleware(execute, middleware))(input),
+      // Wrapping `rawExecute` as `execute` is already wrapped with the default middleware. Warmer doesn't need every default middleware
+      executeFn: async (input) => await (await withMiddleware(rawExecute, middleware))(input),
       data: input,
     }),
   )


### PR DESCRIPTION
Warmer and WS modules keep completely separate, but they need to be aware of each other (warmer needs to be aware of WS in reality)

- If both Warmer and WS are available, WS should always have preference over Warmer
- Warmer needs to know what's the current WS state, to decide if subscribe or not
  - Warmer will be active if there is no WS subscription active, and will be checking on every request if the WS subs is active
  - Warmer will unsubscribe at the moment it finds a WS subscription

- [ ] Acceptance Testing