### PR TITLE
fix: rate limit: removed sec and day intervals

### DIFF
--- a/packages/core/bootstrap/src/lib/rate-limit/reducer.ts
+++ b/packages/core/bootstrap/src/lib/rate-limit/reducer.ts
@@ -4,17 +4,13 @@ import { WARMUP_REQUEST_ID } from '../cache-warmer/config'
 import { successfulRequestObserved } from './actions'
 
 export enum IntervalNames {
-  SEC = 'SEC',
   MINUTE = 'MINUTE',
   HOUR = 'HOUR',
-  DAY = 'DAY',
 }
 
 export const Intervals: { [key: string]: number } = {
-  [IntervalNames.SEC]: 1000,
   [IntervalNames.MINUTE]: 60 * 1000,
   [IntervalNames.HOUR]: 60 * 60 * 1000,
-  [IntervalNames.DAY]: 24 * 60 * 60 * 1000,
 }
 export interface Heartbeat {
   id: string
@@ -36,10 +32,8 @@ export interface Heartbeats {
 }
 
 const initialIntervalsState = () => ({
-  SEC: [],
   MINUTE: [],
   HOUR: [],
-  DAY: [],
 })
 
 const initialHeartbeatsState: Heartbeats = {

--- a/packages/core/bootstrap/test/unit/rate-limit-cache-tests/helpers.ts
+++ b/packages/core/bootstrap/test/unit/rate-limit-cache-tests/helpers.ts
@@ -64,7 +64,7 @@ export const dataProviderMock = (cost = 1): { execute: Execute } => {
 }
 
 export const getRLTokenSpentPerMinute = (hearbeats: rateLimit.reducer.Heartbeats) => {
-  const responses = hearbeats.total[rateLimit.reducer.IntervalNames.DAY]
+  const responses = hearbeats.total[rateLimit.reducer.IntervalNames.HOUR]
     .filter((r) => !r.isCacheHit)
     .map((r) => ({
       ...r,


### PR DESCRIPTION
`SEC` and `DAY` intervals were not being used on Rate Limiting, and were consuming too much memory