### PR TITLE
Ws fix cryptocompare

### DIFF
--- a/packages/core/bootstrap/src/lib/ws/actions.ts
+++ b/packages/core/bootstrap/src/lib/ws/actions.ts
@@ -9,7 +9,6 @@ export interface WSConfigPayload {
   config: WSConfig
   // TODO: wsHandler should not be sent as an event
   wsHandler: WSHandler
-  shouldNotRetryConnecting?: boolean
 }
 
 export interface WSConfigDetailedPayload extends WSConfigPayload {
@@ -103,6 +102,14 @@ export interface WSSubscriptionErrorPayload extends WSErrorPayload {
   subscriptionMsg?: any
   input?: AdapterRequest
   error?: unknown
+  wsHandler: WSHandlerOverride
+}
+
+export interface WSSubscriptionErrorHandlerPayload {
+  connectionInfo: WSConnectionInfo
+  subscriptionMsg?: any
+  shouldNotRetrySubscription: boolean
+  shouldNotRetryConnection: boolean
 }
 
 export const subscribeRequested = createAction(
@@ -116,6 +123,10 @@ export const subscribeFulfilled = createAction(
 export const subscriptionError = createAction(
   'WS/SUBSCRIPTION_ERROR',
   asAction<WSSubscriptionErrorPayload>(),
+)
+export const subscriptionErrorHandler = createAction(
+  'WS/SUBSCRIPTION_ERROR_HANDLER',
+  asAction<WSSubscriptionErrorHandlerPayload>(),
 )
 export const unsubscribeRequested = createAction(
   'WS/UNSUBSCRIBE_REQUESTED',

--- a/packages/core/bootstrap/src/lib/ws/epics.ts
+++ b/packages/core/bootstrap/src/lib/ws/epics.ts
@@ -106,7 +106,7 @@ export const subscribeReadyEpic: Epic<AnyAction, AnyAction, { ws: RootState }, a
 
 export const recordErrorEpic: Epic<AnyAction, AnyAction, { ws: RootState }, any> = (action$) =>
   action$.pipe(
-    filter(subscriptionError.match),
+    filter((action) => subscriptionError.match(action) && !!action.payload.error),
     mergeMap(({ payload }) => {
       const { wsHandler, error, connectionInfo, subscriptionMsg } = payload
       const { shouldNotRetryConnection, shouldNotRetrySubscription } = wsHandler

--- a/packages/core/bootstrap/src/lib/ws/epics.ts
+++ b/packages/core/bootstrap/src/lib/ws/epics.ts
@@ -104,24 +104,6 @@ export const subscribeReadyEpic: Epic<AnyAction, AnyAction, { ws: RootState }, a
     mergeMap(([subscriptionPayload]) => of(subscribeRequested(subscriptionPayload))),
   )
 
-export const recordErrorEpic: Epic<AnyAction, AnyAction, { ws: RootState }, any> = (action$) =>
-  action$.pipe(
-    filter((action) => subscriptionError.match(action) && !!action.payload.error),
-    mergeMap(({ payload }) => {
-      const { wsHandler, error, connectionInfo, subscriptionMsg } = payload
-      const { shouldNotRetryConnection, shouldNotRetrySubscription } = wsHandler
-      return of(
-        subscriptionErrorHandler({
-          connectionInfo,
-          subscriptionMsg,
-          shouldNotRetryConnection: !!shouldNotRetryConnection && shouldNotRetryConnection(error),
-          shouldNotRetrySubscription:
-            !!shouldNotRetrySubscription && shouldNotRetrySubscription(error),
-        }),
-      )
-    }),
-  )
-
 export const connectEpic: Epic<AnyAction, AnyAction, { ws: RootState }, any> = (action$, state$) =>
   action$.pipe(
     filter(connectRequested.match),
@@ -624,6 +606,24 @@ export const connectEpic: Epic<AnyAction, AnyAction, { ws: RootState }, any> = (
         ),
       )
       return concat(of(wsSubscriptionReady(payload)), ws$)
+    }),
+  )
+
+export const recordErrorEpic: Epic<AnyAction, AnyAction, { ws: RootState }, any> = (action$) =>
+  action$.pipe(
+    filter((action) => subscriptionError.match(action) && !!action.payload.error),
+    mergeMap(({ payload }) => {
+      const { wsHandler, error, connectionInfo, subscriptionMsg } = payload
+      const { shouldNotRetryConnection, shouldNotRetrySubscription } = wsHandler
+      return of(
+        subscriptionErrorHandler({
+          connectionInfo,
+          subscriptionMsg,
+          shouldNotRetryConnection: !!shouldNotRetryConnection && shouldNotRetryConnection(error),
+          shouldNotRetrySubscription:
+            !!shouldNotRetrySubscription && shouldNotRetrySubscription(error),
+        }),
+      )
     }),
   )
 

--- a/packages/core/bootstrap/src/lib/ws/reducer.ts
+++ b/packages/core/bootstrap/src/lib/ws/reducer.ts
@@ -90,7 +90,11 @@ export const connectionsReducer = createReducer<ConnectionsState>(
       const { key } = action.payload.config.connectionInfo
       state.all[key].active = false
       state.all[key].connecting = 0 // turn off connecting
-      state.all[key].shouldNotRetryConnecting = action.payload.shouldNotRetryConnecting
+    })
+
+    builder.addCase(actions.subscriptionErrorHandler, (state, action) => {
+      const { key } = action.payload.connectionInfo
+      state.all[key].shouldNotRetryConnecting = !action.payload.shouldNotRetryConnection
     })
 
     builder.addMatcher(
@@ -120,6 +124,7 @@ export interface SubscriptionsState {
       context: AdapterContext
       subscriptionParams?: any
       connectionKey: string
+      shouldNotRetry?: boolean
     }
   }
 }
@@ -178,6 +183,13 @@ export const subscriptionsReducer = createReducer<SubscriptionsState>(
 
       state.all[key].active = false
       state.all[key].unsubscribed = true
+    })
+
+    builder.addCase(actions.subscriptionErrorHandler, (state, action) => {
+      const key = getSubsId(action.payload.subscriptionMsg)
+      if (state.all[key]) {
+        state.all[key].shouldNotRetry = action.payload.shouldNotRetrySubscription
+      }
     })
 
     builder.addCase(actions.disconnectFulfilled, (state) => {

--- a/packages/core/bootstrap/src/lib/ws/reducer.ts
+++ b/packages/core/bootstrap/src/lib/ws/reducer.ts
@@ -94,7 +94,7 @@ export const connectionsReducer = createReducer<ConnectionsState>(
 
     builder.addCase(actions.subscriptionErrorHandler, (state, action) => {
       const { key } = action.payload.connectionInfo
-      state.all[key].shouldNotRetryConnecting = !action.payload.shouldNotRetryConnection
+      state.all[key].shouldNotRetryConnecting = action.payload.shouldNotRetryConnection
     })
 
     builder.addMatcher(

--- a/packages/core/types/@chainlink/index.d.ts
+++ b/packages/core/types/@chainlink/index.d.ts
@@ -246,7 +246,9 @@ declare module '@chainlink/types' {
     // Filters out messages that are not expected from sending a message constructed by one of the onConnect hooks
     isOnConnectChainMessage?: (message: any) => boolean
     // Should try open connection again after error
-    shouldRetryConnection?: (errorMessage: WebsocketErrorMessageSchema) => boolean
+    shouldNotRetryConnection?: (error: unknown) => boolean
+    // Should try resubscribing to a connection again
+    shouldNotRetrySubscription?: (subscription: unknown) => boolean
   }
 
   /* INPUT TYPE VALIDATIONS */

--- a/packages/sources/coinmetrics/src/adapter.ts
+++ b/packages/sources/coinmetrics/src/adapter.ts
@@ -52,6 +52,7 @@ export interface WSError {
 }
 
 export const BAD_PARAMETERS = 'bad_parameters'
+export const BAD_PARAMETER = 'bad_parameter'
 
 export const makeWSHandler = (config?: Config): MakeWSHandler => {
   return () => {
@@ -71,7 +72,7 @@ export const makeWSHandler = (config?: Config): MakeWSHandler => {
           Logger.debug(`Error: Could not find "ReferenceRate" key in WS message. ${message}`)
         return `${message.asset}${metrics}`
       },
-      isError: () => false,
+      isError: (message) => !!message.error,
       filter: () => true,
       toResponse: (message: WebsocketResponseSchema, input) => {
         const { metrics } = getSubKeyInfo(input)
@@ -89,7 +90,7 @@ export const makeWSHandler = (config?: Config): MakeWSHandler => {
       },
       shouldNotRetryConnection: (error) => {
         const wsError = error as WSError
-        return wsError.error.type === BAD_PARAMETERS
+        return wsError.error.type === BAD_PARAMETERS || wsError.error.type === BAD_PARAMETER
       },
     }
   }

--- a/packages/sources/coinmetrics/src/adapter.ts
+++ b/packages/sources/coinmetrics/src/adapter.ts
@@ -44,6 +44,15 @@ const getSubKeyInfo = (input: AdapterRequest) => {
   return { asset, metrics }
 }
 
+export interface WSError {
+  error: {
+    type: string
+    message: string
+  }
+}
+
+export const BAD_PARAMETERS = 'bad_parameters'
+
 export const makeWSHandler = (config?: Config): MakeWSHandler => {
   return () => {
     const defaultConfig = config || makeConfig()
@@ -78,9 +87,9 @@ export const makeWSHandler = (config?: Config): MakeWSHandler => {
           url,
         }
       },
-      shouldRetryConnection: (closeContext) => {
-        // Coinmetrics returns this code after closing a connection due to the pair being unsupported
-        return closeContext.code != 1000
+      shouldNotRetryConnection: (error) => {
+        const wsError = error as WSError
+        return wsError.error.type === BAD_PARAMETERS
       },
     }
   }


### PR DESCRIPTION
Allow adapters to specify when they should not reconnect or resubscribe when there is a request with a bad pair.