### PR TITLE
fix: normalize batch request results keys

### DIFF
--- a/packages/sources/coinapi/src/endpoint/assets.ts
+++ b/packages/sources/coinapi/src/endpoint/assets.ts
@@ -36,7 +36,7 @@ const handleBatchedRequest = (
 ) => {
   const payload: Record<string, number> = {}
   for (const asset of response.data) {
-    payload[asset.asset_id] = Requester.validateResultNumber(asset, [path])
+    payload[asset.asset_id.toUpperCase()] = Requester.validateResultNumber(asset, [path])
   }
   return Requester.success(jobRunID, Requester.withResult(response, undefined, payload), true)
 }

--- a/packages/sources/coingecko/src/endpoint/price.ts
+++ b/packages/sources/coingecko/src/endpoint/price.ts
@@ -34,7 +34,7 @@ const handleBatchedRequest = (
   for (const key in response.data) {
     const symbol = idToSymbol?.[key]
     if (symbol)
-      payload[symbol] = Requester.validateResultNumber(response.data, [
+      payload[symbol.toUpperCase()] = Requester.validateResultNumber(response.data, [
         key,
         param[path] || quote.toLowerCase(),
       ])

--- a/packages/sources/coinmarketcap/src/endpoint/price.ts
+++ b/packages/sources/coinmarketcap/src/endpoint/price.ts
@@ -60,7 +60,7 @@ const handleBatchedRequest = (
 ) => {
   const payload: Record<string, number> = {}
   for (const key in response.data.data) {
-    payload[key] = Requester.validateResultNumber(response.data, [
+    payload[key.toUpperCase()] = Requester.validateResultNumber(response.data, [
       'data',
       key,
       'quote',

--- a/packages/sources/cryptocompare/src/endpoint/price.ts
+++ b/packages/sources/cryptocompare/src/endpoint/price.ts
@@ -126,7 +126,12 @@ const handleBatchedRequest = (
 ) => {
   const payload: Record<string, number> = {}
   for (const fsym in response.data.RAW) {
-    payload[fsym] = Requester.validateResultNumber(response.data, ['RAW', fsym, quote, path])
+    payload[fsym.toUpperCase()] = Requester.validateResultNumber(response.data, [
+      'RAW',
+      fsym,
+      quote,
+      path,
+    ])
   }
   return Requester.success(jobRunID, Requester.withResult(response, undefined, payload), true)
 }

--- a/packages/sources/nomics/src/endpoint/price.ts
+++ b/packages/sources/nomics/src/endpoint/price.ts
@@ -104,7 +104,10 @@ const handleBatchedRequest = (
   const payload: Record<string, number> = {}
   for (const i in response.data) {
     const entry = response.data[i]
-    payload[entry.symbol] = Requester.validateResultNumber(response.data[i], resultPaths[path])
+    payload[entry.symbol.toUpperCase()] = Requester.validateResultNumber(
+      response.data[i],
+      resultPaths[path],
+    )
   }
 
   return Requester.success(jobRunID, Requester.withResult(response, undefined, payload), true)


### PR DESCRIPTION
### Description
Coingecko returns their batch requests with lowercase symbols.

This causes a bug in Token Allocations where we are unable to key into the `results` object.

This PR normalizes the `results` keys for batch requests.