### PR TITLE
Feature/dex uniswap v2

### DIFF
--- a/packages/sources/uniswap-v2/README.md
+++ b/packages/sources/uniswap-v2/README.md
@@ -1,0 +1,72 @@
+# Chainlink External Adapter for UniswapV2.fi
+
+This adapter allows querying UniswapV2.fi contracts
+
+### Environment Variables
+
+| Required? |         Name         |                                                            Description                                                             | Options |                 Defaults to                  |
+| :-------: | :------------------: | :--------------------------------------------------------------------------------------------------------------------------------: | :-----: | :------------------------------------------: |
+|    ✅     |       RPC_URL        |                           An http(s) RPC URL to a blockchain node that can read the UniswapV2 contracts                            |         |                                              |
+|           |   ADDRESS_PROVIDER   |            The address of the UniswapV2 address provider contract. NOTE: THIS SHOULD NOT BE CHANGED ON ETHEREUM MAINNET            |         | `0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D` |
+|           | EXCHANGE_PROVIDER_ID | The index of the exchange provider contract in the address provider contract. NOTE: THIS SHOULD NOT BE CHANGED ON ETHEREUM MAINNET |         |                     `2`                      |
+|           |  BLOCKCHAIN_NETWORK  |             The network to get pre-defined token addresses from. NOTE: THIS SHOULD NOT BE CHANGED ON ETHEREUM MAINNET              |         |                  `ethereum`                  |
+
+---
+
+### Input Parameters
+
+| Required? |   Name   |     Description     |          Options           | Defaults to |
+| :-------: | :------: | :-----------------: | :------------------------: | :---------: |
+|           | endpoint | The endpoint to use | [crypto](#Crypto-Endpoint) |   crypto    |
+
+---
+
+## Crypto Endpoint
+
+Gets the exchange rate between two tokens
+
+### Input Params
+
+| Required? |            Name            |                                                     Description                                                      | Options | Defaults to |
+| :-------: | :------------------------: | :------------------------------------------------------------------------------------------------------------------: | :-----: | :---------: |
+|    ✅     | `base`, `from`, or `coin`  |                                    The symbol or address of the currency to query                                    |         |             |
+|           |       `fromAddress`        |          Optional param to pre-define the address to convert from. If set, it takes precedence over `from`           |         |             |
+|           |       `fromDecimals`       | Optional param to pre-define the number of decimals in the `from` token. Setting this will make the query run faster |         |             |
+|    ✅     | `quote`, `to`, or `market` |                                 The symbol or address of the currency to convert to                                  |         |             |
+|           |        `toAddress`         |            Optional param to pre-define the address to convert to. If set, it takes precedence over `to`             |         |             |
+|           |        `toDecimals`        |  Optional param to pre-define the number of decimals in the `to` token. Setting this will make the query run faster  |         |             |
+|           |          `amount`          |               The exchange amount to get the rate of. The amount is in full units, e.g. 1 USDC, 1 ETH                |         |     `1`     |
+|           |        `resultPath`        |                                                 The result to fetch                                                  |         |   `rate`    |
+
+### Sample Input
+
+```json
+{
+  "id": "1",
+  "data": {
+    "from": "USDC",
+    "to": "USDT"
+  }
+}
+```
+
+### Sample Output
+
+```json
+{
+  "jobRunID": "1",
+  "result": 0.999465,
+  "statusCode": 200,
+  "data": {
+    "pool": "0xA5407eAE9Ba41422680e2e00537571bcC53efBfD",
+    "input": "1000000",
+    "inputToken": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    "inputDecimals": 6,
+    "output": "999465",
+    "outputToken": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+    "outputDecimals": 6,
+    "rate": 0.999465,
+    "result": 0.999465
+  }
+}
+```

--- a/packages/sources/uniswap-v2/README.md
+++ b/packages/sources/uniswap-v2/README.md
@@ -4,12 +4,10 @@ This adapter allows querying UniswapV2.fi contracts
 
 ### Environment Variables
 
-| Required? |         Name         |                                                            Description                                                             | Options |                 Defaults to                  |
-| :-------: | :------------------: | :--------------------------------------------------------------------------------------------------------------------------------: | :-----: | :------------------------------------------: |
-|    ✅     |       RPC_URL        |                           An http(s) RPC URL to a blockchain node that can read the UniswapV2 contracts                            |         |                                              |
-|           |   ADDRESS_PROVIDER   |            The address of the UniswapV2 address provider contract. NOTE: THIS SHOULD NOT BE CHANGED ON ETHEREUM MAINNET            |         | `0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D` |
-|           | EXCHANGE_PROVIDER_ID | The index of the exchange provider contract in the address provider contract. NOTE: THIS SHOULD NOT BE CHANGED ON ETHEREUM MAINNET |         |                     `2`                      |
-|           |  BLOCKCHAIN_NETWORK  |             The network to get pre-defined token addresses from. NOTE: THIS SHOULD NOT BE CHANGED ON ETHEREUM MAINNET              |         |                  `ethereum`                  |
+| Required? |        Name        |                                                Description                                                | Options | Defaults to |
+| :-------: | :----------------: | :-------------------------------------------------------------------------------------------------------: | :-----: | :---------: |
+|    ✅     |      RPC_URL       |               An http(s) RPC URL to a blockchain node that can read the UniswapV2 contracts               |         |             |
+|           | BLOCKCHAIN_NETWORK | The network to get pre-defined token addresses from. NOTE: THIS SHOULD NOT BE CHANGED ON ETHEREUM MAINNET |         | `ethereum`  |
 
 ---
 

--- a/packages/sources/uniswap-v2/package.json
+++ b/packages/sources/uniswap-v2/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@chainlink/uniswap-v2-adapter",
+  "version": "0.0.1",
+  "description": "Chainlink uniswap-v2 adapter.",
+  "keywords": [
+    "Chainlink",
+    "LINK",
+    "blockchain",
+    "oracle",
+    "uniswap-v2"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "url": "https://github.com/smartcontractkit/external-adapters-js",
+    "type": "git"
+  },
+  "license": "MIT",
+  "scripts": {
+    "clean": "rm -rf dist && rm -f tsconfig.tsbuildinfo",
+    "prepack": "yarn build",
+    "build": "tsc -b",
+    "server": "node -e 'require(\"./index.js\").server()'",
+    "server:dist": "node -e 'require(\"./dist/index.js\").server()'",
+    "start": "yarn server:dist"
+  },
+  "dependencies": {
+    "@chainlink/ea-bootstrap": "*",
+    "@chainlink/ea-test-helpers": "*",
+    "decimal.js": "^10.3.1",
+    "ethers": "^5.4.6",
+    "tslib": "^2.1.0"
+  },
+  "devDependencies": {
+    "@chainlink/types": "0.0.1",
+    "@types/jest": "26.0.24",
+    "@types/node": "14.17.17",
+    "@types/supertest": "2.0.11",
+    "nock": "13.1.3",
+    "supertest": "6.1.6",
+    "typescript": "4.3.5"
+  }
+}

