### PR TITLE
Aggregate Synthetix Debt from multple chains

### DIFF
--- a/.changeset/short-pans-sit.md
+++ b/.changeset/short-pans-sit.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/synthetix-debt-pool-adapter': minor
+---
+
+aggregate debt from multiple chains

--- a/packages/sources/synthetix-debt-pool/README.md
+++ b/packages/sources/synthetix-debt-pool/README.md
@@ -4,10 +4,14 @@ The Synthetix debt pool adapter fetches the total debt from the DebtCache contra
 
 ### Environment Variables
 
-| Required? |          Name           |                          Description                          | Options |                Defaults to                 |
-| :-------: | :---------------------: | :-----------------------------------------------------------: | :-----: | :----------------------------------------: |
-|           | DEBT_POOL_CACHE_ADDRESS |             The address of the DebtCache contract             |         | 0x9bB05EF2cA7DBAafFC3da1939D1492e6b00F39b8 |
-|    ✅     |    ETHEREUM_RPC_URL     | A valid Ethereum Mainnet RPC URL to connect to the blockchain |         |                                            |
+| Required? |                    Name                    |                       Description                        | Options | Defaults to |
+| :-------: | :----------------------------------------: | :------------------------------------------------------: | :-----: | :---------: |
+|           | ETHEREUM_ADDRESS_PROVIDER_CONTRACT_ADDRESS | The address of the address provider contract in ethereum |         |             |
+|           |              ETHEREUM_RPC_URL              |             A valid Ethereum Mainnet RPC URL             |         |             |
+|           | OPTIMISM_ADDRESS_PROVIDER_CONTRACT_ADDRESS | The address of the address provider contract in ethereum |         |             |
+|           |              OPTIMISM_RPC_URL              |             A valid Ethereum Mainnet RPC URL             |         |             |
+
+The environment variables above are not required to start the adapter but are required when you want to pull the debt from that chain. Not setting any will not prevent the adapter from starting but it won't be able to pull debt from any chains.
 
 ---
 
@@ -21,9 +25,11 @@ N/A
 
 ### Input Params
 
-N/A
+| Required? |     Name     |       Description        |        Options         | Defaults to |
+| :-------: | :----------: | :----------------------: | :--------------------: | :---------: |
+|           | chainSources | Chains to pull debt from | `ethereum`, `optimism` |             |
 
-### Sample Input
+### Sample Input 1
 
 ```json
 {
@@ -32,16 +38,41 @@ N/A
 }
 ```
 
