### PR TITLE
Add workflow to consume changesets automatically

### DIFF
--- a/.github/workflows/consume-changesets.yml
+++ b/.github/workflows/consume-changesets.yml
@@ -1,0 +1,34 @@
+name: Consume changesets
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  consume-changesets:
+    name: Consume changesets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+        with:
+          # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
+          fetch-depth: 0
+
+      - name: Setup Node.js 14.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+
+      - name: Install Dependencies
+        run: yarn
+
+      - name: Create Release Pull Request
+        uses: changesets/action@v1
+        with:
+          version: yarn changeset version
+          title: Consume changesets
+          commit: Consume changesets
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Currently, consuming changesets is a manual process. This PR adds a workflow (based on https://github.com/changesets/action) that will take any push to `develop` and, if there are new changesets to be consumed, create a PR with those changes. This same PR will be updated with any new commits to that branch until merged, where a new one will take its place upon other new commits.

## Changes

- Adds `Consume changesets` workflow

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. Fork this repo
2. Merge the commit from this PR into the `develop` branch
3. Push new commit to `develop` with new changeset
4. `Consume changesets` workflow should run successfully, and new PR should be created with correct files

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