--- a/packages/sources/uniswap-v2/schemas/env.json
+++ b/packages/sources/uniswap-v2/schemas/env.json
@@ -1,0 +1,22 @@
+{
+  "$id": "https://external-adapters.chainlinklabs.com/schemas/uniswapv2-adapter.json",
+  "title": "@chainlink/uniswapv2-adapter env var schema",
+  "required": ["RPC_URL"],
+  "type": "object",
+  "properties": {
+    "RPC_URL": {
+      "required": true,
+      "type": "string"
+    },
+    "BLOCKCHAIN_NETWORK": {
+      "required": false,
+      "type": "string",
+      "default": "ethereum"
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://external-adapters.chainlinklabs.com/schemas/ea-bootstrap.json"
+    }
+  ]
+}

--- a/packages/sources/uniswap-v2/src/abis/ERC20.json
+++ b/packages/sources/uniswap-v2/src/abis/ERC20.json
@@ -1,0 +1,222 @@
+[
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_spender",
+        "type": "address"
+      },
+      {
+        "name": "_value",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_from",
+        "type": "address"
+      },
+      {
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "name": "_value",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "_owner",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "name": "balance",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "name": "_value",
+        "type": "uint256"
+      }
+    ],
+    "name": "transfer",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "_owner",
+        "type": "address"
+      },
+      {
+        "name": "_spender",
+        "type": "address"
+      }
+    ],
+    "name": "allowance",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "payable": true,
+    "stateMutability": "payable",
+    "type": "fallback"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  }
+]

