### PR TITLE
feat: support multiple RPC_URLs in reference-data-reader

### DIFF
--- a/packages/composites/crypto-volatility-index/src/adapter.ts
+++ b/packages/composites/crypto-volatility-index/src/adapter.ts
@@ -11,6 +11,7 @@ const customParams = {
   deviationThreshold: false,
   lambdaMin: false,
   lambdaK: false,
+  network: false,
 }
 
 export const execute: Execute = async (input: AdapterRequest, context: AdapterContext) => {

--- a/packages/composites/crypto-volatility-index/src/config.ts
+++ b/packages/composites/crypto-volatility-index/src/config.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_NETWORK = 'ETHEREUM'

--- a/packages/composites/crypto-volatility-index/src/cryptoVolatilityIndex.ts
+++ b/packages/composites/crypto-volatility-index/src/cryptoVolatilityIndex.ts
@@ -6,6 +6,7 @@ import { Decimal } from 'decimal.js'
 import moment from 'moment'
 import { dominanceByCurrency, getDominanceAdapter } from './dominanceDataProvider'
 import { AdapterContext, AdapterRequest } from '@chainlink/types'
+import { DEFAULT_NETWORK } from './config'
 
 export const calculate = async (
   validated: Record<string, any>,
@@ -21,6 +22,7 @@ export const calculate = async (
     deviationThreshold = 0.11,
     lambdaMin = 0.031,
     lambdaK = 0.31,
+    network = DEFAULT_NETWORK,
   } = validated.data
 
   // Get all of the required derivatives data for the calculations, for all the relevant currencies
@@ -46,6 +48,7 @@ export const calculate = async (
         deviationThreshold,
         lambdaMin,
         lambdaK,
+        network,
       )
 
   Logger.info(`CVI: ${cvi}`)
@@ -133,8 +136,9 @@ const applySmoothing = async (
   deviationThreshold: number,
   lambdaMin: number,
   lambdaK: number,
+  network: string,
 ): Promise<number> => {
-  const roundData = await getRpcLatestRound(oracleAddress)
+  const roundData = await getRpcLatestRound(network, oracleAddress)
   const latestIndex = new Decimal(roundData.answer.toString()).div(multiply)
   const updatedAt = roundData.updatedAt.mul(1000).toNumber()
 

--- a/packages/composites/market-closure/src/adapter.ts
+++ b/packages/composites/market-closure/src/adapter.ts
@@ -1,7 +1,7 @@
 import { AdapterRequest, AdapterResponse, Execute } from '@chainlink/types'
 import { Requester, Validator } from '@chainlink/ea-bootstrap'
 import { getLatestAnswer } from '@chainlink/ea-reference-data-reader'
-import { Config, makeConfig } from './config'
+import { Config, makeConfig, DEFAULT_NETWORK } from './config'
 import { getCheckImpl, getCheckProvider } from './checks'
 
 const customParams = {
@@ -9,6 +9,7 @@ const customParams = {
   source: true,
   referenceContract: ['referenceContract', 'contract'],
   multiply: true,
+  network: false,
 }
 
 export const execute = async (input: AdapterRequest, config: Config): Promise<AdapterResponse> => {
@@ -21,9 +22,11 @@ export const execute = async (input: AdapterRequest, config: Config): Promise<Ad
   const check = validator.validated.data.check
   const source = validator.validated.data.source
 
+  const network = validator.validated.data.network || DEFAULT_NETWORK
+
   const halted = await getCheckImpl(getCheckProvider(check))(input)
   if (halted) {
-    const result = await getLatestAnswer(referenceContract, multiply, input.meta)
+    const result = await getLatestAnswer(network, referenceContract, multiply, input.meta)
     return Requester.success(jobRunID, { data: { result }, status: 200 })
   }
 

--- a/packages/composites/market-closure/src/config.ts
+++ b/packages/composites/market-closure/src/config.ts
@@ -1,6 +1,8 @@
 import { Requester, util } from '@chainlink/ea-bootstrap'
 import { getDataProvider, PriceAdapter } from './dataProvider'
 
+export const DEFAULT_NETWORK = 'ETHEREUM'
+
 export type GetPriceAdapter = (name: string) => PriceAdapter
 
 export type Config = {

--- a/packages/composites/outlier-detection/src/adapter.ts
+++ b/packages/composites/outlier-detection/src/adapter.ts
@@ -11,6 +11,7 @@ import {
   makeConfig,
   DEFAULT_CHECK_THRESHOLD,
   DEFAULT_ONCHAIN_THRESHOLD,
+  DEFAULT_NETWORK,
   makeOptions,
   Config,
 } from './config'
@@ -32,6 +33,7 @@ const customParams = {
   check: false,
   check_threshold: false,
   onchain_threshold: false,
+  network: false,
 }
 
 const execute: ExecuteWithConfig<Config> = async (input, _, config) => {
@@ -45,8 +47,9 @@ const execute: ExecuteWithConfig<Config> = async (input, _, config) => {
   const check_threshold = validator.validated.data.check_threshold || DEFAULT_CHECK_THRESHOLD
   const onchain_threshold = validator.validated.data.onchain_threshold || DEFAULT_ONCHAIN_THRESHOLD
   const { referenceContract, multiply } = validator.validated.data
+  const network = validator.validated.data.network || DEFAULT_NETWORK
 
-  const onchainValue = await getLatestAnswer(referenceContract, multiply, input.meta)
+  const onchainValue = await getLatestAnswer(network, referenceContract, multiply, input.meta)
 
   const sourceMedian = await getExecuteMedian(config.sources, source, input)
 

--- a/packages/composites/outlier-detection/src/config.ts
+++ b/packages/composites/outlier-detection/src/config.ts
@@ -4,6 +4,7 @@ import { Config as BaseConfig, RequestConfig } from '@chainlink/types'
 
 export const DEFAULT_CHECK_THRESHOLD = 0
 export const DEFAULT_ONCHAIN_THRESHOLD = 0
+export const DEFAULT_NETWORK = 'ETHEREUM'
 
 export type SourceRequestOptions = { [source: string]: RequestConfig }
 export type CheckRequestOptions = { [check: string]: RequestConfig }

--- a/packages/composites/reference-transform/src/adapter.ts
+++ b/packages/composites/reference-transform/src/adapter.ts
@@ -1,6 +1,6 @@
 import { Requester, Validator, AdapterError, Logger } from '@chainlink/ea-bootstrap'
 import { AdapterResponse, Execute, AdapterRequest } from '@chainlink/types'
-import { makeConfig, Config } from './config'
+import { makeConfig, Config, DEFAULT_NETWORK } from './config'
 import { getRpcLatestAnswer } from '@chainlink/ea-reference-data-reader'
 
 const customParams = {
@@ -9,6 +9,7 @@ const customParams = {
   multiply: false,
   operator: ['operator'],
   dividend: false,
+  network: false,
 }
 
 const transform = (offchain: number, onchain: number, operator: string, dividendConfig: string) => {
@@ -36,6 +37,7 @@ export const execute = async (input: AdapterRequest, config: Config): Promise<Ad
   const multiply = validator.validated.data.multiply || 100000000
   const operator = validator.validated.data.operator
   const dividend = validator.validated.data.dividend || 'off-chain'
+  const network = validator.validated.data.network || DEFAULT_NETWORK
 
   if (operator !== 'multiply' && operator !== 'divide')
     throw new AdapterError({
@@ -53,7 +55,7 @@ export const execute = async (input: AdapterRequest, config: Config): Promise<Ad
 
   Logger.debug('Getting value from contract: ' + contract)
 
-  let price = await getRpcLatestAnswer(contract, 1)
+  let price = await getRpcLatestAnswer(network, contract, 1)
   price = price / multiply
   Logger.debug('Value: ' + price)
 

--- a/packages/composites/reference-transform/src/config.ts
+++ b/packages/composites/reference-transform/src/config.ts
@@ -2,6 +2,8 @@ import legos from '@chainlink/ea'
 import { Requester, util } from '@chainlink/ea-bootstrap'
 import { Config as DefaultConfig } from '@chainlink/types'
 
+export const DEFAULT_NETWORK = 'ETHEREUM'
+
 export type Config = {
   sources: { [name: string]: DefaultConfig }
 }

--- a/packages/composites/the-graph/src/config.ts
+++ b/packages/composites/the-graph/src/config.ts
@@ -9,6 +9,8 @@ export type Config = DefaultConfig & {
   }
 }
 
+export const DEFAULT_NETWORK = 'ETHEREUM'
+
 export const WETH = 'WETH'
 export const UNISWAP = 'UNISWAP'
 const DEFAULT_UNISWAP_V2_SUBGRAPH_ENDPOINT =

--- a/packages/composites/the-graph/src/types.ts
+++ b/packages/composites/the-graph/src/types.ts
@@ -34,4 +34,5 @@ export interface DexQueryInputParams {
   referenceContract: string
   referenceContractDivisor: number
   referenceModifierAction: ReferenceModifierAction
+  network: string
 }

--- a/packages/core/reference-data-reader/src/index.ts
+++ b/packages/core/reference-data-reader/src/index.ts
@@ -1,7 +1,7 @@
 import { ethers } from 'ethers'
 import { AggregatorInterfaceFactory } from '@chainlink/contracts/ethers/v0.6/AggregatorInterfaceFactory'
 import { AggregatorV2V3InterfaceFactory } from '@chainlink/contracts/ethers/v0.6/AggregatorV2V3InterfaceFactory'
-import { util, Logger } from '@chainlink/ea-bootstrap'
+import { AdapterError, util, Logger } from '@chainlink/ea-bootstrap'
 import { BigNumber } from 'ethers/utils'
 
 export interface RoundData {
@@ -53,6 +53,10 @@ export const getRpcLatestRound: ReferenceDataRound = async (
 }
 
 export const getRpcUrl = (network: string): string => {
+  // First try with network prefix
+  const rpcUrlWithNetwork = util.getEnv(`${network.toUpperCase}_RPC_URL`)
+  if (rpcUrlWithNetwork) return rpcUrlWithNetwork
+
   // Backwards compatability for RPC_URL
   const rpcURL = util.getEnv('RPC_URL')
   if (rpcURL) {
@@ -61,5 +65,8 @@ export const getRpcUrl = (network: string): string => {
     )
     return rpcURL
   }
-  return util.getRequiredEnv(`${network.toUpperCase}_RPC_URL`)
+
+  throw new Error(
+    `Network ${network} must be configured with an environment variable ${`${network.toUpperCase}_RPC_URL`}`,
+  )
 }

--- a/packages/core/reference-data-reader/src/index.ts
+++ b/packages/core/reference-data-reader/src/index.ts
@@ -54,7 +54,7 @@ export const getRpcLatestRound: ReferenceDataRound = async (
 
 export const getRpcUrl = (network: string): string => {
   // First try with network prefix
-  const rpcUrlWithNetwork = util.getEnv(`${network.toUpperCase}_RPC_URL`)
+  const rpcUrlWithNetwork = util.getEnv(`${network.toUpperCase()}_RPC_URL`)
   if (rpcUrlWithNetwork) return rpcUrlWithNetwork
 
   // Backwards compatability for RPC_URL

--- a/packages/core/reference-data-reader/src/index.ts
+++ b/packages/core/reference-data-reader/src/index.ts
@@ -67,6 +67,6 @@ export const getRpcUrl = (network: string): string => {
   }
 
   throw new Error(
-    `Network ${network} must be configured with an environment variable ${`${network.toUpperCase}_RPC_URL`}`,
+    `Network ${network} must be configured with an environment variable ${`${network.toUpperCase()}_RPC_URL`}`,
   )
 }

--- a/packages/core/reference-data-reader/src/index.ts
+++ b/packages/core/reference-data-reader/src/index.ts
@@ -1,7 +1,7 @@
 import { ethers } from 'ethers'
 import { AggregatorInterfaceFactory } from '@chainlink/contracts/ethers/v0.6/AggregatorInterfaceFactory'
 import { AggregatorV2V3InterfaceFactory } from '@chainlink/contracts/ethers/v0.6/AggregatorV2V3InterfaceFactory'
-import { AdapterError, util, Logger } from '@chainlink/ea-bootstrap'
+import { util, Logger } from '@chainlink/ea-bootstrap'
 import { BigNumber } from 'ethers/utils'
 
 export interface RoundData {


### PR DESCRIPTION
## Description
Now that we are launching on more and more networks there may be multiple `RPC_URL` to use when reading on-chain.
Currently nops will spin up a new adapter instance for each network.
This PR allows one instance with multiple `RPC_URL`s, using a prefix of the network name (e.g. `MATIC_RPC_URL`)

## Changes

- `reference-data-reader` supports multiple `X_RPC_URL`s.

Backwards compatability for `RPC_URL` is kept.

## Steps to Test

Run a composite with multiple RPC_URLs.

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
