### PR TITLE
Private ECR Support to CD Pipeline

### DIFF
--- a/.github/actions/release/matrix-adapters/action.yml
+++ b/.github/actions/release/matrix-adapters/action.yml
@@ -2,14 +2,6 @@ name: Matrix Adapters
 
 description: Read build strategy matrix of adapters, from a json file
 
-inputs:
-  branch:
-    description: The current branch this workflow is running from, to include in an image tag, omit if you do not want to have the branch included in the image tag.
-    required: false
-  latest:
-    description: Set to "true" to create an image tag with the "latest" tag, "false" to use the external adapter's package.json version instead.
-    required: false
-
 outputs:
   result:
     value: ${{ steps.create-matrix.outputs.result }}
@@ -25,6 +17,3 @@ runs:
       id: create-matrix
       shell: bash
       run: yarn generate:gha:matrix
-      env:
-        BRANCH: ${{ inputs.branch }}
-        LATEST: ${{ inputs.latest }}

--- a/.github/actions/release/matrix-adapters/action.yml
+++ b/.github/actions/release/matrix-adapters/action.yml
@@ -9,9 +9,6 @@ inputs:
   latest:
     description: Set to "true" to create an image tag with the "latest" tag, "false" to use the external adapter's package.json version instead.
     required: false
-  image-prefix:
-    description: 'Prefix to apply to docker images, in our case: typically an aws ECR registry'
-    required: true
 
 outputs:
   result:
@@ -31,4 +28,3 @@ runs:
       env:
         BRANCH: ${{ inputs.branch }}
         LATEST: ${{ inputs.latest }}
-        IMAGE_PREFIX: ${{ inputs.image-prefix }}

--- a/.github/actions/release/matrix-adapters/action.yml
+++ b/.github/actions/release/matrix-adapters/action.yml
@@ -1,0 +1,32 @@
+name: Matrix Adapters
+
+description: Read build strategy matrix of adapters, from a json file
+
+inputs:
+  branch:
+    description: The current branch this workflow is running from, to include in an image tag, omit if you do not want to have the branch included in the image tag.
+    required: false
+  latest:
+    description: Set to "true" to create an image tag with the "latest" tag, "false" to use the external adapter's package.json version instead.
+    required: false
+  image-prefix:
+    description: 'Prefix to apply to docker images, in our case: typically an aws ECR registry'
+    required: true
+
+outputs:
+  matrix: ${{ steps.create-matrix.outputs.result }}
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '14.x'
+
+    - name: Generate job matrix
+      id: create-matrix
+      run: yarn generate:gha:matrix
+      env:
+        BRANCH: ${{ inputs.branch }}
+        LATEST: ${{ inputs.latest }}
+        IMAGE_PREFIX: ${{ inputs.image-prefix }}

--- a/.github/actions/release/matrix-adapters/action.yml
+++ b/.github/actions/release/matrix-adapters/action.yml
@@ -14,7 +14,8 @@ inputs:
     required: true
 
 outputs:
-  matrix: ${{ steps.create-matrix.outputs.result }}
+  result:
+    value: ${{ steps.create-matrix.outputs.result }}
 
 runs:
   using: 'composite'
@@ -25,6 +26,7 @@ runs:
 
     - name: Generate job matrix
       id: create-matrix
+      shell: bash
       run: yarn generate:gha:matrix
       env:
         BRANCH: ${{ inputs.branch }}

--- a/.github/actions/release/publish-artifacts/action.yml
+++ b/.github/actions/release/publish-artifacts/action.yml
@@ -10,6 +10,9 @@ inputs:
   image-prefix:
     description: 'Prefix to apply to docker images, in our case: typically an aws ECR registry'
     required: true
+  adapter-name:
+    description: 'The name of the adapter'
+    required: true
 
   aws-region:
     description: The aws region to use
@@ -37,9 +40,19 @@ runs:
         LATEST: ${{ inputs.latest }}
         IMAGE_PREFIX: ${{ inputs.image-prefix }}
 
+    - name: Generate adapter image name
+      shell: bash
+      run: yarn generate:image-name
+      id: generate-image-name
+      env:
+        BRANCH: ${{ inputs.branch }}
+        LATEST: ${{ inputs.latest }}
+        IMAGE_PREFIX: ${{ inputs.image-prefix }}
+        ADAPTER_NAME: ${{ inputs.adapter-name }}
+
     - name: Build Docker containers
       shell: bash
-      run: docker-compose -f docker-compose.generated.yaml build ${{ matrix.adapter.name }}
+      run: docker-compose -f docker-compose.generated.yaml build ${{ inputs.adapter-name }}
 
     - name: Authenticate to ECR
       shell: bash
@@ -47,8 +60,8 @@ runs:
 
     - name: Create a public ECR repository if does not exist
       shell: bash
-      run: aws ecr-public create-repository --region ${{ inputs.aws-region }} --repository-name adapters/${{ matrix.adapter.name }} || true
+      run: aws ecr-public create-repository --region ${{ inputs.aws-region }} --repository-name adapters/${{ inputs.adapter-name }} || true
 
     - name: Push to ECR
       shell: bash
-      run: docker push ${{ matrix.adapter.image_name }}
+      run: docker push ${{ steps.generate-image-name.outputs.image_name }}

--- a/.github/actions/release/publish-artifacts/action.yml
+++ b/.github/actions/release/publish-artifacts/action.yml
@@ -56,11 +56,11 @@ runs:
 
     - name: Authenticate to ECR
       shell: bash
-      run: aws ecr-public get-login-password --region ${{ inputs.aws-region }} | docker login --username AWS --password-stdin ${{ inputs.image-prefix }}
+      run: aws ${{ inputs.aws-ecr-cmd }} get-login-password --region ${{ inputs.aws-region }} | docker login --username AWS --password-stdin ${{ inputs.image-prefix }}
 
     - name: Create a public ECR repository if does not exist
       shell: bash
-      run: aws ecr-public create-repository --region ${{ inputs.aws-region }} --repository-name adapters/${{ inputs.adapter-name }} || true
+      run: aws ${{ inputs.aws-ecr-cmd }} create-repository --region ${{ inputs.aws-region }} --repository-name adapters/${{ inputs.adapter-name }} || true
 
     - name: Push to ECR
       shell: bash

--- a/.github/actions/release/publish-artifacts/action.yml
+++ b/.github/actions/release/publish-artifacts/action.yml
@@ -1,0 +1,48 @@
+name: Release
+description: Creates a release via building the required external adapters and publishing them. Must have aws credentials already configured
+inputs:
+  branch:
+    description: The current branch this workflow is running from, to include in an image tag, omit if you do not want to have the branch included in the image tag.
+    required: false
+  latest:
+    description: Set to "true" to create an image tag with the "latest" tag, "false" to use the external adapter's package.json version instead.
+    required: false
+  image-prefix:
+    description: 'Prefix to apply to docker images, in our case: typically an aws ECR registry'
+    required: true
+
+  aws-region:
+    description: The aws region to use
+    required: true
+  aws-ecr-cmd:
+    description: The aws ecr command to use, either "ecr" or "ecr-public"
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '14.x'
+
+    - name: Install yarn deps
+      run: yarn
+
+    - name: Generate docker-compose file
+      run: yarn generate:docker-compose
+      env:
+        BRANCH: ${{ inputs.branch }}
+        LATEST: ${{ inputs.latest }}
+        IMAGE_PREFIX: ${{ inputs.image-prefix }}
+
+    - name: Build Docker containers
+      run: docker-compose -f docker-compose.generated.yaml build ${{ matrix.adapter.name }}
+
+    - name: Authenticate to ECR
+      run: aws ecr-public get-login-password --region ${{ inputs.aws-region }} | docker login --username AWS --password-stdin ${{ inputs.image-prefix }}
+
+    - name: Create a public ECR repository if does not exist
+      run: aws ecr-public create-repository --region ${{ inputs.aws-region }} --repository-name adapters/${{ matrix.adapter.name }} || true
+
+    - name: Push to ECR
+      run: docker push ${{ matrix.adapter.image_name }}

--- a/.github/actions/release/publish-artifacts/action.yml
+++ b/.github/actions/release/publish-artifacts/action.yml
@@ -58,7 +58,7 @@ runs:
       shell: bash
       run: aws ${{ inputs.aws-ecr-cmd }} get-login-password --region ${{ inputs.aws-region }} | docker login --username AWS --password-stdin ${{ inputs.image-prefix }}
 
-    - name: Create a public ECR repository if does not exist
+    - name: Create a ECR repository if does not exist
       shell: bash
       run: aws ${{ inputs.aws-ecr-cmd }} create-repository --region ${{ inputs.aws-region }} --repository-name adapters/${{ inputs.adapter-name }} || true
 

