### PR TITLE
fix(iexcloud): provider name without dashes and in caps

### DIFF
--- a/packages/core/bootstrap/src/lib/provider-limits/limits.json
+++ b/packages/core/bootstrap/src/lib/provider-limits/limits.json
@@ -670,7 +670,7 @@
     "http": {},
     "ws": {}
   },
-  "iex-cloud": {
+  "iexcloud": {
     "http": {
       "individual": {
         "rateLimit1h": 6944.44444444,

--- a/packages/sources/iex-cloud/src/config.ts
+++ b/packages/sources/iex-cloud/src/config.ts
@@ -1,7 +1,7 @@
 import { Requester } from '@chainlink/ea-bootstrap'
 import { Config } from '@chainlink/types'
 
-export const NAME = 'IEXCloud'
+export const NAME = 'IEXCLOUD'
 
 export const DEFAULT_ENDPOINT = 'stock'
 export const DEFAULT_BASE_URL = 'https://cloud.iexapis.com/stable'


### PR DESCRIPTION
### Description
Correction to name of IEX Cloud adapter for consistency in provider rate limit static config