### PR TITLE
fix amberdata import in por adapter

### DIFF
--- a/packages/composites/proof-of-reserves/src/balance.ts
+++ b/packages/composites/proof-of-reserves/src/balance.ts
@@ -7,7 +7,7 @@ import {
 } from '@chainlink/types'
 import { callAdapter, makeRequestFactory } from './adapter'
 // balance adapters
-import amberdata from '@chainlink/amberdata-adapter'
+import * as amberdata from '@chainlink/amberdata-adapter'
 import bitcoinJsonRpc from '@chainlink/bitcoin-json-rpc-adapter'
 import blockchainCom from '@chainlink/blockchain.com-adapter'
 import blockchair from '@chainlink/blockchair-adapter'


### PR DESCRIPTION
Bug

A recent change in the way the Amberdata adapter exported variables broke the PoR adapter.  This was because the imported value in `PoR` would be undefined hence causing an exception.  We should be careful in the future when we update how variables are exported from an adapter.