### PR TITLE
fix: coingecko and Coinpaprika correctly use overrides for batch requests

### DIFF
--- a/packages/core/bootstrap/src/lib/external-adapter/validator.ts
+++ b/packages/core/bootstrap/src/lib/external-adapter/validator.ts
@@ -109,10 +109,10 @@ export class Validator {
         defaultSymbol
       )
     const multiple: string[] = []
-    for (const sym in defaultSymbol) {
+    for (const sym of defaultSymbol) {
       const overrided = this.validated.overrides.get(adapter.toLowerCase())?.get(sym.toLowerCase())
-      if (!overrided) return defaultSymbol
-      multiple.push(overrided)
+      if (!overrided) multiple.push(sym)
+      else multiple.push(overrided)
     }
     return multiple
   }

--- a/packages/sources/coingecko/src/util.ts
+++ b/packages/sources/coingecko/src/util.ts
@@ -30,6 +30,8 @@ export const getSymbolsToIds = (
 ): Record<string, string> => {
   const idToSymbol: Record<string, string> = {}
   symbols.forEach((symbol) => {
+    const byId = coinList.find((d) => d.id.toLowerCase() === symbol.toLowerCase())
+    if (byId) idToSymbol[byId.id] = byId.symbol
     const coin = coinList.find((d) => d.symbol.toLowerCase() === symbol.toLowerCase())
     if (coin && coin.id) {
       idToSymbol[coin.id] = symbol

--- a/packages/sources/coinpaprika/src/util.ts
+++ b/packages/sources/coinpaprika/src/util.ts
@@ -25,6 +25,8 @@ export function getCoinIds(id: string): Promise<CoinsResponse[]> {
 }
 
 export const getSymbolToId = (symbol: string, coinList: CoinsResponse[]): string => {
+  const isId = coinList.find(({ id }) => id.toLowerCase() === symbol.toLowerCase())
+  if (isId && isId.id) return isId.id.toLowerCase()
   const coin = coinList.find(
     ({ symbol: coinSymbol, rank }) =>
       coinSymbol.toLowerCase() === symbol.toLowerCase() && rank !== 0,


### PR DESCRIPTION
### Description
Fixes Coingecko and Coinpaprika not using overrides correctly for batch requests because of their token list calls.