### PR TITLE
[Feat] Rate limit defaults

### DIFF
--- a/packages/composites/apy-finance/src/index.ts
+++ b/packages/composites/apy-finance/src/index.ts
@@ -4,4 +4,4 @@ import { makeConfig } from './config'
 
 const NAME = 'APY-Finance'
 
-export = { NAME, makeConfig, makeExecute, ...expose(makeExecute()) }
+export = { NAME, makeConfig, makeExecute, ...expose(NAME, makeExecute()) }

--- a/packages/composites/augur/src/index.ts
+++ b/packages/composites/augur/src/index.ts
@@ -4,4 +4,4 @@ import { makeConfig } from './config'
 
 const NAME = 'AUGUR'
 
-export = { NAME, makeConfig, makeExecute, ...expose(makeExecute()) }
+export = { NAME, makeConfig, makeExecute, ...expose(NAME, makeExecute()) }

--- a/packages/composites/bitcoin-json-rpc/src/index.ts
+++ b/packages/composites/bitcoin-json-rpc/src/index.ts
@@ -2,4 +2,4 @@ import { makeExecute } from './adapter'
 import { expose } from '@chainlink/ea-bootstrap'
 
 const NAME = 'BITCOIN_JSON_RPC'
-export = { NAME, makeExecute, ...expose(makeExecute()) }
+export = { NAME, makeExecute, ...expose(NAME, makeExecute()) }

--- a/packages/composites/bob/src/index.ts
+++ b/packages/composites/bob/src/index.ts
@@ -2,4 +2,4 @@ import { makeExecute } from './adapter'
 import { expose } from '@chainlink/ea-bootstrap'
 
 const NAME = 'BOB'
-export = { NAME, makeExecute, ...expose(makeExecute()) }
+export = { NAME, makeExecute, ...expose(NAME, makeExecute()) }

--- a/packages/composites/crypto-volatility-index/src/index.ts
+++ b/packages/composites/crypto-volatility-index/src/index.ts
@@ -3,4 +3,4 @@ import { execute } from './adapter'
 
 const NAME = 'CRYPTO_VOLATILITY_INDEX'
 
-export = { NAME, execute, ...expose(execute) }
+export = { NAME, execute, ...expose(NAME, execute) }

--- a/packages/composites/defi-pulse/src/config.ts
+++ b/packages/composites/defi-pulse/src/config.ts
@@ -1,5 +1,7 @@
 import { util } from '@chainlink/ea-bootstrap'
 
+export const NAME = 'DEFI_PULSE'
+
 export type Config = {
   rpcUrl: string
   network: string

--- a/packages/composites/defi-pulse/src/index.ts
+++ b/packages/composites/defi-pulse/src/index.ts
@@ -1,5 +1,5 @@
 import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute } from './adapter'
-import { makeConfig } from './config'
+import { NAME, makeConfig } from './config'
 
-export = { makeExecute, makeConfig, ...expose(makeExecute()) }
+export = { makeExecute, makeConfig, ...expose(NAME, makeExecute()) }

--- a/packages/composites/dns-record-check/src/config.ts
+++ b/packages/composites/dns-record-check/src/config.ts
@@ -1,6 +1,8 @@
 import DNS from '@chainlink/dns-query-adapter'
 import { Config } from '@chainlink/types'
 
+export const NAME = 'DNS_RECORD_CHECK'
+
 export const makeConfig = (): Config => {
   return DNS.makeConfig()
 }

--- a/packages/composites/dns-record-check/src/index.ts
+++ b/packages/composites/dns-record-check/src/index.ts
@@ -1,4 +1,5 @@
 import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute } from './adapter'
+import { NAME } from './config'
 
-export = { makeExecute, ...expose(makeExecute()) }
+export = { makeExecute, ...expose(NAME, makeExecute()) }

--- a/packages/composites/dxdao/src/index.ts
+++ b/packages/composites/dxdao/src/index.ts
@@ -2,5 +2,5 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-const { server } = expose(makeExecute())
+const { server } = expose(NAME, makeExecute())
 export { NAME, makeExecute, makeConfig, server }

--- a/packages/composites/linear-finance/src/index.ts
+++ b/packages/composites/linear-finance/src/index.ts
@@ -4,4 +4,4 @@ import { makeConfig } from './config'
 
 const NAME = 'LINEAR_FINANCE'
 
-export = { NAME, makeConfig, makeExecute, ...expose(makeExecute()) }
+export = { NAME, makeConfig, makeExecute, ...expose(NAME, makeExecute()) }

--- a/packages/composites/market-closure/src/index.ts
+++ b/packages/composites/market-closure/src/index.ts
@@ -3,6 +3,6 @@ import { makeExecute } from './adapter'
 import { makeConfig } from './config'
 
 const NAME = 'MARKET_CLOSURE'
-const handlers = expose(makeExecute())
+const handlers = expose(NAME, makeExecute())
 
 export { NAME, makeExecute, makeConfig, handlers }

--- a/packages/composites/outlier-detection/src/index.ts
+++ b/packages/composites/outlier-detection/src/index.ts
@@ -4,6 +4,6 @@ import { makeExecute } from './adapter'
 
 const NAME = 'OUTLIER-DETECTION'
 
-const handlers = expose(makeExecute())
+const handlers = expose(NAME, makeExecute())
 
 export = { NAME, makeExecute, makeConfig, handlers }

--- a/packages/composites/proof-of-reserves/src/index.ts
+++ b/packages/composites/proof-of-reserves/src/index.ts
@@ -4,6 +4,6 @@ import { makeConfig } from './config'
 
 const NAME = 'PROOF_OF_RESERVES'
 
-const handlers = expose(makeExecute())
+const handlers = expose(NAME, makeExecute())
 
 export = { NAME, makeConfig, makeExecute, handlers }

--- a/packages/composites/reference-transform/src/index.ts
+++ b/packages/composites/reference-transform/src/index.ts
@@ -4,6 +4,6 @@ import { makeConfig } from './config'
 
 const NAME = 'REFERENCE_TRANSFORM'
 
-const handlers = expose(makeExecute())
+const handlers = expose(NAME, makeExecute())
 
 export = { NAME, makeConfig, makeExecute, handlers }

