### PR TITLE
Feature/17539: add ability to spin up/down adapters in the qa cluster

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,5 @@ test-payload.json
 .yarn
 .vscode
 .pnp.cjs
+
+ephemeral/cl-adapter

--- a/ephemeral/cl-adapter/.helmignore
+++ b/ephemeral/cl-adapter/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/ephemeral/cl-adapter/Chart.yaml
+++ b/ephemeral/cl-adapter/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: cl-adapter
+description: A generic Helm chart for Chainlink adapters
+maintainers:
+  - name: Chainlink
+    url: chain.link
+
+type: application
+version: 0.1.15

--- a/ephemeral/cl-adapter/templates/_helpers.tpl
+++ b/ephemeral/cl-adapter/templates/_helpers.tpl
@@ -1,0 +1,26 @@
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cl-adapter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "cl-adapter.labels" -}}
+helm.sh/chart: {{ include "cl-adapter.chart" . }}
+{{ include "cl-adapter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "cl-adapter.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Values.name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/ephemeral/cl-adapter/templates/deployment.yaml
+++ b/ephemeral/cl-adapter/templates/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "cl-adapter.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "cl-adapter.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ cat (.Values.envVars | toString) (.Values.envSecrets | toString) | sha256sum | quote }}
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "cl-adapter.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ .Values.name }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Values.name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: {{ print .Values.image.repository (hasPrefix "sha256:" .Values.image.tag | ternary "@" ":") .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+            - name: metrics
+              containerPort: {{ .Values.envVars.METRICS_PORT | default 9080 }}
+              protocol: TCP
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          env:
+            {{- if eq (.Values.envVars.CACHE_TYPE | default "") "redis" }}
+            - name: CACHE_REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.cache.redis.secretName }}
+                  key: {{ .Values.cache.redis.secretKey }}
+            {{- end }}
+            {{- range $envKey, $envValue := .Values.envVars }}
+            - name: {{ $envKey }}
+              value: {{ $envValue | quote }}
+            {{- end }}
+          {{- if .Values.envSecrets }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.name }}
+          {{- end }}

--- a/ephemeral/cl-adapter/templates/hpa.yaml
+++ b/ephemeral/cl-adapter/templates/hpa.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Values.name }}
+  minReplicas: 1
+  maxReplicas: 10
+  metrics:
+    - type: Object
+      object:
+        metric:
+          name: nginx_ingress_controller_requests_rate
+        describedObject:
+          apiVersion: extensions/v1beta1
+          kind: Ingress
+          name: {{ .Values.name }}
+        target:
+          averageValue: {{ .Values.hpa.targetAverage }}
+          type: AverageValue
+          value: {{ .Values.hpa.value }}
+{{ end -}}

