### PR TITLE
feat(bootstrap): hashed feedId

### DIFF
--- a/packages/core/bootstrap/src/lib/metrics/util.ts
+++ b/packages/core/bootstrap/src/lib/metrics/util.ts
@@ -1,6 +1,7 @@
 import { AdapterRequest } from '@chainlink/types'
 import { logger, Validator } from '../external-adapter'
 import { excludableAdapterRequestProperties } from '../util'
+import * as crypto from 'crypto'
 
 /**
  * Normalizes http status codes.
@@ -29,6 +30,11 @@ export function normalizeStatusCode(status?: number): string {
   }
   return '5XX'
 }
+
+/**
+ * Maxiumum number of characters that a feedId can contain.
+ */
+export const MAX_FEED_ID_LENGTH = 300
 
 /**
  * Get feed id name based on input params
@@ -74,5 +80,10 @@ export const getFeedId = (input: AdapterRequest): string => {
     .filter((prop) => !excludableAdapterRequestProperties[prop])
     .map((k) => [k, input[k as keyof AdapterRequest]])
 
-  return JSON.stringify(Object.fromEntries(entries))
+  const rawFeedId = JSON.stringify(Object.fromEntries(entries))
+
+  // If feedId exceed the max length use the md5 hash
+  return rawFeedId.length > MAX_FEED_ID_LENGTH
+    ? crypto.createHash('md5').update(rawFeedId).digest('hex')
+    : rawFeedId
 }

--- a/packages/core/bootstrap/test/unit/metrics/util.test.ts
+++ b/packages/core/bootstrap/test/unit/metrics/util.test.ts
@@ -1,5 +1,6 @@
 import { AdapterRequest } from '@chainlink/types'
 import * as util from '../../../src/lib/metrics/util'
+import * as crypto from 'crypto'
 
 describe('Bootstrap/Metrics Utils', () => {
   describe('Get Feed ID', () => {
@@ -13,6 +14,17 @@ describe('Bootstrap/Metrics Utils', () => {
       }
       const feedName = util.getFeedId(input)
       expect(feedName).toBe('ETH/USD')
+    })
+
+    it(`Returns an MD5 hash when the length is exceeded`, () => {
+      const input: AdapterRequest = {
+        id: '1',
+        data: {
+          test: Array(util.MAX_FEED_ID_LENGTH).fill('TEST'),
+        },
+      }
+      const feedName = util.getFeedId(input)
+      expect(feedName).toBe('bbf37d01b4ad1e0649f514db3493bcc7')
     })
 
     it(`Gets the correct feed id with any base/quote combination`, () => {


### PR DESCRIPTION
## Description
Fiews had their Prometheus blow up from Bitcoin-JSON-RPC sending 12MB of metrics on every scrape.
This is due to the requests that go into the adapter being absolutely massive - which gets used to generate the `feedId`.
......

## Changes
`feedId` gets hashed past a certain length.

## Steps to Test
Unit test added

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
