### PR TITLE
Update generator script with new dependency format

### DIFF
--- a/.changeset/long-elephants-speak.md
+++ b/.changeset/long-elephants-speak.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/ea-scripts': patch
+---
+
+Update adapter generator script to write dependencies in the current format

--- a/packages/scripts/src/new/lib.ts
+++ b/packages/scripts/src/new/lib.ts
@@ -108,7 +108,7 @@ async function generate(type: string) {
         return { ...obj, [key]: legoPackage.dependencies[key] }
       }, {}) // capture other dependencies (non-adapter)
     legoPackage.dependencies = adapterList.reduce((obj, adapter) => {
-      return { ...obj, [adapter.name]: '*' }
+      return { ...obj, [adapter.name]: 'workspace:*' }
     }, otherPackages)
     writeData = { ...writeData, [legoPackagePath]: legoPackage }
 


### PR DESCRIPTION
## Description

Dependencies were changed in #1143 from `*` to `workspace:*`, this PR updates the generator script for new adapters to use this format.

## Changes

- `yarn new` script now writes `workspace:*`

## Steps to Test

1. Run `yarn new` script to create a new adapter
2. Changes to `package.json` and relative files should only see specific line changes to your new adapter, leaving the others as is.

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
