### PR TITLE
Poa integration tests

### DIFF
--- a/.changeset/funny-cars-add.md
+++ b/.changeset/funny-cars-add.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/poa-adapter': minor
+---
+
+src export changed

--- a/.changeset/healthy-doors-hope.md
+++ b/.changeset/healthy-doors-hope.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/poa-adapter': minor
+---
+
+change default speed parameter to 'average'

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -6137,6 +6137,8 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@chainlink/types", "workspace:packages/core/types/@chainlink"],
             ["@types/jest", "npm:27.0.3"],
             ["@types/node", "npm:14.17.34"],
+            ["nock", "npm:13.2.1"],
+            ["supertest", "npm:6.1.6"],
             ["tslib", "npm:2.3.1"],
             ["typescript", "patch:typescript@npm%3A4.3.5#~builtin<compat/typescript>::version=4.3.5&hash=d8b4e7"]
           ],

--- a/packages/sources/poa/README.md
+++ b/packages/sources/poa/README.md
@@ -2,9 +2,9 @@
 
 ### Input Params
 
-| Required? |  Name   |             Description             |              Options               | Defaults to |
-| :-------: | :-----: | :---------------------------------: | :--------------------------------: | :---------: |
-|    🟡     | `speed` | The symbol of the currency to query | `slow`,`standard`,`fast`,`instant` | `standard`  |
+| Required? |  Name   |             Description             |         Options         | Defaults to |
+| :-------: | :-----: | :---------------------------------: | :---------------------: | :---------: |
+|    🟡     | `speed` | The symbol of the currency to query | `slow`,`fast`,`average` |  `average`  |
 
 ## Output Format
 

--- a/packages/sources/poa/package.json
+++ b/packages/sources/poa/package.json
@@ -36,6 +36,8 @@
     "@chainlink/types": "workspace:*",
     "@types/jest": "27.0.3",
     "@types/node": "14.17.34",
+    "nock": "13.2.1",
+    "supertest": "6.1.6",
     "typescript": "4.3.5"
   }
 }

--- a/packages/sources/poa/src/adapter.ts
+++ b/packages/sources/poa/src/adapter.ts
@@ -12,7 +12,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
 
   Requester.logConfig(config)
   const jobRunID = validator.validated.id
-  const speed = validator.validated.data.speed || 'standard'
+  const speed = validator.validated.data.speed || 'average'
   const reqConfig = {
     ...config.api,
   }

--- a/packages/sources/poa/src/index.ts
+++ b/packages/sources/poa/src/index.ts
@@ -2,4 +2,5 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-export = { NAME, makeExecute, makeConfig, ...expose(NAME, makeExecute()) }
+const { server } = expose(NAME, makeExecute())
+export { NAME, makeExecute, makeConfig, server }

--- a/packages/sources/poa/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/poa/test/integration/__snapshots__/adapter.test.ts.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`execute gasprice api should return success 1`] = `
+Object {
+  "data": Object {
+    "result": 152500000000,
+  },
+  "jobRunID": "1",
+  "result": 152500000000,
+  "statusCode": 200,
+}
+`;

--- a/packages/sources/poa/test/integration/adapter.test.ts
+++ b/packages/sources/poa/test/integration/adapter.test.ts
@@ -1,0 +1,49 @@
+import { AdapterRequest } from '@chainlink/types'
+import request from 'supertest'
+import * as process from 'process'
+import { server as startServer } from '../../src'
+import * as nock from 'nock'
+import * as http from 'http'
+import { mockResponseSuccess } from './fixtures'
+
+describe('execute', () => {
+  const id = '1'
+  let server: http.Server
+  const req = request('localhost:8080')
+  beforeAll(async () => {
+    if (process.env.RECORD) {
+      nock.recorder.rec()
+    }
+    server = await startServer()
+  })
+  afterAll((done) => {
+    if (process.env.RECORD) {
+      nock.recorder.play()
+    }
+
+    nock.restore()
+    nock.cleanAll()
+    nock.enableNetConnect()
+    server.close(done)
+  })
+
+  describe('gasprice api', () => {
+    const data: AdapterRequest = {
+      id,
+      data: {},
+    }
+
+    it('should return success', async () => {
+      mockResponseSuccess()
+
+      const response = await req
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+      expect(response.body).toMatchSnapshot()
+    })
+  })
+})

--- a/packages/sources/poa/test/integration/fixtures.ts
+++ b/packages/sources/poa/test/integration/fixtures.ts
@@ -1,0 +1,15 @@
+import nock from 'nock'
+
+export const mockResponseSuccess = (): nock =>
+  nock('https://gasprice.poa.network')
+    .get('/')
+    .reply(200, (_, request) => ({ average: 152.5, fast: 174.5, slow: 139.4 }), [
+      'Content-Type',
+      'application/json',
+      'Connection',
+      'close',
+      'Vary',
+      'Accept-Encoding',
+      'Vary',
+      'Origin',
+    ])

--- a/yarn.lock
+++ b/yarn.lock
@@ -3759,6 +3759,8 @@ __metadata:
     "@chainlink/types": "workspace:*"
     "@types/jest": 27.0.3
     "@types/node": 14.17.34
+    nock: 13.2.1
+    supertest: 6.1.6
     tslib: ^2.3.1
     typescript: 4.3.5
   languageName: unknown


### PR DESCRIPTION
## Changes

changed default value for input parameter 'speed'
added integration tests for poa EA

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

` yarn test packages/sources/poa/test/integration/
`
## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [ ] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
