### PR TITLE
[Feat] Version retrieval

### DIFF
--- a/packages/core/bootstrap/src/lib/metrics/index.ts
+++ b/packages/core/bootstrap/src/lib/metrics/index.ts
@@ -2,13 +2,14 @@ import * as client from 'prom-client'
 import { parseBool } from '../util'
 export * as util from './util'
 
-client.collectDefaultMetrics()
-client.register.setDefaultLabels(
-  // we'll inject both name and versions in
-  // when EAEE gets merged, because it'll be a lot easier
-  // to refactor with full type coverage support
-  { app_name: process.env.METRICS_NAME || 'N/A', app_version: 'N/A' },
-)
+export const setupMetrics = (name: string): void => {
+  client.collectDefaultMetrics()
+  client.register.setDefaultLabels({
+    app_name: process.env.METRICS_NAME || name || 'N/A',
+    app_version: process.env.npm_package_version,
+  })
+}
+
 export const METRICS_ENABLED = parseBool(process.env.EXPERIMENTAL_METRICS_ENABLED)
 
 export enum HttpRequestType {

--- a/packages/core/bootstrap/src/lib/server.ts
+++ b/packages/core/bootstrap/src/lib/server.ts
@@ -19,6 +19,7 @@ import { get as getRateLimitConfig } from './rate-limit/config'
 import { toObjectWithNumbers } from './util'
 
 const app = express()
+const version = process.env.npm_package_version
 const port = process.env.EA_PORT || 8080
 const baseUrl = process.env.BASE_URL || '/'
 
@@ -67,12 +68,12 @@ export const initHandler =
         logger.debug('Checking if redis connection initialized')
         const cache = context.cache.instance as redis.RedisCache
         if (!cache.client.connected) {
-          res.status(500).send('Redis not connected')
+          res.status(500).send({ message: 'Redis not connected', version })
           return
         }
       }
 
-      res.status(200).send('OK')
+      res.status(200).send({ message: 'OK', version })
     })
 
     const testPayload = loadTestPayload()

--- a/packages/core/bootstrap/src/lib/server.ts
+++ b/packages/core/bootstrap/src/lib/server.ts
@@ -14,7 +14,7 @@ import {
   HTTP_ERROR_UNSUPPORTED_MEDIA_TYPE_MESSAGE,
 } from './errors'
 import { logger } from './external-adapter'
-import { METRICS_ENABLED, httpRateLimit } from './metrics'
+import { METRICS_ENABLED, httpRateLimit, setupMetrics } from './metrics'
 import { get as getRateLimitConfig } from './rate-limit/config'
 import { toObjectWithNumbers } from './util'
 
@@ -41,7 +41,7 @@ export const initHandler =
     }
 
     if (METRICS_ENABLED) {
-      setupMetricsServer()
+      setupMetricsServer(name)
     }
 
     initExpressMiddleware(app)
@@ -116,10 +116,12 @@ export const initHandler =
     })
   }
 
-function setupMetricsServer() {
+function setupMetricsServer(name: string) {
   const metricsApp = express()
   const metricsPort = process.env.METRICS_PORT || 9080
   const endpoint = process.env.METRICS_USE_BASE_URL ? join(baseUrl, 'metrics') : '/metrics'
+
+  setupMetrics(name)
 
   metricsApp.get(endpoint, async (_, res) => {
     res.type('txt')


### PR DESCRIPTION
## Closes #20767

## Description
Makes it easier to determine the package version of a running External Adapter.
......

## Changes

- Name and version tag to Prometheus metrics
![image](https://user-images.githubusercontent.com/28818476/141181319-9b7a2bfe-5f38-49a8-9288-d6d4b45f9fda.png)
- Sending a GET to the `/health` endpoint will return the version number 

## Steps to Test

1. Run an EA with metrics enabled
2. Query `/metrics`, there should be `ea_name` and `ea_version` tags.
3. Query `/health`, it should be in JSON with a `version` property.

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
