### PR TITLE
add nock integration tests for medianizer adapter

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -5883,7 +5883,8 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/jest", "npm:27.0.3"],
             ["@types/node", "npm:14.17.34"],
             ["axios", "npm:0.24.0"],
-            ["sinon", "npm:12.0.1"],
+            ["nock", "npm:13.2.1"],
+            ["supertest", "npm:6.1.6"],
             ["tslib", "npm:2.3.1"],
             ["typescript", "patch:typescript@npm%3A4.3.5#~builtin<compat/typescript>::version=4.3.5&hash=d8b4e7"]
           ],

--- a/packages/composites/medianizer/package.json
+++ b/packages/composites/medianizer/package.json
@@ -39,7 +39,8 @@
     "@chainlink/types": "workspace:*",
     "@types/jest": "27.0.3",
     "@types/node": "14.17.34",
-    "sinon": "12.0.1",
+    "nock": "13.2.1",
+    "supertest": "6.1.6",
     "typescript": "4.3.5"
   }
 }

--- a/packages/composites/medianizer/src/index.ts
+++ b/packages/composites/medianizer/src/index.ts
@@ -4,4 +4,6 @@ import { makeConfig } from './config'
 
 const NAME = 'MEDIANIZER'
 
-export = { NAME, makeConfig, makeExecute, ...expose(NAME, makeExecute()) }
+const { server } = expose(NAME, makeExecute())
+
+export { NAME, makeConfig, makeExecute, server }

--- a/packages/composites/medianizer/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/composites/medianizer/test/integration/__snapshots__/adapter.test.ts.snap
@@ -1,0 +1,62 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`medianizer erroring calls returns error if not reaching minAnswers 1`] = `
+Object {
+  "error": Object {
+    "feedID": "ETH/USD",
+    "message": "Not returning median: got 1 answers, requiring min. 2 answers",
+    "name": "AdapterError",
+  },
+  "jobRunID": "1",
+  "status": "errored",
+  "statusCode": 500,
+}
+`;
+
+exports[`medianizer successful calls return success without comma separated sources 1`] = `
+Object {
+  "data": Object {
+    "result": 4415.5654504608,
+  },
+  "jobRunID": "1",
+  "result": 4415.5654504608,
+  "statusCode": 200,
+}
+`;
+
+exports[`medianizer successful calls returns success with comma separated sources 1`] = `
+Object {
+  "data": Object {
+    "result": 4415.5654504608,
+  },
+  "jobRunID": "1",
+  "result": 4415.5654504608,
+  "statusCode": 200,
+}
+`;
+
+exports[`medianizer validation error returns a validation error if the request contains unsupported sources 1`] = `
+Object {
+  "error": Object {
+    "feedID": "ETH/USD",
+    "message": "Required parameter not supplied: sources",
+    "name": "AdapterError",
+  },
+  "jobRunID": "2",
+  "status": "errored",
+  "statusCode": 400,
+}
+`;
+
+exports[`medianizer validation error returns a validation error if the request data is empty 1`] = `
+Object {
+  "error": Object {
+    "feedID": "{\\"data\\":{}}",
+    "message": "Required parameter not supplied: sources",
+    "name": "AdapterError",
+  },
+  "jobRunID": "2",
+  "status": "errored",
+  "statusCode": 400,
+}
+`;

--- a/packages/composites/medianizer/test/integration/adapter.test.ts
+++ b/packages/composites/medianizer/test/integration/adapter.test.ts
@@ -1,175 +1,154 @@
-import sinon, { createSandbox } from 'sinon'
-import { assertSuccess, assertError } from '@chainlink/ea-test-helpers'
-import { Requester } from '@chainlink/ea-bootstrap'
-import { Execute, Config } from '@chainlink/types'
+import { AdapterRequest } from '@chainlink/types'
 import { util } from '@chainlink/ea-bootstrap'
-import { makeExecute } from '../../src/adapter'
-import { makeConfig } from '../../src/config'
+import { server as startServer } from '../../src'
+import nock from 'nock'
+import http from 'http'
+import request from 'supertest'
+import {
+  mockSuccessfulResponsesWithCommaSeparatedSources,
+  mockSuccessfulResponsesWithoutCommaSeparatedSources,
+  mockSuccessfulResponsesWithSingleSource,
+} from './fixtures'
 
