### PR TITLE
Add code coverage threshold for project

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,6 +2,16 @@ comment:
   layout: 'reach, diff, flags, files'
   behavior: default
 
+  coverage:
+    status:
+      project:
+        default:
+          target: auto
+          threshold: 1%
+      patch:
+        default:
+          target: 90%
+
 ignore:
   - '.yarn'
   - '.husky'


### PR DESCRIPTION
## Description
We have a little flakeyness on our coverage reporting that sometimes reports 1 to 5 lines as uncovered, causing project level coverage targets to fail.

## Changes

- Add leniency factor of 1% to project coverage target 

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
