### PR TITLE
augur encoding change

### DIFF
--- a/packages/composites/augur/src/methods/createMarkets.ts
+++ b/packages/composites/augur/src/methods/createMarkets.ts
@@ -47,38 +47,39 @@ export const execute: ExecuteWithConfig<Config> = async (input, config) => {
     events.push(...response.result as Event[])
   }
 
-  const filtered = events.filter(event => {
-    const date = Date.parse(event.event_date)
-    if ((date - Date.now()) / 1000 < startBuffer) return false
-
-    return !!getAffiliateId(event)
-  })
-
-  const packed = filtered.map((event) => {
-    const homeTeam = event.teams.find(team => team.is_home)
-    if (!homeTeam) return undefined
-
-    const awayTeam = event.teams.find(team => team.is_away)
-    if (!awayTeam) return undefined
-
+  // filter markets and build payloads for market creation
+  const packed = [];
+  for (let i = 0; i < events.length; i++) {
+    const event = events[i];
     const startTime = Date.parse(event.event_date)
+    if ((startTime - Date.now()) / 1000 < startBuffer) continue // markets would end too soon
 
+    // skip if data is missing
     const affiliateId = getAffiliateId(event)
-    if (!affiliateId) return undefined
+    if (!affiliateId) continue
+    const homeTeam = event.teams.find(team => team.is_home)
+    if (!homeTeam) continue
+    const awayTeam = event.teams.find(team => team.is_away)
+    if (!awayTeam) continue
 
-    const homeSpread = event.lines?.[affiliateId].spread.point_spread_home
-    const totalScore = event.lines?.[affiliateId].total.total_over
-    if (!homeSpread || !totalScore) return undefined
+    const eventId = eventIdToNum(event.event_id)
+    const [ headToHeadMarket, spreadMarket, totalScoreMarket]: [number, number, number] = await contract.getEventMarkets(eventId);
 
-    return packCreation(event.event_id, homeTeam.team_normalized_id, awayTeam.team_normalized_id, startTime, homeSpread, totalScore)
-  }).filter((event) => !!event)
+    // only create spread and totalScore markets if lines exist; always create headToHead market
+    let homeSpread = event.lines?.[affiliateId].spread.point_spread_home
+    let totalScore = event.lines?.[affiliateId].total.total_over
+    const createSpread = typeof homeSpread !== "undefined";
+    const createTotalScore = typeof totalScore !== "undefined";
+    homeSpread = homeSpread || 0;
+    totalScore = totalScore || 0;
+    const canCreate = (!headToHeadMarket) || (!spreadMarket && createSpread) || (!totalScoreMarket && createTotalScore)
+    if (!canCreate) continue;
+
+    packed.push(packCreation(event.event_id, homeTeam.team_normalized_id, awayTeam.team_normalized_id, startTime, homeSpread, totalScore, createSpread, createTotalScore))
+  }
 
   let nonce = await config.wallet.getTransactionCount()
   for (let i = 0; i < packed.length; i++) {
-    const eventId = eventIdToNum(filtered[i].event_id)
-    const isRegistered = await contract.isEventRegistered(eventId)
-    if (isRegistered) continue
-
     await contract.createMarket(packed[i], { nonce: nonce++ })
   }
 
@@ -91,20 +92,30 @@ export const packCreation = (
   awayTeamId: number,
   startTime: number,
   homeSpread: number,
-  totalScore: number
+  totalScore: number,
+  createSpread: boolean,
+  createTotalScore: boolean,
 ): string => {
   const encoded = ethers.utils.defaultAbiCoder.encode(
-    ['uint128', 'uint16', 'uint16', 'uint32', 'int16', 'uint16'],
+    ['uint128', 'uint16', 'uint16', 'uint32', 'int16', 'uint16', 'uint8'],
     [
       eventIdToNum(eventId),
       homeTeamId,
       awayTeamId,
       Math.floor(startTime / 1000),
       Math.round(homeSpread*10),
-      Math.round(totalScore*10)
+      Math.round(totalScore*10),
+      packCreationFlags(createSpread, createTotalScore)
     ]
   )
 
-  const mapping = [16, 2, 2, 4, 2, 2]
+  const mapping = [16, 2, 2, 4, 2, 2, 1]
   return bytesMappingToHexStr(mapping, encoded)
+}
+
+const packCreationFlags = (createSpread: boolean, createTotalScore: boolean): number => {
+  let flags = 0b00000000;
+  if (createSpread) flags += 0b00000001;
+  if (createTotalScore) flags += 0b00000010;
+  return flags;
 }

--- a/packages/composites/augur/src/methods/index.ts
+++ b/packages/composites/augur/src/methods/index.ts
@@ -67,6 +67,18 @@ export const ABI = [
   },
   {
     inputs: [
+      {
+        internalType: "uint256", name: "_eventId", type: "uint256" },
+    ],
+    name: "getEventMarkets",
+    outputs: [
+      { internalType: "uint256[3]", name: "", type: "uint256[3]" },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
       { internalType: "bytes32", name: "_payload", type: "bytes32" }
     ],
     name: "trustedResolveMarkets",

--- a/packages/composites/augur/test/e2e/pack.test.ts
+++ b/packages/composites/augur/test/e2e/pack.test.ts
@@ -9,7 +9,9 @@ describe('packCreation', () => {
         awayTeamId: 0,
         startTime: 0,
         homeSpread: 0,
-        totalScore: 0
+        totalScore: 0,
+        createSpread: false,
+        createTotalScore: false
       },
       expect: "0x0000000000000000000000000000000000000000000000000000000000000000"
     },
@@ -19,16 +21,18 @@ describe('packCreation', () => {
         awayTeamId: 2928,
         startTime: Date.parse("2020-02-02T23:30:00Z"),
         homeSpread: -4.499,
-        totalScore: 53
+        totalScore: 53,
+        createSpread: true,
+        createTotalScore: true
       },
-      expect: "0x9a35b8986a76eaaea364be331cb453ec0b710b705e375b78ffd3021200000000"
+      expect: "0x9a35b8986a76eaaea364be331cb453ec0b710b705e375b78ffd3021203000000"
     },
   ]
 
   requests.forEach((req) => {
     it(`${req.name}`, async () => {
       const p = req.testData
-      const got = create.packCreation(p.eventId, p.homeTeamId, p.awayTeamId, p.startTime, p.homeSpread, p.totalScore)
+      const got = create.packCreation(p.eventId, p.homeTeamId, p.awayTeamId, p.startTime, p.homeSpread, p.totalScore, p.createSpread, p.createTotalScore)
       expect(got).toEqual(req.expect)
 
       const bytes = Buffer.from(got.substr(2), 'hex').byteLength


### PR DESCRIPTION
Originally we expected to always create all three markets at once. We expected to sometimes need to wait for the lines to come in so we could make the spread and over-under markets. However, the lines can come much later so instead we will create head-to-head markets immediately and pass flags to indicate if spread or over-under markets should be created.

QUESTION: My understanding is that TheRundown returns fake scores of something like `0.001` to indicate a lack of data. Do they do so within lines as well? We don't want to create markets where the expected spread or totalScore is zero when they shouldn't be.

This required a contract change so I redeployed.