### PR TITLE
Enable WS support for tiingo equities

### DIFF
--- a/packages/core/bootstrap/src/lib/ws/index.ts
+++ b/packages/core/bootstrap/src/lib/ws/index.ts
@@ -20,6 +20,10 @@ export const withWebSockets =
     if (!makeWsHandler || !wsConfig.enabled) return await execute(input, context) // ignore middleware if conditions are met
 
     const wsHandler = await makeWsHandler()
+    if (wsHandler.shouldNotServeInputUsingWS && wsHandler.shouldNotServeInputUsingWS(input)) {
+      return await execute(input, context)
+    }
+
     if (wsHandler.programmaticConnectionInfo) {
       const programmaticConnectionInfo = wsHandler.programmaticConnectionInfo(input)
       if (programmaticConnectionInfo) {

--- a/packages/core/types/@chainlink/index.d.ts
+++ b/packages/core/types/@chainlink/index.d.ts
@@ -181,6 +181,8 @@ declare module '@chainlink/types' {
       url: string
       protocol?: any
     }
+    // Determines whether or not to server request using WS
+    shouldNotServeInputUsingWS?: (input: AdapterRequest) => boolean
     // Hook to send a message after connection
     onConnect?: () => any
     // Get the subscription message necessary to subscribe to the feed channel

--- a/packages/sources/tiingo/src/adapter.ts
+++ b/packages/sources/tiingo/src/adapter.ts
@@ -91,7 +91,8 @@ export const makeWSHandler = (config?: Config): MakeWSHandler | undefined => {
       connection: {
         url: defaultConfig.api.baseWsURL || DEFAULT_WS_API_ENDPOINT,
       },
-      shouldNotServeInputUsingWS: (input) => input.data.endpoint !== 'iex',
+      shouldNotServeInputUsingWS: (input) =>
+        endpoints.iex.supportedEndpoints.indexOf(input.data.endpoint) === -1,
       subscribe: (input) => getSubscription(getTicker(input)),
       unsubscribe: (input) => getSubscription(getTicker(input), false),
       isError: (message: Message) => message.messageType === 'E',

--- a/packages/sources/tiingo/src/config.ts
+++ b/packages/sources/tiingo/src/config.ts
@@ -5,7 +5,7 @@ export const NAME = 'TIINGO'
 
 export const DEFAULT_ENDPOINT = 'crypto'
 export const DEFAULT_BASE_URL = 'https://api.tiingo.com'
-export const DEFAULT_WS_API_ENDPOINT = 'wss://api.tiingo.com/crypto'
+export const DEFAULT_WS_API_ENDPOINT = 'wss://api.tiingo.com/iex'
 
 export const makeConfig = (prefix?: string): Config => {
   const config = Requester.getDefaultConfig(prefix, true)


### PR DESCRIPTION
This PR adds a new function property to WSHandler to filter out requests that should not be served using WS.  This is applied to the Tiingo adapter so that only requests to the IEX endpoint are served using WS.  I've intentionally left out tests for now and will add them to the PR once we feel good about how this is handled.