### PR TITLE
fix(cryptoapis): bring up to date with newest adapter changes

### DIFF
--- a/packages/sources/cryptoapis-v2/src/adapter.ts
+++ b/packages/sources/cryptoapis-v2/src/adapter.ts
@@ -1,44 +1,21 @@
-import { Requester, Validator, AdapterError } from '@chainlink/ea-bootstrap'
-import { ExecuteWithConfig, ExecuteFactory, Config } from '@chainlink/types'
-import { makeConfig, DEFAULT_ENDPOINT } from './config'
-import { price, bc_info, balance } from './endpoint'
-
-const inputParams = {
-  endpoint: false,
-}
+import { Builder } from '@chainlink/ea-bootstrap'
+import {
+  Config,
+  ExecuteWithConfig,
+  ExecuteFactory,
+  AdapterRequest,
+  APIEndpoint,
+} from '@chainlink/types'
+import { makeConfig } from './config'
+import * as endpoints from './endpoint'
 
 // Export function to integrate with Chainlink node
 export const execute: ExecuteWithConfig<Config> = async (request, context, config) => {
-  const validator = new Validator(request, inputParams)
-  if (validator.error) throw validator.error
-
-  Requester.logConfig(config)
-
-  const jobRunID = validator.validated.id
-  const endpoint = validator.validated.data.endpoint || DEFAULT_ENDPOINT
-
-  switch (endpoint) {
-    case price.Name: {
-      return await price.execute(request, context, config)
-      break
-    }
-    case 'difficulty':
-    case 'height': {
-      return await bc_info.execute(request, context, config)
-      break
-    }
-    case balance.Name: {
-      return balance.makeExecute(config)(request, context)
-    }
-    default: {
-      throw new AdapterError({
-        jobRunID,
-        message: `Endpoint ${endpoint} not supported.`,
-        statusCode: 400,
-      })
-    }
-  }
+  return Builder.buildSelector(request, context, config, endpoints)
 }
