### PR TITLE
chore: replay commit for ID overrides

### DIFF
--- a/packages/sources/coingecko/src/endpoint/price.ts
+++ b/packages/sources/coingecko/src/endpoint/price.ts
@@ -48,7 +48,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, config) => {
   if (validator.error) throw validator.error
 
   const jobRunID = validator.validated.id
-  const symbol = validator.overrideSymbol(AdapterName) as string
+  const symbol = validator.overrideSymbol(AdapterName)
   const quote = validator.validated.data.quote
   const coinid = validator.validated.data.coinid
 

--- a/packages/sources/coingecko/src/util.ts
+++ b/packages/sources/coingecko/src/util.ts
@@ -2,6 +2,16 @@ import { makeExecute } from './adapter'
 import { executeSync } from '@chainlink/ea-bootstrap'
 import { CoinsResponse } from './endpoint/coins'
 
+const coingeckoBlacklist = [
+  'leocoin',
+  'farmatrust',
+  'freetip',
+  'compound-coin',
+  'uni-coin',
+  'unicorn-token',
+  'kyber-network-crystal', // TEMP blacklisted due to no volume
+]
+
 export function getCoinIds(id: string): Promise<CoinsResponse[]> {
   const execute = makeExecute()
   const executeWithMiddleware = executeSync(execute)
@@ -27,12 +37,21 @@ export const getSymbolsToIds = (
   symbols: string[],
   coinList: CoinsResponse[],
 ): Record<string, string> => {
-  const idToSymbol: Record<string, string> = {}
+  const idToSymbol: Record<string, string> = {
+    // Pre-set IDs here
+    'kyber-network': 'KNC',
+  }
+
   symbols.forEach((symbol) => {
-    const coin = coinList.find((d) => d.symbol.toLowerCase() === symbol.toLowerCase())
+    const coin = coinList.find(
+      (d) =>
+        d.symbol.toLowerCase() === symbol.toLowerCase() &&
+        !coingeckoBlacklist.includes(d.id.toLowerCase()),
+    )
     if (coin && coin.id) {
       idToSymbol[coin.id] = symbol
     }
   })
+
   return idToSymbol
 }

--- a/packages/sources/coinpaprika/src/util.ts
+++ b/packages/sources/coinpaprika/src/util.ts
@@ -23,11 +23,24 @@ export function getCoinIds(id: string): Promise<CoinsResponse[]> {
   })
 }
 
+/**
+ * A map containing IDs that are lower in rank,
+ * but should take precedence over higher ranked coins
+ *
+ * NOTE: this is a kludge that will be removed with overrides improvement
+ */
+const directIds: { [key: string]: string } = {
+  cream: 'cream-cream',
+}
+
 export const getSymbolToId = (symbol: string, coinList: CoinsResponse[]): string => {
+  if (directIds[symbol.toLowerCase()]) return directIds[symbol.toLowerCase()]
+
   const coin = coinList.find(
     ({ symbol: coinSymbol, rank }) =>
       coinSymbol.toLowerCase() === symbol.toLowerCase() && rank !== 0,
   )
   if (coin && coin.id) return coin.id.toLowerCase()
+
   throw new Error('Coin id not found')
 }


### PR DESCRIPTION
### Description
In the recent merge to bring `develop` branch up to date with `master` part of [this PR](https://github.com/smartcontractkit/external-adapters-js/commit/877ea9915cf356ad3459fbce4ec4db9be31d52d5) was lost. Replaying it here.

ID overrides in coingecko and coinpaprika adapters.