### PR TITLE
Add new inputParameter config system to Validator

### DIFF
--- a/packages/core/bootstrap/src/lib/external-adapter/validator.ts
+++ b/packages/core/bootstrap/src/lib/external-adapter/validator.ts
@@ -5,7 +5,10 @@ import {
   APIEndpoint,
   Includes,
   IncludePair,
+  InputParameter,
+  InputParameters,
   Config,
+  InputParameterAliases,
 } from '@chainlink/types'
 import { merge } from 'lodash'
 import { isArray, isObject } from '../util'
@@ -18,121 +21,84 @@ import { Requester } from './requester'
 import { inputParameters } from './builder'
 
 export type OverrideType = 'overrides' | 'tokenOverrides' | 'includes'
+
 export class Validator {
-  input: any
-  customParams: any
+  input: {
+    id?: string
+    data?: any
+  }
+  inputConfigs: InputParameters
   options: Record<string, any[]>
-  validated: any
+  validated: {
+    id: string
+    data?: any
+    includes?: Override
+    overrides?: Override
+    tokenOverrides?: Override
+  }
   error: AdapterError | undefined
   errored: AdapterErrorResponse | undefined
+  shouldLogError: boolean
 
-  constructor(input = {}, customParams = {}, options = {}, shouldLogError = true) {
+  constructor(input = {}, inputConfigs = {}, options = {}, shouldLogError = true) {
     this.input = { ...input }
-    this.customParams = { ...customParams }
+    this.inputConfigs = { ...inputConfigs }
     this.options = { ...options }
-    this.validated = { data: {} }
-    this.validateInput(shouldLogError)
-    this.validateOverrides(shouldLogError)
-    this.validateTokenOverrides(shouldLogError)
-    this.validateIncludeOverrides(shouldLogError)
+    this.shouldLogError = shouldLogError
+    this.validated = { id: this.input.id || '1', data: {} }
+    this.validateInput()
+    this.validateOverrides('overrides', presetSymbols)
+    this.validateOverrides('tokenOverrides', presetTokens)
+    this.validateIncludeOverrides()
   }
 
-  validateInput(shouldLogError: boolean) {
-    this.input.id = this.input.id || '1'
-    this.validated.id = this.input.id
-
+  validateInput(): void {
     try {
-      for (const key in this.customParams) {
+      for (const key in this.inputConfigs) {
         const options = this.options[key]
-        if (Array.isArray(this.customParams[key])) {
-          this.validateRequiredParam(
-            this.getRequiredArrayParam(this.customParams[key]),
-            key,
-            options,
-          )
-        } else if (this.customParams[key] === true) {
-          this.validateRequiredParam(this.input.data[key], key, options)
-        } else if (typeof this.input.data[key] !== 'undefined') {
-          this.validateOptionalParam(this.input.data[key], key, options)
+        const inputConfig = this.inputConfigs[key]
+
+        if (Array.isArray(inputConfig)) {
+          const usedKey = this.getUsedKey(key, inputConfig)
+          if (!usedKey) this.throwInvalid(`None of aliases used for required key ${key}`)()
+          this.validateRequiredParam(usedKey as string, options)
+        } else if (typeof inputConfig === 'boolean') {
+          inputConfig
+            ? this.validateRequiredParam(key, options)
+            : this.validateOptionalParam(key, options)
+        } else if (Object.keys(inputConfig).length > 0) {
+          this.validateObjectParam(key)
         }
       }
-    } catch (error) {
-      this.parseError(
-        error,
-        {
-          input: this.input,
-          options: this.options,
-          customParams: this.customParams,
-        },
-        shouldLogError,
-      )
+    } catch (e) {
+      this.parseError(e)
     }
   }
 
-  validateOverrides(shouldLogError: boolean) {
+  validateOverrides(path: 'overrides' | 'tokenOverrides', preset: Record<string, any>): void {
     try {
-      if (!this.input.data?.overrides) {
-        this.validated.overrides = this.formatOverride(presetSymbols)
+      if (!this.input.data?.[path]) {
+        this.validated[path] = this.formatOverride(preset)
         return
       }
-      this.validated.overrides = this.formatOverride(
-        merge({ ...presetSymbols }, this.input.data.overrides),
-      )
+      this.validated[path] = this.formatOverride(merge({ ...preset }, this.input.data[path]))
     } catch (e) {
-      this.parseError(
-        e,
-        {
-          input: this.input,
-          options: this.options,
-          customParams: this.customParams,
-        },
-        shouldLogError,
-      )
+      this.parseError(e)
     }
   }
 
-  validateTokenOverrides(shouldLogError: boolean) {
-    try {
-      if (!this.input.data?.tokenOverrides) {
-        this.validated.tokenOverrides = this.formatTokenOverrides(presetTokens)
-        return
-      }
-      this.validated.tokenOverrides = this.formatTokenOverrides(
-        merge({ ...presetTokens }, this.input.data.tokenOverrides),
-      )
-    } catch (e) {
-      this.parseError(
-        e,
-        {
-          input: this.input,
-          options: this.options,
-          customParams: this.customParams,
-        },
-        shouldLogError,
-      )
-    }
-  }
-
-  validateIncludeOverrides(shouldLogError: boolean) {
+  validateIncludeOverrides(): void {
     try {
       this.validated.includes = this.formatIncludeOverrides([
         ...(this.input.data?.includes || []),
         ...presetIncludes,
       ])
     } catch (e) {
-      this.parseError(
-        e,
-        {
-          input: this.input,
-          options: this.options,
-          customParams: this.customParams,
-        },
-        shouldLogError,
-      )
+      this.parseError(e)
     }
   }
 
-  parseError(error: any, context: any, shouldLogError: boolean) {
+  parseError(error: any): void {
     const message = 'Error validating input.'
     if (error instanceof AdapterError) this.error = error
     else
@@ -142,21 +108,22 @@ export class Validator {
         message,
         cause: error,
       })
-    if (shouldLogError) {
-      logger.error(message, { error: this.error, context })
+    if (this.shouldLogError) {
+      logger.error(message, {
+        error: this.error,
+        context: {
+          input: this.input,
+          options: this.options,
+          inputConfigs: this.inputConfigs,
+        },
+      })
     }
     this.errored = Requester.errored(this.validated.id, this.error)
   }
 
   overrideSymbol = (adapter: string, symbol?: string | string[]): string | string[] => {
     const defaultSymbol = symbol || this.validated.data.base
-    if (!defaultSymbol) {
-      throw new AdapterError({
-        jobRunID: this.validated.id,
-        statusCode: 400,
-        message: `Required parameter not supplied: base`,
-      })
-    }
+    if (!defaultSymbol) this.throwInvalid(`Required parameter not supplied: base`)()
     if (!this.validated.overrides) return defaultSymbol
     if (!Array.isArray(defaultSymbol))
       return (
@@ -173,14 +140,13 @@ export class Validator {
   }
 
   overrideToken = (symbol: string, network = 'ethereum'): string | undefined => {
-    if (!this.validated.tokenOverrides) return undefined
-    return this.validated.tokenOverrides.get(network.toLowerCase())?.get(symbol.toLowerCase())
+    return this.validated.tokenOverrides?.get(network.toLowerCase())?.get(symbol.toLowerCase())
   }
 
   overrideIncludes = (adapter: string, from: string, to: string): IncludePair | undefined => {
     // Search through `presetIncludes` to find matching override for adapter and to/from pairing.
     const pairs = (
-      this.validated.includes.filter(
+      this.validated.includes?.filter(
         (val: string | Includes) => typeof val !== 'string',
       ) as Includes[]
     ).filter(
@@ -203,7 +169,9 @@ export class Validator {
   }
 
   overrideReverseLookup = (adapter: string, type: OverrideType, symbol: string): string => {
-    const overrides: Map<string, string> = this.validated?.[type]?.get(adapter.toLowerCase())
+    const overrides: Map<string, string> | undefined = this.validated?.[type]?.get(
+      adapter.toLowerCase(),
+    )
     if (!overrides) return symbol
     let originalSymbol: string | undefined
     overrides.forEach((overridden, original) => {
@@ -213,30 +181,8 @@ export class Validator {
   }
 
   formatOverride = (param: any): Override => {
-    const _throwInvalid = () => {
-      const message = `Parameter supplied with wrong format: "overrides"`
-      throw new AdapterError({ jobRunID: this.validated.id, statusCode: 400, message })
-    }
-    if (!isObject(param)) _throwInvalid()
+    const _throwInvalid = this.throwInvalid(`Parameter supplied with wrong format: "override"`)
 
-    const _isValid = Object.values(param).every(isObject)
-    if (!_isValid) _throwInvalid()
-
-    const _keyToLowerCase = (entry: [string, any]): [string, any] => {
-      return [entry[0].toLowerCase(), entry[1]]
-    }
-    return new Map(
-      Object.entries(param)
-        .map(_keyToLowerCase)
-        .map(([key, value]) => [key, new Map(Object.entries(value).map(_keyToLowerCase))]),
-    )
-  }
-
-  formatTokenOverrides = (param: any): Override => {
-    const _throwInvalid = () => {
-      const message = `Parameter supplied with wrong format: "tokenOverrides"`
-      throw new AdapterError({ jobRunID: this.validated.id, statusCode: 400, message })
-    }
     if (!isObject(param)) _throwInvalid()
 
     const _isValid = Object.values(param).every(isObject)
@@ -253,10 +199,7 @@ export class Validator {
   }
 
   formatIncludeOverrides = (param: any): Override => {
-    const _throwInvalid = () => {
-      const message = `Parameter supplied with wrong format: "includes"`
-      throw new AdapterError({ jobRunID: this.validated.id, statusCode: 400, message })
-    }
+    const _throwInvalid = this.throwInvalid(`Parameter supplied with wrong format: "includes"`)
     if (!isArray(param)) _throwInvalid()
 
     const _isValid = Object.values(param).every((val) => isObject(val) || typeof val === 'string')
@@ -265,46 +208,82 @@ export class Validator {
     return param
   }
 
-  validateOptionalParam(param: any, key: string, options: any[]) {
+  throwInvalid = (message: string) => (): void => {
+    throw new AdapterError({ jobRunID: this.validated.id, statusCode: 400, message })
+  }
+
+  validateObjectParam(key: string): void {
+    const inputConfig = this.inputConfigs[key] as InputParameter
+
+    const usedKey = this.getUsedKey(key, inputConfig.aliases ?? [])
+
+    const param = usedKey
+      ? this.input.data[usedKey as string] ?? inputConfig.default
+      : inputConfig.default
+
+    if (inputConfig.required && (param === undefined || param === null))
+      this.throwInvalid(`Required parameter ${key} not supplied`)
+
+    if (inputConfig.type && typeof param !== inputConfig.type)
+      this.throwInvalid(`${key} parameter must be of type ${inputConfig.type}`)
+
+    if (inputConfig.options && !inputConfig.options.includes(param))
+      this.throwInvalid(
+        `${key} parameter is not in the set of available options: ${inputConfig.options.join(
+          ', ',
+        )}`,
+      )
+
+    for (const dependency of inputConfig.dependsOn ?? []) {
+      const usedDependencyKey = this.getUsedKey(
+        dependency,
+        (this.inputConfigs[dependency] as InputParameter).aliases ?? [],
+      )
+      if (!usedDependencyKey) this.throwInvalid(`${key} dependency ${dependency} not supplied`)
+    }
+
+    for (const exclusive of inputConfig.exclusive ?? []) {
+      const usedExclusiveKey = this.getUsedKey(
+        exclusive,
+        (this.inputConfigs[exclusive] as InputParameter).aliases ?? [],
+      )
+      if (usedExclusiveKey)
+        this.throwInvalid(`${key} cannot be supplied concurrently with ${exclusive}`)
+    }
+
+    this.validated.data[key] = param
+  }
+
+  validateOptionalParam(key: string, options: any[]): void {
+    const param = this.input.data[key]
     if (param && options) {
-      if (!Array.isArray(options)) {
-        const message = `Parameter options for ${key} must be of an Array type`
-        throw new AdapterError({ jobRunID: this.validated.id, statusCode: 400, message })
-      }
-      if (!options.includes(param)) {
-        const message = `${param} is not a supported ${key} option. Must be one of ${options}`
-        throw new AdapterError({ jobRunID: this.validated.id, statusCode: 400, message })
-      }
+      if (!Array.isArray(options))
+        this.throwInvalid(`Parameter options for ${key} must be of an Array type`)()
+      if (!options.includes(param))
+        this.throwInvalid(`${param} is not a supported ${key} option. Must be one of ${options}`)()
     }
     this.validated.data[key] = param
   }
 
-  validateRequiredParam(param: any, key: string, options: any[]) {
-    if (typeof param === 'undefined') {
-      const message = `Required parameter not supplied: ${key}`
-      throw new AdapterError({ jobRunID: this.validated.id, statusCode: 400, message })
-    }
+  validateRequiredParam(key: string, options: any[]): void {
+    const param = this.input.data[key]
+    if (typeof param === 'undefined') this.throwInvalid(`Required parameter not supplied: ${key}`)()
     if (options) {
-      if (!Array.isArray(options)) {
-        const message = `Parameter options for ${key} must be of an Array type`
-        throw new AdapterError({ jobRunID: this.validated.id, statusCode: 400, message })
-      }
-      if (!options.includes(param)) {
-        const message = `${param} is not a supported ${key} option. Must be one of ${options.join(
-          ' || ',
-        )}`
-        throw new AdapterError({ jobRunID: this.validated.id, statusCode: 400, message })
-      }
+      if (!Array.isArray(options))
+        this.throwInvalid(`Parameter options for ${key} must be of an Array type`)()
+      if (!options.includes(param))
+        this.throwInvalid(
+          `${param} is not a supported ${key} option. Must be one of ${options.join(' || ')}`,
+        )()
     }
     this.validated.data[key] = param
   }
 
-  getRequiredArrayParam(keyArray: string[]) {
-    for (const param of keyArray) {
-      if (typeof this.input.data[param] !== 'undefined') {
-        return this.input.data[param]
-      }
-    }
+  getUsedKey(key: string, keyArray: InputParameterAliases): string | undefined {
+    if (!keyArray.includes(key)) keyArray.push(key)
+
+    const inputParamKeys = Object.keys(this.input.data)
+    return inputParamKeys.find((k) => keyArray.includes(k))
   }
 }
 

--- a/packages/core/types/@chainlink/index.d.ts
+++ b/packages/core/types/@chainlink/index.d.ts
@@ -146,8 +146,18 @@ declare module '@chainlink/types' {
 
   export type RequiredInputParameter = boolean
   export type InputParameterAliases = string[]
+  export type InputParameter = {
+    aliases?: InputParameterAliases
+    description?: string
+    type?: 'bigint' | 'boolean' | 'list' | 'number' | 'object' | 'string'
+    required?: RequiredInputParameter
+    options?: (number | string)[]
+    default?: boolean | number | string
+    dependsOn?: string[]
+    exclusive?: string[]
+  }
   export type InputParameters = {
-    [name: string]: RequiredInputParameter | InputParameterAliases
+    [name: string]: RequiredInputParameter | InputParameterAliases | InputParameter
   }
 
   export interface APIEndpoint<C extends Config = Config> {


### PR DESCRIPTION
<!-- Employees: Please use Clubhouse/Shortcuts's "Open PR" button from the relevant story or include links to relevant Clubhouse/Shortcut stories in your branch name, commit messages, or pull request comments. Do not add links to your pull request description, they will be ignored. https://help.clubhouse.io/hc/en-us/articles/207540323-Using-The-Clubhouse-GitHub-Integration -->

<!-- Employees: Delete this section. -->

## Closes #22342

## Description

This change refactors the input parameter configuration methods for the Validator, while maintaining backwards compatibility with old system.

## Changes
- Add new inputConfig setup with the following type:
```export type InputParameter = {
    aliases?: InputParameterAliases
    description?: string
    type?: 'bigint' | 'boolean' | 'list' | 'number' | 'object' | 'string'
    required?: RequiredInputParameter
    options?: (number | string)[]
    default?: boolean | number | string
    dependsOn?: string[]
    exclusive?: string[]
  }
```
- Refactor some parts of the Validator code to be more efficient or readable

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

TBD (TODO)

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
