### PR TITLE
fix(dydx-rewards): expect activeRootIpfsCid to be base64 encoded

### DIFF
--- a/packages/composites/dydx-rewards/src/method/poke.ts
+++ b/packages/composites/dydx-rewards/src/method/poke.ts
@@ -76,7 +76,8 @@ export const execute: ExecuteWithConfig<Config> = async (input, context, config)
     .toNumber()
   const callbackAddress = parseAddress(validator.validated.data.callbackAddress)
   const newEpoch = BigNumber.from(validator.validated.data.newEpoch)
-  const activeRootIpfsCid = validator.validated.data.activeRootIpfsCid
+  const activeRootIpfsCidBase64 = Buffer.from(validator.validated.data.activeRootIpfsCid, 'base64')
+  const activeRootIpfsCid = activeRootIpfsCidBase64.toString()
 
   const requesterContract = new ethers.Contract(callbackAddress, OracleRequester, config.wallet)
 


### PR DESCRIPTION
## Changes

- Expects the `activeRootIpfsCid` to be base64 encoded in the request from the Chainlink node