-### Sample Output
+### Sample Output 2
 
 ```json
 {
   "jobRunID": 1,
-  "result": "464774989776339326173983425",
+  "result": "325477250609593129853813523",
+  "maxAge": 30000,
   "statusCode": 200,
   "data": {
-    "result": "464774989776339326173983425",
-    "total": "464774989776339326173983425",
+    "result": "325477250609593129853813523",
+    "isInvalid": false
+  }
+}
+```
+
+### Sample Input 2
+
+```json
+{
+  "id": 1,
+  "data": {
+    "chainSources": ["optimism"]
+  }
+}
+```
+
+### Sample Output 2
+
+```json
+{
+  "jobRunID": 1,
+  "result": "50977793699622560436740360",
+  "statusCode": 200,
+  "data": {
+    "result": "50977793699622560436740360",
     "isInvalid": false
   }
 }

--- a/packages/sources/synthetix-debt-pool/schemas/env.json
+++ b/packages/sources/synthetix-debt-pool/schemas/env.json
@@ -1,14 +1,19 @@
 {
   "$id": "https://external-adapters.chainlinklabs.com/schemas/synthetix-debt-pool-adapter.json",
   "title": "@chainlink/synthetix-debt-pool-adapter env var schema",
-  "required": ["ETHEREUM_RPC_URL"],
+  "required": [],
   "type": "object",
   "properties": {
     "ETHEREUM_RPC_URL": {
       "type": "string"
     },
-    "DEBT_POOL_CACHE_ADDRESS": {
-      "default": "0x9bB05EF2cA7DBAafFC3da1939D1492e6b00F39b8",
+    "ETHEREUM_ADDRESS_PROVIDER_CONTRACT_ADDRESS": {
+      "type": "string"
+    },
+    "OPTIMISM_RPC_URL": {
+      "type": "string"
+    },
+    "OPTIMISM_ADDRESS_PROVIDER_CONTRACT_ADDRESS": {
       "type": "string"
     }
   },

--- a/packages/sources/synthetix-debt-pool/src/config.ts
+++ b/packages/sources/synthetix-debt-pool/src/config.ts
@@ -4,18 +4,43 @@ import { Config as DefaultConfig } from '@chainlink/types'
 export const NAME = 'SYNTHETIX_DEBT_POOL'
 
 export const DEFAULT_ENDPOINT = 'debt'
-export const DEFAULT_DEBT_POOL_CACHE_ADDRESS = '0x9bB05EF2cA7DBAafFC3da1939D1492e6b00F39b8'
+
+export enum SUPPORTED_CHAINS {
+  ETHEREUM = 'ETHEREUM',
+  OPTIMISM = 'OPTIMISM',
+}
 
 export interface Config extends DefaultConfig {
-  debtPoolCacheAddress: string
-  rpcUrl: string
+  chains: {
+    [key: string]: {
+      rpcUrl: string
+      addressProviderContractAddress: string
+    }
+  }
 }
 
 export const makeConfig = (prefix?: string): Config => {
-  return {
+  const config: Config = {
     ...Requester.getDefaultConfig(prefix),
     defaultEndpoint: DEFAULT_ENDPOINT,
-    debtPoolCacheAddress: util.getEnv('DEBT_POOL_CACHE_ADDRESS') || DEFAULT_DEBT_POOL_CACHE_ADDRESS,
-    rpcUrl: util.getRequiredEnvWithFallback('ETHEREUM_RPC_URL', ['RPC_URL'], prefix),
+    chains: {},
   }
+
+  for (const chainName of Object.values(SUPPORTED_CHAINS)) {
+    const chainRpcURL = util.getEnv(`${chainName}_RPC_URL`, prefix)
+    const addressProviderContractAddress = util.getEnv(
+      `${chainName}_ADDRESS_PROVIDER_CONTRACT_ADDRESS`,
+      prefix,
+    )
+    if (chainRpcURL && addressProviderContractAddress) {
+      config.chains[chainName] = {
+        rpcUrl: chainRpcURL,
+        addressProviderContractAddress,
+      }
+    }
+  }
+
+  const chains = Object.keys(config.chains)
+  if (chains.length === 0) throw Error('Must set at least one RPC Chain URL')
+  return config
 }

--- a/packages/sources/synthetix-debt-pool/src/endpoint/debt.ts
+++ b/packages/sources/synthetix-debt-pool/src/endpoint/debt.ts
@@ -1,7 +1,7 @@
-import { Requester, Validator } from '@chainlink/ea-bootstrap'
-import { ExecuteWithConfig } from '@chainlink/types'
-import { Config } from '../config'
-import { ethers } from 'ethers'
+import { Requester, Validator, Logger } from '@chainlink/ea-bootstrap'
+import { ExecuteWithConfig, InputParameters } from '@chainlink/types'
+import { Config, SUPPORTED_CHAINS } from '../config'
+import { ethers, utils, BigNumber } from 'ethers'
 
 export const supportedEndpoints = ['debt']
 
@@ -21,15 +21,27 @@ export interface ResponseSchema {
   }
 }
 
+const inputParams: InputParameters = {
+  chainSources: false,
+}
+
 export const execute: ExecuteWithConfig<Config> = async (request, _, config) => {
-  const validator = new Validator(request)
+  const validator = new Validator(request, inputParams)
   if (validator.error) throw validator.error
   const jobRunID = validator.validated.id
-  const debt = await getCurrentDebt(config.rpcUrl, config.debtPoolCacheAddress)
+  let { chainSources } = validator.validated.data
+
+  if (!chainSources || chainSources.length === 0) {
+    Logger.info(
+      'chainSources is either empty or undefined.  Will aggregate debt over all supported chains',
+    )
+    chainSources = Object.values(SUPPORTED_CHAINS)
+  }
+
+  const debt = await getCurrentDebt(chainSources, config.chains)
   const result = {
     data: {
       result: debt.total.toString(),
-      total: debt.total.toString(),
       isInvalid: debt.isInvalid,
     },
   }
@@ -59,13 +71,55 @@ const DEBT_POOL_ABI = [
   },
 ]
 
+const ADDRESS_PROVIDER_ABI = [
+  {
+    constant: true,
+    inputs: [{ internalType: 'bytes32', name: 'name', type: 'bytes32' }],
+    name: 'getAddress',
+    outputs: [{ internalType: 'address', name: '', type: 'address' }],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+]
+
 const getCurrentDebt = async (
-  rpcUrl: string,
-  debtPoolAddress: string,
+  chainSources: string[],
+  chainConfigs: Config['chains'],
 ): Promise<CurrentDebtResults> => {
-  const provider = new ethers.providers.JsonRpcProvider(rpcUrl)
-  const debtPool = new ethers.Contract(debtPoolAddress, DEBT_POOL_ABI, provider)
-  const [totalDebt, isInvalid] = await debtPool.currentDebt()
+  const responses = await Promise.all(
+    chainSources.map(async (chain): Promise<CurrentDebtResults> => {
+      chain = chain.toUpperCase()
+      const chainConfig = chainConfigs[chain]
+      if (!chainConfig) throw Error(`Missing configuration for chain: ${chain}`)
+
+      const { rpcUrl, addressProviderContractAddress } = chainConfig
+      const provider = new ethers.providers.JsonRpcProvider(rpcUrl)
+      const addressProvider = new ethers.Contract(
+        addressProviderContractAddress,
+        ADDRESS_PROVIDER_ABI,
+        provider,
+      )
+      const debtPoolAddress = await addressProvider.getAddress(
+        utils.formatBytes32String('DebtCache'),
+      )
+      const debtPool = new ethers.Contract(debtPoolAddress, DEBT_POOL_ABI, provider)
+      const [totalDebt, isInvalid] = await debtPool.currentDebt()
+      return {
+        total: totalDebt,
+        isInvalid,
+      }
+    }),
+  )
+
+  let totalDebt = BigNumber.from(0)
+  let isInvalid = false
+
+  for (const response of responses) {
+    totalDebt = totalDebt.add(response.total)
+    isInvalid = isInvalid || isInvalid
+  }
+
   return {
     total: totalDebt,
     isInvalid,

--- a/packages/sources/synthetix-debt-pool/test/e2e/adapter.test.ts
+++ b/packages/sources/synthetix-debt-pool/test/e2e/adapter.test.ts
@@ -1,5 +1,4 @@
-import { Requester } from '@chainlink/ea-bootstrap'
-import { assertError, assertSuccess } from '@chainlink/ea-test-helpers'
+import { assertSuccess } from '@chainlink/ea-test-helpers'
 import { AdapterRequest } from '@chainlink/types'
 import { makeExecute } from '../../src/adapter'
 
@@ -10,8 +9,24 @@ describe('execute', () => {
   describe('successful calls @integration', () => {
     const requests = [
       {
-        name: 'id not supplied',
+        name: 'aggregate debt across all chains without defining chainSources',
         testData: { data: {} },
+      },
+      {
+        name: 'aggregate debt across all chains',
+        testData: {
+          data: {
+            chainSources: [],
+          },
+        },
+      },
+      {
+        name: 'get debt from just a single chain',
+        testData: {
+          data: {
+            chainSources: ['ethereum'],
+          },
+        },
       },
     ]
 

--- a/packages/sources/synthetix-debt-pool/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/synthetix-debt-pool/test/integration/__snapshots__/adapter.test.ts.snap
@@ -1,12 +1,47 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`synthetix-debt-pool when making a request to fetch the current debt successfully fetches the current debt size of the synthetix debt pool 1`] = `
+exports[`synthetix-debt-pool errors throws an error if the request contains a source without a chain configuration 1`] = `
 Object {
-  "data": Object {
-    "result": "464590202399031116379217447",
+  "error": Object {
+    "feedID": "{\\"data\\":{\\"chainSources\\":[\\"ethereum-fake\\"]}}",
+    "message": "Missing configuration for chain: ETHEREUM-FAKE",
+    "name": "AdapterError",
   },
   "jobRunID": 1,
-  "result": "464590202399031116379217447",
+  "status": "errored",
+  "statusCode": 500,
+}
+`;
+
+exports[`synthetix-debt-pool when making a request to fetch the current debt successfully fetches the current debt size of the synthetix debt pool across all chains if chainSources is empty 1`] = `
+Object {
+  "data": Object {
+    "result": "325481815165042223715009953",
+  },
+  "jobRunID": 1,
+  "result": "325481815165042223715009953",
+  "statusCode": 200,
+}
+`;
+
+exports[`synthetix-debt-pool when making a request to fetch the current debt successfully fetches the current debt size of the synthetix debt pool across all chains if chainSources is missing 1`] = `
+Object {
+  "data": Object {
+    "result": "325481815165042223715009953",
+  },
+  "jobRunID": 1,
+  "result": "325481815165042223715009953",
+  "statusCode": 200,
+}
+`;
+
+exports[`synthetix-debt-pool when making a request to fetch the current debt successfully fetches the current debt size of the synthetix debt pool for only one chain 1`] = `
+Object {
+  "data": Object {
+    "result": "274504021465419663278269593",
+  },
+  "jobRunID": 1,
+  "result": "274504021465419663278269593",
   "statusCode": 200,
 }
 `;

