### PR TITLE
Provide fixed feed_id for cache warmer requests

### DIFF
--- a/.changeset/purple-fishes-beg.md
+++ b/.changeset/purple-fishes-beg.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/ea-bootstrap': patch
+---
+
+Provide fixed feed_id for cache warmer requests

--- a/packages/core/bootstrap/test/unit/metrics/util.test.ts
+++ b/packages/core/bootstrap/test/unit/metrics/util.test.ts
@@ -86,5 +86,42 @@ describe('Bootstrap/Metrics Utils', () => {
         util.getFeedId(input)
       }).not.toThrow()
     })
+
+    it(`Correctly handles arrays in base/quote parameters`, () => {
+      const input1: AdapterRequest = {
+        id: '1',
+        data: {
+          base: ['BTC', 'ETH', 'DOGE'], // Tests sorting as well
+          quote: 'USD',
+        },
+      }
+      let feedName = util.getFeedId(input1)
+      expect(feedName).toBe('[BTC|DOGE|ETH]/USD')
+
+      const input2: AdapterRequest = {
+        id: '1',
+        data: {
+          base: ['BTC'],
+          quote: ['USD'],
+        },
+      }
+      feedName = util.getFeedId(input2)
+      expect(feedName).toBe('BTC/USD')
+    })
+
+    it(`Returns fixed feed id when debug warmer property is set to true`, () => {
+      const input: AdapterRequest = {
+        id: '1',
+        data: {
+          base: ['BTC', 'ETH', 'DOGE'],
+          quote: 'USD',
+        },
+        debug: {
+          warmer: true,
+        },
+      }
+      const feedName = util.getFeedId(input)
+      expect(feedName).toBe('CACHE_WARMER')
+    })
   })
 })


### PR DESCRIPTION
## Description

The `feed_id` label for metrics currently takes all symbols provided in the `base` parameter and joins them together to form its value. Additionally, the order for symbols is not guaranteed. This means very high cardinality, which [for services like Prometheus is not ideal](https://www.robustperception.io/cardinality-is-key). This PR changes the behavior to normalize the order of the parameters when present, and foregoing this behavior when the request comes from the cache warmer, to reduce the number of values seen in metrics.

## Changes

- `getFeedId` method now returns fixed `CACHE_WARMER` value when requests are triggered by the cache warmer.
- Symbols are sorted before joining to avoid different label values for the same set.

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. Run an adapter e.g. CoinGecko with `EXPERIMENTAL_METRICS_ENABLED=true CACHE_ENABLED=true`
2. Send requests for price information for different tickers
3. Call the metrics endpoint and verify that there are no `feed_id` values for the batch warmer consolidation of requests (something like `"feed_id": "[BTC|ETH|...]/USD"`), being instead replaced and condensed to one `CACHE_WARMER`

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
