### PR TITLE
Bugfix for duplicate ws cache writes

### DIFF
--- a/packages/core/bootstrap/schemas/env.json
+++ b/packages/core/bootstrap/schemas/env.json
@@ -119,6 +119,9 @@
     },
     "REQUEST_COALESCING_ENTROPY_MAX": {
       "type": "string"
+    },
+    "WS_ENABLED": {
+      "type": "boolean"
     }
   }
 }

--- a/packages/core/bootstrap/src/lib/ws/actions.ts
+++ b/packages/core/bootstrap/src/lib/ws/actions.ts
@@ -9,6 +9,7 @@ export interface WSConfigPayload {
   config: WSConfig
   // TODO: wsHandler should not be sent as an event
   wsHandler: WSHandler
+  shouldNotRetryConnecting?: boolean
 }
 
 export interface WSConfigDetailedPayload extends WSConfigPayload {
@@ -101,6 +102,7 @@ export interface WSSubscriptionPayload {
 export interface WSSubscriptionErrorPayload extends WSErrorPayload {
   subscriptionMsg?: any
   input?: AdapterRequest
+  error?: any
 }
 
 export const subscribeRequested = createAction(

--- a/packages/core/bootstrap/src/lib/ws/actions.ts
+++ b/packages/core/bootstrap/src/lib/ws/actions.ts
@@ -102,7 +102,7 @@ export interface WSSubscriptionPayload {
 export interface WSSubscriptionErrorPayload extends WSErrorPayload {
   subscriptionMsg?: any
   input?: AdapterRequest
-  error?: any
+  error?: unknown
 }
 
 export const subscribeRequested = createAction(

--- a/packages/core/bootstrap/src/lib/ws/actions.ts
+++ b/packages/core/bootstrap/src/lib/ws/actions.ts
@@ -131,9 +131,11 @@ export interface WSMessagePayload {
   input: AdapterRequest
   context: AdapterContext
   connectionInfo: WSConnectionInfo
+  wsHandler: WSHandlerOverride
 }
 
 export const messageReceived = createAction('WS/MESSAGE_RECEIVED', asAction<WSMessagePayload>())
+export const writeToCache = createAction('WS/WRITE_MESSAGE_TO_CACHE', asAction<WSMessagePayload>())
 
 /** OVERRIDES */
 export interface WSHandlerOverride extends WSHandler {

--- a/packages/core/bootstrap/src/lib/ws/actions.ts
+++ b/packages/core/bootstrap/src/lib/ws/actions.ts
@@ -137,7 +137,6 @@ export interface WSMessagePayload {
 }
 
 export const messageReceived = createAction('WS/MESSAGE_RECEIVED', asAction<WSMessagePayload>())
-export const writeToCache = createAction('WS/WRITE_MESSAGE_TO_CACHE', asAction<WSMessagePayload>())
 
 /** OVERRIDES */
 export interface WSHandlerOverride extends WSHandler {

--- a/packages/core/bootstrap/src/lib/ws/epics.ts
+++ b/packages/core/bootstrap/src/lib/ws/epics.ts
@@ -52,7 +52,7 @@ import {
   ws_subscription_errors,
   ws_subscription_total,
 } from './metrics'
-import { getSubsId, RootState, SubscriptionsState } from './reducer'
+import { getSubsId, RootState } from './reducer'
 import { separateBatches } from './utils'
 
 // Rxjs deserializer defaults to JSON.parse.
@@ -216,7 +216,7 @@ export const connectEpic: Epic<AnyAction, AnyAction, { ws: RootState }, any> = (
       const close$ = closeObserver.pipe(
         withLatestFrom(state$),
         mergeMap(([closeContext, state]) => {
-          const activeSubs = Object.entries(state.ws.subscriptions as SubscriptionsState)
+          const activeSubs = Object.entries(state.ws.subscriptions.all)
             .filter(([_, info]) => info?.active)
             .map(
               ([_, info]) =>

--- a/packages/core/bootstrap/src/lib/ws/epics.ts
+++ b/packages/core/bootstrap/src/lib/ws/epics.ts
@@ -593,7 +593,7 @@ export const connectEpic: Epic<AnyAction, AnyAction, { ws: RootState }, any> = (
             filter(disconnectFulfilled.match),
             filter((a) => a.payload.config.connectionInfo.key === connectionKey),
             tap((action) => {
-              logger.info('WS: Disconnected Fulfilled', connectionMeta(action.payload))
+              logger.debug('WS: Disconnected Fulfilled', connectionMeta(action.payload))
             }),
           ),
         ),

--- a/packages/core/bootstrap/src/lib/ws/reducer.ts
+++ b/packages/core/bootstrap/src/lib/ws/reducer.ts
@@ -23,6 +23,7 @@ export interface ConnectionsState {
   total: number
   all: {
     [key: string]: {
+      shouldNotRetryConnecting?: boolean
       active: boolean
       connecting: number
       wasEverConnected?: boolean
@@ -50,6 +51,7 @@ export const connectionsReducer = createReducer<ConnectionsState>(
       // Add connection
       const { key } = action.payload.config.connectionInfo
       state.all[key] = {
+        ...state.all[key],
         active: true,
         connecting: 0,
         wasEverConnected: true,
@@ -71,6 +73,7 @@ export const connectionsReducer = createReducer<ConnectionsState>(
 
       const isConnecting = !isNaN(Number(state.all[key]?.connecting))
       state.all[key] = {
+        ...state.all[key],
         active: false,
         connecting: isConnecting ? state.all[key].connecting + 1 : 1,
         requestId: 0,
@@ -87,6 +90,7 @@ export const connectionsReducer = createReducer<ConnectionsState>(
       const { key } = action.payload.config.connectionInfo
       state.all[key].active = false
       state.all[key].connecting = 0 // turn off connecting
+      state.all[key].shouldNotRetryConnecting = action.payload.shouldNotRetryConnecting
     })
 
     builder.addMatcher(
@@ -115,6 +119,7 @@ export interface SubscriptionsState {
       input: AdapterRequest
       context: AdapterContext
       subscriptionParams?: any
+      connectionKey: string
     }
   }
 }
@@ -148,6 +153,7 @@ export const subscriptionsReducer = createReducer<SubscriptionsState>(
         subscribing: 0,
         input: { ...action.payload.input },
         context: action.payload.context,
+        connectionKey: action.payload.connectionInfo.key,
       }
     })
 
@@ -162,6 +168,7 @@ export const subscriptionsReducer = createReducer<SubscriptionsState>(
         subscribing: isSubscribing ? state.all[key].subscribing + 1 : 1,
         input: { ...action.payload.input },
         context: action.payload.context,
+        connectionKey: action.payload.connectionInfo.key,
       }
     })
 

--- a/packages/core/types/@chainlink/index.d.ts
+++ b/packages/core/types/@chainlink/index.d.ts
@@ -176,6 +176,12 @@ declare module '@chainlink/types' {
   }
 
   export type MakeWSHandler = () => WSHandler | Promise<WSHandler>
+  export interface WebsocketErrorMessageSchema {
+    type: string
+    wasClean: boolean
+    reason: string
+    code: number
+  }
   export interface WSHandler {
     // Connection information
     connection: {
@@ -240,7 +246,7 @@ declare module '@chainlink/types' {
     // Filters out messages that are not expected from sending a message constructed by one of the onConnect hooks
     isOnConnectChainMessage?: (message: any) => boolean
     // Should try open connection again after error
-    shouldRetryConnection?: (errorMessage: any) => boolean
+    shouldRetryConnection?: (errorMessage: WebsocketErrorMessageSchema) => boolean
   }
 
   /* INPUT TYPE VALIDATIONS */

--- a/packages/core/types/@chainlink/index.d.ts
+++ b/packages/core/types/@chainlink/index.d.ts
@@ -239,6 +239,8 @@ declare module '@chainlink/types' {
     heartbeatIntervalInMS?: number
     // Filters out messages that are not expected from sending a message constructed by one of the onConnect hooks
     isOnConnectChainMessage?: (message: any) => boolean
+    // Should try open connection again after error
+    shouldRetryConnection?: (errorMessage: any) => boolean
   }
 
   /* INPUT TYPE VALIDATIONS */

--- a/packages/sources/coinmetrics/src/adapter.ts
+++ b/packages/sources/coinmetrics/src/adapter.ts
@@ -78,6 +78,10 @@ export const makeWSHandler = (config?: Config): MakeWSHandler => {
           url,
         }
       },
+      shouldRetryConnection: (closeContext) => {
+        // Coinmetrics returns this code after closing a connection due to the pair being unsupported
+        return closeContext.code != 1000
+      },
     }
   }
 }


### PR DESCRIPTION
We've been seeing issues where adapters running with WS turned on have been maxing out their CPU usage.  This seems to have been because our adapters wrote the same WS message to the cache multiples times instead of just once.  The fix for this is to move the logic to cache messages into a separate epic.