--- a/packages/sources/synthetix-debt-pool/test/integration/adapter.test.ts
+++ b/packages/sources/synthetix-debt-pool/test/integration/adapter.test.ts
@@ -4,21 +4,55 @@ import request from 'supertest'
 import http from 'http'
 import process from 'process'
 
-const mockBigNum = BigNumber.from('464590202399031116379217447')
+const mockChainConfig = {
+  ethereum: {
+    rpcUrl: 'fake-ethereum-rpc-url',
+    addressProviderContractAddress: 'fake-ethereum-address-provider',
+    debtPoolAddress: 'fake-ethereum-debt-pool-address',
+  },
+  optimism: {
+    rpcUrl: 'fake-optimiem-rpc-url',
+    addressProviderContractAddress: 'fake-optimiem-address-provider',
+    debtPoolAddress: 'fake-optimism-debt-pool-address',
+  },
+}
+
+const mockEthereumAddressProviderContract = {
+  getAddress: (_: string) => mockChainConfig.ethereum.debtPoolAddress,
+}
+
+const mockOptimismAddressProviderContract = {
+  getAddress: (_: string) => mockChainConfig.optimism.debtPoolAddress,
+}
+
+const mockEthereumDebtPoolContract = {
+  currentDebt: () => [BigNumber.from('274504021465419663278269593'), false],
+}
+
+const mockOptimismDebtPoolContract = {
+  currentDebt: () => [BigNumber.from('50977793699622560436740360'), false],
+}
 
 jest.mock('ethers', () => ({
   ...jest.requireActual('ethers'),
   ethers: {
     providers: {
-      JsonRpcProvider: function (_: string): ethers.provider.JsonRpcProvider {
+      JsonRpcProvider: function (_: string) {
         return {}
       },
     },
-    Contract: function () {
-      return {
-        currentDebt: () => {
-          return [mockBigNum, true]
-        },
+    Contract: function (address: string) {
+      switch (address) {
+        case mockChainConfig.ethereum.addressProviderContractAddress:
+          return mockEthereumAddressProviderContract
+        case mockChainConfig.optimism.addressProviderContractAddress:
+          return mockOptimismAddressProviderContract
+        case mockChainConfig.ethereum.debtPoolAddress:
+          return mockEthereumDebtPoolContract
+        case mockChainConfig.optimism.debtPoolAddress:
+          return mockOptimismDebtPoolContract
+        default:
+          break
       }
     },
   },
@@ -28,7 +62,12 @@ let oldEnv: NodeJS.ProcessEnv
 
 beforeAll(() => {
   oldEnv = JSON.parse(JSON.stringify(process.env))
-  process.env.ETHEREUM_RPC_URL = 'FAKE_ETHEREUM_RPC_URL'
+  process.env.ETHEREUM_RPC_URL = mockChainConfig.ethereum.rpcUrl
+  process.env.ETHEREUM_ADDRESS_PROVIDER_CONTRACT_ADDRESS =
+    mockChainConfig.ethereum.addressProviderContractAddress
+  process.env.OPTIMISM_RPC_URL = mockChainConfig.optimism.rpcUrl
+  process.env.OPTIMISM_ADDRESS_PROVIDER_CONTRACT_ADDRESS =
+    mockChainConfig.optimism.addressProviderContractAddress
   process.env.CACHE_ENABLED = 'false'
 })
 
@@ -48,11 +87,11 @@ describe('synthetix-debt-pool', () => {
   })
 
   describe('when making a request to fetch the current debt', () => {
-    const request = {
-      id: 1,
-      data: {},
-    }
-    it('successfully fetches the current debt size of the synthetix debt pool', async () => {
+    it('successfully fetches the current debt size of the synthetix debt pool across all chains if chainSources is missing', async () => {
+      const request = {
+        id: 1,
+        data: {},
+      }
       const response = await req
         .post('/')
         .send(request)
@@ -60,6 +99,62 @@ describe('synthetix-debt-pool', () => {
         .set('Content-Type', 'application/json')
         .expect('Content-Type', /json/)
         .expect(200)
+
+      expect(response.body).toMatchSnapshot()
+    })
+
+    it('successfully fetches the current debt size of the synthetix debt pool across all chains if chainSources is empty', async () => {
+      const request = {
+        id: 1,
+        data: {
+          chainSources: [],
+        },
+      }
+      const response = await req
+        .post('/')
+        .send(request)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+
+      expect(response.body).toMatchSnapshot()
+    })
+
+    it('successfully fetches the current debt size of the synthetix debt pool for only one chain', async () => {
+      const request = {
+        id: 1,
+        data: {
+          chainSources: ['ethereum'],
+        },
+      }
+      const response = await req
+        .post('/')
+        .send(request)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+
+      expect(response.body).toMatchSnapshot()
+    })
+  })
+
+  describe('errors', () => {
+    it('throws an error if the request contains a source without a chain configuration', async () => {
+      const request = {
+        id: 1,
+        data: {
+          chainSources: ['ethereum-fake'],
+        },
+      }
+      const response = await req
+        .post('/')
+        .send(request)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(500)
 
       expect(response.body).toMatchSnapshot()
     })


### PR DESCRIPTION
## Closes 14251

## Description

Update the Synthetix Debt Pool adapter to pull debt across multiple chains.

## Changes

- Change set of environment variables for the Synthetix Debt Pool to allow configuring multiple chains
- Update adapter flow so that the adapter fetches the DebtPool contract address from an AddressProvider contract on each chain. 
- Update integration and e2e tests

## Steps to Test

1. Run adapter
2. Send the requests below and verify that each are successful

Multi chain request
```
{
    "id": 1,
    "data": {
    }
}
```

Single chain request
```
{
    "id": 1,
    "data": {
        "chainSources": ["optimism"]
    }
}
```

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