--- a/ephemeral/cl-adapter/templates/ingress.yaml
+++ b/ephemeral/cl-adapter/templates/ingress.yaml
@@ -1,0 +1,26 @@
+{{- $name := .Values.name -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "cl-adapter.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /{{ $name }}
+            pathType: Prefix
+            backend:
+              serviceName: adapter-{{ $name }}
+              servicePort: {{ $svcPort }}
+          - path: /{{ $name }}/(.*)
+            pathType: Prefix
+            backend:
+              serviceName: adapter-{{ $name }}
+              servicePort: {{ $svcPort }}

--- a/ephemeral/cl-adapter/templates/secret.yaml
+++ b/ephemeral/cl-adapter/templates/secret.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.envSecrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+type: Opaque
+stringData:
+  {{ .Values.envSecrets | toYaml | nindent 2 }}
+{{- end }}

--- a/ephemeral/cl-adapter/templates/service.yaml
+++ b/ephemeral/cl-adapter/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  # "adapter-" used due to DNS-1035 RFC requiring first character to be a letter (so no 1forge)
+  name: adapter-{{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "cl-adapter.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "cl-adapter.selectorLabels" . | nindent 4 }}

--- a/ephemeral/cl-adapter/templates/serviceaccount.yaml
+++ b/ephemeral/cl-adapter/templates/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "cl-adapter.labels" . | nindent 4 }}

--- a/ephemeral/cl-adapter/templates/servicemonitor.yaml
+++ b/ephemeral/cl-adapter/templates/servicemonitor.yaml
@@ -1,0 +1,34 @@
+{{ if .Values.envVars.EXPERIMENTAL_METRICS_ENABLED | default false -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: adapter-{{ .Values.name }}-metrics
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "cl-adapter.labels" . | nindent 4 }}
+    type: metrics 
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.envVars.METRICS_PORT | default 9080 }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+  selector:
+    {{- include "cl-adapter.selectorLabels" . | nindent 4 }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: adapter-{{ .Values.name }}
+  labels:
+    {{- include "cl-adapter.labels" . | nindent 4 }}
+    release: prometheus
+spec:
+  selector:
+    matchLabels:
+      {{- include "cl-adapter.labels" . | nindent 6 }}
+      type: metrics
+  endpoints:
+  - port: metrics
+{{- end }}

--- a/ephemeral/cl-adapter/templates/vpa.yaml
+++ b/ephemeral/cl-adapter/templates/vpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.vpa.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ .Values.name }}
+spec:
+  targetRef:
+    apiVersion: "apps/v1"
+    kind:       Deployment
+    name:       {{ .Values.name }}
+  updatePolicy:
+    updateMode: "Auto"
+  resourcePolicy:
+    containerPolicies:
+    - containerName: {{ .Values.name }}
+      minAllowed: 
+        cpu: {{ .Values.vpa.min.cpu }}
+        memory: {{ .Values.vpa.min.memory }}
+      maxAllowed:
+        cpu: {{ .Values.vpa.max.cpu }}
+        memory: {{ .Values.vpa.max.memory }}
+{{ end -}}

--- a/ephemeral/cl-adapter/values.yaml
+++ b/ephemeral/cl-adapter/values.yaml
@@ -1,0 +1,96 @@
+# Default values for cl-adapter.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicas: 1
+
+name: fake-adapter
+namespace: adapters
+
+image:
+  repository: fake.repository.com/fakepath
+  tag: latest
+  pullPolicy: Always
+
+adapter:
+  logLevel: info
+
+envVars:
+  CACHE_ENABLED: true
+  CACHE_TYPE: redis
+  CACHE_REDIS_CONNECTION_TIMEOUT: 2147483647
+  CACHE_REDIS_HOST: redis-master
+  CACHE_REDIS_TIMEOUT: 3000
+  # https://docs.microsoft.com/en-us/azure/azure-cache-for-redis/cache-best-practices
+  EXPERIMENTAL_METRICS_ENABLED: true
+  EXPERIMENTAL_WARMUP_ENABLED: true
+  EXPERIMENTAL_RATE_LIMIT_ENABLED: true
+  LOG_LEVEL: info
+  METRICS_PORT: 9080
+  WS_ENABLED: false
+
+cache:
+  redis:
+    secretName: redis
+    secretKey: redis-password
+
+podSecurityContext:
+  fsGroup: 2000
+
+securityContext:
+  capabilities:
+    drop:
+      - ALL
+  runAsUser: 1000
+  runAsNonRoot: true
+  # readOnlyRootFilesystem: true
+
+service:
+  port: 8080
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+  failureThreshold: 5
+  initialDelaySeconds: 5
+  periodSeconds: 30
+  timeoutSeconds: 15
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: http
+  failureThreshold: 3
+  initialDelaySeconds: 5
+  periodSeconds: 20
+  timeoutSeconds: 10
+
+# vpa uses requests:limits as a direct ratio
+resources:
+  limits:
+    cpu: 100m
+    memory: 192Mi
+  requests:
+    cpu: 30m
+    memory: 64Mi
+
+hpa:
+  enabled: false
+  # The k8s server side diff will add target: '0'
+  # if this is not declared, which breaks edits to the
+  # HPA resource. With this workaround targetAverage
+  # is unused when targetAverage is defined.
+  target: 1
+  targetAverage: 8
+
+# vertical pod autoscaler
+# this is the min/max for requests only
+vpa:
+  enabled: true
+  max:
+    cpu: 300m
+    memory: 384Mi
+  min:
+    cpu: 15m
+    memory: 32Mi

