### PR TITLE
[Fix] Batch warmer overrides

### DIFF
--- a/packages/core/bootstrap/src/lib/external-adapter/validator.ts
+++ b/packages/core/bootstrap/src/lib/external-adapter/validator.ts
@@ -17,6 +17,7 @@ import presetIncludes from './overrides/presetIncludes.json'
 import { Requester } from './requester'
 import { inputParameters } from './builder'
 
+export type OverrideType = 'overrides' | 'tokenOverrides' | 'includes'
 export class Validator {
   input: any
   customParams: any
@@ -199,6 +200,16 @@ export class Validator {
       }
     }
     return
+  }
+
+  overrideReverseLookup = (adapter: string, type: OverrideType, symbol: string): string => {
+    const overrides: Map<string, string> = this.validated?.[type]?.get(adapter.toLowerCase())
+    if (!overrides) return symbol
+    let originalSymbol: string | undefined
+    overrides.forEach((overridden, original) => {
+      if (overridden.toLowerCase() === symbol.toLowerCase()) originalSymbol = original
+    })
+    return originalSymbol || symbol
   }
 
   formatOverride = (param: any): Override => {

--- a/packages/core/bootstrap/src/lib/external-adapter/validator.ts
+++ b/packages/core/bootstrap/src/lib/external-adapter/validator.ts
@@ -312,10 +312,15 @@ export function normalizeInput<C extends Config>(
 
   // remove undefined values
   const data = JSON.parse(JSON.stringify(validator.validated.data))
-  // remove includes
-  delete data.includes
+
   // re-add maxAge
   if (request.data.maxAge) data.maxAge = request.data.maxAge
+
+  // re-add overrides
+  if (request.data.overrides) data.overrides = request.data.overrides
+  if (request.data.tokenOverrides) data.tokenOverrides = request.data.tokenOverrides
+  if (request.data.includes) data.includes = request.data.includes
+
   if (apiEndpoint.batchablePropertyPath) {
     for (const { name } of apiEndpoint.batchablePropertyPath) {
       const value = data[name]

--- a/packages/core/bootstrap/src/lib/util.ts
+++ b/packages/core/bootstrap/src/lib/util.ts
@@ -192,8 +192,19 @@ export const includableAdapterRequestProperties: string[] = ['data'].concat(
   (process.env.CACHE_KEY_INCLUDED_PROPS || '').split(',').filter((k) => k),
 )
 
+/** Common keys within adapter requests that should be ignored within "data" to create a stable key*/
+const excludableInternalAdapterRequestProperties = [
+  'resultPath',
+  'overrides',
+  'tokenOverrides',
+  'includes',
+]
+
 export const getKeyData = (data: AdapterRequest) =>
-  omit(pick(data, includableAdapterRequestProperties), 'data.resultPath')
+  omit(
+    pick(data, includableAdapterRequestProperties),
+    excludableInternalAdapterRequestProperties.map((property) => `data.${property}`),
+  )
 
 export type HashMode = 'include' | 'exclude'
 /**

--- a/packages/sources/coingecko/src/endpoint/crypto.ts
+++ b/packages/sources/coingecko/src/endpoint/crypto.ts
@@ -47,6 +47,7 @@ const handleBatchedRequest = (
   jobRunID: string,
   request: AdapterRequest,
   response: AxiosResponse,
+  validator: Validator,
   endpoint: string,
   idToSymbol: Record<string, string>,
 ) => {
@@ -60,7 +61,7 @@ const handleBatchedRequest = (
           ...request,
           data: {
             ...request.data,
-            base: symbol.toUpperCase(),
+            base: validator.overrideReverseLookup(AdapterName, 'overrides', symbol).toUpperCase(),
             quote: quote.toUpperCase(),
           },
         }
@@ -115,7 +116,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, context, confi
   const response = await Requester.request(options, customError)
 
   if (Array.isArray(base) || Array.isArray(quote))
-    return handleBatchedRequest(jobRunID, request, response, endpoint, idToSymbol)
+    return handleBatchedRequest(jobRunID, request, response, validator, endpoint, idToSymbol)
 
   response.data.result = Requester.validateResultNumber(response.data, [
     ids.toLowerCase(),


### PR DESCRIPTION
## Description
Handling of `overrides` in the batch warmer.
......

## Changes

There were two issues with overrides and batch warming:
- A pair with an override was using its override pair to split out batched requests. This caused subsequent requests that come in using the pre-override symbol to find anything in the cache.

This PR corrects this for all batch warming adapters being used.
(finage, dxfeed, and coinpaprika omitted because they are not used in production yet)

- Overrides that are passed in through input parameters need to join the batch warmer state to remember how to do the override.

- Override data should be kept in when normalizing so that it can be used by the adapter, but not used in building the cache key to keep consistent keys.

- Adds a override reverse lookup helper utility function,

## Steps to Test

1. Run `coingecko` adapter
2. Request using an overridden pair.
```{
    "id": "10",
    "data": {
        "base": "BTDD",
        "overrides": {
            "coingecko": {
                "BTDD": "BTC"
            }
        },
        "quote": "USD"
    }
}
```

3. Request using a second overridden pair

```
{
    "id": "10",
    "data": {
        "base": "ETHddd",
        "overrides": {
            "coingecko": {
                "ETHddd": "ETH"
            }
        },
        "quote": "USD"
    }
}
```

4. After ~60 seconds both of these requests should still be cached.

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
