### PR TITLE
bugfix for onchain gas adapter

### DIFF
--- a/packages/core/bootstrap/src/lib/ws/epics.ts
+++ b/packages/core/bootstrap/src/lib/ws/epics.ts
@@ -435,13 +435,19 @@ export const connectEpic: Epic<AnyAction, AnyAction, { ws: RootState }, any> = (
           const subscription = state.ws.subscriptions.all[key]
           return subscription && !subscription.subscriptionParams
         }),
-        mergeMap(async ([action]) => {
-          return saveFirstMessageReceived({
-            subscriptionKey: action.payload.subscriptionKey,
-            message: wsHandler.toSaveFromFirstMessage
-              ? wsHandler.toSaveFromFirstMessage(action.payload.message)
-              : {},
-          })
+        mergeMap(([action]) => {
+          const toSave = wsHandler.toSaveFromFirstMessage
+            ? wsHandler.toSaveFromFirstMessage(action.payload.message)
+            : undefined
+          if (!toSave) {
+            return EMPTY
+          }
+          return of(
+            saveFirstMessageReceived({
+              subscriptionKey: action.payload.subscriptionKey,
+              message: toSave,
+            }),
+          )
         }),
       )
 

--- a/packages/sources/onchain-gas/src/adapter.ts
+++ b/packages/sources/onchain-gas/src/adapter.ts
@@ -28,9 +28,14 @@ export const makeWSHandler = (config?: Config): MakeWSHandler => {
       connection: {
         url: defaultConfig.api.baseURL,
       },
-      toSaveFromFirstMessage: (message: any) => ({
-        subscriptionId: message.params.subscription,
-      }),
+      toSaveFromFirstMessage: (message: any) => {
+        if (message.method !== 'eth_subscription' || !message.params) {
+          return undefined
+        }
+        return {
+          subscriptionId: message.params.subscription,
+        }
+      },
       noHttp: true,
       subscribe: (input) => ({
         id: input.id,


### PR DESCRIPTION
Fix issue with onchain gas adapter when the first response from the WS RPC endpoint does not have the `params` field with the subscription ID.