### PR TITLE
Orchid bandwidth integration tests

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -5591,6 +5591,8 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@chainlink/types", "workspace:packages/core/types/@chainlink"],
             ["@types/jest", "npm:27.0.2"],
             ["@types/node", "npm:14.17.21"],
+            ["nock", "npm:13.1.3"],
+            ["supertest", "npm:6.1.6"],
             ["tslib", "npm:2.3.1"],
             ["typescript", "patch:typescript@npm%3A4.3.5#~builtin<compat/typescript>::version=4.3.5&hash=d8b4e7"]
           ],

--- a/packages/sources/orchid-bandwidth/package.json
+++ b/packages/sources/orchid-bandwidth/package.json
@@ -35,6 +35,8 @@
     "@chainlink/types": "0.0.1",
     "@types/jest": "27.0.2",
     "@types/node": "14.17.21",
+    "nock": "13.1.3",
+    "supertest": "6.1.6",
     "typescript": "4.3.5"
   }
 }

--- a/packages/sources/orchid-bandwidth/src/index.ts
+++ b/packages/sources/orchid-bandwidth/src/index.ts
@@ -1,10 +1,6 @@
 import { expose } from '@chainlink/ea-bootstrap'
-import { endpointSelector, makeExecute } from './adapter'
+import { makeExecute, endpointSelector } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = {
-  NAME,
-  makeExecute,
-  makeConfig,
-  ...expose(NAME, makeExecute(), undefined, endpointSelector),
-}
+const { server } = expose(NAME, makeExecute(), undefined, endpointSelector)
+export { NAME, makeExecute, makeConfig, server }

--- a/packages/sources/orchid-bandwidth/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/orchid-bandwidth/test/integration/__snapshots__/adapter.test.ts.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`execute api should return success 1`] = `
+Object {
+  "data": Object {
+    "result": 0.06491712005868808,
+  },
+  "jobRunID": "1",
+  "result": 0.06491712005868808,
+  "statusCode": 200,
+}
+`;

--- a/packages/sources/orchid-bandwidth/test/integration/adapter.test.ts
+++ b/packages/sources/orchid-bandwidth/test/integration/adapter.test.ts
@@ -1,0 +1,51 @@
+import { AdapterRequest } from '@chainlink/types'
+import request from 'supertest'
+import * as process from 'process'
+import { server as startServer } from '../../src'
+import * as nock from 'nock'
+import * as http from 'http'
+import { mockResponseSuccess } from './fixtures'
+
+describe('execute', () => {
+  const id = '1'
+  let server: http.Server
+  const req = request('localhost:8080')
+  beforeAll(async () => {
+    process.env.CACHE_ENABLED = 'false'
+    process.env.API_KEY = process.env.API_KEY || 'fake-api-key'
+    if (process.env.RECORD) {
+      nock.recorder.rec()
+    }
+    server = await startServer()
+  })
+  afterAll((done) => {
+    if (process.env.RECORD) {
+      nock.recorder.play()
+    }
+
+    nock.restore()
+    nock.cleanAll()
+    nock.enableNetConnect()
+    server.close(done)
+  })
+
+  describe('api', () => {
+    const data: AdapterRequest = {
+      id,
+      data: {},
+    }
+
+    it('should return success', async () => {
+      mockResponseSuccess()
+
+      const response = await req
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+      expect(response.body).toMatchSnapshot()
+    })
+  })
+})

--- a/packages/sources/orchid-bandwidth/test/integration/fixtures.ts
+++ b/packages/sources/orchid-bandwidth/test/integration/fixtures.ts
@@ -1,0 +1,21 @@
+import nock from 'nock'
+
+export const mockResponseSuccess = (): nock =>
+  nock('https://chainlink.orchid.com/', {
+    encodedQueryParams: true,
+  })
+    .get('/0')
+    .reply(
+      200,
+      (_, request) => 0.06491712005868807976150333365786842895233705955274720070639730258746548395,
+      [
+        'Content-Type',
+        'text/plain',
+        'Connection',
+        'close',
+        'Vary',
+        'Accept-Encoding',
+        'Vary',
+        'Origin',
+      ],
+    )

--- a/yarn.lock
+++ b/yarn.lock
@@ -3288,6 +3288,8 @@ __metadata:
     "@chainlink/types": 0.0.1
     "@types/jest": 27.0.2
     "@types/node": 14.17.21
+    nock: 13.1.3
+    supertest: 6.1.6
     tslib: ^2.3.1
     typescript: 4.3.5
   languageName: unknown


### PR DESCRIPTION


## Changes

added integration tests for Orchid bandwidth EA

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

` yarn test packages/sources/orchid-bandwidth/test/integration
`
## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [ ] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
