### PR TITLE
fix/Fixed Cache Warmer metric issue

### DIFF
--- a/.changeset/tasty-avocados-sparkle.md
+++ b/.changeset/tasty-avocados-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/ea-bootstrap': patch
+---
+
+This PR fixes an issue with the cache warmer metrics that was causing them to go into the negatives

--- a/packages/core/bootstrap/README.md
+++ b/packages/core/bootstrap/README.md
@@ -167,12 +167,12 @@ Being:
 
 \*To use this feature the `CACHE_ENABLED` environment variable must also be enabled.
 
-| Required? |             Name             |                                                                          Description                                                                          | Options |          Defaults to          |
-| :-------: | :--------------------------: | :-----------------------------------------------------------------------------------------------------------------------------------------------------------: | :-----: | :---------------------------: |
-|           |       `WARMUP_ENABLED`       |                                                            Enable the cache warmer functionality.                                                             |         |            `true`             |
-|           | `WARMUP_UNHEALTHY_THRESHOLD` |          The number of times a warmup execution can fail before we drop a warmup subscription for a particular cache key.to. Set to `-1` to disable.          |         |              `3`              |
-|           |  `WARMUP_SUBSCRIPTION_TTL`   | The maximum duration between requests for a cache key to an external adapter before the cache warmer will unsubscribe from warming up a particular cache key. |         |      `3600000` (1 hour)       |
-|           |      `WARMUP_INTERVAL`       |                                        The interval at which the cache warmer should send requests to warm the cache.                                         |         | The cache's minimum TTL (30s) |
+| Required? |             Name             |                                                                                                   Description                                                                                                   | Options |             Defaults to             |
+| :-------: | :--------------------------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-----: | :---------------------------------: |
+|           |       `WARMUP_ENABLED`       |                                                                                     Enable the cache warmer functionality.                                                                                      |         |               `true`                |
+|           | `WARMUP_UNHEALTHY_THRESHOLD` |                                   The number of times a warmup execution can fail before we drop a warmup subscription for a particular cache key.to. Set to `-1` to disable.                                   |         |                 `3`                 |
+|           |  `WARMUP_SUBSCRIPTION_TTL`   |                          The maximum duration between requests for a cache key to an external adapter before the cache warmer will unsubscribe from warming up a particular cache key.                          |         |         `3600000` (1 hour)          |
+|           |      `WARMUP_INTERVAL`       | The interval (in ms) at which the cache warmer should send requests to warm the cache. Prioritizes hard-coded max age, then `WARMUP_INTERVAL` environment variable, lastly the calculated TTL of a cache entry. |         | The cache's minimum TTL (30,000 ms) |
 
 ### Request Coalescing
 

