### PR TITLE
fix(coinapi): batch requests correctly forward to assets endpoint

### DIFF
--- a/packages/composites/token-allocation/src/dataProvider.ts
+++ b/packages/composites/token-allocation/src/dataProvider.ts
@@ -47,7 +47,7 @@ export const getPriceProvider = (
     }
     const response = await Requester.request<AdapterResponse>({
       ...apiConfig,
-      data: data,
+      data,
     })
     const payloadEntries = symbols.map((symbol) => {
       const key = symbol

--- a/packages/sources/coinapi/package.json
+++ b/packages/sources/coinapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/coinapi-adapter",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sources/coinapi/src/adapter.ts
+++ b/packages/sources/coinapi/src/adapter.ts
@@ -18,8 +18,6 @@ export const execute: ExecuteWithConfig<Config> = async (request, config) => {
 
   switch (endpoint) {
     case price.NAME: {
-      const quote = validator.validated.data.quote
-      if (quote?.toUpperCase() === 'USD') return await assets.execute(request, config)
       return await price.execute(request, config)
     }
     case assets.NAME: {
@@ -39,36 +37,33 @@ export const makeExecute: ExecuteFactory<Config> = (config) => {
   return async (request) => execute(request, config || makeConfig())
 }
 
-export const makeWSHandler =
-  (config?: Config): MakeWSHandler =>
-  () => {
-    const defaultConfig = config || makeConfig()
-    const getSubscription = (products: string[]) => ({
-      type: 'hello',
-      apikey: defaultConfig.apiKey,
-      heartbeat: false,
-      subscribe_data_type: ['exrate'],
-      subscribe_filter_asset_id: products,
-    })
-    return {
-      connection: {
-        url: defaultConfig.api.baseWsURL || DEFAULT_WS_API_ENDPOINT,
-      },
-      subscribe: (input) => {
-        const validator = new Validator(input, price.customParams, {}, false)
-        if (validator.error) return
-        const base = (validator.overrideSymbol(NAME) as string).toLowerCase()
-        const quote = validator.validated.data.quote.toLowerCase()
-        return getSubscription([base, quote])
-      },
-      unsubscribe: () => undefined,
-      subsFromMessage: (message) =>
-        getSubscription([message.asset_id_base, message.asset_id_quote]),
-      isError: () => false,
-      filter: (message) => message?.type === 'exrate',
-      toResponse: (message) => {
-        const result = Requester.validateResultNumber(message, ['rate'])
-        return Requester.success('1', { data: { result } })
-      },
-    }
+export const makeWSHandler = (config?: Config): MakeWSHandler => () => {
+  const defaultConfig = config || makeConfig()
+  const getSubscription = (products: string[]) => ({
+    type: 'hello',
+    apikey: defaultConfig.apiKey,
+    heartbeat: false,
+    subscribe_data_type: ['exrate'],
+    subscribe_filter_asset_id: products,
+  })
+  return {
+    connection: {
+      url: defaultConfig.api.baseWsURL || DEFAULT_WS_API_ENDPOINT,
+    },
+    subscribe: (input) => {
+      const validator = new Validator(input, price.customParams, {}, false)
+      if (validator.error) return
+      const base = (validator.overrideSymbol(NAME) as string).toLowerCase()
+      const quote = validator.validated.data.quote.toLowerCase()
+      return getSubscription([base, quote])
+    },
+    unsubscribe: () => undefined,
+    subsFromMessage: (message) => getSubscription([message.asset_id_base, message.asset_id_quote]),
+    isError: () => false,
+    filter: (message) => message?.type === 'exrate',
+    toResponse: (message) => {
+      const result = Requester.validateResultNumber(message, ['rate'])
+      return Requester.success('1', { data: { result } })
+    },
   }
+}

--- a/packages/sources/coinapi/src/endpoint/price.ts
+++ b/packages/sources/coinapi/src/endpoint/price.ts
@@ -1,6 +1,7 @@
 import { Requester, Validator } from '@chainlink/ea-bootstrap'
 import { ExecuteWithConfig, Config } from '@chainlink/types'
 import { NAME as AdapterName } from '../config'
+import { assets } from '.'
 
 export const NAME = 'price'
 
@@ -15,9 +16,12 @@ export const execute: ExecuteWithConfig<Config> = async (request, config) => {
   const validator = new Validator(request, customParams)
   if (validator.error) throw validator.error
 
+  const quote = validator.validated.data.quote.toUpperCase()
+  // The Assets endpoint supports batch requests for USD quotes. If possible, use it.
+  if (quote?.toUpperCase() === 'USD') return await assets.execute(request, config)
+
   const jobRunID = validator.validated.id
   const symbol = (validator.overrideSymbol(AdapterName) as string).toUpperCase()
-  const quote = validator.validated.data.quote.toUpperCase()
   const url = `exchangerate/${symbol}/${quote}`
 
   const options = {


### PR DESCRIPTION
### Description
We use a check for `quote === 'USD'` to determine if the `assets` endpoint should be used.
This needs the validator to know about a `quote` input param, which isn't happening in `adapter.ts`, but instead in the `price` endpoint.
Moves that check inside of the `price` endpoint. 