--- a/packages/composites/synth-index/src/index.ts
+++ b/packages/composites/synth-index/src/index.ts
@@ -2,4 +2,4 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute } from './adapter'
 
 export const NAME = 'SYNTH-INDEX'
-export const server = expose(makeExecute()).server
+export const server = expose(NAME, makeExecute()).server

--- a/packages/composites/the-graph/src/index.ts
+++ b/packages/composites/the-graph/src/index.ts
@@ -4,4 +4,4 @@ import { makeConfig } from './config'
 
 const NAME = 'THE_GRAPH'
 
-export = { NAME, makeConfig, makeExecute, ...expose(makeExecute()) }
+export = { NAME, makeConfig, makeExecute, ...expose(NAME, makeExecute()) }

--- a/packages/composites/token-allocation/src/index.ts
+++ b/packages/composites/token-allocation/src/index.ts
@@ -4,6 +4,6 @@ import { makeConfig } from './config'
 import * as types from './types'
 
 const NAME = 'Token-Allocation'
-const handlers = expose(makeExecute())
+const handlers = expose(NAME, makeExecute())
 
 export { NAME, types, makeExecute, makeConfig, handlers }

--- a/packages/composites/vesper/src/index.ts
+++ b/packages/composites/vesper/src/index.ts
@@ -4,4 +4,4 @@ import { makeConfig } from './config'
 
 const NAME = 'VESPER'
 
-export = { NAME, makeConfig, makeExecute, ...expose(makeExecute()) }
+export = { NAME, makeConfig, makeExecute, ...expose(NAME, makeExecute()) }

--- a/packages/core/bootstrap/src/index.ts
+++ b/packages/core/bootstrap/src/index.ts
@@ -212,13 +212,14 @@ export type ExecuteHandler = {
 }
 
 export const expose = (
+  name: string,
   execute: Execute,
   makeWsHandler?: MakeWSHandler,
   endpointSelector?: (request: AdapterRequest) => APIEndpoint,
 ): ExecuteHandler => {
   const middleware = makeMiddleware(execute, makeWsHandler, endpointSelector)
   return {
-    server: server.initHandler(execute, middleware),
+    server: server.initHandler(name, execute, middleware),
   }
 }
 

