### PR TITLE
Double the default max allowed entries in the local cache

### DIFF
--- a/.changeset/soft-oranges-collect.md
+++ b/.changeset/soft-oranges-collect.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/ea-bootstrap': patch
+---
+
+Increase default local cache MAX_ITEMS to 1000

--- a/packages/core/bootstrap/README.md
+++ b/packages/core/bootstrap/README.md
@@ -83,7 +83,7 @@ For example, if the `CACHE_KEY_IGNORED_PROPS=timestamp` is set, these requests w
 
 | Required? |           Name            |                                                                                                                              Description                                                                                                                               | Options | Defaults to |
 | :-------: | :-----------------------: | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-----: | :---------: |
-|           |     `CACHE_MAX_ITEMS`     |                                                                                   The maximum size of the cache, checked by applying the length function to all values in the cache.                                                                                   |         |    `500`    |
+|           |     `CACHE_MAX_ITEMS`     |                                                                                   The maximum size of the cache, checked by applying the length function to all values in the cache.                                                                                   |         |   `1000`    |
 |           | `CACHE_UPDATE_AGE_ON_GET` | When using time-expiring entries with maxAge, setting this to true will make each item's effective time update to the current time whenever it is retrieved from cache, causing it to not expire. (It can still fall out of cache based on recency of use, of course.) |         |   `false`   |
 
 ### Redis

--- a/packages/core/bootstrap/src/lib/cache/local.ts
+++ b/packages/core/bootstrap/src/lib/cache/local.ts
@@ -3,7 +3,7 @@ import { parseBool } from '../util'
 import { CacheEntry } from './types'
 
 // Options
-const DEFAULT_CACHE_MAX_ITEMS = 500
+const DEFAULT_CACHE_MAX_ITEMS = 1000
 const DEFAULT_CACHE_MAX_AGE = 1000 * 60 * 1.5 // 1.5 minutes
 const DEFAULT_CACHE_UPDATE_AGE_ON_GET = false
 


### PR DESCRIPTION
<!-- Employees: Please use Clubhouse/Shortcuts's "Open PR" button from the relevant story or include links to relevant Clubhouse/Shortcut stories in your branch name, commit messages, or pull request comments. Do not add links to your pull request description, they will be ignored. https://help.clubhouse.io/hc/en-us/articles/207540323-Using-The-Clubhouse-GitHub-Integration -->

<!-- Employees: Delete this section. -->

## Closes 21552

## Description
The local cache has a setting for the max number of entries in the cache.
Nops are at a scale where their caching breaks because this cap is hit.
......

## Changes
- Double local cache MAX_ITEMS

## Steps to Test
-

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