-const AdapterStubs: Record<string, any> = {
-  COINGECKO: {
-    jobRunID: '1',
-    data: {
-      result: 1000,
-    },
-    result: 1000,
-    statusCode: 200,
-  },
-  COINPAPRIKA: {
-    jobRunID: '1',
-    data: {
-      result: 2000,
-    },
-    result: 2000,
-    statusCode: 200,
-  },
-}
+let oldEnv: NodeJS.ProcessEnv
 
 const setupEnvironment = (adapters: string[]) => {
   for (const a of adapters) {
-    process.env[`${a.toUpperCase()}_${util.ENV_ADAPTER_URL}`] = `http://test/${a}`
+    process.env[
+      `${a.toUpperCase()}_${util.ENV_ADAPTER_URL}`
+    ] = `https://adapters.main.stage.cldev.sh/${a}`
   }
 }
 
 describe('medianizer', () => {
-  let execute: Execute
-  let config: Config
-  let sandbox: sinon.SinonSandbox
-  let server: sinon.SinonFakeServer
+  let server: http.Server
+  const req = request('localhost:8080')
 
-  beforeEach(() => {
-    execute = makeExecute()
-    config = makeConfig()
-    sandbox = createSandbox()
-    server = sandbox.useFakeServer()
-  })
-  afterEach(() => {
-    server.restore()
-    sandbox.restore()
+  beforeAll(async () => {
+    oldEnv = JSON.parse(JSON.stringify(process.env))
+    server = await startServer()
+    setupEnvironment(['coingecko', 'coinpaprika', 'failing'])
+    if (process.env.RECORD) {
+      nock.recorder.rec()
+    }
   })
 
-  setupEnvironment(['coingecko', 'coinpaprika', 'failing'])
-  beforeAll(() => ({}))
+  afterAll((done) => {
+    if (process.env.RECORD) {
+      nock.recorder.play()
+    }
+    process.env = oldEnv
+    nock.restore()
+    nock.cleanAll()
+    nock.enableNetConnect()
+    server.close(done)
+  })
 
   describe('successful calls', () => {
     const jobID = '1'
 
-    const requests = [
-      {
-        name: 'successful adapter call',
-        input: {
-          id: jobID,
-          data: {
-            sources: ['coingecko', 'coinpaprika'],
-            from: 'ETH',
-            to: 'USD',
-          },
+    it('return success without comma separated sources', async () => {
+      mockSuccessfulResponsesWithoutCommaSeparatedSources()
+      const data: AdapterRequest = {
+        id: jobID,
+        data: {
+          sources: ['coingecko', 'coinpaprika'],
+          from: 'ETH',
+          to: 'USD',
         },
-        output: 1500,
-      },
-      {
-        name: 'comma separated sources',
-        input: {
-          id: jobID,
-          data: {
-            sources: 'coingecko,coinpaprika',
-            from: 'ETH',
-            to: 'USD',
-          },
-        },
-        output: 1500,
-      },
-    ]
+      }
 
-    requests.forEach((req) => {
-      it(`${req.name}`, async () => {
-        const HTTP = sandbox.stub(Requester, 'request')
-        for (const stub in AdapterStubs) {
-          HTTP.withArgs({
-            ...config.api,
-            method: 'post',
-            url: process.env[`${stub.toUpperCase()}_${util.ENV_ADAPTER_URL}`],
-            data: req.input,
-          }).returns(new Promise<any>((resolve) => resolve(AdapterStubs[stub])))
-        }
-        const data = await execute(req.input, {})
-        assertSuccess({ expected: 200, actual: data.statusCode }, data, jobID)
-        expect(data.result).toEqual(req.output)
-        expect(data.data.result).toEqual(req.output)
-      })
+      const response = await req
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+      expect(response.body).toMatchSnapshot()
+    })
+
+    it('returns success with comma separated sources', async () => {
+      mockSuccessfulResponsesWithCommaSeparatedSources()
+      const data: AdapterRequest = {
+        id: jobID,
+        data: {
+          sources: 'coingecko,coinpaprika',
+          from: 'ETH',
+          to: 'USD',
+        },
+      }
+
+      const response = await req
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+      expect(response.body).toMatchSnapshot()
     })
   })
 
   describe('erroring calls', () => {
     const jobID = '1'
 
-    const requests = [
-      {
-        name: 'returns error if not reaching minAnswers',
-        input: {
-          id: jobID,
-          data: {
-            sources: 'coingecko',
-            from: 'ETH',
-            to: 'USD',
-            minAnswers: 2,
-          },
+    it('returns error if not reaching minAnswers', async () => {
+      mockSuccessfulResponsesWithSingleSource()
+      const data: AdapterRequest = {
+        id: jobID,
+        data: {
+          sources: 'coingecko',
+          from: 'ETH',
+          to: 'USD',
+          minAnswers: 2,
         },
-      },
-    ]
-
-    requests.forEach((req) => {
-      it(`${req.name}`, async () => {
-        const HTTP = sandbox.stub(Requester, 'request')
-        for (const stub in AdapterStubs) {
-          HTTP.withArgs({
-            ...config.api,
-            method: 'post',
-            url: process.env[`${stub.toUpperCase()}_${util.ENV_ADAPTER_URL}`],
-            data: req.input,
-          }).returns(new Promise<any>((resolve) => resolve(AdapterStubs[stub])))
-        }
-        try {
-          await await execute(req.input, {})
-        } catch (error) {
-          const errorResp = Requester.errored(jobID, error)
-          assertError({ expected: 500, actual: errorResp.statusCode }, errorResp, jobID)
-        }
-      })
+      }
+      const response = await req
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(500)
+      expect(response.body).toMatchSnapshot()
     })
   })
 
   describe('validation error', () => {
     const jobID = '2'
 
-    const requests = [
-      {
-        name: 'empty data',
-        input: { id: jobID, data: {} },
-      },
-      {
-        name: 'unsupported source',
-        input: {
-          id: jobID,
-          data: {
-            source: 'NOT_REAL',
-            from: 'ETH',
-            to: 'USD',
-          },
-        },
-        output: 999,
-      },
-    ]
+    it('returns a validation error if the request data is empty', async () => {
+      const data: AdapterRequest = { id: jobID, data: {} }
 
-    requests.forEach((req) => {
-      it(`${req.name}`, async () => {
-        try {
-          await execute(req.input, {})
-        } catch (error) {
-          const errorResp = Requester.errored(jobID, error)
-          assertError({ expected: 400, actual: errorResp.statusCode }, errorResp, jobID)
-        }
-      })
+      const response = await req
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(400)
+      expect(response.body).toMatchSnapshot()
+    })
+
+    it('returns a validation error if the request contains unsupported sources', async () => {
+      const data: AdapterRequest = {
+        id: jobID,
+        data: {
+          source: 'NOT_REAL',
+          from: 'ETH',
+          to: 'USD',
+        },
+      }
+
+      const response = await req
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(400)
+      expect(response.body).toMatchSnapshot()
     })
   })
 })

--- a/packages/composites/medianizer/test/integration/fixtures.ts
+++ b/packages/composites/medianizer/test/integration/fixtures.ts
@@ -1,0 +1,169 @@
+import nock from 'nock'
+
+export const mockSuccessfulResponsesWithoutCommaSeparatedSources = () => {
+  nock('https://adapters.main.stage.cldev.sh')
+    .post('/coingecko', {
+      id: '1',
+      data: { sources: ['coingecko', 'coinpaprika'], from: 'ETH', to: 'USD' },
+    })
+    .reply(
+      200,
+      { jobRunID: '1', result: 4417.18, maxAge: 30000, statusCode: 200, data: { result: 4417.18 } },
+      [
+        'X-Powered-By',
+        'Express',
+        'X-RateLimit-Limit',
+        '250',
+        'X-RateLimit-Remaining',
+        '249',
+        'Date',
+        'Tue, 30 Nov 2021 05:33:00 GMT',
+        'X-RateLimit-Reset',
+        '1638250385',
+        'Content-Type',
+        'application/json; charset=utf-8',
+        'Content-Length',
+        '91',
+        'ETag',
+        'W/"5b-336W6SWFMKfGuh90hvQDQ8pBArM"',
+        'Connection',
+        'close',
+      ],
+    )
+
+  nock('https://adapters.main.stage.cldev.sh')
+    .post('/coinpaprika', {
+      id: '1',
+      data: { sources: ['coingecko', 'coinpaprika'], from: 'ETH', to: 'USD' },
+    })
+    .reply(
+      200,
+      {
+        jobRunID: '1',
+        result: 4413.9509009216,
+        maxAge: 30000,
+        statusCode: 200,
+        data: { result: 4413.9509009216 },
+      },
+      [
+        'X-Powered-By',
+        'Express',
+        'X-RateLimit-Limit',
+        '250',
+        'X-RateLimit-Remaining',
+        '249',
+        'Date',
+        'Tue, 30 Nov 2021 05:33:00 GMT',
+        'X-RateLimit-Reset',
+        '1638250383',
+        'Content-Type',
+        'application/json; charset=utf-8',
+        'Content-Length',
+        '107',
+        'ETag',
+        'W/"6b-lQYlgZnpNzhbNYmlxSm02Pk34qo"',
+        'Connection',
+        'close',
+      ],
+    )
+}
+
+export const mockSuccessfulResponsesWithCommaSeparatedSources = () => {
+  nock('https://adapters.main.stage.cldev.sh')
+    .post('/coingecko', {
+      id: '1',
+      data: { sources: 'coingecko,coinpaprika', from: 'ETH', to: 'USD' },
+    })
+    .reply(
+      200,
+      { jobRunID: '1', result: 4417.18, maxAge: 30000, statusCode: 200, data: { result: 4417.18 } },
+      [
+        'X-Powered-By',
+        'Express',
+        'X-RateLimit-Limit',
+        '250',
+        'X-RateLimit-Remaining',
+        '249',
+        'Date',
+        'Tue, 30 Nov 2021 05:33:00 GMT',
+        'X-RateLimit-Reset',
+        '1638250385',
+        'Content-Type',
+        'application/json; charset=utf-8',
+        'Content-Length',
+        '91',
+        'ETag',
+        'W/"5b-336W6SWFMKfGuh90hvQDQ8pBArM"',
+        'Connection',
+        'close',
+      ],
+    )
+
+  nock('https://adapters.main.stage.cldev.sh')
+    .post('/coinpaprika', {
+      id: '1',
+      data: { sources: 'coingecko,coinpaprika', from: 'ETH', to: 'USD' },
+    })
+    .reply(
+      200,
+      {
+        jobRunID: '1',
+        result: 4413.9509009216,
+        maxAge: 30000,
+        statusCode: 200,
+        data: { result: 4413.9509009216 },
+      },
+      [
+        'X-Powered-By',
+        'Express',
+        'X-RateLimit-Limit',
+        '250',
+        'X-RateLimit-Remaining',
+        '249',
+        'Date',
+        'Tue, 30 Nov 2021 05:33:00 GMT',
+        'X-RateLimit-Reset',
+        '1638250383',
+        'Content-Type',
+        'application/json; charset=utf-8',
+        'Content-Length',
+        '107',
+        'ETag',
+        'W/"6b-lQYlgZnpNzhbNYmlxSm02Pk34qo"',
+        'Connection',
+        'close',
+      ],
+    )
+}
+
+export const mockSuccessfulResponsesWithSingleSource = () => {
+  nock('https://adapters.main.stage.cldev.sh')
+    .post('/coingecko', {
+      id: '1',
+      data: { sources: 'coingecko', from: 'ETH', to: 'USD', minAnswers: 2 },
+    })
+    .reply(
+      200,
+      { jobRunID: '1', result: 4417.18, maxAge: 30000, statusCode: 200, data: { result: 4417.18 } },
+      [
+        'X-Powered-By',
+        'Express',
+        'X-RateLimit-Limit',
+        '250',
+        'X-RateLimit-Remaining',
+        '249',
+        'Date',
+        'Tue, 30 Nov 2021 05:33:00 GMT',
+        'X-RateLimit-Reset',
+        '1638250385',
+        'Content-Type',
+        'application/json; charset=utf-8',
+        'Content-Length',
+        '91',
+        'ETag',
+        'W/"5b-336W6SWFMKfGuh90hvQDQ8pBArM"',
+        'Connection',
+        'close',
+      ],
+    )
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3535,7 +3535,8 @@ __metadata:
     "@types/jest": 27.0.3
     "@types/node": 14.17.34
     axios: ^0.24.0
-    sinon: 12.0.1
+    nock: 13.2.1
+    supertest: 6.1.6
     tslib: ^2.3.1
     typescript: 4.3.5
   languageName: unknown


### PR DESCRIPTION
## Closes 18469

## Description

Update medianizer integration tests to use nock mocks.

## Changes

- Update the way variables are exported from the medianizer adapter.
- Update integration tests to use nock

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. Run medianizer adapter integration tests and verify that they pass.  Do this by running `yarn test medianizer/test/integration` from the root of the external adapters js project.

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