--- a/packages/core/bootstrap/src/lib/burst-limit/index.ts
+++ b/packages/core/bootstrap/src/lib/burst-limit/index.ts
@@ -19,7 +19,7 @@ export const withBurstLimit = (store?: Store<BurstLimitState>): Middleware => as
   execute,
   context,
 ) => async (input) => {
-  const config = rateLimitConfig.get()
+  const config = rateLimitConfig.get(context)
   if (!store || !config.enabled) return await execute(input, context)
 
   const state = store.getState()

--- a/packages/core/bootstrap/src/lib/provider-limits/index.ts
+++ b/packages/core/bootstrap/src/lib/provider-limits/index.ts
@@ -68,7 +68,7 @@ const getProviderLimits = (
     logger.debug(
       `Rate Limit: "${provider} does not have tier ${tier} defined. Falling back to lowest tier"`,
     )
-    limitsConfig = protocolConfig['0']
+    limitsConfig = Object.values(protocolConfig)?.[0]
   }
 
   if (!limitsConfig)

--- a/packages/core/bootstrap/src/lib/provider-limits/index.ts
+++ b/packages/core/bootstrap/src/lib/provider-limits/index.ts
@@ -1,6 +1,7 @@
+import { logger } from '../external-adapter'
 import limits from './limits.json'
 
-export const DEFAULT_MINUTE_RATE_LIMIT = 60 
+export const DEFAULT_MINUTE_RATE_LIMIT = 60
 export const BURST_UNDEFINED_QUOTA_MULTIPLE = 2
 
 export const DEFAULT_WS_CONNECTIONS = 2
@@ -33,40 +34,57 @@ interface ProviderRateLimit {
   minute: number
 }
 
-export const getRateLimit = (
-  provider: string,
-  tier: string,
-): ProviderRateLimit => {
+export const getRateLimit = (provider: string, tier: string): ProviderRateLimit => {
   const providerLimit = getProviderLimits(provider, tier, 'http')
-  if (!providerLimit) {
-    throw new Error(`Rate Limit: Provider: "${provider}" and Tier: "${tier}" doesn't match any provider spec in limits.json`)
-  }
   return calculateRateLimit(providerLimit as HTTPTier)
 }
 
-export const getWSLimits = (
-  provider: string,
-  tier: string,
-): WSTier => {
+export const getWSLimits = (provider: string, tier: string): WSTier => {
   const providerLimit = getProviderLimits(provider, tier, 'ws')
-  if (!providerLimit) {
-    throw new Error(`WS Limit: Provider: "${provider}" and Tier: "${tier}" doesn't match any provider spec in limits.json`)
-  }
   return calculateWSLimits(providerLimit as WSTier)
 }
 
-const getProviderLimits = (provider: string, tier: string, protocol: string): HTTPTier | WSTier | undefined => {
+const getProviderLimits = (
+  provider: string,
+  tier: string,
+  protocol: 'ws' | 'http',
+): HTTPTier | WSTier | undefined => {
   const parsedLimits = parseLimits(limits)
-  const providerLimit = parsedLimits[provider.toLowerCase()]
-  return protocol === 'http' ? providerLimit?.http[tier.toLowerCase()] : providerLimit?.ws[tier.toLowerCase()]
+  const providerConfig = parsedLimits[provider.toLowerCase()]
+  if (!providerConfig)
+    throw new Error(
+      `Rate Limit: Provider: "${provider}" doesn't match any provider spec in limits.json`,
+    )
+
+  const protocolConfig = providerConfig[protocol]
+  if (!protocolConfig)
+    throw new Error(
+      `Rate Limit: "${provider}" doesn't have any configuration for ${protocol} in limits.json`,
+    )
+
+  let limitsConfig = protocolConfig[tier.toLowerCase()]
+
+  if (!limitsConfig) {
+    logger.debug(
+      `Rate Limit: "${provider} does not have tier ${tier} defined. Falling back to lowest tier"`,
+    )
+    limitsConfig = protocolConfig['0']
+  }
+
+  if (!limitsConfig)
+    throw new Error(
+      `Rate Limit: Provider: "${provider}" has no tiers defined for ${protocol} in limits.json`,
+    )
+
+  return limitsConfig
 }
 
 const parseLimits = (limits: any): Limits => {
   const _mapObject = (fn: any) => (o: any) => Object.fromEntries(Object.entries(o).map(fn))
-  const _formatProtocol = _mapObject(((entry: any[]) => {
+  const _formatProtocol = _mapObject((entry: any[]) => {
     const [tierName, rest] = entry
-    return [tierName.toLowerCase(), { ...rest as any }]
-  }))
+    return [tierName.toLowerCase(), { ...(rest as any) }]
+  })
   const _formatProvider = _mapObject((entry: any[]) => {
     const [providerName, protocol] = entry
     const http = _formatProtocol(protocol.http)
@@ -74,14 +92,13 @@ const parseLimits = (limits: any): Limits => {
     return [providerName.toLowerCase(), { http, ws }]
   })
 
-  
   return _formatProvider(limits)
 }
 
 const calculateWSLimits = (providerLimit: WSTier): WSTier => {
   return {
     connections: providerLimit.connections,
-    subscriptions: providerLimit.subscriptions
+    subscriptions: providerLimit.subscriptions,
   }
 }
 
@@ -93,7 +110,7 @@ const calculateRateLimit = (providerLimit: HTTPTier): ProviderRateLimit => {
     quota = providerLimit?.rateLimit1s * 60
   }
   return {
-    second: providerLimit?.rateLimit1s || (quota as number / 60) * BURST_UNDEFINED_QUOTA_MULTIPLE,
-    minute: quota as number
+    second: providerLimit?.rateLimit1s || ((quota as number) / 60) * BURST_UNDEFINED_QUOTA_MULTIPLE,
+    minute: quota as number,
   }
 }

--- a/packages/core/bootstrap/src/lib/rate-limit/config.ts
+++ b/packages/core/bootstrap/src/lib/rate-limit/config.ts
@@ -20,7 +20,7 @@ export function get(context: AdapterContext): Config {
   const enabled = parseBool(getEnv('EXPERIMENTAL_RATE_LIMIT_ENABLED'))
   let capacity = parseInt(getEnv('RATE_LIMIT_CAPACITY') || '')
   if (!capacity && enabled) {
-    const provider = getEnv('RATE_LIMIT_API_PROVIDER') || context.name || ''
+    const provider = getEnv('RATE_LIMIT_API_PROVIDER') || context.name?.toLowerCase() || ''
     const tier = getEnv('RATE_LIMIT_API_TIER') || ''
     try {
       const providerConfig = getRateLimit(provider, tier)

--- a/packages/core/bootstrap/src/lib/rate-limit/config.ts
+++ b/packages/core/bootstrap/src/lib/rate-limit/config.ts
@@ -1,7 +1,7 @@
-import objectHash from 'object-hash'
 import { getRateLimit } from '../provider-limits'
-import { getHashOpts, getEnv, parseBool } from '../util'
+import { getEnv, parseBool } from '../util'
 import { logger } from '../external-adapter'
+import { AdapterContext } from '@chainlink/types'
 
 export interface Config {
   /**
@@ -11,21 +11,16 @@ export interface Config {
   totalCapacity: number
 
   /**
-   * Hashing options for differentiating requests
-   */
-  hashOpts: Required<Parameters<typeof objectHash>>['1']
-
-  /**
    * Determines if Rate Limit option is activated
    */
   enabled: boolean
 }
 
-export function get(): Config {
+export function get(context: AdapterContext): Config {
   const enabled = parseBool(getEnv('EXPERIMENTAL_RATE_LIMIT_ENABLED'))
   let capacity = parseInt(getEnv('RATE_LIMIT_CAPACITY') || '')
   if (!capacity && enabled) {
-    const provider = getEnv('RATE_LIMIT_API_PROVIDER') || ''
+    const provider = getEnv('RATE_LIMIT_API_PROVIDER') || context.name || ''
     const tier = getEnv('RATE_LIMIT_API_TIER') || ''
     try {
       const providerConfig = getRateLimit(provider, tier)
@@ -35,7 +30,6 @@ export function get(): Config {
     }
   }
   return {
-    hashOpts: getHashOpts(),
     totalCapacity: capacity,
     enabled: enabled && !!capacity,
   }

--- a/packages/core/bootstrap/src/lib/rate-limit/index.ts
+++ b/packages/core/bootstrap/src/lib/rate-limit/index.ts
@@ -1,6 +1,7 @@
 import { AdapterRequest, Middleware } from '@chainlink/types'
 import hash from 'object-hash'
 import { Store } from 'redux'
+import { getHashOpts } from '../util'
 import { successfulResponseObserved } from './actions'
 import * as config from './config'
 import * as metrics from './metrics'
@@ -23,6 +24,7 @@ export * as reducer from './reducer'
  * @param id Participant ID to get participants heartbeats
  */
 export const computeThroughput = (
+  config: config.Config,
   state: Heartbeats,
   interval: IntervalNames,
   id: string,
@@ -36,7 +38,7 @@ export const computeThroughput = (
   // Compute max throughput by weight
   const weight = throughputOfParticipant / totalThroughtput
 
-  return maxThroughput(weight, costOfParticipant)
+  return maxThroughput(weight, costOfParticipant, config.totalCapacity)
 }
 
 const getAverageCost = (requests: Heartbeat[]): number => {
@@ -44,8 +46,8 @@ const getAverageCost = (requests: Heartbeat[]): number => {
   return requests.reduce((totalCost, h) => totalCost + h.c, 0) / requests.length
 }
 
-const maxThroughput = (weight: number, cost: number): number => {
-  const maxAllowedCapacity = 0.9 * (config.get().totalCapacity / cost)
+const maxThroughput = (weight: number, cost: number, totalCapacity: number): number => {
+  const maxAllowedCapacity = 0.9 * (totalCapacity / cost)
   return weight * maxAllowedCapacity
 }
 
@@ -54,7 +56,7 @@ const maxThroughput = (weight: number, cost: number): number => {
  *
  * @param request payload
  */
-export const makeId = (request: AdapterRequest): string => hash(request, config.get().hashOpts)
+export const makeId = (request: AdapterRequest): string => hash(request, getHashOpts())
 
 /**
  * Calculate maxAge to keep the item cached so we allow the specified throughput.
@@ -69,11 +71,17 @@ export const withRateLimit = (store: Store<RootState>): Middleware => async (
   execute,
   context,
 ) => async (input) => {
-  if (!config.get().enabled) return await execute(input, context)
+  const rateLimitConfig = config.get(context)
+  if (!rateLimitConfig.enabled) return await execute(input, context)
   let state = store.getState()
   const { heartbeats } = state
   const requestTypeId = makeId(input)
-  const maxThroughput = computeThroughput(heartbeats, IntervalNames.HOUR, requestTypeId)
+  const maxThroughput = computeThroughput(
+    rateLimitConfig,
+    heartbeats,
+    IntervalNames.HOUR,
+    requestTypeId,
+  )
   const maxAge = maxAgeFor(maxThroughput, Intervals[IntervalNames.MINUTE])
   const result = await execute({ ...input, rateLimitMaxAge: maxAge }, context)
 

--- a/packages/core/bootstrap/src/lib/server.ts
+++ b/packages/core/bootstrap/src/lib/server.ts
@@ -22,10 +22,13 @@ export const HEADER_CONTENT_TYPE = 'Content-Type'
 export const CONTENT_TYPE_APPLICATION_JSON = 'application/json'
 export const CONTENT_TYPE_TEXT_PLAIN = 'text/plain'
 
-export const initHandler = (execute: Execute, middleware: Middleware[]) => async (): Promise<
-  http.Server
-> => {
+export const initHandler = (
+  name: string,
+  execute: Execute,
+  middleware: Middleware[],
+) => async (): Promise<http.Server> => {
   const context: AdapterContext = {
+    name,
     cache: null,
   }
   const cacheOptions = defaultOptions()

--- a/packages/core/bootstrap/test/unit/provider-limits/limits.test.ts
+++ b/packages/core/bootstrap/test/unit/provider-limits/limits.test.ts
@@ -2,48 +2,50 @@ import * as limits from '../../../src/lib/provider-limits'
 
 const limitsJSONPath = '../../../src/lib/provider-limits/limits.json'
 
-jest.mock('../../../src/lib/provider-limits/limits.json', () => ({
-  amberdata: {
-    http: {
-      starter: {
-        rateLimit1h: 10
+jest.mock(
+  '../../../src/lib/provider-limits/limits.json',
+  () => ({
+    amberdata: {
+      http: {
+        starter: {
+          rateLimit1h: 10,
+        },
+        premium: {
+          rateLimit1h: 20,
+        },
+        business: {
+          rateLimit1h: 30,
+        },
       },
-      premium: {
-        rateLimit1h: 20
-      },
-      business: {
-        rateLimit1h: 30
+      ws: {
+        starter: {
+          connections: 10,
+          subscriptions: 20,
+        },
       },
     },
-    ws: {
-      starter: {
-        connections: 10,
-        subscriptions: 20
-      }
-    }
-  }
-}), { virtual: true })
-
+  }),
+  { virtual: true },
+)
 
 describe('Provider Limits', () => {
   describe('Limits API', () => {
     it('gets the correct rate limits', () => {
       const limit = limits.getRateLimit('amberdata', 'starter')
-      expect(limit.minute).toBe(10/60)
-      expect(limit.second).toBe(10/60/60 * 2)
+      expect(limit.minute).toBe(10 / 60)
+      expect(limit.second).toBe((10 / 60 / 60) * 2)
     })
 
-    it('rate limit throws if no tier match', () => {
-      expect(() => {
-        limits.getRateLimit('amberdata', 'non-existent')
-      }).toThrow(Error)
+    it('rate limit defaults to lowest tier if no tier match', () => {
+      const limit = limits.getRateLimit('amberdata', 'non-existant')
+      expect(limit.minute).toBe(10 / 60)
+      expect(limit.second).toBe((10 / 60 / 60) * 2)
     })
 
     it('rate limit throws if no provider match', () => {
       expect(() => {
         limits.getRateLimit('non-existent', 'non-existent')
       }).toThrow(Error)
-      
     })
 
     it('gets the correct ws limits', () => {
@@ -53,9 +55,9 @@ describe('Provider Limits', () => {
     })
 
     it('WS limit throws if no tier match', () => {
-      expect(() => {
-        limits.getWSLimits('amberdata', 'non-existent')
-      }).toThrow(Error)
+      const limit = limits.getWSLimits('amberdata', 'non-existant')
+      expect(limit.connections).toBe(10)
+      expect(limit.subscriptions).toBe(20)
     })
 
     it('WS limit throws if no provider match', () => {
@@ -73,7 +75,7 @@ describe('Provider Limits', () => {
     let limits
 
     beforeAll(async () => {
-      limits =  await import(limitsJSONPath)
+      limits = await import(limitsJSONPath)
       delete limits.default
     })
 
@@ -88,7 +90,9 @@ describe('Provider Limits', () => {
       Object.values(limits).forEach((limit: any) => {
         if (Object.keys(limit.http).length > 0) {
           Object.values(limit.http).forEach((plan: any) => {
-            const hasSomeRateLimit = ['rateLimit1s', 'rateLimit1m', 'rateLimit1h'].some((rate) => Object.keys(plan).includes(rate))
+            const hasSomeRateLimit = ['rateLimit1s', 'rateLimit1m', 'rateLimit1h'].some((rate) =>
+              Object.keys(plan).includes(rate),
+            )
             expect(hasSomeRateLimit).toBe(true)
           })
         }

--- a/packages/core/bootstrap/test/unit/rate-limit.test.ts
+++ b/packages/core/bootstrap/test/unit/rate-limit.test.ts
@@ -2,6 +2,7 @@ import { AdapterRequest, Execute } from '@chainlink/types'
 import { createStore, Store } from 'redux'
 import { useFakeTimers } from 'sinon'
 import * as rateLimit from '../../src/lib/rate-limit'
+import { Config, get } from '../../src/lib/rate-limit/config'
 import {
   IntervalNames,
   Intervals,
@@ -9,43 +10,46 @@ import {
   selectTotalNumberOfHeartbeatsFor,
 } from '../../src/lib/rate-limit/reducer'
 
-const counterFrom =
-  (i = 0): Execute =>
-  async (request) => {
-    const result = i++
-    return {
-      jobRunID: request.id,
-      data: { jobRunID: request.id, statusCode: 200, data: request, result },
-      result,
-      statusCode: 200,
-    }
+const counterFrom = (i = 0): Execute => async (request) => {
+  const result = i++
+  return {
+    jobRunID: request.id,
+    data: { jobRunID: request.id, statusCode: 200, data: request, result },
+    result,
+    statusCode: 200,
   }
+}
 
-const expectRequestToBe =
-  (field: string, expected: any): Execute =>
-  async (request) => {
-    expect(request[field]).toBe(expected)
-    return {
-      jobRunID: request.id,
-      data: { jobRunID: request.id, statusCode: 200, data: request, result: '' },
-      result: '',
-      statusCode: 200,
-    }
+const expectRequestToBe = (field: string, expected: any): Execute => async (request) => {
+  expect(request[field]).toBe(expected)
+  return {
+    jobRunID: request.id,
+    data: { jobRunID: request.id, statusCode: 200, data: request, result: '' },
+    result: '',
+    statusCode: 200,
   }
+}
 
-const getMaxAge = (store: Store, input: AdapterRequest) => {
+const getMaxAge = (config: Config, store: Store, input: AdapterRequest) => {
   const requestTypeId = rateLimit.makeId(input)
   const state = store.getState()
   const { heartbeats } = state
-  const maxThroughput = rateLimit.computeThroughput(heartbeats, IntervalNames.HOUR, requestTypeId)
+  const maxThroughput = rateLimit.computeThroughput(
+    config,
+    heartbeats,
+    IntervalNames.HOUR,
+    requestTypeId,
+  )
   return rateLimit.maxAgeFor(maxThroughput, Intervals[IntervalNames.MINUTE])
 }
 
 describe('Rate Limit Middleware', () => {
   const capacity = 50
+  let config
   beforeAll(() => {
     process.env.EXPERIMENTAL_RATE_LIMIT_ENABLED = String(true)
     process.env.RATE_LIMIT_CAPACITY = String(capacity)
+    config = get({})
   })
 
   describe('Max Age Calculation', () => {
@@ -63,9 +67,10 @@ describe('Rate Limit Middleware', () => {
       const input = { id: '6', data: { base: 1 } }
 
       const execute = await rateLimit.withRateLimit(store)(
-        expectRequestToBe('rateLimitMaxAge', getMaxAge(store, input)),
+        expectRequestToBe('rateLimitMaxAge', getMaxAge(config, store, input)),
+        {},
       )
-      await execute(input)
+      await execute(input, {})
     })
 
     it('Max Age increases on every request', async () => {
@@ -75,9 +80,10 @@ describe('Rate Limit Middleware', () => {
       for (let i = 0; i <= 5; i++) {
         const input = { id: String(i), data: { base: 1 } }
         const execute = await withRateLimit(
-          expectRequestToBe('rateLimitMaxAge', getMaxAge(store, input)),
+          expectRequestToBe('rateLimitMaxAge', getMaxAge(config, store, input)),
+          {},
         )
-        await execute(input)
+        await execute(input, {})
       }
     })
 
@@ -88,19 +94,23 @@ describe('Rate Limit Middleware', () => {
       for (let i = 1; i <= 5; i++) {
         const input = { id: String(i), data: { base: i } }
         const execute = await withRateLimit(
-          expectRequestToBe('rateLimitMaxAge', getMaxAge(store, input)),
+          expectRequestToBe('rateLimitMaxAge', getMaxAge(config, store, input)),
+          {},
         )
-        await execute(input)
+        await execute(input, {})
       }
 
       const input = { id: '1', data: { base: 1 } }
       // After passing the first minute, the max age should be reduced due to expired participants
       clock.tick(Intervals.MINUTE + 1)
-      let execute = await withRateLimit(counterFrom(0))
-      await execute({ id: '1', data: { base: 1 } })
+      let execute = await withRateLimit(counterFrom(0), {})
+      await execute({ id: '1', data: { base: 1 } }, {})
 
-      execute = await withRateLimit(expectRequestToBe('rateLimitMaxAge', getMaxAge(store, input)))
-      await execute({ id: '1', data: { base: 1 } })
+      execute = await withRateLimit(
+        expectRequestToBe('rateLimitMaxAge', getMaxAge(config, store, input)),
+        {},
+      )
+      await execute({ id: '1', data: { base: 1 } }, {})
     })
 
     it('Max Age is lower on recurrent participants', async () => {
@@ -109,19 +119,23 @@ describe('Rate Limit Middleware', () => {
       const uniquePair = 'unique'
       for (let i = 1; i <= 10; i++) {
         const isUnique = i % 2 === 0
-        const execute = await withRateLimit(counterFrom(0))
-        await execute({ id: String(i), data: { base: isUnique ? uniquePair : i } })
+        const execute = await withRateLimit(counterFrom(0), {})
+        await execute({ id: String(i), data: { base: isUnique ? uniquePair : i } }, {})
       }
 
       const input = { id: '1', data: { base: 11 } }
       let execute = await withRateLimit(
-        expectRequestToBe('rateLimitMaxAge', getMaxAge(store, input)),
+        expectRequestToBe('rateLimitMaxAge', getMaxAge(config, store, input)),
+        {},
       )
-      await execute(input)
+      await execute(input, {})
 
       const input2 = { id: '1', data: { base: uniquePair } }
-      execute = await withRateLimit(expectRequestToBe('rateLimitMaxAge', getMaxAge(store, input2)))
-      await execute(input2)
+      execute = await withRateLimit(
+        expectRequestToBe('rateLimitMaxAge', getMaxAge(config, store, input2)),
+        {},
+      )
+      await execute(input2, {})
     })
   })
 
@@ -139,20 +153,20 @@ describe('Rate Limit Middleware', () => {
       const intervalName = IntervalNames.HOUR
       const interval = Intervals[intervalName]
       const store = createStore(rateLimit.reducer.rootReducer, {})
-      const execute = await rateLimit.withRateLimit(store)(counterFrom(0))
+      const execute = await rateLimit.withRateLimit(store)(counterFrom(0), {})
       for (let i = 0; i <= 5; i++) {
-        await execute({ id: String(i), data: {} })
+        await execute({ id: String(i), data: {} }, {})
       }
       let state = store.getState()
       expect(selectTotalNumberOfHeartbeatsFor(state.heartbeats, intervalName)).toBe(7)
 
       clock.tick(interval - 1)
-      await execute({ id: '6', data: {} })
+      await execute({ id: '6', data: {} }, {})
       state = store.getState()
       expect(selectTotalNumberOfHeartbeatsFor(state.heartbeats, intervalName)).toBe(8)
 
       clock.tick(2)
-      await execute({ id: '6', data: {} })
+      await execute({ id: '6', data: {} }, {})
       state = store.getState()
       expect(selectTotalNumberOfHeartbeatsFor(state.heartbeats, intervalName)).toBe(3)
     })
@@ -161,9 +175,9 @@ describe('Rate Limit Middleware', () => {
       const intervalName = IntervalNames.HOUR
       const interval = Intervals[intervalName]
       const store = createStore(rateLimit.reducer.rootReducer, {})
-      const execute = await rateLimit.withRateLimit(store)(counterFrom(0))
+      const execute = await rateLimit.withRateLimit(store)(counterFrom(0), {})
       for (let i = 0; i <= 5; i++) {
-        await execute({ id: String(i), data: { base: i } })
+        await execute({ id: String(i), data: { base: i } }, {})
       }
 
       let state = store.getState()
@@ -176,7 +190,7 @@ describe('Rate Limit Middleware', () => {
       ).toBe(1)
 
       const input = { id: '5', data: { base: 5 } }
-      await execute(input)
+      await execute(input, {})
       state = store.getState()
       expect(
         selectParticiantsHeartbeatsFor(state.heartbeats, intervalName, rateLimit.makeId(input))
@@ -185,7 +199,7 @@ describe('Rate Limit Middleware', () => {
 
       // Just before the first sec/minute/hour/day requests should be still stored
       clock.tick(interval - 1)
-      await execute(input)
+      await execute(input, {})
       state = store.getState()
       expect(
         selectParticiantsHeartbeatsFor(state.heartbeats, intervalName, rateLimit.makeId(input))
@@ -194,7 +208,7 @@ describe('Rate Limit Middleware', () => {
 
       // Right after the first sec/minute/hour/day, first request should have been expired
       clock.tick(2)
-      await execute(input)
+      await execute(input, {})
       state = store.getState()
       expect(
         selectParticiantsHeartbeatsFor(state.heartbeats, intervalName, rateLimit.makeId(input))

--- a/packages/core/types/@chainlink/index.d.ts
+++ b/packages/core/types/@chainlink/index.d.ts
@@ -2,6 +2,7 @@
 declare module '@chainlink/types' {
   import type { CacheOptions } from '@chainlink/ea-bootstrap'
   export interface AdapterContext {
+    name?: string
     cache?: CacheOptions
   }
 
@@ -190,10 +191,14 @@ declare module '@chainlink/types' {
     subsFromMessage: (message: any, subscriptionMsg: any) => any
     // Allows for connection info to be set programmatically based on the input request
     // This is useful for data providers that only allow subscriptions based on URL params
-    programmaticConnectionInfo?: (input: AdapterRequest) => {
-      key: string
-      url: string
-    } | undefined
+    programmaticConnectionInfo?: (
+      input: AdapterRequest,
+    ) =>
+      | {
+          key: string
+          url: string
+        }
+      | undefined
   }
 
   /* INPUT TYPE VALIDATIONS */

--- a/packages/examples/composite/src/index.ts
+++ b/packages/examples/composite/src/index.ts
@@ -4,4 +4,4 @@ import { makeConfig } from './config'
 
 const NAME = 'EXAMPLE_COMPOSITE'
 
-export = { NAME, makeConfig, makeExecute, ...expose(makeExecute()) }
+export = { NAME, makeConfig, makeExecute, ...expose(NAME, makeExecute()) }

--- a/packages/examples/source/src/index.ts
+++ b/packages/examples/source/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute, endpointSelector } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/1forge/src/index.ts
+++ b/packages/sources/1forge/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/alphachain/src/index.ts
+++ b/packages/sources/alphachain/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/alphavantage/src/index.ts
+++ b/packages/sources/alphavantage/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/amberdata/src/index.ts
+++ b/packages/sources/amberdata/src/index.ts
@@ -6,5 +6,5 @@ export = {
   NAME,
   makeExecute,
   makeConfig,
-  ...expose(makeExecute(), makeWSHandler(), endpointSelector),
+  ...expose(NAME, makeExecute(), makeWSHandler(), endpointSelector),
 }

--- a/packages/sources/anyblock/src/index.ts
+++ b/packages/sources/anyblock/src/index.ts
@@ -4,4 +4,9 @@ import { makeConfig } from './config'
 
 const NAME = 'ANYBLOCK'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/binance-dex/src/index.ts
+++ b/packages/sources/binance-dex/src/index.ts
@@ -4,4 +4,4 @@ import { makeConfig } from './config'
 
 const NAME = 'BINANCE_DEX'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }

--- a/packages/sources/binance/src/index.ts
+++ b/packages/sources/binance/src/index.ts
@@ -6,5 +6,5 @@ export = {
   NAME,
   makeExecute,
   makeConfig,
-  ...expose(makeExecute(), makeWSHandler(), endpointSelector),
+  ...expose(NAME, makeExecute(), makeWSHandler(), endpointSelector),
 }

--- a/packages/sources/bitex/src/index.ts
+++ b/packages/sources/bitex/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/bitso/src/index.ts
+++ b/packages/sources/bitso/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/blockchain.com/src/index.ts
+++ b/packages/sources/blockchain.com/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/blockchair/src/index.ts
+++ b/packages/sources/blockchair/src/index.ts
@@ -2,4 +2,4 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }

--- a/packages/sources/blockcypher/src/index.ts
+++ b/packages/sources/blockcypher/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/blockstream/src/index.ts
+++ b/packages/sources/blockstream/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/bravenewcoin/src/index.ts
+++ b/packages/sources/bravenewcoin/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/btc.com/src/index.ts
+++ b/packages/sources/btc.com/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/cache.gold/src/index.ts
+++ b/packages/sources/cache.gold/src/index.ts
@@ -2,4 +2,4 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }

--- a/packages/sources/cfbenchmarks/src/index.ts
+++ b/packages/sources/cfbenchmarks/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/coinapi/src/index.ts
+++ b/packages/sources/coinapi/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute, endpointSelector } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/coinbase/src/index.ts
+++ b/packages/sources/coinbase/src/index.ts
@@ -6,5 +6,5 @@ export = {
   NAME,
   makeExecute,
   makeConfig,
-  ...expose(makeExecute(), makeWSHandler(), endpointSelector),
+  ...expose(NAME, makeExecute(), makeWSHandler(), endpointSelector),
 }

--- a/packages/sources/coincodex/src/index.ts
+++ b/packages/sources/coincodex/src/index.ts
@@ -2,4 +2,4 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }

--- a/packages/sources/coingecko/src/index.ts
+++ b/packages/sources/coingecko/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute, endpointSelector } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/coinlore/src/index.ts
+++ b/packages/sources/coinlore/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/coinmarketcap/src/index.ts
+++ b/packages/sources/coinmarketcap/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute, endpointSelector } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeConfig, makeExecute, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeConfig,
+  makeExecute,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/coinmetrics/src/index.ts
+++ b/packages/sources/coinmetrics/src/index.ts
@@ -2,4 +2,4 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute, makeWSHandler } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), makeWSHandler()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute(), makeWSHandler()) }

--- a/packages/sources/coinpaprika/src/index.ts
+++ b/packages/sources/coinpaprika/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/coinranking/src/index.ts
+++ b/packages/sources/coinranking/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeConfig, NAME } from './config'
 import { endpointSelector, makeExecute } from './adapter'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/covid-tracker/src/index.ts
+++ b/packages/sources/covid-tracker/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/cryptoapis-v2/src/index.ts
+++ b/packages/sources/cryptoapis-v2/src/index.ts
@@ -2,4 +2,4 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }

