### PR TITLE
Refactor release with composite actions

### DIFF
--- a/.github/actions/release/matrix-adapters/action.yml
+++ b/.github/actions/release/matrix-adapters/action.yml
@@ -1,0 +1,32 @@
+name: Matrix Adapters
+
+description: Read build strategy matrix of adapters, from a json file
+
+inputs:
+  branch:
+    description: The current branch this workflow is running from, to include in an image tag, omit if you do not want to have the branch included in the image tag.
+    required: false
+  latest:
+    description: Set to "true" to create an image tag with the "latest" tag, "false" to use the external adapter's package.json version instead.
+    required: false
+  image-prefix:
+    description: 'Prefix to apply to docker images, in our case: typically an aws ECR registry'
+    required: true
+
+outputs:
+  matrix: ${{ steps.create-matrix.outputs.result }}
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '14.x'
+
+    - name: Generate job matrix
+      id: create-matrix
+      run: yarn generate:gha:matrix
+      env:
+        BRANCH: ${{ inputs.branch }}
+        LATEST: ${{ inputs.latest }}
+        IMAGE_PREFIX: ${{ inputs.image-prefix }}

--- a/.github/actions/release/publish-artifacts/action.yml
+++ b/.github/actions/release/publish-artifacts/action.yml
@@ -1,0 +1,48 @@
+name: Release
+description: Creates a release via building the required external adapters and publishing them. Must have aws credentials already configured
+inputs:
+  branch:
+    description: The current branch this workflow is running from, to include in an image tag, omit if you do not want to have the branch included in the image tag.
+    required: false
+  latest:
+    description: Set to "true" to create an image tag with the "latest" tag, "false" to use the external adapter's package.json version instead.
+    required: false
+  image-prefix:
+    description: 'Prefix to apply to docker images, in our case: typically an aws ECR registry'
+    required: true
+
+  aws-region:
+    description: The aws region to use
+    required: true
+  aws-ecr-cmd:
+    description: The aws ecr command to use, either "ecr" or "ecr-public"
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '14.x'
+
+    - name: Install yarn deps
+      run: yarn
+
+    - name: Generate docker-compose file
+      run: yarn generate:docker-compose
+      env:
+        BRANCH: ${{ inputs.branch }}
+        LATEST: ${{ inputs.latest }}
+        IMAGE_PREFIX: ${{ inputs.image-prefix }}
+
+    - name: Build Docker containers
+      run: docker-compose -f docker-compose.generated.yaml build ${{ matrix.adapter.name }}
+
+    - name: Authenticate to ECR
+      run: aws ecr-public get-login-password --region ${{ inputs.aws-region }} | docker login --username AWS --password-stdin ${{ inputs.image-prefix }}
+
+    - name: Create a public ECR repository if does not exist
+      run: aws ecr-public create-repository --region ${{ inputs.aws-region }} --repository-name adapters/${{ matrix.adapter.name }} || true
+
+    - name: Push to ECR
+      run: docker push ${{ matrix.adapter.image_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
       # On develop, we build and publish containers, with the tag of "develop-latest"
 
       # Ex. A newly build coingecko adapter is built and pushed to ECR.
-      # The ECR registry is reachable at public.ecr.aws/chainlink/adapters/
+      # The ECR registry is reachable at public.ecr.aws/chainlink/adapters/, or at the private registry
 
       # You would be able to pull the coingecko adapter with the following command:
       # docker pull public.ecr.aws/chainlink/adapters/coingecko-adapter:develop-latest
@@ -33,23 +33,19 @@ env:
   publicecr-name: chainlink
 
 jobs:
-  # Read build strategy matrix of adapters, from a json file
   matrix-adapters:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.create-matrix.outputs.result }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '14.x'
       - name: Generate job matrix
         id: create-matrix
-        run: yarn generate:gha:matrix
-        env:
-          BRANCH: ${{ fromJSON('[undefined, "develop"]')[github.ref == 'refs/heads/develop'] }}
-          LATEST: ${{ fromJSON('[undefined, true]')[github.ref == 'refs/heads/develop'] }}
-          IMAGE_PREFIX: public.ecr.aws/${{ env.publicecr-name }}/adapters/
+        uses: ./.github/actions/release/matrix-adapters
+        with:
+          branch: ${{ fromJSON('[undefined, "develop"]')[github.ref == 'refs/heads/develop'] }}
+          latest: ${{ fromJSON('[undefined, true]')[github.ref == 'refs/heads/develop'] }}
+          image-prefix: public.ecr.aws/${{ env.publicecr-name }}/adapters/
 
   publish-artifacts:
     needs: [matrix-adapters]
@@ -59,20 +55,6 @@ jobs:
       matrix: ${{fromJson(needs.matrix-adapters.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '14.x'
-      - name: Install yarn deps
-        run: yarn
-      - name: Generate docker-compose file
-        run: yarn generate:docker-compose
-        env:
-          BRANCH: ${{ fromJSON('[undefined, "develop"]')[github.ref == 'refs/heads/develop'] }}
-          LATEST: ${{ fromJSON('[undefined, true]')[github.ref == 'refs/heads/develop'] }}
-          IMAGE_PREFIX: public.ecr.aws/${{ env.publicecr-name }}/adapters/
-      - name: Build Docker containers
-        run: docker-compose -f docker-compose.generated.yaml build ${{ matrix.adapter.name }}
-      # Public ECR portion
       - name: Configure AWS Credentials for SDLC Public ECR
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -81,25 +63,49 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
           role-to-assume: ${{ secrets.AWS_PUBLICECR_ROLE_ARN }}
           role-duration-seconds: 1200
-      - name: Authenticate to public ECR
-        run: aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/${{ env.publicecr-name }}
-      - name: Create a public ECR repository if does not exist
-        run: aws ecr-public create-repository --region us-east-1 --repository-name adapters/${{ matrix.adapter.name }} || true
-      - name: Push to public ECR
-        run: docker push ${{ matrix.adapter.image_name }}
-      # Private ECR portion
+      - uses: ./.github/actions/release/publish-artifacts
+        with:
+          branch: ${{ fromJSON('[undefined, "develop"]')[github.ref == 'refs/heads/develop'] }}
+          latest: ${{ fromJSON('[undefined, true]')[github.ref == 'refs/heads/develop'] }}
+          image-prefix: public.ecr.aws/${{ env.publicecr-name }}/adapters/
+          aws-region: us-east-1
+          aws-ecr-cmd: ecr-public
+
+  matrix-adapters-private:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.create-matrix.outputs.result }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Generate job matrix
+        id: create-matrix
+        uses: ./.github/actions/release/matrix-adapters
+        with:
+          branch: ${{ fromJSON('[undefined, "develop"]')[github.ref == 'refs/heads/develop'] }}
+          latest: ${{ fromJSON('[undefined, true]')[github.ref == 'refs/heads/develop'] }}
+          image-prefix: ${{ secrets.STAGING_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/
+
+  publish-artifacts-private:
+    needs: [matrix-adapters-private]
+    runs-on: ubuntu-latest
+    name: (${{ matrix.adapter.type }}) Publish ${{ matrix.adapter.name }} adapter Docker image
+    strategy:
+      matrix: ${{fromJson(needs.matrix-adapters-private.outputs.matrix)}}
+    steps:
+      - uses: actions/checkout@v2
       - name: Configure AWS Credentials for Staging Private ECR
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_PRIVATEECR_ACCESSKEY }}
           aws-secret-access-key: ${{ secrets.AWS_PRIVATEECR_SECRETKEY }}
           aws-region: ${{ secrets.AWS_REGION }}
-      - name: Authenticate to ECR
-        run: aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | docker login --username AWS --password-stdin ${{ secrets.STAGING_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com
-      - name: Create a private staging ECR repository if does not exist
-        run: aws ecr create-repository --region ${{ secrets.AWS_REGION }} --repository-name adapters/${{ matrix.adapter.name }} || true
-      - name: Push to ECR
-        run: docker push ${{ matrix.adapter.image_name }}
+      - uses: ./.github/actions/release/publish-artifacts
+        with:
+          branch: ${{ fromJSON('[undefined, "develop"]')[github.ref == 'refs/heads/develop'] }}
+          latest: ${{ fromJSON('[undefined, true]')[github.ref == 'refs/heads/develop'] }}
+          image-prefix: ${{ secrets.STAGING_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/
+          aws-region: ${{ secrets.AWS_REGION }}
+          aws-ecr-cmd: ecr
 
   # Run the same steps as above, but this is to re-tag release images as latest
   # So released images have a latest tag on them too.
@@ -113,15 +119,12 @@ jobs:
       matrix: ${{ steps.create-matrix.outputs.result }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '14.x'
       - name: Generate job matrix
         id: create-matrix
-        run: yarn generate:gha:matrix
-        env:
-          LATEST: true
-          IMAGE_PREFIX: public.ecr.aws/${{ env.publicecr-name }}/adapters/
+        uses: ./.github/actions/release/matrix-adapters
+        with:
+          latest: true
+          image-prefix: public.ecr.aws/${{ env.publicecr-name }}/adapters/
 
   publish-artifacts-release-latest:
     if: github.ref != 'refs/heads/develop'
@@ -132,19 +135,6 @@ jobs:
       matrix: ${{fromJson(needs.matrix-adapters-release-latest.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '14.x'
-      - name: Install yarn deps
-        run: yarn
-      - name: Generate docker-compose file
-        run: yarn generate:docker-compose
-        env:
-          LATEST: true
-          IMAGE_PREFIX: public.ecr.aws/${{ env.publicecr-name }}/adapters/
-      - name: Build Docker containers
-        run: docker-compose -f docker-compose.generated.yaml build ${{ matrix.adapter.name }}
-      # Public ECR portion
       - name: Configure AWS Credentials for SDLC Public ECR
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -153,22 +143,45 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
           role-to-assume: ${{ secrets.AWS_PUBLICECR_ROLE_ARN }}
           role-duration-seconds: 1200
-      - name: Authenticate to public ECR
-        run: aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/${{ env.publicecr-name }}
-      - name: Create a public ECR repository if does not exist
-        run: aws ecr-public create-repository --region us-east-1 --repository-name adapters/${{ matrix.adapter.name }} || true
-      - name: Push to public ECR
-        run: docker push ${{ matrix.adapter.image_name }}
-      # Private ECR portion
+      - uses: ./.github/actions/release/publish-artifacts
+        with:
+          latest: true
+          image-prefix: public.ecr.aws/${{ env.publicecr-name }}/adapters/
+          aws-region: us-east-1
+          aws-ecr-cmd: ecr-public
+
+  matrix-adapters-release-private-latest:
+    if: github.ref != 'refs/heads/develop'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.create-matrix.outputs.result }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Generate job matrix
+        id: create-matrix
+        uses: ./.github/actions/release/matrix-adapters
+        with:
+          latest: true
+          image-prefix: ${{ secrets.STAGING_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/
+
+  publish-artifacts-release-private-latest:
+    if: github.ref != 'refs/heads/develop'
+    needs: [matrix-adapters-release-private-latest]
+    runs-on: ubuntu-latest
+    name: (${{ matrix.adapter.type }}) Publish ${{ matrix.adapter.name }} adapter Docker image
+    strategy:
+      matrix: ${{fromJson(needs.matrix-adapters-release-latest.outputs.matrix)}}
+    steps:
+      - uses: actions/checkout@v2
       - name: Configure AWS Credentials for Staging Private ECR
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_PRIVATEECR_ACCESSKEY }}
           aws-secret-access-key: ${{ secrets.AWS_PRIVATEECR_SECRETKEY }}
           aws-region: ${{ secrets.AWS_REGION }}
-      - name: Authenticate to ECR
-        run: aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | docker login --username AWS --password-stdin ${{ secrets.STAGING_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com
-      - name: Create a private staging ECR repository if does not exist
-        run: aws ecr create-repository --region ${{ secrets.AWS_REGION }} --repository-name adapters/${{ matrix.adapter.name }} || true
-      - name: Push to ECR
-        run: docker push ${{ matrix.adapter.image_name }}
+      - uses: ./.github/actions/release/publish-artifacts
+        with:
+          latest: true
+          image-prefix: ${{ secrets.STAGING_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com
+          aws-region: ${{ secrets.AWS_REGION }}
+          aws-ecr-cmd: ecr-public


### PR DESCRIPTION
We needed to add 2 more jobs to our release workflow to properly publish private artifacts, but this caused ballooning of the release file due to redundancy. This PR splits out common steps into composite actions and reuses them across our 8 release jobs.