### PR TITLE
adding override for BCH on coingecko

### DIFF
--- a/packages/core/bootstrap/src/lib/external-adapter/overrides/presetSymbols.json
+++ b/packages/core/bootstrap/src/lib/external-adapter/overrides/presetSymbols.json
@@ -8,7 +8,8 @@
     "PAX": "paxos-standard",
     "RUNE": "thorchain",
     "UNI": "uniswap",
-    "grt": "the-graph"
+    "grt": "the-graph",
+    "BCH": "bitcoin-cash"
   },
   "coinmarketcap": {
     "PAX": "USDP"


### PR DESCRIPTION
Adding override for Bitcoin cash to use id bitcoin-cash instead of BCH.