--- a/packages/sources/cryptoapis/src/index.ts
+++ b/packages/sources/cryptoapis/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/cryptocompare/src/index.ts
+++ b/packages/sources/cryptocompare/src/index.ts
@@ -6,5 +6,5 @@ export = {
   NAME,
   makeExecute,
   makeConfig,
-  ...expose(makeExecute(), makeWSHandler(), endpointSelector),
+  ...expose(NAME, makeExecute(), makeWSHandler(), endpointSelector),
 }

--- a/packages/sources/cryptoid/src/index.ts
+++ b/packages/sources/cryptoid/src/index.ts
@@ -2,4 +2,4 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }

--- a/packages/sources/cryptomkt/src/index.ts
+++ b/packages/sources/cryptomkt/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/currencylayer/src/index.ts
+++ b/packages/sources/currencylayer/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/deribit/src/index.ts
+++ b/packages/sources/deribit/src/index.ts
@@ -2,4 +2,4 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }

--- a/packages/sources/dns-query/src/index.ts
+++ b/packages/sources/dns-query/src/index.ts
@@ -4,4 +4,4 @@ import { makeConfig } from './config'
 
 const NAME = 'DNS-Query'
 
-export = { NAME, makeConfig, makeExecute, ...expose(makeExecute()) }
+export = { NAME, makeConfig, makeExecute, ...expose(NAME, makeExecute()) }

