### PR TITLE
[Feature] Tiingo crypto endpoint

### DIFF
--- a/tiingo/README.md
+++ b/tiingo/README.md
@@ -10,9 +10,9 @@
 
 ### Input Parameters
 
-| Required? |   Name   |     Description     |       Options        | Defaults to |
-| :-------: | :------: | :-----------------: | :------------------: | :---------: |
-|           | endpoint | The endpoint to use | [eod](#EOD-Endpoint) |    `eod`    |
+| Required? |   Name   |     Description     |                                            Options                                            | Defaults to |
+| :-------: | :------: | :-----------------: | :-------------------------------------------------------------------------------------------: | :---------: |
+|           | endpoint | The endpoint to use | [`eod`](#EOD-Endpoint), [`iex` or `stock`](#IEX-Endpoint), [`top` or `crypto`](#Top-Endpoint) |  `crypto`   |
 
 ---
 
@@ -22,10 +22,10 @@ https://api.tiingo.com/documentation/end-of-day
 
 ### Input Params
 
-| Required? |                     Name                      |        Description        | Options | Defaults to |
-| :-------: | :-------------------------------------------: | :-----------------------: | :-----: | :---------: |
+| Required? |                Name                 |        Description        | Options | Defaults to |
+| :-------: | :---------------------------------: | :-----------------------: | :-----: | :---------: |
 |    ✅     | `ticker`, `base`, `from`, or `coin` | The stock ticker to query |         |             |
-|           |                    `field`                    |    The value to return    |         |   `close`   |
+|           |               `field`               |    The value to return    |         |   `close`   |
 
 ### Sample Input
 
@@ -35,6 +35,84 @@ https://api.tiingo.com/documentation/end-of-day
   "data": {
     "ticker": "aapl",
     "field": "close"
+  }
+}
+```
+
+### Sample Output
+
+```json
+{
+  "jobRunID": "1",
+  "data": {
+    "result": 130.27
+  },
+  "result": 130.27,
+  "statusCode": 200
+}
+```
+
+---
+
+## IEX Endpoint
+
+https://api.tiingo.com/documentation/iex
+
+### Input Params
+
+| Required? |                Name                 |        Description        | Options | Defaults to |
+| :-------: | :---------------------------------: | :-----------------------: | :-----: | :---------: |
+|    ✅     | `ticker`, `base`, `from`, or `coin` | The stock ticker to query |         |             |
+|           |               `field`               |    The value to return    |         | `tngoLast`  |
+
+### Sample Input
+
+```json
+{
+  "id": "1",
+  "data": {
+    "ticker": "aapl"
+  }
+}
+```
+
+### Sample Output
+
+```json
+{
+  "jobRunID": "1",
+  "result": 130.125,
+  "statusCode": 200,
+  "data": {
+    "result": 130.125
+  }
+}
+```
+
+---
+
+## Top Endpoint
+
+The top of order book endpoint from:
+
+https://api.tiingo.com/documentation/crypto
+
+### Input Params
+
+| Required? |            Name            |                Description                 | Options | Defaults to |
+| :-------: | :------------------------: | :----------------------------------------: | :-----: | :---------: |
+|    ✅     | `base`, `from`, or `coin`  |     The cryptocurrency symbol to query     |         |             |
+|    ✅     | `quote`, `to`, or `market` | The output currency to return the price in |         |             |
+|           |          `field`           |            The value to return             |         | `lastPrice` |
+
+### Sample Input
+
+```json
+{
+  "id": "1",
+  "data": {
+    "base": "btc",
+    "quote": "usd"
   }
 }
 ```

--- a/tiingo/package.json
+++ b/tiingo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/tiingo-adapter",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "Chainlink tiingo adapter.",
   "keywords": [
     "Chainlink",

--- a/tiingo/src/adapter.ts
+++ b/tiingo/src/adapter.ts
@@ -1,7 +1,7 @@
 import { Requester, Validator } from '@chainlink/external-adapter'
 import { Config, ExecuteWithConfig, ExecuteFactory } from '@chainlink/types'
 import { makeConfig, DEFAULT_ENDPOINT } from './config'
-import { eod, iex } from './endpoint'
+import { eod, iex, top } from './endpoint'
 
 const inputParams = {
   endpoint: false,
@@ -20,9 +20,13 @@ export const execute: ExecuteWithConfig<Config> = async (request, config) => {
       return await eod.execute(request, config)
 
     case iex.NAME:
-    default: {
+    case 'stock':
       return await iex.execute(request, config)
-    }
+
+    case top.NAME:
+    case 'crypto':
+    default:
+      return await top.execute(request, config)
   }
 }
 

--- a/tiingo/src/config.ts
+++ b/tiingo/src/config.ts
@@ -1,7 +1,7 @@
 import { Requester } from '@chainlink/external-adapter'
 import { Config } from '@chainlink/types'
 
-export const DEFAULT_ENDPOINT = 'iex'
+export const DEFAULT_ENDPOINT = 'top'
 export const DEFAULT_BASE_URL = 'https://api.tiingo.com'
 
 export const makeConfig = (prefix?: string): Config => {

--- a/tiingo/src/endpoint/crypto/top.ts
+++ b/tiingo/src/endpoint/crypto/top.ts
@@ -1,0 +1,68 @@
+import { Requester, Validator } from '@chainlink/external-adapter'
+import { ExecuteWithConfig, Config } from '@chainlink/types'
+
+export const NAME = 'top'
+
+export interface ResponseSchema {
+  ticker: string
+  baseCurrency: string
+  quoteCurrency: string
+  topOfBookData: {
+    askSize: number
+    bidSize: number
+    lastSaleTimestamp: string
+    lastPrice: number
+    askPrice: number
+    quoteTimestamp: string
+    bidExchange: string
+    lastSizeNotional: number
+    lastExchange: string
+    askExchange: string
+    bidPrice: number
+    lastSize: number
+  }[]
+}
+
+const customParams = {
+  base: ['base', 'from', 'coin'],
+  quote: ['quote', 'to', 'market'],
+  field: false,
+}
+
+// When an invalid symbol is given the response body is empty
+const customError = (data: ResponseSchema[]) => !data.length
+
+export const execute: ExecuteWithConfig<Config> = async (request, config) => {
+  const validator = new Validator(request, customParams)
+  if (validator.error) throw validator.error
+
+  const jobRunID = validator.validated.id
+  const base = validator.validated.data.base.toLowerCase()
+  const quote = validator.validated.data.quote.toLowerCase()
+  const field = validator.validated.data.field || 'lastPrice'
+
+  const url = '/tiingo/crypto/top'
+
+  const options = {
+    ...config.api,
+    params: {
+      token: config.apiKey,
+      tickers: base + quote,
+    },
+    url,
+  }
+
+  const response = await Requester.request(options, customError)
+  const result = Requester.validateResultNumber(response.data as ResponseSchema[], [
+    0,
+    'topOfBookData',
+    0,
+    field,
+  ])
+
+  return Requester.success(jobRunID, {
+    data: config.verbose ? { ...response.data, result } : { result },
+    result,
+    status: 200,
+  })
+}

--- a/tiingo/src/endpoint/index.ts
+++ b/tiingo/src/endpoint/index.ts
@@ -1,2 +1,3 @@
 export * as eod from './eod'
 export * as iex from './iex'
+export * as top from './crypto/top'

--- a/tiingo/test/adapter.test.ts
+++ b/tiingo/test/adapter.test.ts
@@ -13,23 +13,23 @@ describe('execute', () => {
     const requests = [
       {
         name: 'id not supplied',
-        testData: { data: { ticker: 'aapl' } },
+        testData: { data: { base: 'btc', quote: 'usd' } },
       },
       {
         name: 'ticker',
-        testData: { id: jobID, data: { ticker: 'aapl' } },
+        testData: { id: jobID, data: { base: 'btc', quote: 'usd' } },
       },
       {
         name: 'ticker & field',
-        testData: { id: jobID, data: { ticker: 'aapl', field: 'open' } },
+        testData: { id: jobID, data: { endpoint: 'iex', ticker: 'aapl', field: 'open' } },
       },
       {
         name: 'iex endpoint',
-        testData: { id: jobID, data: { ticker: 'aapl', endpoint: 'price' } },
+        testData: { id: jobID, data: { ticker: 'aapl', endpoint: 'stock' } },
       },
       {
-        name: 'price endpoint',
-        testData: { id: jobID, data: { ticker: 'aapl', endpoint: 'price' } },
+        name: 'eod endpoint',
+        testData: { id: jobID, data: { ticker: 'aapl', endpoint: 'eod' } },
       },
     ]
 
@@ -69,11 +69,11 @@ describe('execute', () => {
     const requests = [
       {
         name: 'unknown ticker',
-        testData: { id: jobID, data: { ticker: 'not_real' } },
+        testData: { id: jobID, data: { endpoint: 'iex', ticker: 'not_real' } },
       },
       {
         name: 'unknown field',
-        testData: { id: jobID, data: { ticker: 'aapl', field: 'not_real' } },
+        testData: { id: jobID, data: { endpoint: 'iex', ticker: 'aapl', field: 'not_real' } },
       },
     ]
 


### PR DESCRIPTION
### Description

Adds a new endpoint to retrieve top of book prices for cryptocurrencies under the name `crypto`.

Changes the default endpoint to be this new `crypto` endpoint.

Names the previous default endpoint to fetch from IEX as `stock`.

### Caveats
NOTE: this is a breaking change for anyone who was previously relying on the default to be `stock` functionality.

Minor version has been bumped.

This endpoint will also soon become a WS endpoint once the WS framework has been released to master.

### Story
https://app.clubhouse.io/chainlinklabs/story/9004/add-support-for-crypto-data-to-tiingo-adapter