--- a/ephemeral/startAdapter.sh
+++ b/ephemeral/startAdapter.sh
@@ -9,14 +9,14 @@
 # IMAGE_REPOSITORY - Defaults to the chainlink public ecr for adapters.
 # IMAGE_TAG - Defaults to develop-latest. Can also be an image sha256
 #
-# Example: ADAPTER=coingecko RELEASE_TAG=tate yarn qa:adapter:start
+# Example: ADAPTER=coingecko RELEASE_TAG=test yarn qa:adapter:start
 #
 ###### ----- ######
 
 ## The name of the adapter you want to deploy
 ADAPTER=${ADAPTER:=}
 ## A unique release tag, in ci this will be the pr number, keeps us from having collisions
-RELEASE_TAG=${RELEASE_TAG:=tate}
+RELEASE_TAG=${RELEASE_TAG:=}
 ## Path to the helm chart directory
 HELM_CHART_DIR=${HELM_CHART_DIR:=./ephemeral/cl-adapter}
 ## The repository where your built image is

--- a/ephemeral/startAdapter.sh
+++ b/ephemeral/startAdapter.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+###### Usage ######
+#
+# Uses environment variables to determine which adapter to deploy. Tools required: kubectl, helm, grep
+# ADAPTER - Required.
+# RELEASE_TAG - Required. Used to create a unique release of the adapter. If used locally you can just use your name. If used in CI then the PR number should be used.
+# HELM_CHART_DIR - Defaults to a temporary chart in this repo. To be replaced by an internal helm chart repository pull in the future.
+# IMAGE_REPOSITORY - Defaults to the chainlink public ecr for adapters.
+# IMAGE_TAG - Defaults to develop-latest. Can also be an image sha256
+#
+# Example: ADAPTER=coingecko RELEASE_TAG=tate yarn qa:adapter:start
+#
+###### ----- ######
+
+## The name of the adapter you want to deploy
+ADAPTER=${ADAPTER:=}
+## A unique release tag, in ci this will be the pr number, keeps us from having collisions
+RELEASE_TAG=${RELEASE_TAG:=tate}
+## Path to the helm chart directory
+HELM_CHART_DIR=${HELM_CHART_DIR:=./ephemeral/cl-adapter}
+## The repository where your built image is
+IMAGE_REPOSITORY=${IMAGE_REPOSITORY:=public.ecr.aws/chainlink/adapters/}
+## The image tag, can also be an image sha
+IMAGE_TAG=${IMAGE_TAG:=develop-latest}
+
+## The release name to be used in helm
+NAME=qa-ea-${ADAPTER}-${RELEASE_TAG}
+## The namespace for the k8s release
+NAMESPACE=ephemeral-adapters
+
+# check that we are in the qa-staging-cluster k8s context
+KUBE_CONTEXT=$(kubectl config get-contexts | grep '*' | grep qa-stage-cluster)
+if [ -z "$KUBE_CONTEXT" ]; then
+    echo "We only want to deploy ephemeral adapters into the qa staging cluster, please switch your kube context to the qa staging cluster"
+    exit 1
+fi
+
+# do we have an adapter specified
+if [ -z "$ADAPTER" ]; then
+    echo "Need an ADAPTER specified."
+    exit 1
+fi
+
+# do we have a release tag specified
+if [ -z "$RELEASE_TAG" ]; then
+    echo "Need a RELEASE_TAG specified. Use your name if running this locally. Use the PR number if running in CI"
+    exit 1
+fi
+
+# deploy the adapter
+helm upgrade ${NAME} ${HELM_CHART_DIR} \
+    --install \
+    --namespace ${NAMESPACE} \
+    --create-namespace \
+    --set image.repository="${IMAGE_REPOSITORY}${ADAPTER}-adapter" \
+    --set image.tag=${IMAGE_TAG} \
+    --set name=${NAME}