--- a/packages/sources/dwolla/src/index.ts
+++ b/packages/sources/dwolla/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/dxfeed-secondary/src/index.ts
+++ b/packages/sources/dxfeed-secondary/src/index.ts
@@ -2,4 +2,4 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }

--- a/packages/sources/dxfeed/src/index.ts
+++ b/packages/sources/dxfeed/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/eodhistoricaldata/src/index.ts
+++ b/packages/sources/eodhistoricaldata/src/index.ts
@@ -2,4 +2,4 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }

--- a/packages/sources/etherchain/src/index.ts
+++ b/packages/sources/etherchain/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/ethgasstation/src/index.ts
+++ b/packages/sources/ethgasstation/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/expert-car-broker/src/index.ts
+++ b/packages/sources/expert-car-broker/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/fcsapi/src/index.ts
+++ b/packages/sources/fcsapi/src/index.ts
@@ -2,4 +2,4 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }

--- a/packages/sources/finage/src/index.ts
+++ b/packages/sources/finage/src/index.ts
@@ -2,4 +2,4 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }

--- a/packages/sources/finnhub/src/index.ts
+++ b/packages/sources/finnhub/src/index.ts
@@ -2,4 +2,4 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }

--- a/packages/sources/fixer/src/index.ts
+++ b/packages/sources/fixer/src/index.ts
@@ -2,4 +2,4 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }

