### PR TITLE
fix: increase TTL of coin list calls to an hour

### DIFF
--- a/packages/sources/coingecko/src/util.ts
+++ b/packages/sources/coingecko/src/util.ts
@@ -8,6 +8,7 @@ export function getCoinIds(id: string): Promise<CoinsResponse[]> {
   const options = {
     data: {
       endpoint: 'coins',
+      maxAge: 60 * 60 * 1000, // 1 hour
     },
     method: 'post',
     id,

--- a/packages/sources/coinpaprika/src/util.ts
+++ b/packages/sources/coinpaprika/src/util.ts
@@ -8,6 +8,7 @@ export function getCoinIds(id: string): Promise<CoinsResponse[]> {
   const options = {
     data: {
       endpoint: 'coins',
+      maxAge: 60 * 60 * 1000, // 1 hour
     },
     method: 'post',
     id,


### PR DESCRIPTION
### Description
For certain requests, such as getting a list of coin tickers to IDs, the response does do not change often. 

For these types of requests we can store them for longer in the cache.

Increases TTL to 1 hour.