--- a/ephemeral/startAdapter.sh
+++ b/ephemeral/startAdapter.sh
@@ -55,4 +55,5 @@ helm upgrade ${NAME} ${HELM_CHART_DIR} \
     --create-namespace \
     --set image.repository="${IMAGE_REPOSITORY}${ADAPTER}-adapter" \
     --set image.tag=${IMAGE_TAG} \
-    --set name=${NAME}
+    --set name=${NAME} \
+    --wait

--- a/ephemeral/stopAdapter.sh
+++ b/ephemeral/stopAdapter.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+###### Usage ######
+#
+# Uses environment variables to determine which adapter to uninstall. Tools required: helm
+# ADAPTER - Required.
+# RELEASE_TAG - Required. Used to remove a unique release of the adapter. Use the same one you used when starting the adapter.
+#
+# Example: ADAPTER=coingecko RELEASE_TAG=tate yarn qa:adapter:stop
+#
+###### ----- ######
+
+## The name of the adapter you want to deploy
+ADAPTER=${ADAPTER:=}
+## A unique release tag, in ci this will be the pr number, keeps us from having collisions
+RELEASE_TAG=${RELEASE_TAG:=}
+## The release name to be used in helm
+NAME=qa-ea-${ADAPTER}-${RELEASE_TAG}
+## The namespace for the k8s release
+NAMESPACE=ephemeral-adapters
+
+# do we have an adapter
+if [ -z "$ADAPTER" ]; then
+    echo "Need an ADAPTER specified."
+    exit 1
+fi
+
+# do we have a release tag
+if [ -z "$RELEASE_TAG" ]; then
+    echo "Need a RELEASE_TAG specified. Use your name if running this locally. Use the PR number if running in CI"
+    exit 1
+fi
+
+helm uninstall ${NAME} \
+    --namespace ${NAMESPACE}

--- a/ephemeral/stopAdapter.sh
+++ b/ephemeral/stopAdapter.sh
@@ -6,7 +6,7 @@
 # ADAPTER - Required.
 # RELEASE_TAG - Required. Used to remove a unique release of the adapter. Use the same one you used when starting the adapter.
 #
-# Example: ADAPTER=coingecko RELEASE_TAG=tate yarn qa:adapter:stop
+# Example: ADAPTER=coingecko RELEASE_TAG=test yarn qa:adapter:stop
 #
 ###### ----- ######
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "generate:healthcheck:payloads": "ts-node-transpile-only ./packages/scripts/src/healthchecks",
     "generate:image-name": "ts-node-transpile-only ./packages/scripts/src/generate-image-name",
     "postinstall": "husky install",
-    "cm": "cz"
+    "cm": "cz",
+    "qa:adapter:start": "./ephemeral/startAdapter.sh",
+    "qa:adapter:stop": "./ephemeral/stopAdapter.sh"
   },
   "dependencies": {
     "@babel/core": "7.15.0",


### PR DESCRIPTION
## Description

Add scripts to spin up and down ephemeral adapters in the qa cluster. Currently coingecko and coinpaprika work with these changes.

## Changes

- Added scripts to start and stop adapters in the qa cluster. The scripts can be used for testing local changes or in CI.
- Added the cl-adapter helm chart temporarily. Once we have an internal helm repository to pull from then this can go away.

## Steps to Test

1. Run `ADAPTER=coingecko RELEASE_TAG=test yarn qa:adapter:start` with your kubectx set to the qa cluster to start an ephemeral adapter.
2. Run `ADAPTER=coingecko RELEASE_TAG=test yarn qa:adapter:stop` with your kubectx set to the qa cluster to stop an ephemeral adapter.