--- a/packages/sources/fmpcloud/src/index.ts
+++ b/packages/sources/fmpcloud/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/genesis-volatility/src/index.ts
+++ b/packages/sources/genesis-volatility/src/index.ts
@@ -2,4 +2,4 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }

--- a/packages/sources/geodb/src/index.ts
+++ b/packages/sources/geodb/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/graphql/src/index.ts
+++ b/packages/sources/graphql/src/index.ts
@@ -2,4 +2,4 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }

--- a/packages/sources/iex-cloud/src/index.ts
+++ b/packages/sources/iex-cloud/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/intrinio/src/index.ts
+++ b/packages/sources/intrinio/src/index.ts
@@ -2,4 +2,4 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute, makeWSHandler } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), makeWSHandler()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute(), makeWSHandler()) }

--- a/packages/sources/json-rpc/src/index.ts
+++ b/packages/sources/json-rpc/src/index.ts
@@ -4,4 +4,4 @@ import { makeConfig } from './config'
 
 const NAME = 'JSON-RPC'
 
-export = { NAME, execute, makeConfig, ...expose(makeExecute()) }
+export = { NAME, execute, makeConfig, ...expose(NAME, makeExecute()) }

--- a/packages/sources/kaiko/src/index.ts
+++ b/packages/sources/kaiko/src/index.ts
@@ -2,4 +2,4 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }

