### PR TITLE
[Refactor] Terra View multi-chainId & resultPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,10 +367,10 @@ To get started from one of the example adapters seen in [examples](./packages/ex
 yarn new [template-type] [name-of-adapter]
 ```
 
-|     Parameter     |           Description           |         Options         |
-| :---------------: | :-----------------------------: | :---------------------: |
-|  `template-type`  | the name of the template to use | `composites`, `sources` |
-| `name-of-adapter` |  what to call the new adapter   |      user-defined       |
+|     Parameter     |           Description           |        Options        |
+| :---------------: | :-----------------------------: | :-------------------: |
+|  `template-type`  | the name of the template to use | `composite`, `source` |
+| `name-of-adapter` |  what to call the new adapter   |     user-defined      |
 
 For example
 

--- a/packages/core/legos/package.json
+++ b/packages/core/legos/package.json
@@ -127,7 +127,7 @@
     "@chainlink/stasis-adapter": "1.0.0",
     "@chainlink/synthetix-debt-pool-adapter": "1.0.0",
     "@chainlink/taapi-adapter": "1.0.0",
-    "@chainlink/terra-view-function-adapter": "1.0.0",
+    "@chainlink/terra-view-function-adapter": "2.0.0",
     "@chainlink/therundown-adapter": "1.0.0",
     "@chainlink/tiingo-adapter": "1.0.0",
     "@chainlink/tradermade-adapter": "1.0.0",

--- a/packages/sources/terra-view-function/README.md
+++ b/packages/sources/terra-view-function/README.md
@@ -4,10 +4,14 @@ This external adapter allows querying contracts on the Terra blockchain.
 
 ### Environment Variables
 
-| Required? |       Name       |              Description              | Options | Defaults to |
-| :-------: | :--------------: | :-----------------------------------: | :-----: | :---------: |
-|    ✅     | ETHEREUM_RPC_URL | The Ethereum Mainnet RPC URL to query |         |             |
-|    ✅     |     CHAIN_ID     |   Which chain ID it's connecting to   |         |             |
+| Required? |        Name        |                               Description                                | Options | Defaults to  |
+| :-------: | :----------------: | :----------------------------------------------------------------------: | :-----: | :----------: |
+|    ✅     | COLUMBUS_5_RPC_URL | The URL to a Terra `columbus-5` full node to query on-chain mainnet data |         |              |
+|    ✅     | BOMBAY_12_RPC_URL  | The URL to a Terra `bombay-12` full node to query on-chain testnet data  |         |              |
+|    ✅     | LOCALTERRA_RPC_URL |   The URL to a locally running Terra full node to query on-chain data    |         |              |
+|           |  DEFAULT_CHAIN_ID  |         The default `chainId` value to use as an input parameter         |         | `columbus-5` |
+
+A list of public endpoints can be found [here](https://docs.terra.money/Reference/endpoints.html). Please only use these for testing, not in production, as they are not secure.
 
 ---
 
@@ -23,11 +27,13 @@ This external adapter allows querying contracts on the Terra blockchain.
 
 ### Input Params
 
-| Required? |          Name           |                  Description                   | Options | Defaults to |
-| :-------: | :---------------------: | :--------------------------------------------: | :-----: | :---------: |
-|    ✅     | `address` or `contract` |              The address to query              |         |             |
-|    ✅     |         `query`         |                The query object                |         |             |
-|           |        `params`         | Optional params object to include in the query |         |             |
+| Required? |          Name           |                                                                           Description                                                                            |                 Options                 |               Defaults to               |
+| :-------: | :---------------------: | :--------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-------------------------------------: | :-------------------------------------: |
+|    ✅     | `address` or `contract` |                                                                       The address to query                                                                       |                                         |                                         |
+|    ✅     |         `query`         |                                                                         The query object                                                                         |                                         |                                         |
+|           |        `params`         |                                                          Optional params object to include in the query                                                          |                                         |                                         |
+|           |        `chainId`        |                                                                   Which chain ID to connect to                                                                   | `columbus-5`, `bombay-12`, `localterra` | `DEFAULT_CHAIN_ID` environment variable |
+|           |      `resultPath`       | The [object-path](https://github.com/mariocasciaro/object-path) string to parse a single `result` value. When not provided the entire response will be provided. |                                         |                                         |
 
 ### Sample Input
 

--- a/packages/sources/terra-view-function/package.json
+++ b/packages/sources/terra-view-function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/terra-view-function-adapter",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Chainlink terra-view-function adapter.",
   "keywords": [
     "Chainlink",

--- a/packages/sources/terra-view-function/schemas/env.json
+++ b/packages/sources/terra-view-function/schemas/env.json
@@ -1,15 +1,19 @@
 {
   "$id": "https://external-adapters.chainlinklabs.com/schemas/terra-view-function-adapter.json",
   "title": "@chainlink/terra-view-function-adapter env var schema",
-  "required": ["ETHEREUM_RPC_URL", "CHAIN_ID"],
+  "required": [],
   "type": "object",
   "properties": {
-    "ETHEREUM_RPC_URL": {
-      "required": true,
+    "COLUMBUS_5_RPC_URL": {
       "type": "string"
     },
-    "CHAIN_ID": {
-      "required": true,
+    "BOMBAY_12_RPC_URL": {
+      "type": "string"
+    },
+    "LOCALTERRA_RPC_URL": {
+      "type": "string"
+    },
+    "DEFAULT_CHAIN_ID": {
       "type": "string"
     }
   },

--- a/packages/sources/terra-view-function/src/config.ts
+++ b/packages/sources/terra-view-function/src/config.ts
@@ -5,18 +5,44 @@ export const NAME = 'TERRA_VIEW_FUNCTION'
 
 export const DEFAULT_ENDPOINT = 'view'
 
-export const ENV_ETHEREUM_RPC_URL = 'ETHEREUM_RPC_URL'
-export const ENV_FALLBACK_RPC_URL = 'RPC_URL'
-export const ENV_CHAIN_ID = 'CHAIN_ID'
+export const SUPPORTED_CHAIN_IDS = ['columbus-5', 'bombay-12', 'localterra'] as const
+export type ChainId = typeof SUPPORTED_CHAIN_IDS[number]
+
+export const ENV_DEFAULT_CHAIN_ID = 'DEFAULT_CHAIN_ID'
+export const DEFAULT_CHAIN_ID = 'columbus-5'
+
+export const ENV_RPC_URL = 'RPC_URL'
 
 export type Config = BaseConfig & {
-  rpcUrl: string
-  chainId: string
+  rpcUrls: Partial<Record<ChainId, string>>
+  defaultChainId: string
 }
 
-export const makeConfig = (prefix?: string): Config => ({
-  ...Requester.getDefaultConfig(prefix),
-  rpcUrl: util.getRequiredEnvWithFallback(ENV_ETHEREUM_RPC_URL, [ENV_FALLBACK_RPC_URL], prefix),
-  chainId: util.getRequiredEnv(ENV_CHAIN_ID, prefix),
-  defaultEndpoint: DEFAULT_ENDPOINT,
-})
+export const makeConfig = (prefix?: string): Config => {
+  const baseConfig = Requester.getDefaultConfig(prefix)
+
+  return {
+    ...baseConfig,
+    rpcUrls: buildRpcUrlMapping(),
+    defaultChainId: util.getEnv(ENV_DEFAULT_CHAIN_ID, prefix) || DEFAULT_CHAIN_ID,
+    defaultEndpoint: DEFAULT_ENDPOINT,
+  }
+}
+
+const buildRpcUrlMapping = () => {
+  const output: Partial<Record<ChainId, string>> = {}
+  let hasAtLeastOneURL = false
+  for (const chainId of SUPPORTED_CHAIN_IDS) {
+    // Underscore-ize and capitalize to format for environment variables
+    const prefix = chainId.replace('-', '_').toUpperCase()
+    const envVar = util.getEnv(ENV_RPC_URL, prefix)
+    if (envVar) {
+      output[chainId] = envVar
+      hasAtLeastOneURL = true
+    }
+  }
+
+  if (!hasAtLeastOneURL) throw new Error('At least one RPC URL must be defined')
+
+  return output
+}

--- a/packages/sources/terra-view-function/src/endpoint/view.ts
+++ b/packages/sources/terra-view-function/src/endpoint/view.ts
@@ -1,7 +1,7 @@
-import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import { Requester, Validator, AdapterError } from '@chainlink/ea-bootstrap'
 import { ExecuteWithConfig, InputParameters } from '@chainlink/types'
 import { LCDClient } from '@terra-money/terra.js'
-import { Config } from '../config'
+import { Config, ChainId, SUPPORTED_CHAIN_IDS } from '../config'
 
 export const supportedEndpoints = ['view']
 
@@ -9,28 +9,41 @@ export const inputParameters: InputParameters = {
   address: ['address', 'contract'],
   query: true,
   params: false,
+  chainId: false,
+  resultPath: false,
 }
 
 export const execute: ExecuteWithConfig<Config> = async (request, _, config) => {
-  const validator = new Validator(request, inputParameters)
+  const validator = new Validator(request, inputParameters, { chainId: SUPPORTED_CHAIN_IDS })
   if (validator.error) throw validator.error
 
   const jobRunID = validator.validated.id
   const address = validator.validated.data.address
   const query = validator.validated.data.query
   const params = validator.validated.data.params
+  const chainID = (validator.validated.data.chainId || config.defaultChainId) as ChainId
+  const resultPath = validator.validated.data.resultPath as string
+
+  const URL = config.rpcUrls[chainID]
+  if (!URL)
+    throw new AdapterError({
+      jobRunID,
+      statusCode: 400,
+      message: `RPC URL for ${chainID} is not configured as an environment variable.`,
+    })
 
   const terra = new LCDClient({
-    URL: config.rpcUrl,
-    chainID: config.chainId,
+    URL,
+    chainID,
   })
 
-  const result = await terra.wasm.contractQuery(address, query, params)
+  const response = await terra.wasm.contractQuery<Record<string, unknown>>(address, query, params)
+  const result = resultPath ? Requester.validateResultNumber(response, [resultPath]) : response
 
-  const response = {
+  const output = {
     data: { result },
     result,
   }
 
-  return Requester.success(jobRunID, response, config.verbose)
+  return Requester.success(jobRunID, output, config.verbose)
 }

--- a/packages/sources/terra-view-function/src/index.ts
+++ b/packages/sources/terra-view-function/src/index.ts
@@ -3,4 +3,5 @@ import { makeExecute, endpointSelector } from './adapter'
 import { makeConfig, NAME } from './config'
 
 const { server } = expose(NAME, makeExecute(), undefined, endpointSelector)
+
 export { NAME, makeExecute, makeConfig, server }

--- a/packages/sources/terra-view-function/test-payload.json
+++ b/packages/sources/terra-view-function/test-payload.json
@@ -1,6 +1,7 @@
 {
  "requests": [{
-  "from": "LINK",
-  "to": "USD"
- }]
+    "address": "terra1dw5ex5g802vgrek3nzppwt29tfzlpa38ep97qy",
+    "query": { "aggregator_query": { "get_latest_round_data": {} } },
+    "chainId": "bombay-12"
+  }]
 }

--- a/packages/sources/terra-view-function/test/e2e/view.test.ts
+++ b/packages/sources/terra-view-function/test/e2e/view.test.ts
@@ -9,8 +9,7 @@ let oldEnv: NodeJS.ProcessEnv
 beforeAll(() => {
   oldEnv = JSON.parse(JSON.stringify(process.env))
   process.env.CACHE_ENABLED = 'false'
-  process.env.ETHEREUM_RPC_URL = process.env.ETHEREUM_RPC_URL || 'https://bombay-lcd.terra.dev'
-  process.env.CHAIN_ID = process.env.CHAIN_ID || 'bombay-12'
+  process.env.BOMBAY_12_RPC_URL = process.env.BOMBAY_12_RPC_URL || 'https://bombay-lcd.terra.dev'
 })
 
 afterAll(() => {
@@ -29,6 +28,7 @@ describe('execute', () => {
           data: {
             address: 'terra1dw5ex5g802vgrek3nzppwt29tfzlpa38ep97qy',
             query: { aggregator_query: { get_latest_round_data: {} } },
+            chainId: 'bombay-12',
           },
         },
       },
@@ -39,6 +39,7 @@ describe('execute', () => {
           data: {
             address: 'terra1dw5ex5g802vgrek3nzppwt29tfzlpa38ep97qy',
             query: { aggregator_query: { get_latest_round_data: {} } },
+            chainId: 'bombay-12',
           },
         },
       },
@@ -62,6 +63,7 @@ describe('execute', () => {
           data: {
             address: 'not_real',
             query: { aggregator_query: { get_latest_round_data: {} } },
+            chainId: 'bombay-12',
           },
         },
       },
@@ -72,6 +74,7 @@ describe('execute', () => {
           data: {
             address: 'terra1dw5ex5g802vgrek3nzppwt29tfzlpa38ep97qy',
             query: { get_latest_round_data: {} },
+            chainId: 'bombay-12',
           },
         },
       },

--- a/packages/sources/terra-view-function/test/integration/view.test.ts
+++ b/packages/sources/terra-view-function/test/integration/view.test.ts
@@ -11,9 +11,8 @@ let oldEnv: NodeJS.ProcessEnv
 beforeAll(() => {
   oldEnv = JSON.parse(JSON.stringify(process.env))
   process.env.CACHE_ENABLED = 'false'
-  process.env.ETHEREUM_RPC_URL = process.env.ETHEREUM_RPC_URL || 'http://localhost:1234/'
-  process.env.CHAIN_ID = process.env.CHAIN_ID || 'bombay-12'
-  process.env.API_VERBOSE = true
+  process.env.COLUMBUS_5_RPC_URL = process.env.COLUMBUS_5_RPC_URL || 'http://localhost:1234/'
+  process.env.API_VERBOSE = 'true'
   if (process.env.RECORD) {
     nock.recorder.rec()
   }

--- a/packages/sources/terra-view-function/test/unit/view.test.ts
+++ b/packages/sources/terra-view-function/test/unit/view.test.ts
@@ -8,8 +8,7 @@ let oldEnv: NodeJS.ProcessEnv
 
 beforeAll(() => {
   oldEnv = JSON.parse(JSON.stringify(process.env))
-  process.env.ETHEREUM_RPC_URL = process.env.ETHEREUM_RPC_URL || 'http://localhost:1234/'
-  process.env.CHAIN_ID = process.env.CHAIN_ID || 'bombay-12'
+  process.env.COLUMBUS_5_RPC_URL = process.env.COLUMBUS_5_RPC_URL || 'http://localhost:1234/'
 })
 
 afterAll(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2529,7 +2529,7 @@ __metadata:
     "@chainlink/stasis-adapter": 1.0.0
     "@chainlink/synthetix-debt-pool-adapter": 1.0.0
     "@chainlink/taapi-adapter": 1.0.0
-    "@chainlink/terra-view-function-adapter": 1.0.0
+    "@chainlink/terra-view-function-adapter": 2.0.0
     "@chainlink/therundown-adapter": 1.0.0
     "@chainlink/tiingo-adapter": 1.0.0
     "@chainlink/tradermade-adapter": 1.0.0
@@ -3651,7 +3651,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@chainlink/terra-view-function-adapter@1.0.0, @chainlink/terra-view-function-adapter@workspace:packages/sources/terra-view-function":
+"@chainlink/terra-view-function-adapter@2.0.0, @chainlink/terra-view-function-adapter@workspace:packages/sources/terra-view-function":
   version: 0.0.0-use.local
   resolution: "@chainlink/terra-view-function-adapter@workspace:packages/sources/terra-view-function"
   dependencies:


### PR DESCRIPTION
## Closes sc-21373

## Description

Refactors the Terra-View-Function EA so that it is flexible enough to handle price feeds.

......

## Changes

- Support multiple chainIds at once on the same adapter instance. RPC URLs are now prefixed with the chain ID.
- ChainId can be passed in as an input parameter to change
- Added `DEFAULT_CHAIN_ID` environment parameter
- Passing a `resultPath` input parameter selects a `result` from the response.

## Steps to Test

1. Add a `BOMBAY_12_RPC_URL`
2. Start adapter
3. Query with
```
{
  "jobID": "1",
  "data": {
    "address": "terra1dw5ex5g802vgrek3nzppwt29tfzlpa38ep97qy",
    "query": { "aggregator_query": { "get_latest_round_data": {} } },
    "chainId": "bombay-12"
  }
}
```

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
