### PR TITLE
Setup codecov

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,29 @@ jobs:
         run: npm install -g yarn
       - run: yarn install
       - run: yarn setup
-      - run: yarn test:integration
+      - run: yarn test:ci:integration
+      - uses: codecov/codecov-action@v2
+        with:
+          flags: integration
+          fail_ci_if_error: true
+
+  run-unit-tests:
+    name: Run unit tests
+    runs-on: [self-hosted, sdlc-ghr-prod]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+      - name: Install Yarn
+        run: npm install -g yarn
+      - run: yarn install
+      - run: yarn setup
+      - run: yarn test:ci:unit
+      - uses: codecov/codecov-action@v2
+        with:
+          flags: unit
+          fail_ci_if_error: true
 
   run-basic-checks:
     name: Run linters and unit tests
@@ -48,7 +70,6 @@ jobs:
       - run: yarn setup
       - run: yarn lint
       - run: yarn format:check
-      - run: yarn test:unit
 
   # Read build strategy matrix of adapters, from a json file
   matrix-adapters:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,31 @@
+comment:
+  layout: 'reach, diff, flags, files'
+  behavior: default
+
+ignore:
+  - '.yarn'
+  - '.husky'
+  - '.github'
+  - '.vscode'
+  - 'grafana'
+  - '**/*.test.ts'
+  - '**/tests/'
+  - '**/test/'
+  - '**/generated/'
+  - '**/dist/'
+  - '**/vendor/'
+  - '**/schemas/'
+  - 'tsconfig.tsbuildinfo'
+
+flag_management:
+  default_rules:
+    statuses:
+      # Project-wide coverage must increase on every PR, with a 1% leeway
+      - name_prefix: project-
+        type: project
+        target: auto
+        threshold: 1%
+      # Every PR must have a minimum of 90% coverage on adjusted lines
+      - name_prefix: patch-
+        type: patch
+        target: 90%

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "test": "jest",
     "test:unit": "jest unit",
     "test:integration": "jest --runInBand integration",
+    "test:ci:unit": "jest --coverage unit",
+    "test:ci:integration": "jest --coverage --runInBand integration",
     "generate:docker-compose": "ts-node-transpile-only ./packages/scripts/src/docker-build",
     "generate:gha:matrix": "ts-node-transpile-only ./packages/scripts/src/gha",
     "generate:healthcheck:payloads": "ts-node-transpile-only ./packages/scripts/src/healthchecks",


### PR DESCRIPTION
# Motivation
We should start tracking code coverage and enforce that we're never regressing on it.

# Summary
- Add codecov uploader as an GHA
- Split out unit tests into its own job to increase job clarity
- Added a codecov.yml file to start out with
- Added automatic flag support. It should let us track coverage of `integration` and `unit` coverage as separate metrics

# TODO 
- [x] Waiting on codecov integration to be added to this repository before letting this PR out of draft
- [x] Test integration with supplied uploader and configuration