### PR TITLE
Fix WS issue for no-http adapters

### DIFF
--- a/packages/core/bootstrap/src/lib/ws/index.ts
+++ b/packages/core/bootstrap/src/lib/ws/index.ts
@@ -33,14 +33,6 @@ export const withWebSockets =
 
     store.dispatch(connectRequested({ config: wsConfig, wsHandler }))
 
-    // Check if adapter only supports WS
-    if (wsHandler.noHttp) {
-      // If so, we try to get a result from cache within API_TIMEOUT
-      const requestTimeout = Number(process.env.API_TIMEOUT) || 30000
-      const deadline = Date.now() + requestTimeout
-      return await awaitResult(context, input, deadline)
-    }
-
     await separateBatches(input, async (singleInput: AdapterRequest) => {
       const subscriptionMsg = wsHandler.subscribe(singleInput)
       if (!subscriptionMsg) return
@@ -56,6 +48,13 @@ export const withWebSockets =
 
       store.dispatch(subscribeRequested(subscriptionPayload))
     })
+    // Check if adapter only supports WS
+    if (wsHandler.noHttp) {
+      // If so, we try to get a result from cache within API_TIMEOUT
+      const requestTimeout = Number(process.env.API_TIMEOUT) || 30000
+      const deadline = Date.now() + requestTimeout
+      return await awaitResult(context, input, deadline)
+    }
     return await execute(input, context)
   }
 


### PR DESCRIPTION
There was an issue with no http adapters where the code would poll for a result from the cache before setting up a WS connection.  This lead to every request timing out as there would be nothing in the cache to poll for.  The fix was to dispatch the action to setup the WS subscription first prior to polling the cache.