+
+export const endpointSelector = (request: AdapterRequest): APIEndpoint =>
+  Builder.selectEndpoint(request, makeConfig(), endpoints)
 
 export const makeExecute: ExecuteFactory<Config> = (config) => {
   return async (request, context) => execute(request, context, config || makeConfig())

--- a/packages/sources/cryptoapis-v2/src/config.ts
+++ b/packages/sources/cryptoapis-v2/src/config.ts
@@ -2,11 +2,35 @@ import { Requester } from '@chainlink/ea-bootstrap'
 import { Config } from '@chainlink/types'
 
 export const DEFAULT_ENDPOINT = 'price'
-export const NAME = "CRYPTOAPIS_V2"
+export const NAME = 'CRYPTOAPIS_V2'
 
 export const makeConfig = (prefix?: string): Config => {
   const config = Requester.getDefaultConfig(prefix, true)
   config.api.headers['X-API-Key'] = config.apiKey
   config.api.baseURL = 'https://rest.cryptoapis.io'
   return config
+}
+
+export const BLOCKCHAIN_NAME_MAP: { [key: string]: string } = {
+  btc: 'bitcoin',
+  eth: 'ethereum',
+  ltc: 'litecoin',
+  etc: 'ethereum-classic',
+  bch: 'bitcoin-cash',
+  dash: 'dash',
+  doge: 'dogecoin',
+}
+
+export function isCoinType(key: string): boolean {
+  return !!BLOCKCHAIN_NAME_MAP[key.toLowerCase()]
+}
+export const CHAIN_KEYS = ['mainnet', 'testnet'] as const
+export type ChainType = typeof CHAIN_KEYS[number]
+export function isChainType(key: string): key is ChainType {
+  return CHAIN_KEYS.includes(key as ChainType)
+}
+
+export const TESTNET_BLOCKCHAINS: { [ticker: string]: string } = {
+  ethereum: 'rinkeby',
+  'ethereum-classic': 'mordor',
 }

--- a/packages/sources/cryptoapis-v2/src/endpoint/balance.ts
+++ b/packages/sources/cryptoapis-v2/src/endpoint/balance.ts
@@ -1,9 +1,11 @@
 import { balance } from '@chainlink/ea-factories'
 import { Requester } from '@chainlink/ea-bootstrap'
-import { Config } from '@chainlink/types'
-import { isCoinType, isChainType, TESTNET_BLOCKCHAINS, BLOCKCHAIN_NAME_MAP } from '.'
+import { Config, ExecuteFactory } from '@chainlink/types'
+import { isCoinType, isChainType, TESTNET_BLOCKCHAINS, BLOCKCHAIN_NAME_MAP } from '../config'
 
-export const Name = 'balance'
+export const supportedEndpoints = ['balance']
+
+export const inputParameters = balance.inputParameters
 
 const getBalanceURI = (address: string, chain: string, coin: string) => {
   if (chain === 'testnet') chain = Requester.toVendorName(coin, TESTNET_BLOCKCHAINS) || chain
@@ -30,4 +32,5 @@ const getBalance: balance.GetBalance = async (account, config) => {
 
 const isSupported: balance.IsSupported = (coin, chain) => isChainType(chain) && isCoinType(coin)
 
-export const makeExecute = (config: Config) => balance.make({ ...config, getBalance, isSupported })
+export const makeExecute: ExecuteFactory<Config> = (config?: Config) =>
+  balance.make({ ...config, getBalance, isSupported })

--- a/packages/sources/cryptoapis-v2/src/endpoint/index.ts
+++ b/packages/sources/cryptoapis-v2/src/endpoint/index.ts
@@ -1,27 +1,3 @@
 export * as balance from './balance'
 export * as price from './price'
 export * as bc_info from './bc_info'
-
-export const BLOCKCHAIN_NAME_MAP: { [key: string]: string } = {
-  "btc": "bitcoin",
-  "eth": "ethereum",
-  "ltc": "litecoin",
-  "etc": "ethereum-classic",
-  "bch": "bitcoin-cash",
-  "dash": "dash",
-  "doge": "dogecoin"
-}
-
-export function isCoinType(key: string): boolean {
-  return !!BLOCKCHAIN_NAME_MAP[key.toLowerCase()]
-}
-export const CHAIN_KEYS = ['mainnet', 'testnet'] as const
-export type ChainType = typeof CHAIN_KEYS[number]
-export function isChainType(key: string): key is ChainType {
-  return CHAIN_KEYS.includes(key as ChainType)
-}
-
-export const TESTNET_BLOCKCHAINS: { [ticker: string]: string } = {
-  "ethereum": 'rinkeby',
-  "ethereum-classic": 'mordor',
-}

--- a/packages/sources/cryptoapis-v2/src/endpoint/price.ts
+++ b/packages/sources/cryptoapis-v2/src/endpoint/price.ts
@@ -1,8 +1,7 @@
 import { Requester, Validator } from '@chainlink/ea-bootstrap'
-import { ExecuteWithConfig, Config } from '@chainlink/types'
+import { ExecuteWithConfig, Config, InputParameters } from '@chainlink/types'
 
-export const Name = 'price'
-
+export const supportedEndpoints = ['price']
 export interface ResponseSchema {
   apiVersion: string
   requestId: string
@@ -18,13 +17,13 @@ export interface ResponseSchema {
   }
 }
 
-const priceParams = {
+export const inputParameters: InputParameters = {
   base: ['base', 'from', 'coin'],
   quote: ['quote', 'to', 'market'],
 }
 
 export const execute: ExecuteWithConfig<Config> = async (request, _, config) => {
-  const validator = new Validator(request, priceParams)
+  const validator = new Validator(request, inputParameters)
   if (validator.error) throw validator.error
 
   const jobRunID = validator.validated.id

--- a/packages/sources/cryptoapis-v2/src/index.ts
+++ b/packages/sources/cryptoapis-v2/src/index.ts
@@ -1,5 +1,10 @@
 import { expose } from '@chainlink/ea-bootstrap'
-import { makeExecute } from './adapter'
+import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }
+export = {
+  NAME,
+  makeExecute,
+  makeConfig,
+  ...expose(NAME, makeExecute(), undefined, endpointSelector),
+}


### PR DESCRIPTION
### Description
Nops were having problems with hitting their tier caps. Turns out the `bc_info` endpoint on v2 is using 5 credits per call.

This PR tracks that and also brings the adapter up to date with latest EA patterns.