### PR TITLE
Allow private ECR secondary account access

### DIFF
--- a/.github/actions/release/publish-artifacts/action.yml
+++ b/.github/actions/release/publish-artifacts/action.yml
@@ -62,6 +62,15 @@ runs:
       shell: bash
       run: aws ${{ fromJSON('["ecr-public", "ecr"]')[inputs.aws-ecr-private == true] }} create-repository --region ${{ inputs.aws-region }} --repository-name adapters/${{ inputs.adapter-name }} || true
 
+    - if: inputs.aws-ecr-private
+      name: Set ECR repository permissions for secondary account access on private ECR repos only
+      # secrets.AWS_PRIVATE_ECR_SECONDARY_ACCOUNT_ACCESS_IDS string format are comma seperated, double quoted strings. E.g. "1","2","3"
+      run: >
+        aws ecr set-repository-policy
+        --region ${{ inputs.aws-region }}
+        --repository-name adapters/${{ inputs.adapter-name }}
+        --policy-text "$(jq '.Statement[0].Principal.AWS |= [${{ secrets.AWS_PRIVATE_ECR_SECONDARY_ACCOUNT_ACCESS_IDS }}]' .github/actions/release/publish-artifacts/secondary-account-access-policy.json)"
+
     - name: Push to ECR
       shell: bash
       run: docker push ${{ steps.generate-image-name.outputs.image_name }}

--- a/.github/actions/release/publish-artifacts/action.yml
+++ b/.github/actions/release/publish-artifacts/action.yml
@@ -17,8 +17,8 @@ inputs:
   aws-region:
     description: The aws region to use
     required: true
-  aws-ecr-cmd:
-    description: The aws ecr command to use, either "ecr" or "ecr-public"
+  aws-ecr-private:
+    description: If this action is being used to publish to private ecr
     required: true
 
 runs:
@@ -56,11 +56,11 @@ runs:
 
     - name: Authenticate to ECR
       shell: bash
-      run: aws ${{ inputs.aws-ecr-cmd }} get-login-password --region ${{ inputs.aws-region }} | docker login --username AWS --password-stdin ${{ inputs.image-prefix }}
+      run: aws ${{ fromJSON('["ecr-public", "ecr"]')[inputs.aws-ecr-private == true] }} get-login-password --region ${{ inputs.aws-region }} | docker login --username AWS --password-stdin ${{ inputs.image-prefix }}
 
     - name: Create a ECR repository if does not exist
       shell: bash
-      run: aws ${{ inputs.aws-ecr-cmd }} create-repository --region ${{ inputs.aws-region }} --repository-name adapters/${{ inputs.adapter-name }} || true
+      run: aws ${{ fromJSON('["ecr-public", "ecr"]')[inputs.aws-ecr-private == true] }} create-repository --region ${{ inputs.aws-region }} --repository-name adapters/${{ inputs.adapter-name }} || true
 
     - name: Push to ECR
       shell: bash

--- a/.github/actions/release/publish-artifacts/secondary-account-access-policy.json
+++ b/.github/actions/release/publish-artifacts/secondary-account-access-policy.json
@@ -1,0 +1,24 @@
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": ["ACCOUNT_IDS"]
+      },
+      "Action": [
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:BatchGetImage",
+        "ecr:DescribeImageScanFindings",
+        "ecr:DescribeImages",
+        "ecr:DescribeRepositories",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:GetLifecyclePolicy",
+        "ecr:GetLifecyclePolicyPreview",
+        "ecr:GetRepositoryPolicy",
+        "ecr:ListImages",
+        "ecr:ListTagsForResource"
+      ]
+    }
+  ]
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
           image-prefix: public.ecr.aws/${{ env.publicecr-name }}/adapters/
           adapter-name: ${{ matrix.adapter.name }}
           aws-region: us-east-1
-          aws-ecr-cmd: ecr-public
+          aws-ecr-private: false
       # If we're on master, publish again with a forced 'latest' tag
       - if: github.ref == 'refs/heads/master'
         name: Publish adapter to public ECR, with forced latest tag
@@ -82,8 +82,7 @@ jobs:
           image-prefix: public.ecr.aws/${{ env.publicecr-name }}/adapters/
           adapter-name: ${{ matrix.adapter.name }}
           aws-region: us-east-1
-          aws-ecr-cmd: ecr-public
-
+          aws-ecr-private: false
       # Handle publishing to our private ECR repo
       - name: Configure AWS Credentials for SDLC Private ECR
         uses: aws-actions/configure-aws-credentials@v1
@@ -100,7 +99,7 @@ jobs:
           image-prefix: ${{ secrets.SDLC_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/adapters/
           adapter-name: ${{ matrix.adapter.name }}
           aws-region: ${{ secrets.AWS_REGION }}
-          aws-ecr-cmd: ecr
+          aws-ecr-private: true
       # If we're on master, publish again with a forced 'latest' tag
       - if: github.ref == 'refs/heads/master'
         name: Publish adapter to private ECR, with forced latest tag
@@ -111,4 +110,4 @@ jobs:
           image-prefix: ${{ secrets.SDLC_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/adapters/
           adapter-name: ${{ matrix.adapter.name }}
           aws-region: ${{ secrets.AWS_REGION }}
-          aws-ecr-cmd: ecr
+          aws-ecr-private: true


### PR DESCRIPTION
- Use boolean flag against hard coded ecr cmds
- Support secondary account access on private ecr

