### PR TITLE
WS: Handle state + metrics when TTL parameter is too short

### DIFF
--- a/packages/core/bootstrap/prometheus.yml
+++ b/packages/core/bootstrap/prometheus.yml
@@ -16,8 +16,8 @@ scrape_configs:
     ## Development only
     # Linux
     # In the case of the `bridge` network, Docker subnet is 172.17.0.0/16, and 172.17.0.1 is allocated for the gateway.
-    # - targets: ['172.17.0.1:9080']
+    - targets: ['172.17.0.1:9080']
     # Windows
     # - targets: ['docker.for.win.host.internal:9080']
     # Mac
-    - targets: ['docker.for.mac.host.internal:9080']
+    # - targets: ['docker.for.mac.host.internal:9080']


### PR DESCRIPTION
Edge case that was noticed while acceptance testing warmer + WS.

If the `WS_SUBSCRIPTION_TTL` parameter is too short (like 10 ms instead of 10000 ms) for a connection & subscription to be established. It will still Unsubscribe + Disconnect which subtracts 1 from `total` and in metrics, and leave an active `connecting` state that blocks further subscription attempts even though it is disconnected.

Fix: introduce a `wasEverConnected` parameter similar to `wasEverActive` for subscriptions to prevent negative values, and resetting the `connecting` parameter.