### PR TITLE
fix(coinpaprika): sort tickers

### DIFF
--- a/packages/core/bootstrap/src/lib/provider-limits/limits.json
+++ b/packages/core/bootstrap/src/lib/provider-limits/limits.json
@@ -291,6 +291,10 @@
         "rateLimit1m": 500,
         "rateLimit1h": 690
       },
+      "chainlink": {
+        "rateLimit1m": 500,
+        "rateLimit1h": 4166
+      },
       "pro": {
         "rateLimit1m": 500,
         "rateLimit1h": 6900

--- a/packages/sources/coinpaprika/src/util.ts
+++ b/packages/sources/coinpaprika/src/util.ts
@@ -9,6 +9,7 @@ export const getCoin = (
   symbol?: string,
   coinId?: string,
 ): ResponseSchema | undefined => {
+  data.sort((a, b) => a.rank - b.rank)
   if (coinId) {
     return data.find(({ id }) => id.toLowerCase() === coinId.toLowerCase())
   } else if (symbol) {


### PR DESCRIPTION
### Description
The recent addition of a batch API endpoint needs to sort tickers response by rank to ensure the expected response.