### PR TITLE
fix: blocks can fall behind delta blocks

### DIFF
--- a/packages/sources/layer2-sequencer-health/README.md
+++ b/packages/sources/layer2-sequencer-health/README.md
@@ -7,6 +7,7 @@ Adapter that checks the Layer 2 Sequencer status
 | Required? |            Name            |                                  Description                                   | Options |                 Defaults to                  |
 | :-------: | :------------------------: | :----------------------------------------------------------------------------: | :-----: | :------------------------------------------: |
 |           |          `DELTA`           | Maximum time in miliseconds from last seen block to consider sequencer healthy |         |                120000 (2 min)                |
+|           |       `DELTA_BLOCKS`       |          Maximum allowed number of blocks that Nodes can fall behind           |         |                      6                       |
 |           |  `ARBITRUM_RPC_ENDPOINT`   |                             Arbitrum RPC Endpoint                              |         |         https://arb1.arbitrum.io/rpc         |
 |           | `ARBITRUM_HEALTH_ENDPOINT` |                            Arbitrum Health Endpoint                            |         |                                              |
 |           |  `OPTIMISM_RPC_ENDPOINT`   |                             Optimism RPC Endpoint                              |         |         https://mainnet.optimism.io          |

--- a/packages/sources/layer2-sequencer-health/src/config.ts
+++ b/packages/sources/layer2-sequencer-health/src/config.ts
@@ -5,6 +5,8 @@ export const NAME = 'L2_SEQUENCER_HEALTH'
 
 // 2 minutes
 export const DEFAULT_DELTA_TIME = 2 * 60 * 1000
+// Blocks that replica nodes can fall behind
+export const DEFAULT_DELTA_BLOCKS = 6
 
 export enum Networks {
   Arbitrum = 'arbitrum',
@@ -30,6 +32,7 @@ export const HEALTH_ENDPOINTS = {
 
 export interface ExtendedConfig extends Config {
   delta: number
+  deltaBlocks: number
 }
 
 export const makeConfig = (prefix?: string): ExtendedConfig => {
@@ -39,5 +42,6 @@ export const makeConfig = (prefix?: string): ExtendedConfig => {
   }
   const config = Requester.getDefaultConfig(prefix)
   const delta = Number(util.getEnv('DELTA', prefix)) || DEFAULT_DELTA_TIME
-  return { ...config, delta }
+  const deltaBlocks = Number(util.getEnv('DELTA_BLOCKS', prefix)) || DEFAULT_DELTA_BLOCKS
+  return { ...config, delta, deltaBlocks }
 }

--- a/packages/sources/layer2-sequencer-health/src/network.ts
+++ b/packages/sources/layer2-sequencer-health/src/network.ts
@@ -3,7 +3,7 @@ import { HEALTH_ENDPOINTS, Networks, RPC_ENDPOINTS } from './config'
 import { BigNumber } from 'ethers'
 
 export interface NetworkHealthCheck {
-  (network: Networks, delta: number): Promise<undefined | boolean>
+  (network: Networks, delta: number, deltaBlocks: number): Promise<undefined | boolean>
 }
 
 export const getSequencerHealth: NetworkHealthCheck = async (

--- a/packages/sources/layer2-sequencer-health/test/unit/adapter.test.ts
+++ b/packages/sources/layer2-sequencer-health/test/unit/adapter.test.ts
@@ -18,43 +18,55 @@ describe('adapter', () => {
     it('Stale blocks are unhealthy after Delta seconds', async () => {
       jest.spyOn(network, 'requestBlockHeight').mockReturnValue(Promise.resolve(1))
       const getNetworkStatus = adapter.makeNetworkStatusCheck(Networks.Arbitrum)
+      const deltaBlocks = 0
       // 2 minutes delta
       const delta = 120 * 1000
       const timeBetweenCalls = 10 * 1000
       // During first two minutes of the block is not considered stale
       for (let i = 0; i < delta / timeBetweenCalls; i++) {
-        expect(await getNetworkStatus(delta)).toBe(true)
+        expect(await getNetworkStatus(delta, deltaBlocks)).toBe(true)
         clock.tick(timeBetweenCalls)
       }
       // After delta time passed, is considered stale
-      expect(await getNetworkStatus(delta)).toBe(false)
+      expect(await getNetworkStatus(delta, deltaBlocks)).toBe(false)
     })
 
     it('Blocks are healthy after Delta seconds if blocks change', async () => {
       const getNetworkStatus = adapter.makeNetworkStatusCheck(Networks.Arbitrum)
+      const deltaBlocks = 0
       // 2 minutes delta
       const delta = 120 * 1000
       const timeBetweenCalls = 10 * 1000
       // If blocks change, is not considered stale
       for (let i = 0; i < delta / timeBetweenCalls; i++) {
         jest.spyOn(network, 'requestBlockHeight').mockReturnValue(Promise.resolve(i))
-        expect(await getNetworkStatus(delta)).toBe(true)
+        expect(await getNetworkStatus(delta, deltaBlocks)).toBe(true)
         clock.tick(timeBetweenCalls)
       }
       // After delta time passed the current block should be considered healthy
-      expect(await getNetworkStatus(delta)).toBe(true)
+      expect(await getNetworkStatus(delta, deltaBlocks)).toBe(true)
       clock.tick(timeBetweenCalls)
-      expect(await getNetworkStatus(delta)).toBe(true)
+      expect(await getNetworkStatus(delta, deltaBlocks)).toBe(true)
     })
 
-    it('Blocks are unhealthy if current is previous to the last seen', async () => {
+    it('Blocks are healthy if current is previous to the last seen within a delta difference', async () => {
       const getNetworkStatus = adapter.makeNetworkStatusCheck(Networks.Arbitrum)
 
-      jest.spyOn(network, 'requestBlockHeight').mockReturnValue(Promise.resolve(3))
-      expect(await getNetworkStatus(30)).toBe(true)
+      const deltaBlocks = 5
+      jest.spyOn(network, 'requestBlockHeight').mockReturnValue(Promise.resolve(10))
+      expect(await getNetworkStatus(30, deltaBlocks)).toBe(true)
 
-      jest.spyOn(network, 'requestBlockHeight').mockReturnValue(Promise.resolve(2))
-      await expect(getNetworkStatus(30)).rejects.toThrow('Block found is previous to last seen')
+      jest.spyOn(network, 'requestBlockHeight').mockReturnValue(Promise.resolve(6))
+      expect(await getNetworkStatus(30, deltaBlocks)).toBe(true)
+
+      jest.spyOn(network, 'requestBlockHeight').mockReturnValue(Promise.resolve(5))
+      expect(await getNetworkStatus(30, deltaBlocks)).toBe(true)
+
+      jest.spyOn(network, 'requestBlockHeight').mockReturnValue(Promise.resolve(4))
+      await expect(getNetworkStatus(30, deltaBlocks)).rejects.toThrow()
+
+      jest.spyOn(network, 'requestBlockHeight').mockReturnValue(Promise.resolve(3))
+      await expect(getNetworkStatus(30, deltaBlocks)).rejects.toThrow()
     })
   })
 


### PR DESCRIPTION
There's the case where some replica nodes on Layer 2 fall behind, and its `blockHeight` is not yet completely updated. Considering this case by adding a `deltaBlocks` with a default value of `6` blocks