### PR TITLE
Make sure integration tests exits immediately

### DIFF
--- a/.changeset/chilly-cooks-turn.md
+++ b/.changeset/chilly-cooks-turn.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/ea-bootstrap': patch
+---
+
+send shutdown signal to cache warmer

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm install -g yarn
       - run: yarn install
       - run: yarn setup
-      - run: yarn test:ci:integration
+      - run: timeout 300 yarn test:ci:integration
       - uses: codecov/codecov-action@v2
         with:
           flags: integration

--- a/packages/core/bootstrap/src/index.ts
+++ b/packages/core/bootstrap/src/index.ts
@@ -55,7 +55,7 @@ export const store = configureStore(rootReducer, initState, [
 cacheWarmer.epics.epicMiddleware.run(cacheWarmer.epics.rootEpic)
 ws.epics.epicMiddleware.run(ws.epics.rootEpic)
 
-const storeSlice = (slice: ReduxMiddleware) =>
+export const storeSlice = (slice: ReduxMiddleware): Store =>
   ({
     getState: () => store.getState()[slice],
     dispatch: (a) => store.dispatch(a),

--- a/packages/core/bootstrap/src/lib/cache-warmer/actions.ts
+++ b/packages/core/bootstrap/src/lib/cache-warmer/actions.ts
@@ -49,11 +49,11 @@ export interface WarmupSubscribedMultiplePayload {
   members: WarmupSubscribedPayload[]
 }
 
-interface WarmupUnsubscribedPayload {
+export interface WarmupUnsubscribedPayload {
   key: string
   reason: string
 }
-interface WarmupStoppedPayload {
+export interface WarmupStoppedPayload {
   keys: string[]
 }
 interface WarmupSubscriptionTimeoutResetPayload {
@@ -81,6 +81,7 @@ export const warmupUnsubscribed = createAction<WarmupUnsubscribedPayload>('WARMU
 export const warmupStopped = createAction<WarmupStoppedPayload>('WARMUP/STOPPED')
 export const warmupJoinGroup = createAction<WarmupJoinGroupPayload>('WARMUP/JOIN_GROUP')
 export const warmupLeaveGroup = createAction<WarmupLeaveGroupPayload>('WARMUP/LEAVE_GROUP')
+export const warmupShutdown = createAction('WARMUP/SHUTDOWN')
 
 interface WarmupRequestedPayload {
   /**

--- a/packages/core/bootstrap/src/lib/cache-warmer/reducer.ts
+++ b/packages/core/bootstrap/src/lib/cache-warmer/reducer.ts
@@ -257,6 +257,10 @@ export const warmupReducer = createReducer<RequestState>({}, (builder) => {
     delete state[key]
   })
 
+  builder.addCase(actions.warmupShutdown, () => {
+    logger.info('[warmupReducer] Shutting down... ')
+  })
+
   builder.addCase(actions.warmupStopped, (state, action) => {
     logger.info('[warmupReducer] Stopping subscriptions', {
       warmupSubscriptionKey: action.payload.keys,

--- a/packages/sources/synthetix-debt-pool/test/integration/adapter.test.ts
+++ b/packages/sources/synthetix-debt-pool/test/integration/adapter.test.ts
@@ -1,6 +1,8 @@
 import { server as startServer } from '../../src/index'
 import { ethers, BigNumber } from 'ethers'
 import request from 'supertest'
+import http from 'http'
+import process from 'process'
 
 const mockBigNum = BigNumber.from('464590202399031116379217447')
 
@@ -24,17 +26,24 @@ jest.mock('ethers', () => ({
 
 let oldEnv: NodeJS.ProcessEnv
 
+beforeAll(() => {
+  oldEnv = JSON.parse(JSON.stringify(process.env))
+  process.env.ETHEREUM_RPC_URL = 'FAKE_ETHEREUM_RPC_URL'
+  process.env.CACHE_ENABLED = 'false'
+})
+
+afterAll(() => {
+  process.env = oldEnv
+})
+
 describe('synthetix-debt-pool', () => {
   let server: http.Server
   const req = request('localhost:8080')
 
   beforeAll(async () => {
     server = await startServer()
-    process.env.ETHEREUM_RPC_URL = 'FAKE_ETHEREUM_RPC_URL'
-    process.env.CACHE_ENABLED = 'false'
   })
   afterAll((done) => {
-    process.env = oldEnv
     server.close(done)
   })
 


### PR DESCRIPTION
## Changes

- Add timeout to CI integration tests
- Add shutdown event to cache warmer (cancels timers)
- Fix a failing test for synthetix-debt-pool

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. Run `yarn test:ci:integration` and make sure it exits cleanly as soon as tests are completed

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
