### PR TITLE
add temp logging to debug cryptocompare

### DIFF
--- a/packages/core/bootstrap/src/lib/ws/reducer.ts
+++ b/packages/core/bootstrap/src/lib/ws/reducer.ts
@@ -1,5 +1,6 @@
 import { AdapterContext, AdapterRequest } from '@chainlink/types'
 import { combineReducers, createReducer, isAnyOf } from '@reduxjs/toolkit'
+import { logger } from '../external-adapter'
 import { getHashOpts, hash } from '../util'
 import * as actions from './actions'
 
@@ -59,6 +60,10 @@ export const connectionsReducer = createReducer<ConnectionsState>(
       }
     })
     builder.addCase(actions.subscribeRequested, (state, action) => {
+      if (!action.payload.connectionInfo) {
+        logger.error('Missing connection info', action.payload)
+        return
+      }
       const key = action.payload.connectionInfo.key
       if (!state.all[key]) return
       state.all[key] = {


### PR DESCRIPTION
Logs in K6 indicate that the `action.payload.connectionInfo` evaluates to `undefined` when we try fetch the connection's key.  This should never happen.  Temporarily adding logs in the code here to debug it in K8s as we can't repro this locally.