### PR TITLE
Fix/coingecko get symbols to ids

### DIFF
--- a/packages/core/bootstrap/src/lib/external-adapter/overrides/presetSymbols.json
+++ b/packages/core/bootstrap/src/lib/external-adapter/overrides/presetSymbols.json
@@ -6,8 +6,7 @@
     "grt": "the-graph",
     "LINA": "linear",
     "FTT": "ftx-token",
-    "MDX": "mdex",
-    "LINK": "chainlink"
+    "MDX": "mdex"
   },
   "nomics": {
     "FNX": "FNX2",

--- a/packages/sources/coingecko/src/util.ts
+++ b/packages/sources/coingecko/src/util.ts
@@ -30,14 +30,15 @@ export const getSymbolsToIds = (
 ): Record<string, string> => {
   const idToSymbol: Record<string, string> = {}
   symbols.forEach((symbol) => {
-    const byId = coinList.find((d) => d.id.toLowerCase() === symbol.toLowerCase())
-    if (byId) {
-      idToSymbol[byId.id] = byId.symbol
-      return
-    }
     const coin = coinList.find((d) => d.symbol.toLowerCase() === symbol.toLowerCase())
     if (coin && coin.id) {
-      idToSymbol[coin.id] = symbol
+      idToSymbol[coin.id] = coin.id
+      return
+    }
+    const byId = coinList.find((d) => d.id.toLowerCase() === symbol.toLowerCase())
+    if (byId) {
+      idToSymbol[byId.id] = byId.id
+      return
     }
   })
   return idToSymbol


### PR DESCRIPTION
### Description
Keeps continuity with `master` branch's functionality.
Previously Coingecko was queried using `id`, erroneously using `symbol` here.
`getSymbolsToIds` also needs to match on `symbol` before `id`.