### PR TITLE
hotfix/coingecko add tiers

### DIFF
--- a/packages/core/bootstrap/src/lib/provider-limits/limits.json
+++ b/packages/core/bootstrap/src/lib/provider-limits/limits.json
@@ -286,11 +286,11 @@
         "rateLimit1s": 10,
         "rateLimit1m": 50,
         "note": "1s found in ToS, 1m found at https://www.coingecko.com/en/api"
-      }
+      },
       "analyst": {
         "rateLimit1m": 500,
         "rateLimit1h": 690,
-      }
+      },
       "pro": {
         "rateLimit1m": 500,
         "rateLimit1h": 6900,

--- a/packages/core/bootstrap/src/lib/provider-limits/limits.json
+++ b/packages/core/bootstrap/src/lib/provider-limits/limits.json
@@ -289,11 +289,11 @@
       },
       "analyst": {
         "rateLimit1m": 500,
-        "rateLimit1h": 690,
+        "rateLimit1h": 690
       },
       "pro": {
         "rateLimit1m": 500,
-        "rateLimit1h": 6900,
+        "rateLimit1h": 6900
       }
     },
     "ws": {}

--- a/packages/core/bootstrap/src/lib/provider-limits/limits.json
+++ b/packages/core/bootstrap/src/lib/provider-limits/limits.json
@@ -287,6 +287,14 @@
         "rateLimit1m": 50,
         "note": "1s found in ToS, 1m found at https://www.coingecko.com/en/api"
       }
+      "analyst": {
+        "rateLimit1m": 500,
+        "rateLimit1h": 690,
+      }
+      "pro": {
+        "rateLimit1m": 500,
+        "rateLimit1h": 6900,
+      }
     },
     "ws": {}
   },


### PR DESCRIPTION
This PR replays #855 commits as if the original branch was `master` via `git rebase --onto master develop coingecko-add-tiers`. This is needed as it's a hotfix.


- Add more coingecko subscription tiers
- Update limits.json
- Update limits.json
