### PR TITLE
Add missing step-id from image check

### DIFF
--- a/.github/actions/release/publish-artifacts/action.yml
+++ b/.github/actions/release/publish-artifacts/action.yml
@@ -58,6 +58,7 @@ runs:
         ADAPTER_NAME: ${{ inputs.adapter-name }}
 
     - name: Check if image already exists on the public/private ECR repository
+      id: check-image-exists
       # Disable default fast fail functionality since we care about exit code handling in the script itself
       shell: bash --noprofile --norc {0}
       env:


### PR DESCRIPTION
Without a step id, steps that were referencing the check-image-exists
step were getting null values