### PR TITLE
fix(cryptomkt): move to v3 API

### DIFF
--- a/packages/sources/cryptomkt/src/config.ts
+++ b/packages/sources/cryptomkt/src/config.ts
@@ -4,7 +4,7 @@ import { Config } from '@chainlink/types'
 export const NAME = 'CRYPTOMKT'
 
 export const DEFAULT_ENDPOINT = 'crypto'
-export const DEFAULT_BASE_URL = 'https://api.cryptomkt.com/v1/'
+export const DEFAULT_BASE_URL = 'https://api.exchange.cryptomkt.com/api/3/'
 
 export const makeConfig = (prefix?: string): Config => {
   const config = Requester.getDefaultConfig(prefix)


### PR DESCRIPTION
## Closes [#17340](https://app.shortcut.com/chainlinklabs/story/17340/cryptomkt-adapter-to-v3)

## Description

Using V2 API this adapter is unable to query `BTC/ARS` pair.

......

## Changes

- Switch to V3 API

## Steps to Test

1. Start `cryptomkt` adapter
2. Query 
```
{
    "id": "1",
    "data": {
        "from": "BTC",
        "to": "ARS"
    }
}
```

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