--- a/packages/sources/lcx/src/index.ts
+++ b/packages/sources/lcx/src/index.ts
@@ -2,4 +2,4 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }

--- a/packages/sources/linkpool/src/index.ts
+++ b/packages/sources/linkpool/src/index.ts
@@ -2,4 +2,4 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }

--- a/packages/sources/lition/src/index.ts
+++ b/packages/sources/lition/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/marketstack/src/index.ts
+++ b/packages/sources/marketstack/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/messari/src/index.ts
+++ b/packages/sources/messari/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/metalsapi/src/index.ts
+++ b/packages/sources/metalsapi/src/index.ts
@@ -2,4 +2,4 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }

--- a/packages/sources/ncfx/src/index.ts
+++ b/packages/sources/ncfx/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute, makeWSHandler, endpointSelector } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), makeWSHandler(), endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), makeWSHandler(), endpointSelector),
+}

--- a/packages/sources/nikkei/src/index.ts
+++ b/packages/sources/nikkei/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/nomics/src/index.ts
+++ b/packages/sources/nomics/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute, endpointSelector } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/oilpriceapi/src/index.ts
+++ b/packages/sources/oilpriceapi/src/index.ts
@@ -2,4 +2,4 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }

--- a/packages/sources/onchain/src/index.ts
+++ b/packages/sources/onchain/src/index.ts
@@ -2,4 +2,4 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }

