### PR TITLE
Added actualarrivaltime endpoint to flightaware EA

### DIFF
--- a/packages/sources/flightaware/README.md
+++ b/packages/sources/flightaware/README.md
@@ -13,9 +13,9 @@ An example adapter description
 
 ### Input Parameters
 
-| Required? |   Name   |     Description     |                    Options                     |     Defaults to      |
-| :-------: | :------: | :-----------------: | :--------------------------------------------: | :------------------: |
-|           | endpoint | The endpoint to use | [estimatedarrivaltime](#FlightInfoEx-Endpoint) | estimatedarrivaltime |
+| Required? |   Name   |     Description     |                    Options                                                                   |     Defaults to      |
+| :-------: | :------: | :-----------------: | :------------------------------------------------------------------------------------------: | :------------------: |
+|           | endpoint | The endpoint to use | [estimatedarrivaltime](#FlightInfoEx-Endpoint) / [actualarrivaltime](#FlightInfoEx-Endpoint) | estimatedarrivaltime |
 
 ---
 

--- a/packages/sources/flightaware/README.md
+++ b/packages/sources/flightaware/README.md
@@ -13,7 +13,7 @@ An example adapter description
 
 ### Input Parameters
 
-| Required? |   Name   |     Description     |                    Options                                                                   |     Defaults to      |
+| Required? |   Name   |     Description     |                                           Options                                            |     Defaults to      |
 | :-------: | :------: | :-----------------: | :------------------------------------------------------------------------------------------: | :------------------: |
 |           | endpoint | The endpoint to use | [estimatedarrivaltime](#FlightInfoEx-Endpoint) / [actualarrivaltime](#FlightInfoEx-Endpoint) | estimatedarrivaltime |
 

--- a/packages/sources/flightaware/src/endpoint/flightinfoex.ts
+++ b/packages/sources/flightaware/src/endpoint/flightinfoex.ts
@@ -1,10 +1,11 @@
 import { Requester, Validator } from '@chainlink/ea-bootstrap'
 import { Config, ExecuteWithConfig, InputParameters } from '@chainlink/types'
 
-export const supportedEndpoints = ['estimatedarrivaltime']
+export const supportedEndpoints = ['estimatedarrivaltime', 'actualarrivaltime']
 
 export const endpointResultPaths = {
   estimatedarrivaltime: 'FlightInfoExResult.flights.0.estimatedarrivaltime',
+  actualarrivaltime: 'FlightInfoExResult.flights.0.actualarrivaltime',
 }
 
 interface Flights {


### PR DESCRIPTION
## Description

Added actualarrivaltime field of flightinfoex endpoint (default is still
estimatedarrivaltime).

## Changes

Added `actualarrivaltime` . If flight not arrived yet, gives 500 error because the validator doesn't accepts 0.

## Steps to Test

```python
import requests
r = requests.post("http://localhost:8080/", json={"id": "1", "data": {"flight": "CCA1593", "departure": 1636030903, "endpoint": "actualarrivaltime"}})
print(r.json())
```
