### PR TITLE
Dxfeed WS batch requests fix

### DIFF
--- a/packages/core/bootstrap/src/lib/ws/index.ts
+++ b/packages/core/bootstrap/src/lib/ws/index.ts
@@ -63,9 +63,14 @@ export const withWebSockets =
 
 const isConnected = (store: Store<RootState>, connectionKey: string): boolean => {
   const state = store.getState()
-  const isActiveConnection = state.connections.all[connectionKey]?.active
-  const isConnecting = state.connections.all[connectionKey]?.connecting > 1
-  return isActiveConnection && !isConnecting
+  const connectionState = state.connections.all[connectionKey]
+  if (!connectionState) {
+    return false
+  }
+  const isActiveConnection = connectionState.active
+  const isConnecting = connectionState.connecting > 1
+  const hasOnConnectChainCompleted = connectionState.isOnConnectChainComplete
+  return isActiveConnection && !isConnecting && hasOnConnectChainCompleted
 }
 
 const awaitResult = async (context: AdapterContext, input: AdapterRequest, deadline: number) => {

--- a/packages/core/bootstrap/src/lib/ws/reducer.ts
+++ b/packages/core/bootstrap/src/lib/ws/reducer.ts
@@ -31,6 +31,7 @@ export interface ConnectionsState {
         [T: string]: string
       }
       requestId: number
+      isOnConnectChainComplete: boolean
     }
   }
 }
@@ -45,6 +46,15 @@ export const connectionsReducer = createReducer<ConnectionsState>(
       state.all[connectionKey] = {
         ...state.all[connectionKey],
         connectionParams: message,
+      }
+    })
+    builder.addCase(actions.onConnectComplete, (state, action) => {
+      const {
+        connectionInfo: { key },
+      } = action.payload
+      state.all[key] = {
+        ...state.all[key],
+        isOnConnectChainComplete: true,
       }
     })
     builder.addCase(actions.connectFulfilled, (state, action) => {
@@ -68,15 +78,20 @@ export const connectionsReducer = createReducer<ConnectionsState>(
     })
     builder.addCase(actions.connectRequested, (state, action) => {
       const { key } = action.payload.config.connectionInfo
-      const isActive = state.all[key]?.active
+      const connectionState = state.all[key]
+      const isActive = connectionState?.active
       if (isActive) return
+      if (connectionState && !connectionState.isOnConnectChainComplete) {
+        return
+      }
 
-      const isConnecting = !isNaN(Number(state.all[key]?.connecting))
+      const isConnecting = !isNaN(Number(connectionState?.connecting))
       state.all[key] = {
-        ...state.all[key],
+        ...connectionState,
         active: false,
-        connecting: isConnecting ? state.all[key].connecting + 1 : 1,
+        connecting: isConnecting ? connectionState.connecting + 1 : 1,
         requestId: 0,
+        isOnConnectChainComplete: false,
       }
     })
 
@@ -91,6 +106,7 @@ export const connectionsReducer = createReducer<ConnectionsState>(
       state.all[key].active = false
       state.all[key].connecting = 0 // turn off connecting
       state.all[key].shouldNotRetryConnecting = action.payload.shouldNotRetryConnecting
+      state.all[key].requestId = 0
     })
 
     builder.addMatcher(

--- a/packages/core/types/@chainlink/index.d.ts
+++ b/packages/core/types/@chainlink/index.d.ts
@@ -247,6 +247,8 @@ declare module '@chainlink/types' {
     isOnConnectChainMessage?: (message: any) => boolean
     // Should try open connection again after error
     shouldRetryConnection?: (errorMessage: WebsocketErrorMessageSchema) => boolean
+    // Whether or not message is sent to subscribe to a pair/ticker
+    isDataMessage?: (message: unknown) => boolean
   }
 
   /* INPUT TYPE VALIDATIONS */

--- a/packages/core/types/@chainlink/index.d.ts
+++ b/packages/core/types/@chainlink/index.d.ts
@@ -249,6 +249,10 @@ declare module '@chainlink/types' {
     shouldRetryConnection?: (errorMessage: WebsocketErrorMessageSchema) => boolean
     // Whether or not message is sent to subscribe to a pair/ticker
     isDataMessage?: (message: unknown) => boolean
+    // Whether or not to reply to a heartbeat message from the server
+    shouldReplyToServerHeartbeat?: (message: unknown) => boolean
+    // The message that will be sent back to the WS server
+    heartbeatReplyMessage?: (message: unknown, id: number, connectionParams: any) => unknown
   }
 
   /* INPUT TYPE VALIDATIONS */

--- a/packages/k6/src/test.ts
+++ b/packages/k6/src/test.ts
@@ -11,7 +11,7 @@ import {
 
 export const options = {
   vus: 1,
-  duration: '12h',
+  duration: '30s',
   thresholds: {
     http_req_failed: ['rate<0.01'], // http errors should be less than 1%
     http_req_duration: ['p(95)<200'], // 95% of requests should be below 200ms

--- a/packages/sources/dxfeed/src/adapter.ts
+++ b/packages/sources/dxfeed/src/adapter.ts
@@ -101,6 +101,7 @@ export const makeWSHandler = (config?: Config): MakeWSHandler => {
       shouldSaveToStore: (subscriptionMessage: any) => isDataSubscriptionMsg(subscriptionMessage),
       isOnConnectChainMessage: (message: any) =>
         message[0].channel === '/meta/handshake' || message[0].channel === '/meta/connect',
+      isDataMessage: (message: unknown) => isDataSubscriptionMsg(message),
       onConnectChain: [
         () => [
           {


### PR DESCRIPTION
This PR addresses the issue when a DXFeed adapter with WS turned on receives batch requests before it's on connect chain has finished running.  The issue was that subscription requests that were sent before the on connect chain completed never got a response from the server.  The fix is to prevent sending these requests until after the on connect chain has finished running.  

Another issue this PR fixes is the heartbeat mechanism to the WS server.  The code previously sent the heartbeat message in 30s intervals.  This didn't work as DXFeed requires the client to response to the server's heartbeat message instead of sending a message every 30s.