### PR TITLE
ci(changelog-checker): update changed-files action

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Check for changed files
         id: changedfiles
-        uses: futuratrepadeira/changed-files@186b5b30b1f5e44ed655a59652746c3ce00d53ef # Version v3.1.1
+        uses: umani/changed-files@v3.3.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           pattern: '^CHANGELOG.*$'


### PR DESCRIPTION
The changed-files action has moved name and a new version is available.

This PR replaces #864