### PR TITLE
Make `aws-ecr-private` a bool in all cases

### DIFF
--- a/.github/actions/release/publish-artifacts/action.yml
+++ b/.github/actions/release/publish-artifacts/action.yml
@@ -82,12 +82,12 @@ runs:
     - name: Authenticate to ECR
       if: inputs.latest || ! steps.check-image-exists.outputs.image-exists
       shell: bash
-      run: aws ${{ fromJSON('["ecr-public", "ecr"]')[inputs.aws-ecr-private == 'true'] }} get-login-password --region ${{ inputs.aws-region }} | docker login --username AWS --password-stdin ${{ inputs.image-prefix }}
+      run: aws ${{ fromJSON('["ecr-public", "ecr"]')[inputs.aws-ecr-private] }} get-login-password --region ${{ inputs.aws-region }} | docker login --username AWS --password-stdin ${{ inputs.image-prefix }}
 
     - name: Create a ECR repository if does not exist
       if: inputs.latest || ! steps.check-image-exists.outputs.image-exists
       shell: bash
-      run: aws ${{ fromJSON('["ecr-public", "ecr"]')[inputs.aws-ecr-private == 'true'] }} create-repository --region ${{ inputs.aws-region }} --repository-name adapters/${{ inputs.adapter-name }} || true
+      run: aws ${{ fromJSON('["ecr-public", "ecr"]')[inputs.aws-ecr-private] }} create-repository --region ${{ inputs.aws-region }} --repository-name adapters/${{ inputs.adapter-name }} || true
 
     - name: Set ECR repository permissions for secondary account access on private ECR repos
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
           image-prefix: ${{ secrets.SDLC_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/adapters/
           adapter-name: ${{ matrix.adapter.name }}
           aws-region: ${{ secrets.AWS_REGION }}
-          aws-ecr-private: 'true'
+          aws-ecr-private: true
           aws-ecr-account-ids: ${{ secrets.AWS_PRIVATE_ECR_SECONDARY_ACCOUNT_ACCESS_IDS }}
 
       # For our private ECR repo that we use for staging, we keep the latest tag around to have staging auto-update
@@ -87,7 +87,7 @@ jobs:
           image-prefix: ${{ secrets.SDLC_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/adapters/
           adapter-name: ${{ matrix.adapter.name }}
           aws-region: ${{ secrets.AWS_REGION }}
-          aws-ecr-private: 'true'
+          aws-ecr-private: true
           aws-ecr-account-ids: ${{ secrets.AWS_PRIVATE_ECR_SECONDARY_ACCOUNT_ACCESS_IDS }}
 
       #
@@ -115,4 +115,4 @@ jobs:
           image-prefix: public.ecr.aws/${{ env.publicecr-name }}/adapters/
           adapter-name: ${{ matrix.adapter.name }}
           aws-region: us-east-1
-          aws-ecr-private: 'false'
+          aws-ecr-private: false


### PR DESCRIPTION
In the `true` case we were comparing `'true' == 'true'` but in the false case we were evaluating `'false'` as a bool (which is a string and thus `true`)

See: https://github.com/smartcontractkit/external-adapters-js/blob/878d1e53c64b41e993be316e620ba8de0bbd2100/.github/actions/release/publish-artifacts/action.yml#L94