--- a/packages/sources/uniswap-v2/src/abis/uniswap_v2_router_02.json
+++ b/packages/sources/uniswap-v2/src/abis/uniswap_v2_router_02.json
@@ -1,0 +1,340 @@
+[
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_factory", "type": "address" },
+      { "internalType": "address", "name": "_WETH", "type": "address" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "WETH",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "tokenA", "type": "address" },
+      { "internalType": "address", "name": "tokenB", "type": "address" },
+      { "internalType": "uint256", "name": "amountADesired", "type": "uint256" },
+      { "internalType": "uint256", "name": "amountBDesired", "type": "uint256" },
+      { "internalType": "uint256", "name": "amountAMin", "type": "uint256" },
+      { "internalType": "uint256", "name": "amountBMin", "type": "uint256" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "deadline", "type": "uint256" }
+    ],
+    "name": "addLiquidity",
+    "outputs": [
+      { "internalType": "uint256", "name": "amountA", "type": "uint256" },
+      { "internalType": "uint256", "name": "amountB", "type": "uint256" },
+      { "internalType": "uint256", "name": "liquidity", "type": "uint256" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "token", "type": "address" },
+      { "internalType": "uint256", "name": "amountTokenDesired", "type": "uint256" },
+      { "internalType": "uint256", "name": "amountTokenMin", "type": "uint256" },
+      { "internalType": "uint256", "name": "amountETHMin", "type": "uint256" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "deadline", "type": "uint256" }
+    ],
+    "name": "addLiquidityETH",
+    "outputs": [
+      { "internalType": "uint256", "name": "amountToken", "type": "uint256" },
+      { "internalType": "uint256", "name": "amountETH", "type": "uint256" },
+      { "internalType": "uint256", "name": "liquidity", "type": "uint256" }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "factory",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amountOut", "type": "uint256" },
+      { "internalType": "uint256", "name": "reserveIn", "type": "uint256" },
+      { "internalType": "uint256", "name": "reserveOut", "type": "uint256" }
+    ],
+    "name": "getAmountIn",
+    "outputs": [{ "internalType": "uint256", "name": "amountIn", "type": "uint256" }],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amountIn", "type": "uint256" },
+      { "internalType": "uint256", "name": "reserveIn", "type": "uint256" },
+      { "internalType": "uint256", "name": "reserveOut", "type": "uint256" }
+    ],
+    "name": "getAmountOut",
+    "outputs": [{ "internalType": "uint256", "name": "amountOut", "type": "uint256" }],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amountOut", "type": "uint256" },
+      { "internalType": "address[]", "name": "path", "type": "address[]" }
+    ],
+    "name": "getAmountsIn",
+    "outputs": [{ "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amountIn", "type": "uint256" },
+      { "internalType": "address[]", "name": "path", "type": "address[]" }
+    ],
+    "name": "getAmountsOut",
+    "outputs": [{ "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amountA", "type": "uint256" },
+      { "internalType": "uint256", "name": "reserveA", "type": "uint256" },
+      { "internalType": "uint256", "name": "reserveB", "type": "uint256" }
+    ],
+    "name": "quote",
+    "outputs": [{ "internalType": "uint256", "name": "amountB", "type": "uint256" }],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "tokenA", "type": "address" },
+      { "internalType": "address", "name": "tokenB", "type": "address" },
+      { "internalType": "uint256", "name": "liquidity", "type": "uint256" },
+      { "internalType": "uint256", "name": "amountAMin", "type": "uint256" },
+      { "internalType": "uint256", "name": "amountBMin", "type": "uint256" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "deadline", "type": "uint256" }
+    ],
+    "name": "removeLiquidity",
+    "outputs": [
+      { "internalType": "uint256", "name": "amountA", "type": "uint256" },
+      { "internalType": "uint256", "name": "amountB", "type": "uint256" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "token", "type": "address" },
+      { "internalType": "uint256", "name": "liquidity", "type": "uint256" },
+      { "internalType": "uint256", "name": "amountTokenMin", "type": "uint256" },
+      { "internalType": "uint256", "name": "amountETHMin", "type": "uint256" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "deadline", "type": "uint256" }
+    ],
+    "name": "removeLiquidityETH",
+    "outputs": [
+      { "internalType": "uint256", "name": "amountToken", "type": "uint256" },
+      { "internalType": "uint256", "name": "amountETH", "type": "uint256" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "token", "type": "address" },
+      { "internalType": "uint256", "name": "liquidity", "type": "uint256" },
+      { "internalType": "uint256", "name": "amountTokenMin", "type": "uint256" },
+      { "internalType": "uint256", "name": "amountETHMin", "type": "uint256" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "deadline", "type": "uint256" }
+    ],
+    "name": "removeLiquidityETHSupportingFeeOnTransferTokens",
+    "outputs": [{ "internalType": "uint256", "name": "amountETH", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "token", "type": "address" },
+      { "internalType": "uint256", "name": "liquidity", "type": "uint256" },
+      { "internalType": "uint256", "name": "amountTokenMin", "type": "uint256" },
+      { "internalType": "uint256", "name": "amountETHMin", "type": "uint256" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "deadline", "type": "uint256" },
+      { "internalType": "bool", "name": "approveMax", "type": "bool" },
+      { "internalType": "uint8", "name": "v", "type": "uint8" },
+      { "internalType": "bytes32", "name": "r", "type": "bytes32" },
+      { "internalType": "bytes32", "name": "s", "type": "bytes32" }
+    ],
+    "name": "removeLiquidityETHWithPermit",
+    "outputs": [
+      { "internalType": "uint256", "name": "amountToken", "type": "uint256" },
+      { "internalType": "uint256", "name": "amountETH", "type": "uint256" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "token", "type": "address" },
+      { "internalType": "uint256", "name": "liquidity", "type": "uint256" },
+      { "internalType": "uint256", "name": "amountTokenMin", "type": "uint256" },
+      { "internalType": "uint256", "name": "amountETHMin", "type": "uint256" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "deadline", "type": "uint256" },
+      { "internalType": "bool", "name": "approveMax", "type": "bool" },
+      { "internalType": "uint8", "name": "v", "type": "uint8" },
+      { "internalType": "bytes32", "name": "r", "type": "bytes32" },
+      { "internalType": "bytes32", "name": "s", "type": "bytes32" }
+    ],
+    "name": "removeLiquidityETHWithPermitSupportingFeeOnTransferTokens",
+    "outputs": [{ "internalType": "uint256", "name": "amountETH", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "tokenA", "type": "address" },
+      { "internalType": "address", "name": "tokenB", "type": "address" },
+      { "internalType": "uint256", "name": "liquidity", "type": "uint256" },
+      { "internalType": "uint256", "name": "amountAMin", "type": "uint256" },
+      { "internalType": "uint256", "name": "amountBMin", "type": "uint256" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "deadline", "type": "uint256" },
+      { "internalType": "bool", "name": "approveMax", "type": "bool" },
+      { "internalType": "uint8", "name": "v", "type": "uint8" },
+      { "internalType": "bytes32", "name": "r", "type": "bytes32" },
+      { "internalType": "bytes32", "name": "s", "type": "bytes32" }
+    ],
+    "name": "removeLiquidityWithPermit",
+    "outputs": [
+      { "internalType": "uint256", "name": "amountA", "type": "uint256" },
+      { "internalType": "uint256", "name": "amountB", "type": "uint256" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amountOut", "type": "uint256" },
+      { "internalType": "address[]", "name": "path", "type": "address[]" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "deadline", "type": "uint256" }
+    ],
+    "name": "swapETHForExactTokens",
+    "outputs": [{ "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amountOutMin", "type": "uint256" },
+      { "internalType": "address[]", "name": "path", "type": "address[]" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "deadline", "type": "uint256" }
+    ],
+    "name": "swapExactETHForTokens",
+    "outputs": [{ "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amountOutMin", "type": "uint256" },
+      { "internalType": "address[]", "name": "path", "type": "address[]" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "deadline", "type": "uint256" }
+    ],
+    "name": "swapExactETHForTokensSupportingFeeOnTransferTokens",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amountIn", "type": "uint256" },
+      { "internalType": "uint256", "name": "amountOutMin", "type": "uint256" },
+      { "internalType": "address[]", "name": "path", "type": "address[]" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "deadline", "type": "uint256" }
+    ],
+    "name": "swapExactTokensForETH",
+    "outputs": [{ "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amountIn", "type": "uint256" },
+      { "internalType": "uint256", "name": "amountOutMin", "type": "uint256" },
+      { "internalType": "address[]", "name": "path", "type": "address[]" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "deadline", "type": "uint256" }
+    ],
+    "name": "swapExactTokensForETHSupportingFeeOnTransferTokens",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amountIn", "type": "uint256" },
+      { "internalType": "uint256", "name": "amountOutMin", "type": "uint256" },
+      { "internalType": "address[]", "name": "path", "type": "address[]" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "deadline", "type": "uint256" }
+    ],
+    "name": "swapExactTokensForTokens",
+    "outputs": [{ "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amountIn", "type": "uint256" },
+      { "internalType": "uint256", "name": "amountOutMin", "type": "uint256" },
+      { "internalType": "address[]", "name": "path", "type": "address[]" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "deadline", "type": "uint256" }
+    ],
+    "name": "swapExactTokensForTokensSupportingFeeOnTransferTokens",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amountOut", "type": "uint256" },
+      { "internalType": "uint256", "name": "amountInMax", "type": "uint256" },
+      { "internalType": "address[]", "name": "path", "type": "address[]" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "deadline", "type": "uint256" }
+    ],
+    "name": "swapTokensForExactETH",
+    "outputs": [{ "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amountOut", "type": "uint256" },
+      { "internalType": "uint256", "name": "amountInMax", "type": "uint256" },
+      { "internalType": "address[]", "name": "path", "type": "address[]" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "deadline", "type": "uint256" }
+    ],
+    "name": "swapTokensForExactTokens",
+    "outputs": [{ "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  { "stateMutability": "payable", "type": "receive" }
+]

--- a/packages/sources/uniswap-v2/src/adapter.ts
+++ b/packages/sources/uniswap-v2/src/adapter.ts
@@ -1,0 +1,15 @@
+import { Builder } from '@chainlink/ea-bootstrap'
+import { ExecuteWithConfig, ExecuteFactory, AdapterRequest, APIEndpoint } from '@chainlink/types'
+import { makeConfig, Config } from './config'
+import * as endpoints from './endpoint'
+
+export const execute: ExecuteWithConfig<Config> = async (request, context, config) => {
+  return Builder.buildSelector(request, context, config, endpoints)
+}
+
+export const endpointSelector = (request: AdapterRequest): APIEndpoint<Config> =>
+  Builder.selectEndpoint(request, makeConfig(), endpoints)
+
+export const makeExecute: ExecuteFactory<Config> = (config) => {
+  return async (request, context) => execute(request, context, config || makeConfig())
+}

--- a/packages/sources/uniswap-v2/src/config.ts
+++ b/packages/sources/uniswap-v2/src/config.ts
@@ -1,0 +1,28 @@
+import { Requester, util } from '@chainlink/ea-bootstrap'
+import { Config as BaseConfig, ConfigFactory } from '@chainlink/types'
+import { ethers } from 'ethers'
+
+export const NAME = 'UNISWAP-V2'
+
+export const ENV_RPC_URL = 'RPC_URL'
+export const ENV_BLOCKCHAIN_NETWORK = 'BLOCKCHAIN_NETWORK'
+
+export const DEFAULT_ENDPOINT = 'crypto'
+export const DEFAULT_BLOCKCHAIN_NETWORK = 'ethereum'
+export const UNISWAP_ROUTER_CONTRACT = '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D'
+
+export type Config = BaseConfig & {
+  provider: ethers.providers.Provider
+  network: string
+  uniswapRouter: string
+}
+
+export const makeConfig: ConfigFactory<Config> = (prefix: string | undefined) => {
+  return {
+    ...Requester.getDefaultConfig(prefix),
+    defaultEndpoint: DEFAULT_ENDPOINT,
+    provider: new ethers.providers.JsonRpcProvider(util.getRequiredEnv(ENV_RPC_URL, prefix)),
+    network: util.getEnv(ENV_BLOCKCHAIN_NETWORK, prefix) || DEFAULT_BLOCKCHAIN_NETWORK,
+    uniswapRouter: UNISWAP_ROUTER_CONTRACT,
+  }
+}

--- a/packages/sources/uniswap-v2/src/endpoint/crypto.ts
+++ b/packages/sources/uniswap-v2/src/endpoint/crypto.ts
@@ -1,0 +1,122 @@
+import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import { ExecuteWithConfig, InputParameters } from '@chainlink/types'
+import { NAME as AdapterName, Config } from '../config'
+import { ethers, BigNumber } from 'ethers'
+import uniswapRouterV2ABI from '../abis/uniswap_v2_router_02.json'
+import erc20ABI from '../abis/ERC20.json'
+import { Decimal } from 'decimal.js'
+
+export const supportedEndpoints = ['crypto']
+
+export const endpointResultPaths = {
+  crypto: 'rate',
+}
+
+export interface ResponseSchema {
+  input: string
+  inputToken: string
+  inputDecimals: number
+  output: string
+  outputToken: string
+  outputDecimals: number
+  rate: number
+}
+
+export const inputParameters: InputParameters = {
+  from: ['base', 'from', 'coin'],
+  fromAddress: false,
+  fromDecimals: false,
+  to: ['quote', 'to', 'market'],
+  toAddress: false,
+  toDecimals: false,
+  amount: false,
+  resultPath: false,
+}
+
+export const execute: ExecuteWithConfig<Config> = async (request, _, config) => {
+  const validator = new Validator(request, inputParameters)
+  if (validator.error) throw validator.error
+
+  const jobRunID = validator.validated.id
+  const { address: from, decimals: fromDecimals } = await getTokenDetails(validator, 'from', config)
+  const { address: to, decimals: toDecimals } = await getTokenDetails(validator, 'to', config)
+  const inputAmount = validator.validated.data.amount || 1
+  const amount = BigNumber.from(inputAmount).mul(BigNumber.from(10).pow(fromDecimals))
+  const resultPath = validator.validated.data.resultPath
+
+  const [_amountIn, output] = await getBestRate(from, to, amount, config)
+
+  const outputAmount = new Decimal(output.toString()).div(new Decimal(10).pow(toDecimals))
+  const rate = outputAmount.div(inputAmount)
+
+  const data: ResponseSchema = {
+    input: amount.toString(),
+    inputToken: from,
+    inputDecimals: fromDecimals,
+    output: output.toString(),
+    outputToken: to,
+    outputDecimals: toDecimals,
+    rate: rate.toNumber(),
+  }
+
+  const response = {
+    status: 200,
+    statusText: 'OK',
+    headers: {},
+    config: {},
+    data: data,
+  }
+  const result = Requester.validateResultNumber(response.data, [resultPath])
+
+  return Requester.success(jobRunID, Requester.withResult(response, result), config.verbose)
+}
+
+/**
+ * getTokenDetails will find the address and number of decimal for a token.
+ *
+ * The order of operations is as follows:
+ *  - address:
+ *     1. Check if the address was provided in the request.
+ *     2. If not, check the symbol in the request to see if we have pre-set the address for this symbol/network.
+ *     3. If not, we assume the symbol param was actually the address.
+ *  - decimals:
+ *     1. Check if the number of decimals was provided in the request.
+ *     2. Query the contract at the address found above to see how many decimals it's set to.
+ * @param validator The validation class to use
+ * @param direction Used to get the params in the request
+ * - `{direction}` is the symbol of the token (to find pre-set token details)
+ * - `{direction}Address` is the token address as set in the request
+ * - `{direction}Decimals` is the number of decimals for the token as set in the request
+ * @param config Configuration to extract token decimals from
+ */
+const getTokenDetails = async (
+  validator: Validator,
+  direction: string,
+  config: Config,
+): Promise<{ address: string; decimals: number }> => {
+  const symbol = validator.overrideSymbol(
+    AdapterName,
+    validator.validated.data[direction],
+  ) as string
+  const address =
+    validator.validated.data[`${direction}Address`] ||
+    validator.overrideToken(symbol, config.network) ||
+    symbol
+  const decimals =
+    validator.validated.data[`${direction}Decimals`] || (await getDecimals(address, config))
+
+  return { address, decimals }
+}
+
+const getDecimals = async (address: string, config: Config): Promise<number> =>
+  new ethers.Contract(address, erc20ABI, config.provider).decimals()
+
+const getBestRate = async (
+  from: string,
+  to: string,
+  amount: BigNumber,
+  config: Config,
+): Promise<[amountIn: BigNumber, output: BigNumber]> => {
+  const uniRouter = new ethers.Contract(config.uniswapRouter, uniswapRouterV2ABI, config.provider)
+  return await uniRouter.getAmountsOut(amount, [from, to])
+}

--- a/packages/sources/uniswap-v2/src/endpoint/index.ts
+++ b/packages/sources/uniswap-v2/src/endpoint/index.ts
@@ -1,0 +1,1 @@
+export * as crypto from './crypto'

--- a/packages/sources/uniswap-v2/src/index.ts
+++ b/packages/sources/uniswap-v2/src/index.ts
@@ -1,0 +1,7 @@
+import { expose } from '@chainlink/ea-bootstrap'
+import { makeExecute, endpointSelector } from './adapter'
+import { makeConfig, NAME } from './config'
+import * as types from './endpoint'
+
+const { server } = expose(NAME, makeExecute(), undefined, endpointSelector)
+export { NAME, makeExecute, makeConfig, server, types }

--- a/packages/sources/uniswap-v2/test-payload.json
+++ b/packages/sources/uniswap-v2/test-payload.json
@@ -1,0 +1,6 @@
+{
+ "requests": [{
+  "from": "LINK",
+  "to": "USDC"
+ }]
+}

--- a/packages/sources/uniswap-v2/test/unit/crypto.test.ts
+++ b/packages/sources/uniswap-v2/test/unit/crypto.test.ts
@@ -1,0 +1,38 @@
+import { Requester } from '@chainlink/ea-bootstrap'
+import { assertError } from '@chainlink/ea-test-helpers'
+import { AdapterRequest } from '@chainlink/types'
+import { makeExecute } from '../../src/adapter'
+import { ENV_RPC_URL } from '../../src/config'
+import * as process from 'process'
+
+describe('execute', () => {
+  const jobID = '1'
+  const execute = makeExecute()
+  process.env[ENV_RPC_URL] = process.env[ENV_RPC_URL] || 'http://localhost:8546/'
+
+  describe('validation error', () => {
+    const requests = [
+      { name: 'empty body', testData: {} },
+      { name: 'empty data', testData: { data: {} } },
+      {
+        name: 'base not supplied',
+        testData: { id: jobID, data: { quote: 'USD' } },
+      },
+      {
+        name: 'quote not supplied',
+        testData: { id: jobID, data: { base: 'ETH' } },
+      },
+    ]
+
+    requests.forEach((req) => {
+      it(`${req.name}`, async () => {
+        try {
+          await execute(req.testData as AdapterRequest, {})
+        } catch (error) {
+          const errorResp = Requester.errored(jobID, error)
+          assertError({ expected: 400, actual: errorResp.statusCode }, errorResp, jobID)
+        }
+      })
+    })
+  })
+})

--- a/packages/sources/uniswap-v2/tsconfig.json
+++ b/packages/sources/uniswap-v2/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*", "src/abis/*.json"],
+  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
+  "references": [
+    { "path": "../../core/test-helpers" },
+    { "path": "../../core/bootstrap" },
+    { "path": "../../core/test-helpers" }
+  ]
+}


### PR DESCRIPTION
wip: adding integration tests before moving draft PR to PR

## Steps to Test

Test like other adapter as specified on top level readme

```bash
yarn test uniswap-v2/test/unit
```

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)


## Additional Considerations

Slippage impacts the output price if there is not sufficient liquidity - this can cause very low/high prices if the pool is small. How do we guard against this? Is there a specific amount of liquidity that is needed to allow reporting?

Would we like to handle multihop paths? Right now we are only showing the price of a single swap - however sometimes better prices are provided if there is multiple hops in the transaction.