### PR TITLE
Catch errors thrown in `execute()` internally

### DIFF
--- a/.changeset/stale-books-flash.md
+++ b/.changeset/stale-books-flash.md
@@ -1,0 +1,10 @@
+---
+'@chainlink/apy-finance-adapter': patch
+'@chainlink/set-token-index-adapter': patch
+'@chainlink/vesper-adapter': patch
+'@chainlink/xsushi-price-adapter': patch
+'@chainlink/coingecko-adapter': patch
+'@chainlink/coinpaprika-adapter': patch
+---
+
+Make sure errors are caught to not keep the socket open

--- a/packages/composites/apy-finance/src/endpoint/tvl.ts
+++ b/packages/composites/apy-finance/src/endpoint/tvl.ts
@@ -23,7 +23,9 @@ export function getAllocations(
     const middleware = makeMiddleware(execute)
     withMiddleware(execute, context, middleware)
       .then((executeWithMiddleware) => {
-        executeWithMiddleware(options, context).then((value) => resolve(value.data))
+        executeWithMiddleware(options, context)
+          .then((value) => resolve(value.data))
+          .catch(reject)
       })
       .catch((error) => reject(error))
   })

--- a/packages/composites/set-token-index/src/endpoint/allocations.ts
+++ b/packages/composites/set-token-index/src/endpoint/allocations.ts
@@ -26,7 +26,9 @@ export function getToken(
     const middleware = makeMiddleware(execute)
     withMiddleware(execute, context, middleware)
       .then((executeWithMiddleware) => {
-        executeWithMiddleware(options, context).then((value) => resolve(value.data))
+        executeWithMiddleware(options, context)
+          .then((value) => resolve(value.data))
+          .catch(reject)
       })
       .catch((error) => reject(error))
   })

--- a/packages/composites/set-token-index/src/endpoint/token-index.ts
+++ b/packages/composites/set-token-index/src/endpoint/token-index.ts
@@ -27,7 +27,9 @@ export function getAllocations(
     const middleware = makeMiddleware(execute)
     withMiddleware(execute, context, middleware)
       .then((executeWithMiddleware) => {
-        executeWithMiddleware(options, context).then((value) => resolve(value.data))
+        executeWithMiddleware(options, context)
+          .then((value) => resolve(value.data))
+          .catch(reject)
       })
       .catch((error) => reject(error))
   })

--- a/packages/composites/vesper/src/endpoint/tvl.ts
+++ b/packages/composites/vesper/src/endpoint/tvl.ts
@@ -23,7 +23,9 @@ export function getAllocations(
     const middleware = makeMiddleware(execute)
     withMiddleware(execute, context, middleware)
       .then((executeWithMiddleware) => {
-        executeWithMiddleware(options, context).then((value) => resolve(value.data))
+        executeWithMiddleware(options, context)
+          .then((value) => resolve(value.data))
+          .catch(reject)
       })
       .catch((error) => reject(error))
   })

--- a/packages/composites/xsushi-price/src/endpoint/price.ts
+++ b/packages/composites/xsushi-price/src/endpoint/price.ts
@@ -20,7 +20,9 @@ export function getRatio(context: AdapterContext, id: string): Promise<string> {
     const middleware = makeMiddleware(execute)
     withMiddleware(execute, context, middleware)
       .then((executeWithMiddleware) => {
-        executeWithMiddleware(options, context).then((value) => resolve(value.data))
+        executeWithMiddleware(options, context)
+          .then((value) => resolve(value.data))
+          .catch(reject)
       })
       .catch((error) => reject(error))
   })

--- a/packages/composites/xsushi-price/src/endpoint/ratio.ts
+++ b/packages/composites/xsushi-price/src/endpoint/ratio.ts
@@ -21,7 +21,9 @@ export function getSushiAddress(context: AdapterContext, id: string): Promise<st
     const middleware = makeMiddleware(execute)
     withMiddleware(execute, context, middleware)
       .then((executeWithMiddleware) => {
-        executeWithMiddleware(options, context).then((value) => resolve(value.data))
+        executeWithMiddleware(options, context)
+          .then((value) => resolve(value.data))
+          .catch(reject)
       })
       .catch((error) => reject(error))
   })

--- a/packages/sources/coingecko/src/util.ts
+++ b/packages/sources/coingecko/src/util.ts
@@ -17,7 +17,9 @@ export function getCoinIds(context: AdapterContext, id: string): Promise<CoinsRe
     const middleware = makeMiddleware(execute, undefined, endpointSelector)
     withMiddleware(execute, context, middleware)
       .then((executeWithMiddleware) => {
-        executeWithMiddleware(options, context).then((value) => resolve(value.data))
+        executeWithMiddleware(options, context)
+          .then((value) => resolve(value.data))
+          .catch(reject)
       })
       .catch((error) => reject(error))
   })

--- a/packages/sources/coinpaprika/src/util.ts
+++ b/packages/sources/coinpaprika/src/util.ts
@@ -35,7 +35,9 @@ export function getCoinIds(context: AdapterContext, id: string): Promise<CoinsRe
     const middleware = makeMiddleware(execute)
     withMiddleware(execute, context, middleware)
       .then((executeWithMiddleware) => {
-        executeWithMiddleware(options, context).then((value) => resolve(value.data))
+        executeWithMiddleware(options, context)
+          .then((value) => resolve(value.data))
+          .catch(reject)
       })
       .catch((error) => reject(error))
   })


### PR DESCRIPTION
## Changes

- Catch errors caught from `execute()`s in adapters that cache responses internally

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. Run coingecko/coinpaprika without cache
2. Send many requests until it 429s
3. Now it will return an error and close the socket, where it would keep it open previously

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
