### PR TITLE
Add redis metrics

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,6 @@
 .git
 node_modules
-dist
+**/dist
 
 # Build artifacts
 packages/**/*.zip

--- a/grafana/src/eaDetailed.jsonnet
+++ b/grafana/src/eaDetailed.jsonnet
@@ -41,6 +41,32 @@ local redisConnectionsOpen = graphPanel.new(
   )
 );
 
+local redisRetriesCount = addSideLegend(graphPanel.new(
+  title='Redis connection retries',
+  sort='decreasing',
+  datasource=cortexDataSource,
+  format='retries',
+).addTarget(
+  prometheus.target(
+    'sum(redis_retries_count{' + instanceFilter + '})',
+    legendFormat='retries'
+  )
+));
+
+
+local redisCommandsSentCount = addSideLegend(graphPanel.new(
+  title='Redis commands sent / minute per status',
+  sort='decreasing',
+  datasource=cortexDataSource,
+  format='sent',
+).addTarget(
+  prometheus.target(
+    'rate(redis_commands_sent_count{' + instanceFilter + '}' + interval + ') * 60 ',
+    legendFormat='{{status}}'
+  )
+));
+
+
 local heapUsedPanel = graphPanel.new(
   title='Heap usage MB',
   sort='decreasing',
@@ -325,6 +351,8 @@ local grid = [
   {
     panels: [
       redisConnectionsOpen { size:: 1 },
+      redisRetriesCount { size:: 1 },
+      redisCommandsSentCount { size:: 1 },
       wsConnectionActiveGraph { size:: 1 },
       wsConnectionErrorsGraph { size:: 1 },
       wsConnectionRetriesGraph { size:: 1 },

--- a/grafana/src/eaOverview.jsonnet
+++ b/grafana/src/eaOverview.jsonnet
@@ -39,6 +39,31 @@ local redisConnectionsOpen = addSideLegend(graphPanel.new(
   )
 ));
 
+local redisRetriesCount = addSideLegend(graphPanel.new(
+  title='Redis connection retries',
+  sort='decreasing',
+  datasource=cortexDataSource,
+  format='retries',
+).addTarget(
+  prometheus.target(
+    'sum(redis_retries_count{' + instanceFilter + '}) by (app_name)',
+    legendFormat='{{app_name}}'
+  )
+));
+
+
+local redisCommandsSentCount = addSideLegend(graphPanel.new(
+  title='Redis commands sent / minute per app',
+  sort='decreasing',
+  datasource=cortexDataSource,
+  format='sent',
+).addTarget(
+  prometheus.target(
+    'sum(rate(redis_commands_sent_count{' + instanceFilter + '}' + interval + ') * 60) by (app_name)',
+    legendFormat='{{app_name}}'
+  )
+));
+
 local heapUsedPanel = addSideLegend(graphPanel.new(
   title='Heap usage MB',
   sort='decreasing',
@@ -266,6 +291,8 @@ local grid = [
   {
     panels: [
       redisConnectionsOpen { size:: 1 },
+      redisRetriesCount { size:: 1 },
+      redisCommandsSentCount { size:: 1 },
       wsConnectionActiveGraph { size:: 1 },
       wsConnectionErrorsGraph { size:: 1 },
       wsConnectionRetriesGraph { size:: 1 },

--- a/packages/core/bootstrap/src/lib/cache/metrics.ts
+++ b/packages/core/bootstrap/src/lib/cache/metrics.ts
@@ -44,11 +44,6 @@ export const beginObserveCacheMetrics = ({
   }
 }
 
-export const redis_connections_open = new client.Counter({
-  name: 'redis_connections_open',
-  help: 'The number of redis connections that are open',
-})
-
 enum CacheTypes {
   Redis = 'redis',
   Local = 'local',

--- a/packages/core/bootstrap/src/lib/cache/redis/index.ts
+++ b/packages/core/bootstrap/src/lib/cache/redis/index.ts
@@ -1,0 +1,1 @@
+export * from './redis'

--- a/packages/core/bootstrap/src/lib/cache/redis/metrics.ts
+++ b/packages/core/bootstrap/src/lib/cache/redis/metrics.ts
@@ -1,0 +1,21 @@
+import * as client from 'prom-client'
+
+export const redis_connections_open = new client.Counter({
+  name: 'redis_connections_open',
+  help: 'The number of redis connections that are open',
+})
+
+export const redis_retries_count = new client.Counter({
+  name: 'redis_retries_count',
+  help: 'The number of retries that have been made to establish a redis connection',
+})
+
+export enum CMD_SENT_STATUS {
+  FAIL = 'FAIL',
+  SUCCESS = 'SUCCESS',
+}
+export const redis_commands_sent_count = new client.Counter({
+  name: 'redis_commands_sent_count',
+  help: 'The number of redis commands sent',
+  labelNames: ['status', 'function_name'],
+})


### PR DESCRIPTION
## Description

Adds redis metrics to external adapters, viewable on the included dashboards

# High level changes
- Added `redis_retries_count` metric
- Added `redis_commands_sent_count` metric

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. `cd grafana`
2. `jb init`
3. `./scripts/compose.sh coingecko-adapter`
4. `./scripts/deploy.sh`

Metrics should then be viewable on `localhost:3000`

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
