### PR TITLE
refactor(token-allocation): add extra logs to assist with debugging

### DIFF
--- a/packages/composites/token-allocation/src/dataProvider.ts
+++ b/packages/composites/token-allocation/src/dataProvider.ts
@@ -1,6 +1,7 @@
 import { Requester } from '@chainlink/ea-bootstrap'
 import { RequestConfig } from '@chainlink/types'
 import { ResponsePayload } from './types'
+import { Logger } from '@chainlink/ea-bootstrap'
 
 /**
  * @description
@@ -24,7 +25,7 @@ import { ResponsePayload } from './types'
  */
 
 export const getPriceProvider =
-  (jobRunID: string, apiConfig: RequestConfig) =>
+  (source: string, jobRunID: string, apiConfig: RequestConfig) =>
   async (symbols: string[], quote: string, withMarketCap = false): Promise<ResponsePayload> => {
     const results = await Promise.all(
       symbols.map(async (base) => {
@@ -32,8 +33,15 @@ export const getPriceProvider =
           id: jobRunID,
           data: { base, quote, endpoint: withMarketCap ? 'marketcap' : 'crypto' },
         }
-        const response = await Requester.request({ ...apiConfig, data: data })
-        return response.data.result
+        try {
+          const response = await Requester.request({ ...apiConfig, data: data })
+          return response.data.result
+        } catch (error) {
+          Logger.error(`Request to ${source} adapter failed: ${error}`)
+          throw new Error(
+            `Failed to request the ${source} adapter. Ensure that the ${source.toUpperCase()}_ADAPTER_URL environment variable is correctly pointed to the adapter location.`,
+          )
+        }
       }),
     )
     const payloadEntries = symbols.map((symbol, i) => {

--- a/packages/composites/token-allocation/test/unit/adapter.test.ts
+++ b/packages/composites/token-allocation/test/unit/adapter.test.ts
@@ -24,7 +24,7 @@ describe('execute', () => {
     requests.forEach((req) => {
       it(`${req.name}`, async () => {
         try {
-          await execute(req.testData as AdapterRequest)
+          await execute(req.testData as AdapterRequest, {})
         } catch (error) {
           const errorResp = Requester.errored(jobID, error)
           assertError({ expected: 400, actual: errorResp.statusCode }, errorResp, jobID)
@@ -64,7 +64,7 @@ describe('execute', () => {
           },
         },
       }
-      const value = priceTotalValue(allocations, 'USD', data)
+      const value = priceTotalValue('test', allocations, 'USD', data)
       const expectedValue = 11
       expect(value).toBe(expectedValue)
     })
@@ -86,7 +86,7 @@ describe('execute', () => {
           },
         },
       }
-      const value = priceTotalValue(allocations, 'USD', data)
+      const value = priceTotalValue('test', allocations, 'USD', data)
       const expectedValue = 34.1
       expect(value).toBe(expectedValue)
     })

--- a/packages/core/bootstrap/src/lib/external-adapter/requester.ts
+++ b/packages/core/bootstrap/src/lib/external-adapter/requester.ts
@@ -51,9 +51,10 @@ export class Requester {
         // Request error
         if (n === 1) {
           logger.error(`Could not reach endpoint: ${JSON.stringify(error.message)}`)
+
           throw new AdapterError({
-            statusCode: error.response.status,
-            message: error.message,
+            statusCode: error?.response?.status,
+            message: error?.message,
             cause: error,
           })
         }


### PR DESCRIPTION
## Description
Adds additional logs for debugging Token Allocations, which is used by many composite adapters.

Handles two cases:
1. Source adapter request errors
2. Null or 0 value returned for a pair

Story #17460