--- a/packages/core/bootstrap/src/lib/cache-warmer/actions.ts
+++ b/packages/core/bootstrap/src/lib/cache-warmer/actions.ts
@@ -51,10 +51,12 @@ export interface WarmupSubscribedMultiplePayload {
 
 export interface WarmupUnsubscribedPayload {
   key: string
+  isBatched: boolean
   reason: string
 }
 export interface WarmupStoppedPayload {
   keys: string[]
+  isBatched: boolean
 }
 interface WarmupSubscriptionTimeoutResetPayload {
   key: string

--- a/packages/core/bootstrap/src/lib/cache-warmer/config.ts
+++ b/packages/core/bootstrap/src/lib/cache-warmer/config.ts
@@ -1,8 +1,11 @@
 import objectHash from 'object-hash'
 import { getHashOpts } from '../util'
+import { logger } from '../external-adapter'
 
 export const WARMUP_REQUEST_ID = '9001'
 export const WARMUP_BATCH_REQUEST_ID = '9002'
+export const MINIMUM_WARMUP_INTERVAL = 500
+export const WARMUP_POLL_OFFSET = 1000
 
 export interface Config {
   /**
@@ -32,6 +35,13 @@ export interface Config {
 }
 
 export function get(): Config {
+  const warmupInterval = Number(process.env.WARMUP_INTERVAL)
+  if (warmupInterval < MINIMUM_WARMUP_INTERVAL) {
+    logger.warn(
+      `Warmup Interval configured at ${warmupInterval}ms. Using minimum allowed time of ${MINIMUM_WARMUP_INTERVAL}ms`,
+    )
+  }
+
   return {
     hashOpts: getHashOpts(),
     unhealthyThreshold: Number(process.env.WARMUP_UNHEALTHY_THRESHOLD) || 3,

--- a/packages/core/bootstrap/src/lib/cache-warmer/index.ts
+++ b/packages/core/bootstrap/src/lib/cache-warmer/index.ts
@@ -79,9 +79,12 @@ export const withCacheWarmer =
                   batchablePropertyPath: isActiveCWSubsciption.batchablePropertyPath,
                 }),
               )
+            const isBatched =
+              !!warmerStore.getState().subscriptions[cacheWarmerKey]?.childLastSeenById
             warmerStore.dispatch(
               actions.warmupUnsubscribed({
                 key: cacheWarmerKey,
+                isBatched,
                 reason: 'Turning off Cache Warmer to use WS.',
               }),
             )

--- a/packages/core/bootstrap/test/unit/cache-warmer.test.ts
+++ b/packages/core/bootstrap/test/unit/cache-warmer.test.ts
@@ -351,6 +351,7 @@ describe('side effect tests', () => {
           actions.warmupUnsubscribed({
             key: batchKeyParent,
             reason: 'Unsubscribe test',
+            isBatched: true,
           }),
         ),
       ).toEqual({})
@@ -369,6 +370,7 @@ describe('side effect tests', () => {
           b: actions.warmupUnsubscribed({
             key: key1,
             reason: 'Unsubscribe test',
+            isBatched: true,
           }),
           c: actions.warmupSubscribed({
             executeFn: stub(),
@@ -408,6 +410,7 @@ describe('side effect tests', () => {
           b: actions.warmupUnsubscribed({
             key: key1,
             reason: 'Unsubscribe test',
+            isBatched: true,
           }),
           c: actions.warmupSubscribed({
             executeFn: stub(),
@@ -683,7 +686,7 @@ describe('side effect tests', () => {
       scheduler.run(({ hot, expectObservable }) => {
         const action$ = actionStream(hot, 'a', {
           a: actions.warmupFailed({
-            key: key1,
+            key: key2,
             error: Error('We havin a bad time'),
             feedLabel: '{"data":{"data":{"foo":"bar"},"id":"0"}}',
           }),
@@ -691,17 +694,33 @@ describe('side effect tests', () => {
         const state$ = stateStream({
           cacheWarmer: {
             warmups: {
-              [key1]: {
+              [key2]: {
                 error: null,
                 errorCount: 3,
                 successCount: 0,
+              },
+            },
+            subscriptions: {
+              [key2]: {
+                executeFn: async () => null,
+                origin: adapterRequest2,
+                startedAt: Date.now(),
+                isDuplicate: false,
+                batchablePropertyPath: [{ name: 'foo' }],
+                childLastSeenById: {
+                  [key2]: 2,
+                },
               },
             },
           },
         })
         const output$ = warmupUnsubscriber(action$, state$, epicDependencies)
         expectObservable(output$).toBe('a', {
-          a: actions.warmupUnsubscribed({ key: key1, reason: 'Errored: We havin a bad time' }),
+          a: actions.warmupUnsubscribed({
+            key: key2,
+            isBatched: true,
+            reason: 'Errored: We havin a bad time',
+          }),
         })
       })
     })
@@ -744,11 +763,33 @@ describe('side effect tests', () => {
             result: adapterResult,
           }),
         })
-        const state$ = stateStream({ cacheWarmer: {} })
+        const state$ = stateStream({
+          cacheWarmer: {
+            warmups: {
+              [key2]: {
+                error: null,
+                errorCount: 0,
+                successCount: 0,
+              },
+            },
+            subscriptions: {
+              [key2]: {
+                executeFn: async () => null,
+                origin: adapterRequest2,
+                startedAt: Date.now(),
+                isDuplicate: false,
+                batchablePropertyPath: [{ name: 'foo' }],
+                childLastSeenById: {
+                  [key2]: 2,
+                },
+              },
+            },
+          },
+        })
         const output$ = warmupUnsubscriber(action$, state$, epicDependencies)
         expectObservable(output$, '^ 120m !').toBe('50m -- a 9m 59s 998ms b 40m - a', {
           a: actions.warmupSubscriptionTimeoutReset({ key: key1 }),
-          b: actions.warmupUnsubscribed({ key: key2, reason: 'Timeout' }),
+          b: actions.warmupUnsubscribed({ key: key2, isBatched: true, reason: 'Timeout' }),
         })
       })
     })


### PR DESCRIPTION
## Closes #18396

## Description
Fixes the error with the cache warmer metrics causing them to go into the negatives

## Changes
- Changes logic in `epics.ts` to correctly decrement on the correct events
- Alters the way cache intervals are inputted

## Steps to Test

1. Run an adapter locally with EXPIERIMENTAL_METRICS_ENABLED = true
2. Run Prometheus metrics
3. Keep track of the `cache_warmer_get_count` metric in Prometheus, ensuring it never dips below 0 after losing connection or failing in some other way
4. Once we have this live, we know it will be working because the metrics will never dip below 0 like they have been doing.
## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