--- a/packages/sources/openexchangerates/src/index.ts
+++ b/packages/sources/openexchangerates/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/orchid-bandwidth/src/index.ts
+++ b/packages/sources/orchid-bandwidth/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/paxos/src/index.ts
+++ b/packages/sources/paxos/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/paypal/src/index.ts
+++ b/packages/sources/paypal/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/poa/src/index.ts
+++ b/packages/sources/poa/src/index.ts
@@ -2,4 +2,4 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }

--- a/packages/sources/polygon/src/index.ts
+++ b/packages/sources/polygon/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/reduce/src/index.ts
+++ b/packages/sources/reduce/src/index.ts
@@ -3,4 +3,4 @@ import { execute } from './adapter'
 
 const NAME = 'REDUCE'
 
-export = { NAME, execute, ...expose(execute) }
+export = { NAME, execute, ...expose(NAME, execute) }

--- a/packages/sources/renvm-address-set/src/index.ts
+++ b/packages/sources/renvm-address-set/src/index.ts
@@ -2,4 +2,4 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }

--- a/packages/sources/satoshitango/src/index.ts
+++ b/packages/sources/satoshitango/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/sochain/src/index.ts
+++ b/packages/sources/sochain/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/sportsdataio/src/index.ts
+++ b/packages/sources/sportsdataio/src/index.ts
@@ -2,4 +2,4 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }

--- a/packages/sources/stasis/src/index.ts
+++ b/packages/sources/stasis/src/index.ts
@@ -2,4 +2,4 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }

--- a/packages/sources/taapi/src/index.ts
+++ b/packages/sources/taapi/src/index.ts
@@ -2,4 +2,4 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }

--- a/packages/sources/therundown/src/index.ts
+++ b/packages/sources/therundown/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/tiingo/src/index.ts
+++ b/packages/sources/tiingo/src/index.ts
@@ -6,5 +6,5 @@ export = {
   NAME,
   makeExecute,
   makeConfig,
-  ...expose(makeExecute(), makeWSHandler(), endpointSelector),
+  ...expose(NAME, makeExecute(), makeWSHandler(), endpointSelector),
 }

--- a/packages/sources/tradermade/src/index.ts
+++ b/packages/sources/tradermade/src/index.ts
@@ -2,4 +2,4 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }

--- a/packages/sources/tradingeconomics/src/index.ts
+++ b/packages/sources/tradingeconomics/src/index.ts
@@ -2,4 +2,4 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute, makeWSHandler } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), makeWSHandler()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute(), makeWSHandler()) }

--- a/packages/sources/trueusd/src/index.ts
+++ b/packages/sources/trueusd/src/index.ts
@@ -2,4 +2,4 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }

--- a/packages/sources/twelvedata/src/index.ts
+++ b/packages/sources/twelvedata/src/index.ts
@@ -2,4 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute(), undefined, endpointSelector) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}

--- a/packages/sources/unibit/src/index.ts
+++ b/packages/sources/unibit/src/index.ts
@@ -2,4 +2,4 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }

--- a/packages/sources/wbtc-address-set/src/index.ts
+++ b/packages/sources/wbtc-address-set/src/index.ts
@@ -2,4 +2,4 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }

--- a/packages/sources/xbto/src/index.ts
+++ b/packages/sources/xbto/src/index.ts
@@ -3,4 +3,4 @@ import { makeConfig, makeExecute } from './adapter'
 
 const NAME = 'XBTO'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }

--- a/packages/targets/agoric/src/index.ts
+++ b/packages/targets/agoric/src/index.ts
@@ -4,4 +4,4 @@ import { makeConfig } from './config'
 
 const NAME = 'Agoric'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }

--- a/packages/targets/conflux/src/index.ts
+++ b/packages/targets/conflux/src/index.ts
@@ -4,4 +4,4 @@ import { makeConfig } from './config'
 
 const NAME = 'conflux'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }

--- a/packages/targets/dydx-stark/src/index.ts
+++ b/packages/targets/dydx-stark/src/index.ts
@@ -4,4 +4,4 @@ import { makeConfig } from './config'
 
 const NAME = 'dydx_stark'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }

--- a/packages/targets/ethwrite/src/index.ts
+++ b/packages/targets/ethwrite/src/index.ts
@@ -4,4 +4,4 @@ import { makeConfig } from './config'
 
 const NAME = 'ETHWRITE'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }

--- a/packages/targets/harmony/src/index.ts
+++ b/packages/targets/harmony/src/index.ts
@@ -4,4 +4,4 @@ import { makeConfig } from './config'
 
 const NAME = 'harmony'
 
-export = { NAME, makeExecute, makeConfig, ...expose(makeExecute()) }
+export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }


### PR DESCRIPTION
### Description
Currently nops need to configure the Rate Limit middleware by providing two environment variables for:

    EXPERIMENTAL_RATE_LIMIT_ENABLED
    RATE_LIMIT_API_PROVIDER
    RATE_LIMIT_API_TIER

This PR makes setup easier by adding defaults:
- `RATE_LIMIT_API_PROVIDER` is pulled from a new name context that gets passed in from the adapter code.
- `RATE_LIMIT_API_TIER` defaults to the lowest tier

### Story
https://app.clubhouse.io/chainlinklabs/story/13705/rate-limit-tier-config-defaults