### PR TITLE
Support for WS only adapters

### DIFF
--- a/packages/core/types/@chainlink/index.d.ts
+++ b/packages/core/types/@chainlink/index.d.ts
@@ -202,7 +202,7 @@ declare module '@chainlink/types' {
           url: string
         }
       | undefined
-    //
+    // Optional flag to ensure adapter only uses WS and doesn't send HTTP requests
     noHttp?: boolean
   }
 

--- a/packages/core/types/@chainlink/index.d.ts
+++ b/packages/core/types/@chainlink/index.d.ts
@@ -202,6 +202,8 @@ declare module '@chainlink/types' {
           url: string
         }
       | undefined
+    //
+    noHttp?: boolean
   }
 
   /* INPUT TYPE VALIDATIONS */

--- a/packages/sources/ncfx/README.md
+++ b/packages/sources/ncfx/README.md
@@ -1,10 +1,6 @@
 # Chainlink External Adapter for NCFX
 
-A template to be used as an example for new [External Adapters](https://github.com/smartcontractkit/external-adapters-js)
-
-(please fill out with corresponding information)
-
-An example adapter description
+This adapter only supports WS connections. Make sure WS is enabled in your configuration in order to run this adapter.
 
 ### Environment Variables
 
@@ -12,12 +8,6 @@ An example adapter description
 | :-------: | :-----: | :------------------------------------------------------------------------------------------------------------------------: | :-----: | :---------: |
 |     ✅      | API_USERNAME | The username to the NCFX account |         |             |
 |      ✅     | API_PASSWORD | The password to the NCFX account |         |             |
-
----
-
-### Input Parameters
-
-No adapter specific input parameters
 
 ---
 

--- a/packages/sources/ncfx/src/adapter.ts
+++ b/packages/sources/ncfx/src/adapter.ts
@@ -39,6 +39,7 @@ export const makeWSHandler = (config?: Config): MakeWSHandler => {
       connection: {
         url: `${defaultConfig.api.baseWebsocketURL}/cryptodata`,
       },
+      noHttp: true,
       subscribe: (input) => getSubscription('subscribe', getPair(input)),
       unsubscribe: (input) => getSubscription('unsubscribe', getPair(input)),
       subsFromMessage: (message, subscriptionMsg) => {

--- a/packages/sources/ncfx/src/endpoint/crypto.ts
+++ b/packages/sources/ncfx/src/endpoint/crypto.ts
@@ -11,5 +11,5 @@ export const inputParameters: InputParameters = {
 export const execute: ExecuteWithConfig<Config> = async (request) => {
     const validator = new Validator(request, inputParameters)
     if (validator.error) throw validator.error
-    throw Error("The NCFX adapter does not support making HTTP requests.  Please wait a few seconds while the adapter sets up the WebSockets connection.")
+    throw Error("The NCFX adapter does not support making HTTP requests. Make sure WS is enabled in the adapter configuration.")
 }


### PR DESCRIPTION
This PR adds support for WS only adapters.

The motivation behind it is that we have data providers who only support WS and no HTTP. Instead of making the first request fail, we go directly to WS. The users initial request will wait until a result has been stored in cache, before they get a response. This prevents the first request from failing. The WS middleware will poll the cache every second until API_TIMEOUT is hit, or it gets a result.

In order to support this, some refactoring was done to the cache lib in order to make it easier to fetch results from cache.