--- a/.github/actions/release/publish-artifacts/action.yml
+++ b/.github/actions/release/publish-artifacts/action.yml
@@ -26,9 +26,11 @@ runs:
         node-version: '14.x'
 
     - name: Install yarn deps
+      shell: bash
       run: yarn
 
     - name: Generate docker-compose file
+      shell: bash
       run: yarn generate:docker-compose
       env:
         BRANCH: ${{ inputs.branch }}
@@ -36,13 +38,17 @@ runs:
         IMAGE_PREFIX: ${{ inputs.image-prefix }}
 
     - name: Build Docker containers
+      shell: bash
       run: docker-compose -f docker-compose.generated.yaml build ${{ matrix.adapter.name }}
 
     - name: Authenticate to ECR
+      shell: bash
       run: aws ecr-public get-login-password --region ${{ inputs.aws-region }} | docker login --username AWS --password-stdin ${{ inputs.image-prefix }}
 
     - name: Create a public ECR repository if does not exist
+      shell: bash
       run: aws ecr-public create-repository --region ${{ inputs.aws-region }} --repository-name adapters/${{ matrix.adapter.name }} || true
 
     - name: Push to ECR
+      shell: bash
       run: docker push ${{ matrix.adapter.image_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
         with:
           branch: ${{ fromJSON('[undefined, "develop"]')[github.ref == 'refs/heads/develop'] }}
           latest: ${{ fromJSON('[undefined, true]')[github.ref == 'refs/heads/develop'] }}
-          image-prefix: ${{ secrets.STAGING_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/
+          image-prefix: ${{ secrets.SDLC_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/
 
   publish-artifacts-private:
     needs: [matrix-adapters-private]
@@ -93,7 +93,7 @@ jobs:
       matrix: ${{fromJson(needs.matrix-adapters-private.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v2
-      - name: Configure AWS Credentials for Staging Private ECR
+      - name: Configure AWS Credentials for SDLC Private ECR
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_PRIVATEECR_ACCESSKEY }}
@@ -103,7 +103,7 @@ jobs:
         with:
           branch: ${{ fromJSON('[undefined, "develop"]')[github.ref == 'refs/heads/develop'] }}
           latest: ${{ fromJSON('[undefined, true]')[github.ref == 'refs/heads/develop'] }}
-          image-prefix: ${{ secrets.STAGING_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/
+          image-prefix: ${{ secrets.SDLC_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/
           aws-region: ${{ secrets.AWS_REGION }}
           aws-ecr-cmd: ecr
 
@@ -162,7 +162,7 @@ jobs:
         uses: ./.github/actions/release/matrix-adapters
         with:
           latest: true
-          image-prefix: ${{ secrets.STAGING_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/
+          image-prefix: ${{ secrets.SDLC_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/
 
   publish-artifacts-release-private-latest:
     if: github.ref != 'refs/heads/develop'
@@ -173,7 +173,7 @@ jobs:
       matrix: ${{fromJson(needs.matrix-adapters-release-latest.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v2
-      - name: Configure AWS Credentials for Staging Private ECR
+      - name: Configure AWS Credentials for SDLC Private ECR
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_PRIVATEECR_ACCESSKEY }}
@@ -182,6 +182,6 @@ jobs:
       - uses: ./.github/actions/release/publish-artifacts
         with:
           latest: true
-          image-prefix: ${{ secrets.STAGING_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com
+          image-prefix: ${{ secrets.SDLC_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com
           aws-region: ${{ secrets.AWS_REGION }}
           aws-ecr-cmd: ecr-public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,9 +43,6 @@ jobs:
       - name: Generate job matrix
         id: create-matrix
         uses: ./.github/actions/release/matrix-adapters
-        with:
-          branch: ${{ fromJSON('[undefined, "develop"]')[github.ref == 'refs/heads/develop'] }}
-          latest: ${{ fromJSON('[undefined, true]')[github.ref == 'refs/heads/develop'] }}
 
   publish-artifacts:
     needs: [matrix-adapters]
@@ -81,9 +78,6 @@ jobs:
       - name: Generate job matrix
         id: create-matrix
         uses: ./.github/actions/release/matrix-adapters
-        with:
-          branch: ${{ fromJSON('[undefined, "develop"]')[github.ref == 'refs/heads/develop'] }}
-          latest: ${{ fromJSON('[undefined, true]')[github.ref == 'refs/heads/develop'] }}
 
   publish-artifacts-private:
     needs: [matrix-adapters-private]
@@ -112,9 +106,9 @@ jobs:
   # So released images have a latest tag on them too.
   # E.g. Releasing @chainlink/coingecko@0.0.3 will have the tag of 0.0.3 from the above jobs
   # and a tag of 'latest' from the below jobs.
-  # This is only needed for non-develop jobs since the same image needs to be tagged twice
+  # This is only needed for master jobs since the same image needs to be tagged twice
   matrix-adapters-release-latest:
-    if: github.ref != 'refs/heads/develop'
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.create-matrix.outputs.result }}
@@ -123,11 +117,9 @@ jobs:
       - name: Generate job matrix
         id: create-matrix
         uses: ./.github/actions/release/matrix-adapters
-        with:
-          latest: true
 
   publish-artifacts-release-latest:
-    if: github.ref != 'refs/heads/develop'
+    if: github.ref == 'refs/heads/master'
     needs: [matrix-adapters-release-latest]
     runs-on: ubuntu-latest
     name: (${{ matrix.adapter.type }}) Publish ${{ matrix.adapter.name }} adapter Docker image
@@ -153,7 +145,7 @@ jobs:
           aws-ecr-cmd: ecr-public
 
   matrix-adapters-release-private-latest:
-    if: github.ref != 'refs/heads/develop'
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.create-matrix.outputs.result }}
@@ -162,11 +154,9 @@ jobs:
       - name: Generate job matrix
         id: create-matrix
         uses: ./.github/actions/release/matrix-adapters
-        with:
-          latest: true
 
   publish-artifacts-release-private-latest:
-    if: github.ref != 'refs/heads/develop'
+    if: github.ref == 'refs/heads/master'
     needs: [matrix-adapters-release-private-latest]
     runs-on: ubuntu-latest
     name: (${{ matrix.adapter.type }}) Publish ${{ matrix.adapter.name }} adapter Docker image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,6 @@ jobs:
         with:
           branch: ${{ fromJSON('[undefined, "develop"]')[github.ref == 'refs/heads/develop'] }}
           latest: ${{ fromJSON('[undefined, true]')[github.ref == 'refs/heads/develop'] }}
-          image-prefix: public.ecr.aws/${{ env.publicecr-name }}/adapters/
 
   publish-artifacts:
     needs: [matrix-adapters]
@@ -84,7 +83,6 @@ jobs:
         with:
           branch: ${{ fromJSON('[undefined, "develop"]')[github.ref == 'refs/heads/develop'] }}
           latest: ${{ fromJSON('[undefined, true]')[github.ref == 'refs/heads/develop'] }}
-          image-prefix: ${{ secrets.SDLC_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/
 
   publish-artifacts-private:
     needs: [matrix-adapters-private]
@@ -125,7 +123,6 @@ jobs:
         uses: ./.github/actions/release/matrix-adapters
         with:
           latest: true
-          image-prefix: public.ecr.aws/${{ env.publicecr-name }}/adapters/
 
   publish-artifacts-release-latest:
     if: github.ref != 'refs/heads/develop'
@@ -163,7 +160,6 @@ jobs:
         uses: ./.github/actions/release/matrix-adapters
         with:
           latest: true
-          image-prefix: ${{ secrets.SDLC_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/
 
   publish-artifacts-release-private-latest:
     if: github.ref != 'refs/heads/develop'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,13 +77,16 @@ jobs:
       matrix: ${{ steps.create-matrix.outputs.result }}
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
       - name: Generate job matrix
         id: create-matrix
-        uses: ./.github/actions/release/matrix-adapters
-        with:
-          branch: ${{ fromJSON('[undefined, "develop"]')[github.ref == 'refs/heads/develop'] }}
-          latest: ${{ fromJSON('[undefined, true]')[github.ref == 'refs/heads/develop'] }}
-          image-prefix: ${{ secrets.SDLC_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/
+        run: yarn generate:gha:matrix
+        env:
+          BRANCH: ${{ fromJSON('[undefined, "develop"]')[github.ref == 'refs/heads/develop'] }}
+          LATEST: ${{ fromJSON('[undefined, true]')[github.ref == 'refs/heads/develop'] }}
+          IMAGE_PREFIX: ${{ secrets.SDLC_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/
 
   publish-artifacts-private:
     needs: [matrix-adapters-private]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,7 @@ jobs:
           branch: ${{ fromJSON('[undefined, "develop"]')[github.ref == 'refs/heads/develop'] }}
           latest: ${{ fromJSON('[undefined, true]')[github.ref == 'refs/heads/develop'] }}
           image-prefix: public.ecr.aws/${{ env.publicecr-name }}/adapters/
+          adapter-name: ${{ matrix.adapter.name }}
           aws-region: us-east-1
           aws-ecr-cmd: ecr-public
 
@@ -103,6 +104,7 @@ jobs:
           branch: ${{ fromJSON('[undefined, "develop"]')[github.ref == 'refs/heads/develop'] }}
           latest: ${{ fromJSON('[undefined, true]')[github.ref == 'refs/heads/develop'] }}
           image-prefix: ${{ secrets.SDLC_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/
+          adapter-name: ${{ matrix.adapter.name }}
           aws-region: ${{ secrets.AWS_REGION }}
           aws-ecr-cmd: ecr
 
@@ -145,6 +147,8 @@ jobs:
         with:
           latest: true
           image-prefix: public.ecr.aws/${{ env.publicecr-name }}/adapters/
+          adapter-name: ${{ matrix.adapter.name }}
+
           aws-region: us-east-1
           aws-ecr-cmd: ecr-public
 
@@ -180,5 +184,7 @@ jobs:
         with:
           latest: true
           image-prefix: ${{ secrets.SDLC_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com
+          adapter-name: ${{ matrix.adapter.name }}
+
           aws-region: ${{ secrets.AWS_REGION }}
           aws-ecr-cmd: ecr-public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,16 +78,13 @@ jobs:
       matrix: ${{ steps.create-matrix.outputs.result }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '14.x'
       - name: Generate job matrix
         id: create-matrix
-        run: yarn generate:gha:matrix
-        env:
-          BRANCH: ${{ fromJSON('[undefined, "develop"]')[github.ref == 'refs/heads/develop'] }}
-          LATEST: ${{ fromJSON('[undefined, true]')[github.ref == 'refs/heads/develop'] }}
-          IMAGE_PREFIX: ${{ secrets.SDLC_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/
+        uses: ./.github/actions/release/matrix-adapters
+        with:
+          branch: ${{ fromJSON('[undefined, "develop"]')[github.ref == 'refs/heads/develop'] }}
+          latest: ${{ fromJSON('[undefined, true]')[github.ref == 'refs/heads/develop'] }}
+          image-prefix: ${{ secrets.SDLC_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/
 
   publish-artifacts-private:
     needs: [matrix-adapters-private]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
       # On develop, we build and publish containers, with the tag of "develop-latest"
 
       # Ex. A newly build coingecko adapter is built and pushed to ECR.
-      # The ECR registry is reachable at public.ecr.aws/chainlink/adapters/
+      # The ECR registry is reachable at public.ecr.aws/chainlink/adapters/, or at the private registry
 
       # You would be able to pull the coingecko adapter with the following command:
       # docker pull public.ecr.aws/chainlink/adapters/coingecko-adapter:develop-latest
@@ -33,23 +33,19 @@ env:
   publicecr-name: chainlink
 
 jobs:
-  # Read build strategy matrix of adapters, from a json file
   matrix-adapters:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.create-matrix.outputs.result }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '14.x'
       - name: Generate job matrix
         id: create-matrix
-        run: yarn generate:gha:matrix
-        env:
-          BRANCH: ${{ fromJSON('[undefined, "develop"]')[github.ref == 'refs/heads/develop'] }}
-          LATEST: ${{ fromJSON('[undefined, true]')[github.ref == 'refs/heads/develop'] }}
-          IMAGE_PREFIX: public.ecr.aws/${{ env.publicecr-name }}/adapters/
+        uses: ./.github/actions/release/matrix-adapters
+        with:
+          branch: ${{ fromJSON('[undefined, "develop"]')[github.ref == 'refs/heads/develop'] }}
+          latest: ${{ fromJSON('[undefined, true]')[github.ref == 'refs/heads/develop'] }}
+          image-prefix: public.ecr.aws/${{ env.publicecr-name }}/adapters/
 
   publish-artifacts:
     needs: [matrix-adapters]
@@ -59,20 +55,6 @@ jobs:
       matrix: ${{fromJson(needs.matrix-adapters.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '14.x'
-      - name: Install yarn deps
-        run: yarn
-      - name: Generate docker-compose file
-        run: yarn generate:docker-compose
-        env:
-          BRANCH: ${{ fromJSON('[undefined, "develop"]')[github.ref == 'refs/heads/develop'] }}
-          LATEST: ${{ fromJSON('[undefined, true]')[github.ref == 'refs/heads/develop'] }}
-          IMAGE_PREFIX: public.ecr.aws/${{ env.publicecr-name }}/adapters/
-      - name: Build Docker containers
-        run: docker-compose -f docker-compose.generated.yaml build ${{ matrix.adapter.name }}
-      # Public ECR portion
       - name: Configure AWS Credentials for SDLC Public ECR
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -81,25 +63,49 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
           role-to-assume: ${{ secrets.AWS_PUBLICECR_ROLE_ARN }}
           role-duration-seconds: 1200
-      - name: Authenticate to public ECR
-        run: aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/${{ env.publicecr-name }}
-      - name: Create a public ECR repository if does not exist
-        run: aws ecr-public create-repository --region us-east-1 --repository-name adapters/${{ matrix.adapter.name }} || true
-      - name: Push to public ECR
-        run: docker push ${{ matrix.adapter.image_name }}
-      # Private ECR portion
+      - uses: ./.github/actions/release/publish-artifacts
+        with:
+          branch: ${{ fromJSON('[undefined, "develop"]')[github.ref == 'refs/heads/develop'] }}
+          latest: ${{ fromJSON('[undefined, true]')[github.ref == 'refs/heads/develop'] }}
+          image-prefix: public.ecr.aws/${{ env.publicecr-name }}/adapters/
+          aws-region: us-east-1
+          aws-ecr-cmd: ecr-public
+
+  matrix-adapters-private:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.create-matrix.outputs.result }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Generate job matrix
+        id: create-matrix
+        uses: ./.github/actions/release/matrix-adapters
+        with:
+          branch: ${{ fromJSON('[undefined, "develop"]')[github.ref == 'refs/heads/develop'] }}
+          latest: ${{ fromJSON('[undefined, true]')[github.ref == 'refs/heads/develop'] }}
+          image-prefix: ${{ secrets.STAGING_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/
+
+  publish-artifacts-private:
+    needs: [matrix-adapters-private]
+    runs-on: ubuntu-latest
+    name: (${{ matrix.adapter.type }}) Publish ${{ matrix.adapter.name }} adapter Docker image
+    strategy:
+      matrix: ${{fromJson(needs.matrix-adapters-private.outputs.matrix)}}
+    steps:
+      - uses: actions/checkout@v2
       - name: Configure AWS Credentials for Staging Private ECR
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_PRIVATEECR_ACCESSKEY }}
           aws-secret-access-key: ${{ secrets.AWS_PRIVATEECR_SECRETKEY }}
           aws-region: ${{ secrets.AWS_REGION }}
-      - name: Authenticate to ECR
-        run: aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | docker login --username AWS --password-stdin ${{ secrets.STAGING_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com
-      - name: Create a private staging ECR repository if does not exist
-        run: aws ecr create-repository --region ${{ secrets.AWS_REGION }} --repository-name adapters/${{ matrix.adapter.name }} || true
-      - name: Push to ECR
-        run: docker push ${{ matrix.adapter.image_name }}
+      - uses: ./.github/actions/release/publish-artifacts
+        with:
+          branch: ${{ fromJSON('[undefined, "develop"]')[github.ref == 'refs/heads/develop'] }}
+          latest: ${{ fromJSON('[undefined, true]')[github.ref == 'refs/heads/develop'] }}
+          image-prefix: ${{ secrets.STAGING_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/
+          aws-region: ${{ secrets.AWS_REGION }}
+          aws-ecr-cmd: ecr
 
   # Run the same steps as above, but this is to re-tag release images as latest
   # So released images have a latest tag on them too.
@@ -113,15 +119,12 @@ jobs:
       matrix: ${{ steps.create-matrix.outputs.result }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '14.x'
       - name: Generate job matrix
         id: create-matrix
-        run: yarn generate:gha:matrix
-        env:
-          LATEST: true
-          IMAGE_PREFIX: public.ecr.aws/${{ env.publicecr-name }}/adapters/
+        uses: ./.github/actions/release/matrix-adapters
+        with:
+          latest: true
+          image-prefix: public.ecr.aws/${{ env.publicecr-name }}/adapters/
 
   publish-artifacts-release-latest:
     if: github.ref != 'refs/heads/develop'
@@ -132,19 +135,6 @@ jobs:
       matrix: ${{fromJson(needs.matrix-adapters-release-latest.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '14.x'
-      - name: Install yarn deps
-        run: yarn
-      - name: Generate docker-compose file
-        run: yarn generate:docker-compose
-        env:
-          LATEST: true
-          IMAGE_PREFIX: public.ecr.aws/${{ env.publicecr-name }}/adapters/
-      - name: Build Docker containers
-        run: docker-compose -f docker-compose.generated.yaml build ${{ matrix.adapter.name }}
-      # Public ECR portion
       - name: Configure AWS Credentials for SDLC Public ECR
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -153,22 +143,45 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
           role-to-assume: ${{ secrets.AWS_PUBLICECR_ROLE_ARN }}
           role-duration-seconds: 1200
-      - name: Authenticate to public ECR
-        run: aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/${{ env.publicecr-name }}
-      - name: Create a public ECR repository if does not exist
-        run: aws ecr-public create-repository --region us-east-1 --repository-name adapters/${{ matrix.adapter.name }} || true
-      - name: Push to public ECR
-        run: docker push ${{ matrix.adapter.image_name }}
-      # Private ECR portion
+      - uses: ./.github/actions/release/publish-artifacts
+        with:
+          latest: true
+          image-prefix: public.ecr.aws/${{ env.publicecr-name }}/adapters/
+          aws-region: us-east-1
+          aws-ecr-cmd: ecr-public
+
+  matrix-adapters-release-private-latest:
+    if: github.ref != 'refs/heads/develop'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.create-matrix.outputs.result }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Generate job matrix
+        id: create-matrix
+        uses: ./.github/actions/release/matrix-adapters
+        with:
+          latest: true
+          image-prefix: ${{ secrets.STAGING_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/
+
+  publish-artifacts-release-private-latest:
+    if: github.ref != 'refs/heads/develop'
+    needs: [matrix-adapters-release-private-latest]
+    runs-on: ubuntu-latest
+    name: (${{ matrix.adapter.type }}) Publish ${{ matrix.adapter.name }} adapter Docker image
+    strategy:
+      matrix: ${{fromJson(needs.matrix-adapters-release-latest.outputs.matrix)}}
+    steps:
+      - uses: actions/checkout@v2
       - name: Configure AWS Credentials for Staging Private ECR
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_PRIVATEECR_ACCESSKEY }}
           aws-secret-access-key: ${{ secrets.AWS_PRIVATEECR_SECRETKEY }}
           aws-region: ${{ secrets.AWS_REGION }}
-      - name: Authenticate to ECR
-        run: aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | docker login --username AWS --password-stdin ${{ secrets.STAGING_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com
-      - name: Create a private staging ECR repository if does not exist
-        run: aws ecr create-repository --region ${{ secrets.AWS_REGION }} --repository-name adapters/${{ matrix.adapter.name }} || true
-      - name: Push to ECR
-        run: docker push ${{ matrix.adapter.image_name }}
+      - uses: ./.github/actions/release/publish-artifacts
+        with:
+          latest: true
+          image-prefix: ${{ secrets.STAGING_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com
+          aws-region: ${{ secrets.AWS_REGION }}
+          aws-ecr-cmd: ecr-public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,7 @@ jobs:
     name: (${{ matrix.adapter.type }}) Publish ${{ matrix.adapter.name }} adapter Docker image
     strategy:
       matrix: ${{fromJson(needs.matrix-adapters.outputs.matrix)}}
+      max-parallel: 50
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,8 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
           role-to-assume: ${{ secrets.AWS_PUBLICECR_ROLE_ARN }}
           role-duration-seconds: 1200
-      - uses: ./.github/actions/release/publish-artifacts
+      - name: Publish adapter to public ECR
+        uses: ./.github/actions/release/publish-artifacts
         with:
           branch: ${{ fromJSON('[undefined, "develop"]')[github.ref == 'refs/heads/develop'] }}
           latest: ${{ fromJSON('[undefined, true]')[github.ref == 'refs/heads/develop'] }}
@@ -73,6 +74,7 @@ jobs:
           aws-ecr-cmd: ecr-public
       # If we're on master, publish again with a forced 'latest' tag
       - if: github.ref == 'refs/heads/master'
+        name: Publish adapter to public ECR, with forced latest tag
         uses: ./.github/actions/release/publish-artifacts
         with:
           latest: true
@@ -89,7 +91,8 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_PRIVATEECR_ACCESSKEY }}
           aws-secret-access-key: ${{ secrets.AWS_PRIVATEECR_SECRETKEY }}
           aws-region: ${{ secrets.AWS_REGION }}
-      - uses: ./.github/actions/release/publish-artifacts
+      - name: Publish adapter to private ECR
+        uses: ./.github/actions/release/publish-artifacts
         with:
           branch: ${{ fromJSON('[undefined, "develop"]')[github.ref == 'refs/heads/develop'] }}
           latest: ${{ fromJSON('[undefined, true]')[github.ref == 'refs/heads/develop'] }}
@@ -100,6 +103,7 @@ jobs:
           aws-ecr-cmd: ecr
       # If we're on master, publish again with a forced 'latest' tag
       - if: github.ref == 'refs/heads/master'
+        name: Publish adapter to private ECR, with forced latest tag
         uses: ./.github/actions/release/publish-artifacts
         with:
           latest: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,8 @@ jobs:
       matrix: ${{fromJson(needs.matrix-adapters.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v2
+
+      # Handle publishing to our public ECR repo
       - name: Configure AWS Credentials for SDLC Public ECR
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -64,29 +66,23 @@ jobs:
         with:
           branch: ${{ fromJSON('[undefined, "develop"]')[github.ref == 'refs/heads/develop'] }}
           latest: ${{ fromJSON('[undefined, true]')[github.ref == 'refs/heads/develop'] }}
+
+          image-prefix: public.ecr.aws/${{ env.publicecr-name }}/adapters/
+          adapter-name: ${{ matrix.adapter.name }}
+          aws-region: us-east-1
+          aws-ecr-cmd: ecr-public
+      # If we're on master, publish again with a forced 'latest' tag
+      - if: github.ref == 'refs/heads/master'
+        uses: ./.github/actions/release/publish-artifacts
+        with:
+          latest: true
+
           image-prefix: public.ecr.aws/${{ env.publicecr-name }}/adapters/
           adapter-name: ${{ matrix.adapter.name }}
           aws-region: us-east-1
           aws-ecr-cmd: ecr-public
 
-  matrix-adapters-private:
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.create-matrix.outputs.result }}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Generate job matrix
-        id: create-matrix
-        uses: ./.github/actions/release/matrix-adapters
-
-  publish-artifacts-private:
-    needs: [matrix-adapters-private]
-    runs-on: ubuntu-latest
-    name: (${{ matrix.adapter.type }}) Publish ${{ matrix.adapter.name }} adapter Docker image
-    strategy:
-      matrix: ${{fromJson(needs.matrix-adapters-private.outputs.matrix)}}
-    steps:
-      - uses: actions/checkout@v2
+      # Handle publishing to our private ECR repo
       - name: Configure AWS Credentials for SDLC Private ECR
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -97,84 +93,18 @@ jobs:
         with:
           branch: ${{ fromJSON('[undefined, "develop"]')[github.ref == 'refs/heads/develop'] }}
           latest: ${{ fromJSON('[undefined, true]')[github.ref == 'refs/heads/develop'] }}
+
           image-prefix: ${{ secrets.SDLC_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/
           adapter-name: ${{ matrix.adapter.name }}
           aws-region: ${{ secrets.AWS_REGION }}
           aws-ecr-cmd: ecr
-
-  # Run the same steps as above, but this is to re-tag release images as latest
-  # So released images have a latest tag on them too.
-  # E.g. Releasing @chainlink/coingecko@0.0.3 will have the tag of 0.0.3 from the above jobs
-  # and a tag of 'latest' from the below jobs.
-  # This is only needed for master jobs since the same image needs to be tagged twice
-  matrix-adapters-release-latest:
-    if: github.ref == 'refs/heads/master'
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.create-matrix.outputs.result }}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Generate job matrix
-        id: create-matrix
-        uses: ./.github/actions/release/matrix-adapters
-
-  publish-artifacts-release-latest:
-    if: github.ref == 'refs/heads/master'
-    needs: [matrix-adapters-release-latest]
-    runs-on: ubuntu-latest
-    name: (${{ matrix.adapter.type }}) Publish ${{ matrix.adapter.name }} adapter Docker image
-    strategy:
-      matrix: ${{fromJson(needs.matrix-adapters-release-latest.outputs.matrix)}}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Configure AWS Credentials for SDLC Public ECR
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_PUBLICECR_ACCESSKEY }}
-          aws-secret-access-key: ${{ secrets.AWS_PUBLICECR_SECRETKEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-to-assume: ${{ secrets.AWS_PUBLICECR_ROLE_ARN }}
-          role-duration-seconds: 1200
-      - uses: ./.github/actions/release/publish-artifacts
+      # If we're on master, publish again with a forced 'latest' tag
+      - if: github.ref == 'refs/heads/master'
+        uses: ./.github/actions/release/publish-artifacts
         with:
           latest: true
-          image-prefix: public.ecr.aws/${{ env.publicecr-name }}/adapters/
+
+          image-prefix: ${{ secrets.SDLC_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/
           adapter-name: ${{ matrix.adapter.name }}
-
-          aws-region: us-east-1
-          aws-ecr-cmd: ecr-public
-
-  matrix-adapters-release-private-latest:
-    if: github.ref == 'refs/heads/master'
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.create-matrix.outputs.result }}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Generate job matrix
-        id: create-matrix
-        uses: ./.github/actions/release/matrix-adapters
-
-  publish-artifacts-release-private-latest:
-    if: github.ref == 'refs/heads/master'
-    needs: [matrix-adapters-release-private-latest]
-    runs-on: ubuntu-latest
-    name: (${{ matrix.adapter.type }}) Publish ${{ matrix.adapter.name }} adapter Docker image
-    strategy:
-      matrix: ${{fromJson(needs.matrix-adapters-release-latest.outputs.matrix)}}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Configure AWS Credentials for SDLC Private ECR
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_PRIVATEECR_ACCESSKEY }}
-          aws-secret-access-key: ${{ secrets.AWS_PRIVATEECR_SECRETKEY }}
           aws-region: ${{ secrets.AWS_REGION }}
-      - uses: ./.github/actions/release/publish-artifacts
-        with:
-          latest: true
-          image-prefix: ${{ secrets.SDLC_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com
-          adapter-name: ${{ matrix.adapter.name }}
-
-          aws-region: ${{ secrets.AWS_REGION }}
-          aws-ecr-cmd: ecr-public
+          aws-ecr-cmd: ecr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 on:
+  pull_request:
   push:
     branches:
       # On develop, we build and publish containers, with the tag of "develop-latest"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
           branch: ${{ fromJSON('[undefined, "develop"]')[github.ref == 'refs/heads/develop'] }}
           latest: ${{ fromJSON('[undefined, true]')[github.ref == 'refs/heads/develop'] }}
 
-          image-prefix: ${{ secrets.SDLC_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/
+          image-prefix: ${{ secrets.SDLC_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/adapters/
           adapter-name: ${{ matrix.adapter.name }}
           aws-region: ${{ secrets.AWS_REGION }}
           aws-ecr-cmd: ecr
@@ -108,7 +108,7 @@ jobs:
         with:
           latest: true
 
-          image-prefix: ${{ secrets.SDLC_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/
+          image-prefix: ${{ secrets.SDLC_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/adapters/
           adapter-name: ${{ matrix.adapter.name }}
           aws-region: ${{ secrets.AWS_REGION }}
           aws-ecr-cmd: ecr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,4 @@
 on:
-  pull_request:
   push:
     branches:
       # On develop, we build and publish containers, with the tag of "develop-latest"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "generate:docker-compose": "ts-node-transpile-only ./packages/scripts/src/docker-build",
     "generate:gha:matrix": "ts-node-transpile-only ./packages/scripts/src/gha",
     "generate:healthcheck:payloads": "ts-node-transpile-only ./packages/scripts/src/healthchecks",
+    "generate:image-name": "ts-node-transpile-only ./packages/scripts/src/generate-image-name",
     "postinstall": "husky install",
     "cm": "cz"
   },

--- a/packages/scripts/src/docker-build/lib.ts
+++ b/packages/scripts/src/docker-build/lib.ts
@@ -90,11 +90,11 @@ async function makeDockerComposeFile(
   }
 }
 
-function generateImageName(
+export function generateImageName(
   descopedName: string,
   version: string,
   { prefix, branch, useLatest }: ImageNameConfig,
-) {
+): string {
   const tag = [branch, useLatest ? 'latest' : version].filter(Boolean).join('-')
 
   return `${prefix}${descopedName}:${tag}`

--- a/packages/scripts/src/generate-image-name/__snapshots__/lib.test.ts.snap
+++ b/packages/scripts/src/generate-image-name/__snapshots__/lib.test.ts.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`generateImageName when an adapter name is provided should generate a valid name with name:coinmarketcap-adapter, branch:, prefix:, latest: 1`] = `"coinmarketcap-adapter:0.1.0"`;
+
+exports[`generateImageName when an adapter name is provided should generate a valid name with name:coinmarketcap-adapter, branch:, prefix:, latest:TRUE 1`] = `"coinmarketcap-adapter:latest"`;
+
+exports[`generateImageName when an adapter name is provided should generate a valid name with name:coinmarketcap-adapter, branch:, prefix:aws/, latest: 1`] = `"aws/coinmarketcap-adapter:0.1.0"`;
+
+exports[`generateImageName when an adapter name is provided should generate a valid name with name:coinmarketcap-adapter, branch:, prefix:aws/, latest:TRUE 1`] = `"aws/coinmarketcap-adapter:latest"`;
+
+exports[`generateImageName when an adapter name is provided should generate a valid name with name:coinmarketcap-adapter, branch:develop, prefix:, latest: 1`] = `"coinmarketcap-adapter:develop-0.1.0"`;
+
+exports[`generateImageName when an adapter name is provided should generate a valid name with name:coinmarketcap-adapter, branch:develop, prefix:aws/, latest: 1`] = `"aws/coinmarketcap-adapter:develop-0.1.0"`;
+
+exports[`generateImageName when an adapter name is provided should generate a valid name with name:coinmarketcap-adapter, branch:develop, prefix:aws/, latest:TRUE 1`] = `"aws/coinmarketcap-adapter:develop-latest"`;

--- a/packages/scripts/src/generate-image-name/index.ts
+++ b/packages/scripts/src/generate-image-name/index.ts
@@ -1,0 +1,7 @@
+import { setOutput } from '@actions/core'
+import { generateImageName } from './lib'
+
+async function main() {
+  setOutput('image_name', await generateImageName())
+}
+main()

--- a/packages/scripts/src/generate-image-name/lib.test.ts
+++ b/packages/scripts/src/generate-image-name/lib.test.ts
@@ -1,0 +1,63 @@
+import { generateImageName } from './lib'
+
+describe('generateImageName', () => {
+  beforeEach(() => {
+    process.env.ADAPTER_NAME = ''
+    process.env.BRANCH = ''
+    process.env.IMAGE_PREFIX = ''
+    process.env.LATEST = ''
+  })
+
+  afterAll(() => {
+    process.env.ADAPTER_NAME = ''
+    process.env.BRANCH = ''
+    process.env.IMAGE_PREFIX = ''
+    process.env.LATEST = ''
+  })
+
+  describe('when no adapter name is provided', () =>
+    it('should error and exit', async () => {
+      await expect(generateImageName()).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"A descoped adapter name must be available as an environment variable under ADAPTER_NAME"`,
+      )
+    }))
+
+  describe('when an invalid adapter name is provided', () => {
+    it('should error and exit', async () => {
+      process.env.ADAPTER_NAME = 'invalid-adapter'
+
+      await expect(generateImageName()).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"Invalid adapter name provided, no matching adapter name found in workspace packages."`,
+      )
+    })
+  })
+  describe('when an adapter name is provided', () => {
+    const name = 'coinmarketcap-adapter'
+    const prefix = 'aws/'
+    const branch = 'develop'
+    const latest = 'TRUE'
+    const table = [
+      { name, branch: '', prefix: '', latest: '' },
+
+      { name, branch, prefix: '', latest: '' },
+      { name, branch, prefix, latest: '' },
+      { name, branch, prefix, latest },
+
+      { name, branch: '', prefix, latest: '' },
+      { name, branch: '', prefix, latest },
+
+      { name, branch: '', prefix: '', latest },
+    ]
+    it.each(table)(
+      'should generate a valid name with name:$name, branch:$branch, prefix:$prefix, latest:$latest',
+      async ({ name, branch, prefix, latest }) => {
+        process.env.ADAPTER_NAME = name
+        process.env.BRANCH = branch
+        process.env.IMAGE_PREFIX = prefix
+        process.env.LATEST = latest
+
+        expect(await generateImageName()).toMatchSnapshot()
+      },
+    )
+  })
+})

--- a/packages/scripts/src/generate-image-name/lib.ts
+++ b/packages/scripts/src/generate-image-name/lib.ts
@@ -1,0 +1,38 @@
+import { generateFileJSON } from '../docker-build/lib'
+
+/**
+ * Create a image name that matches what the "docker-build" script outputs as a docker-compose file.
+ *
+ * Used as a workaround to a gha restriction where we were unable to use the output of the "gha" action if it contained secrets.
+ */
+export async function generateImageName(): Promise<string> {
+  // A descoped adapter name is the name field of package.json of an adapter, without the org scope of "@chainlink/"
+  const descopedName = process.env.ADAPTER_NAME
+  const branch = process.env.BRANCH || ''
+  const prefix = process.env.IMAGE_PREFIX || ''
+  const useLatest = !!process.env.LATEST
+
+  if (!descopedName) {
+    throw Error(
+      'A descoped adapter name must be available as an environment variable under ADAPTER_NAME',
+    )
+  }
+
+  const dockerfile = await generateFileJSON({ prefix, branch, useLatest })
+  const adapters = Object.entries(dockerfile.services)
+    .filter(([k]) => k === descopedName)
+    .map(([, v]) => v.image)
+
+  if (adapters.length === 0) {
+    throw Error(
+      `Invalid adapter name provided, no matching adapter name found in workspace packages.`,
+    )
+  }
+  if (adapters.length > 1) {
+    throw Error(
+      `Ambiguous adapter name provided, multiple matching adapter names found in workspace packages.`,
+    )
+  }
+
+  return adapters[0]
+}

--- a/packages/scripts/src/gha/__snapshots__/lib.test.ts.snap
+++ b/packages/scripts/src/gha/__snapshots__/lib.test.ts.snap
@@ -4,497 +4,494 @@ exports[`job matrix generation should generate a job matrix consumable by gha 1`
 Object {
   "adapter": Array [
     Object {
-      "image_name": "apy-finance-adapter:0.0.3",
       "name": "apy-finance-adapter",
       "type": "composites",
     },
     Object {
-      "image_name": "bitcoin-json-rpc-adapter:0.0.2",
+      "name": "augur-adapter",
+      "type": "composites",
+    },
+    Object {
       "name": "bitcoin-json-rpc-adapter",
       "type": "composites",
     },
     Object {
-      "image_name": "crypto-volatility-index-adapter:0.0.2",
+      "name": "bob-adapter",
+      "type": "composites",
+    },
+    Object {
       "name": "crypto-volatility-index-adapter",
       "type": "composites",
     },
     Object {
-      "image_name": "defi-pulse-adapter:0.0.4",
       "name": "defi-pulse-adapter",
       "type": "composites",
     },
     Object {
-      "image_name": "dns-record-check-adapter:0.0.2",
       "name": "dns-record-check-adapter",
       "type": "composites",
     },
     Object {
-      "image_name": "market-closure-adapter:0.0.4",
+      "name": "dxdao-adapter",
+      "type": "composites",
+    },
+    Object {
+      "name": "google-weather-adapter",
+      "type": "composites",
+    },
+    Object {
+      "name": "linear-finance-adapter",
+      "type": "composites",
+    },
+    Object {
       "name": "market-closure-adapter",
       "type": "composites",
     },
     Object {
-      "image_name": "outlier-detection-adapter:0.0.2",
+      "name": "medianizer-adapter",
+      "type": "composites",
+    },
+    Object {
       "name": "outlier-detection-adapter",
       "type": "composites",
     },
     Object {
-      "image_name": "proof-of-reserves-adapter:0.0.4",
       "name": "proof-of-reserves-adapter",
       "type": "composites",
     },
     Object {
-      "image_name": "reference-transform-adapter:0.0.1",
       "name": "reference-transform-adapter",
       "type": "composites",
     },
     Object {
-      "image_name": "synth-index-adapter:0.0.2",
       "name": "synth-index-adapter",
       "type": "composites",
     },
     Object {
-      "image_name": "token-allocation-adapter:0.0.2",
+      "name": "the-graph-adapter",
+      "type": "composites",
+    },
+    Object {
       "name": "token-allocation-adapter",
       "type": "composites",
     },
     Object {
-      "image_name": "example-composite-adapter:0.0.1",
+      "name": "vesper-adapter",
+      "type": "composites",
+    },
+    Object {
       "name": "example-composite-adapter",
       "type": "examples",
     },
     Object {
-      "image_name": "example-source-adapter:0.0.4",
       "name": "example-source-adapter",
       "type": "examples",
     },
     Object {
-      "image_name": "1forge-adapter:0.0.4",
       "name": "1forge-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "alphachain-adapter:0.0.4",
       "name": "alphachain-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "alphavantage-adapter:0.0.4",
       "name": "alphavantage-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "amberdata-adapter:0.0.4",
       "name": "amberdata-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "amberdata-gasprice-adapter:0.0.4",
-      "name": "amberdata-gasprice-adapter",
+      "name": "anyblock-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "anyblock-gasprice-adapter:0.0.4",
-      "name": "anyblock-gasprice-adapter",
+      "name": "binance-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "anyblock-uniswap-vwap-adapter:0.0.4",
-      "name": "anyblock-uniswap-vwap-adapter",
-      "type": "sources",
-    },
-    Object {
-      "image_name": "binance-dex-adapter:0.0.4",
       "name": "binance-dex-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "bitex-adapter:0.0.4",
       "name": "bitex-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "bitso-adapter:0.0.4",
       "name": "bitso-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "blockchain.com-adapter:0.0.4",
       "name": "blockchain.com-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "blockchair-adapter:0.0.4",
       "name": "blockchair-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "blockcypher-adapter:0.0.4",
       "name": "blockcypher-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "blockstream-adapter:0.0.2",
       "name": "blockstream-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "bravenewcoin-adapter:0.0.4",
       "name": "bravenewcoin-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "btc.com-adapter:0.0.2",
       "name": "btc.com-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "cfbenchmarks-adapter:0.0.2",
+      "name": "cache.gold-adapter",
+      "type": "sources",
+    },
+    Object {
       "name": "cfbenchmarks-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "coinapi-adapter:0.0.4",
       "name": "coinapi-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "coinbase-adapter:0.0.4",
       "name": "coinbase-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "coincodex-adapter:0.0.4",
       "name": "coincodex-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "coingecko-adapter:0.0.4",
       "name": "coingecko-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "coinlore-adapter:0.0.4",
       "name": "coinlore-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "coinmarketcap-adapter:0.0.5",
       "name": "coinmarketcap-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "coinpaprika-adapter:0.0.3",
+      "name": "coinmetrics-adapter",
+      "type": "sources",
+    },
+    Object {
       "name": "coinpaprika-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "coinranking-adapter:0.0.4",
       "name": "coinranking-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "covid-tracker-adapter:0.0.4",
       "name": "covid-tracker-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "cryptoapis-adapter:0.0.4",
       "name": "cryptoapis-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "cryptocompare-adapter:0.0.4",
+      "name": "cryptoapis-v2-adapter",
+      "type": "sources",
+    },
+    Object {
       "name": "cryptocompare-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "cryptoid-adapter:0.0.4",
       "name": "cryptoid-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "cryptomkt-adapter:0.0.4",
       "name": "cryptomkt-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "currencylayer-adapter:0.0.4",
       "name": "currencylayer-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "deribit-adapter:0.0.2",
+      "name": "curve-adapter",
+      "type": "sources",
+    },
+    Object {
       "name": "deribit-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "dns-query-adapter:0.0.2",
       "name": "dns-query-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "dwolla-adapter:0.0.1",
       "name": "dwolla-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "dxfeed-adapter:0.0.4",
       "name": "dxfeed-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "dxfeed-secondary-adapter:0.0.2",
       "name": "dxfeed-secondary-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "eodhistoricaldata-adapter:0.0.4",
+      "name": "enzyme-adapter",
+      "type": "sources",
+    },
+    Object {
       "name": "eodhistoricaldata-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "etherchain-adapter:0.0.4",
       "name": "etherchain-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "ethgasstation-adapter:0.0.4",
+      "name": "etherscan-adapter",
+      "type": "sources",
+    },
+    Object {
       "name": "ethgasstation-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "fcsapi-adapter:0.0.4",
+      "name": "ethgaswatch-adapter",
+      "type": "sources",
+    },
+    Object {
+      "name": "expert-car-broker-adapter",
+      "type": "sources",
+    },
+    Object {
       "name": "fcsapi-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "finage-adapter:0.0.4",
       "name": "finage-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "finnhub-adapter:0.0.4",
       "name": "finnhub-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "fixer-adapter:0.0.4",
       "name": "fixer-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "fmpcloud-adapter:0.0.4",
       "name": "fmpcloud-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "genesis-volatility-adapter:0.0.4",
       "name": "genesis-volatility-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "geodb-adapter:0.0.2",
       "name": "geodb-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "iex-cloud-adapter:0.0.2",
+      "name": "google-bigquery-adapter",
+      "type": "sources",
+    },
+    Object {
+      "name": "graphql-adapter",
+      "type": "sources",
+    },
+    Object {
       "name": "iex-cloud-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "intrinio-adapter:0.0.1",
       "name": "intrinio-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "json-rpc-adapter:0.0.4",
       "name": "json-rpc-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "kaiko-adapter:0.0.4",
       "name": "kaiko-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "lcx-adapter:0.0.4",
+      "name": "layer2-sequencer-health-adapter",
+      "type": "sources",
+    },
+    Object {
       "name": "lcx-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "linkpool-adapter:0.0.4",
       "name": "linkpool-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "lition-adapter:0.0.4",
       "name": "lition-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "marketstack-adapter:0.0.4",
       "name": "marketstack-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "messari-adapter:0.0.4",
       "name": "messari-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "metalsapi-adapter:0.0.4",
       "name": "metalsapi-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "nikkei-adapter:0.0.4",
+      "name": "mycryptoapi-adapter",
+      "type": "sources",
+    },
+    Object {
+      "name": "ncfx-adapter",
+      "type": "sources",
+    },
+    Object {
       "name": "nikkei-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "nomics-adapter:0.0.4",
       "name": "nomics-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "oilpriceapi-adapter:0.0.4",
       "name": "oilpriceapi-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "onchain-adapter:0.0.4",
       "name": "onchain-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "openexchangerates-adapter:0.0.4",
       "name": "openexchangerates-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "orchid-bandwidth-adapter:0.0.4",
       "name": "orchid-bandwidth-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "paxos-adapter:0.0.2",
       "name": "paxos-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "paypal-adapter:0.0.1",
       "name": "paypal-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "poa-gasprice-adapter:0.0.4",
-      "name": "poa-gasprice-adapter",
+      "name": "poa-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "polygon-adapter:0.0.4",
       "name": "polygon-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "reduce-adapter:0.0.4",
       "name": "reduce-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "renvm-address-set-adapter:0.0.4",
       "name": "renvm-address-set-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "satoshitango-adapter:0.0.4",
       "name": "satoshitango-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "sochain-adapter:0.0.2",
       "name": "sochain-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "stasis-adapter:0.0.4",
+      "name": "sportsdataio-adapter",
+      "type": "sources",
+    },
+    Object {
       "name": "stasis-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "taapi-adapter:0.0.4",
+      "name": "synthetix-debt-pool-adapter",
+      "type": "sources",
+    },
+    Object {
       "name": "taapi-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "therundown-adapter:0.0.2",
       "name": "therundown-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "tiingo-adapter:0.0.2",
       "name": "tiingo-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "tradermade-adapter:0.0.5",
       "name": "tradermade-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "tradingeconomics-adapter:0.0.4",
       "name": "tradingeconomics-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "trueusd-adapter:0.0.4",
       "name": "trueusd-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "twelvedata-adapter:0.0.1",
       "name": "twelvedata-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "unibit-adapter:0.0.1",
       "name": "unibit-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "wbtc-address-set-adapter:0.0.4",
+      "name": "upvest-adapter",
+      "type": "sources",
+    },
+    Object {
       "name": "wbtc-address-set-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "xbto-adapter:0.0.4",
+      "name": "wootrade-adapter",
+      "type": "sources",
+    },
+    Object {
       "name": "xbto-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "agoric-adapter:0.0.2",
       "name": "agoric-adapter",
       "type": "targets",
     },
     Object {
-      "image_name": "conflux-adapter:0.0.3",
       "name": "conflux-adapter",
       "type": "targets",
     },
     Object {
-      "image_name": "dydx-stark-adapter:0.0.2",
       "name": "dydx-stark-adapter",
       "type": "targets",
     },
     Object {
-      "image_name": "ethwrite-adapter:0.0.3",
       "name": "ethwrite-adapter",
       "type": "targets",
     },
     Object {
-      "image_name": "harmony-adapter:0.0.2",
       "name": "harmony-adapter",
       "type": "targets",
     },
@@ -506,497 +503,494 @@ exports[`job matrix generation should generate a job matrix suitable for pushing
 Object {
   "adapter": Array [
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/apy-finance-adapter:EAEE-0.0.3",
       "name": "apy-finance-adapter",
       "type": "composites",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/bitcoin-json-rpc-adapter:EAEE-0.0.2",
+      "name": "augur-adapter",
+      "type": "composites",
+    },
+    Object {
       "name": "bitcoin-json-rpc-adapter",
       "type": "composites",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/crypto-volatility-index-adapter:EAEE-0.0.2",
+      "name": "bob-adapter",
+      "type": "composites",
+    },
+    Object {
       "name": "crypto-volatility-index-adapter",
       "type": "composites",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/defi-pulse-adapter:EAEE-0.0.4",
       "name": "defi-pulse-adapter",
       "type": "composites",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/dns-record-check-adapter:EAEE-0.0.2",
       "name": "dns-record-check-adapter",
       "type": "composites",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/market-closure-adapter:EAEE-0.0.4",
+      "name": "dxdao-adapter",
+      "type": "composites",
+    },
+    Object {
+      "name": "google-weather-adapter",
+      "type": "composites",
+    },
+    Object {
+      "name": "linear-finance-adapter",
+      "type": "composites",
+    },
+    Object {
       "name": "market-closure-adapter",
       "type": "composites",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/outlier-detection-adapter:EAEE-0.0.2",
+      "name": "medianizer-adapter",
+      "type": "composites",
+    },
+    Object {
       "name": "outlier-detection-adapter",
       "type": "composites",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/proof-of-reserves-adapter:EAEE-0.0.4",
       "name": "proof-of-reserves-adapter",
       "type": "composites",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/reference-transform-adapter:EAEE-0.0.1",
       "name": "reference-transform-adapter",
       "type": "composites",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/synth-index-adapter:EAEE-0.0.2",
       "name": "synth-index-adapter",
       "type": "composites",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/token-allocation-adapter:EAEE-0.0.2",
+      "name": "the-graph-adapter",
+      "type": "composites",
+    },
+    Object {
       "name": "token-allocation-adapter",
       "type": "composites",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/example-composite-adapter:EAEE-0.0.1",
+      "name": "vesper-adapter",
+      "type": "composites",
+    },
+    Object {
       "name": "example-composite-adapter",
       "type": "examples",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/example-source-adapter:EAEE-0.0.4",
       "name": "example-source-adapter",
       "type": "examples",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/1forge-adapter:EAEE-0.0.4",
       "name": "1forge-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/alphachain-adapter:EAEE-0.0.4",
       "name": "alphachain-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/alphavantage-adapter:EAEE-0.0.4",
       "name": "alphavantage-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/amberdata-adapter:EAEE-0.0.4",
       "name": "amberdata-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/amberdata-gasprice-adapter:EAEE-0.0.4",
-      "name": "amberdata-gasprice-adapter",
+      "name": "anyblock-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/anyblock-gasprice-adapter:EAEE-0.0.4",
-      "name": "anyblock-gasprice-adapter",
+      "name": "binance-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/anyblock-uniswap-vwap-adapter:EAEE-0.0.4",
-      "name": "anyblock-uniswap-vwap-adapter",
-      "type": "sources",
-    },
-    Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/binance-dex-adapter:EAEE-0.0.4",
       "name": "binance-dex-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/bitex-adapter:EAEE-0.0.4",
       "name": "bitex-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/bitso-adapter:EAEE-0.0.4",
       "name": "bitso-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/blockchain.com-adapter:EAEE-0.0.4",
       "name": "blockchain.com-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/blockchair-adapter:EAEE-0.0.4",
       "name": "blockchair-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/blockcypher-adapter:EAEE-0.0.4",
       "name": "blockcypher-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/blockstream-adapter:EAEE-0.0.2",
       "name": "blockstream-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/bravenewcoin-adapter:EAEE-0.0.4",
       "name": "bravenewcoin-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/btc.com-adapter:EAEE-0.0.2",
       "name": "btc.com-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/cfbenchmarks-adapter:EAEE-0.0.2",
+      "name": "cache.gold-adapter",
+      "type": "sources",
+    },
+    Object {
       "name": "cfbenchmarks-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/coinapi-adapter:EAEE-0.0.4",
       "name": "coinapi-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/coinbase-adapter:EAEE-0.0.4",
       "name": "coinbase-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/coincodex-adapter:EAEE-0.0.4",
       "name": "coincodex-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/coingecko-adapter:EAEE-0.0.4",
       "name": "coingecko-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/coinlore-adapter:EAEE-0.0.4",
       "name": "coinlore-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/coinmarketcap-adapter:EAEE-0.0.5",
       "name": "coinmarketcap-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/coinpaprika-adapter:EAEE-0.0.3",
+      "name": "coinmetrics-adapter",
+      "type": "sources",
+    },
+    Object {
       "name": "coinpaprika-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/coinranking-adapter:EAEE-0.0.4",
       "name": "coinranking-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/covid-tracker-adapter:EAEE-0.0.4",
       "name": "covid-tracker-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/cryptoapis-adapter:EAEE-0.0.4",
       "name": "cryptoapis-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/cryptocompare-adapter:EAEE-0.0.4",
+      "name": "cryptoapis-v2-adapter",
+      "type": "sources",
+    },
+    Object {
       "name": "cryptocompare-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/cryptoid-adapter:EAEE-0.0.4",
       "name": "cryptoid-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/cryptomkt-adapter:EAEE-0.0.4",
       "name": "cryptomkt-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/currencylayer-adapter:EAEE-0.0.4",
       "name": "currencylayer-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/deribit-adapter:EAEE-0.0.2",
+      "name": "curve-adapter",
+      "type": "sources",
+    },
+    Object {
       "name": "deribit-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/dns-query-adapter:EAEE-0.0.2",
       "name": "dns-query-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/dwolla-adapter:EAEE-0.0.1",
       "name": "dwolla-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/dxfeed-adapter:EAEE-0.0.4",
       "name": "dxfeed-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/dxfeed-secondary-adapter:EAEE-0.0.2",
       "name": "dxfeed-secondary-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/eodhistoricaldata-adapter:EAEE-0.0.4",
+      "name": "enzyme-adapter",
+      "type": "sources",
+    },
+    Object {
       "name": "eodhistoricaldata-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/etherchain-adapter:EAEE-0.0.4",
       "name": "etherchain-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/ethgasstation-adapter:EAEE-0.0.4",
+      "name": "etherscan-adapter",
+      "type": "sources",
+    },
+    Object {
       "name": "ethgasstation-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/fcsapi-adapter:EAEE-0.0.4",
+      "name": "ethgaswatch-adapter",
+      "type": "sources",
+    },
+    Object {
+      "name": "expert-car-broker-adapter",
+      "type": "sources",
+    },
+    Object {
       "name": "fcsapi-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/finage-adapter:EAEE-0.0.4",
       "name": "finage-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/finnhub-adapter:EAEE-0.0.4",
       "name": "finnhub-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/fixer-adapter:EAEE-0.0.4",
       "name": "fixer-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/fmpcloud-adapter:EAEE-0.0.4",
       "name": "fmpcloud-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/genesis-volatility-adapter:EAEE-0.0.4",
       "name": "genesis-volatility-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/geodb-adapter:EAEE-0.0.2",
       "name": "geodb-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/iex-cloud-adapter:EAEE-0.0.2",
+      "name": "google-bigquery-adapter",
+      "type": "sources",
+    },
+    Object {
+      "name": "graphql-adapter",
+      "type": "sources",
+    },
+    Object {
       "name": "iex-cloud-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/intrinio-adapter:EAEE-0.0.1",
       "name": "intrinio-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/json-rpc-adapter:EAEE-0.0.4",
       "name": "json-rpc-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/kaiko-adapter:EAEE-0.0.4",
       "name": "kaiko-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/lcx-adapter:EAEE-0.0.4",
+      "name": "layer2-sequencer-health-adapter",
+      "type": "sources",
+    },
+    Object {
       "name": "lcx-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/linkpool-adapter:EAEE-0.0.4",
       "name": "linkpool-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/lition-adapter:EAEE-0.0.4",
       "name": "lition-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/marketstack-adapter:EAEE-0.0.4",
       "name": "marketstack-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/messari-adapter:EAEE-0.0.4",
       "name": "messari-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/metalsapi-adapter:EAEE-0.0.4",
       "name": "metalsapi-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/nikkei-adapter:EAEE-0.0.4",
+      "name": "mycryptoapi-adapter",
+      "type": "sources",
+    },
+    Object {
+      "name": "ncfx-adapter",
+      "type": "sources",
+    },
+    Object {
       "name": "nikkei-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/nomics-adapter:EAEE-0.0.4",
       "name": "nomics-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/oilpriceapi-adapter:EAEE-0.0.4",
       "name": "oilpriceapi-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/onchain-adapter:EAEE-0.0.4",
       "name": "onchain-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/openexchangerates-adapter:EAEE-0.0.4",
       "name": "openexchangerates-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/orchid-bandwidth-adapter:EAEE-0.0.4",
       "name": "orchid-bandwidth-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/paxos-adapter:EAEE-0.0.2",
       "name": "paxos-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/paypal-adapter:EAEE-0.0.1",
       "name": "paypal-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/poa-gasprice-adapter:EAEE-0.0.4",
-      "name": "poa-gasprice-adapter",
+      "name": "poa-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/polygon-adapter:EAEE-0.0.4",
       "name": "polygon-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/reduce-adapter:EAEE-0.0.4",
       "name": "reduce-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/renvm-address-set-adapter:EAEE-0.0.4",
       "name": "renvm-address-set-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/satoshitango-adapter:EAEE-0.0.4",
       "name": "satoshitango-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/sochain-adapter:EAEE-0.0.2",
       "name": "sochain-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/stasis-adapter:EAEE-0.0.4",
+      "name": "sportsdataio-adapter",
+      "type": "sources",
+    },
+    Object {
       "name": "stasis-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/taapi-adapter:EAEE-0.0.4",
+      "name": "synthetix-debt-pool-adapter",
+      "type": "sources",
+    },
+    Object {
       "name": "taapi-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/therundown-adapter:EAEE-0.0.2",
       "name": "therundown-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/tiingo-adapter:EAEE-0.0.2",
       "name": "tiingo-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/tradermade-adapter:EAEE-0.0.5",
       "name": "tradermade-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/tradingeconomics-adapter:EAEE-0.0.4",
       "name": "tradingeconomics-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/trueusd-adapter:EAEE-0.0.4",
       "name": "trueusd-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/twelvedata-adapter:EAEE-0.0.1",
       "name": "twelvedata-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/unibit-adapter:EAEE-0.0.1",
       "name": "unibit-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/wbtc-address-set-adapter:EAEE-0.0.4",
+      "name": "upvest-adapter",
+      "type": "sources",
+    },
+    Object {
       "name": "wbtc-address-set-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/xbto-adapter:EAEE-0.0.4",
+      "name": "wootrade-adapter",
+      "type": "sources",
+    },
+    Object {
       "name": "xbto-adapter",
       "type": "sources",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/agoric-adapter:EAEE-0.0.2",
       "name": "agoric-adapter",
       "type": "targets",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/conflux-adapter:EAEE-0.0.3",
       "name": "conflux-adapter",
       "type": "targets",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/dydx-stark-adapter:EAEE-0.0.2",
       "name": "dydx-stark-adapter",
       "type": "targets",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/ethwrite-adapter:EAEE-0.0.3",
       "name": "ethwrite-adapter",
       "type": "targets",
     },
     Object {
-      "image_name": "public.ecr.aws/chainlink-staging/adapters/harmony-adapter:EAEE-0.0.2",
       "name": "harmony-adapter",
       "type": "targets",
     },

--- a/packages/scripts/src/gha/lib.ts
+++ b/packages/scripts/src/gha/lib.ts
@@ -3,7 +3,6 @@ import { DockerLabels, generateFileJSON } from '../docker-build/lib'
 interface JobMatrix {
   adapter: {
     name: string
-    image_name: string
     type: string
   }[]
 }
@@ -21,7 +20,6 @@ export async function getJobMatrix(): Promise<JobMatrix> {
   const adapter = Object.entries(dockerfile.services).map(([k, v]) => {
     return {
       name: k,
-      image_name: v.image,
       type: v.build.labels[DockerLabels.EA_TYPE],
     }
   })


### PR DESCRIPTION
# Motivation
The argo cd image-updater allows us to have automatic deployments to our staging environments when PRs are merged into develop. 

The image-updater has a restriction where it cannot use public ECR, it must use a private ECR repository.

# Summary
- Images are now pushed to both public ECR and private ECR. No behaviour changes should have been made to how images are pushed to public ECR.
- Private ECR tagging and pushing logic mirrors public ECR
- The job matrix generation script has been refactored, and is now minimal. It no longer contains any information on image tags. This functionality was split into a script `generate-image-name` that is run inside each job of a matrix so that github secrets can be used in generating an image name.
- Common logic between publish jobs have been extracted into their own actions as [composite actions](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action).
- Job parallelism is capped to 50. The previous unlimited job parallelism caused API rate limiting issues with AWS

# Review
- See https://github.com/smartcontractkit/external-adapters-js/actions/runs/1211104101 for a successful run that pushes images to both public and private ECR.