### PR TITLE
[Fix] Redis request coalescing

### DIFF
--- a/.changeset/poor-tomatoes-tap.md
+++ b/.changeset/poor-tomatoes-tap.md
@@ -2,4 +2,4 @@
 '@chainlink/ea-bootstrap': patch
 ---
 
-Remove Redis request coalescing
+Redis request coalescing sends a string value

--- a/.changeset/poor-tomatoes-tap.md
+++ b/.changeset/poor-tomatoes-tap.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/ea-bootstrap': patch
+---
+
+Remove Redis request coalescing

--- a/packages/core/bootstrap/src/lib/cache/index.ts
+++ b/packages/core/bootstrap/src/lib/cache/index.ts
@@ -183,10 +183,9 @@ export class AdapterCache {
       feedId: adapterRequest.metricsMeta?.feedId || 'N/A',
     })
 
-    const cachedAdapterResponse =
-      this.options.requestCoalescing.enabled && this.options.cacheImplOptions.type === 'local'
-        ? await this.getWithCoalescing(key)
-        : await this.cache.getResponse(key)
+    const cachedAdapterResponse = this.options.requestCoalescing.enabled
+      ? await this.getWithCoalescing(key)
+      : await this.cache.getResponse(key)
 
     if (cachedAdapterResponse) {
       const maxAgeOverride = getMaxAgeOverride(adapterRequest)

--- a/packages/core/bootstrap/src/lib/cache/index.ts
+++ b/packages/core/bootstrap/src/lib/cache/index.ts
@@ -183,9 +183,10 @@ export class AdapterCache {
       feedId: adapterRequest.metricsMeta?.feedId || 'N/A',
     })
 
-    const cachedAdapterResponse = this.options.requestCoalescing.enabled
-      ? await this.getWithCoalescing(key)
-      : await this.cache.getResponse(key)
+    const cachedAdapterResponse =
+      this.options.requestCoalescing.enabled && this.options.cacheImplOptions.type === 'local'
+        ? await this.getWithCoalescing(key)
+        : await this.cache.getResponse(key)
 
     if (cachedAdapterResponse) {
       const maxAgeOverride = getMaxAgeOverride(adapterRequest)

--- a/packages/core/bootstrap/src/lib/cache/redis/redis.ts
+++ b/packages/core/bootstrap/src/lib/cache/redis/redis.ts
@@ -104,9 +104,11 @@ export class RedisCache {
     )
   }
 
-  async setFlightMarker(): Promise<void> {
-    // NOTE: node-redis v4 supports auto-pipelining
-    // See https://github.com/redis/node-redis/issues/492
+  async setFlightMarker(key: string, maxAge: number) {
+    return this.contextualTimeout(this.client.set(key, 'true', { PX: maxAge }), 'setFlightMarker', {
+      key,
+      maxAge,
+    })
   }
 
   async getResponse(key: string): Promise<CacheEntry | undefined> {
@@ -114,10 +116,12 @@ export class RedisCache {
     return JSON.parse(entry)
   }
 
-  async getFlightMarker(): Promise<boolean> {
-    // NOTE: node-redis v4 supports auto-pipelining
-    // See https://github.com/redis/node-redis/issues/492
-    return false
+  async getFlightMarker(key: string): Promise<boolean> {
+    const entry: string = await this.contextualTimeout(this.client.get(key), 'getFlightMarker', {
+      key,
+    })
+
+    return JSON.parse(entry)
   }
 
   async del(key: string) {


### PR DESCRIPTION
<!-- Employees: Please use Clubhouse/Shortcuts's "Open PR" button from the relevant story or include links to relevant Clubhouse/Shortcut stories in your branch name, commit messages, or pull request comments. Do not add links to your pull request description, they will be ignored. https://help.clubhouse.io/hc/en-us/articles/207540323-Using-The-Clubhouse-GitHub-Integration -->

<!-- Employees: Delete this section. -->


## Description
Previously our redis client was able to use the `set` command with a value of a boolean
Our move to node-redis v4 is closer to the actual redis command (https://redis.io/commands/set) which only allows strings to be set.
This caused a breaking to our implementation of request coalescing causing the following error:

```
ReplyError: ERR Protocol error: expected '$', got '*'
```

......

## Changes

- Sets `true` as a string value for the request coalescing marker.
<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

Run and query an adapter with request coalescing on.

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
