### PR TITLE
fix(agoric): don't scale Agoric fees, avoid 'number' requiredFee

### DIFF
--- a/.changeset/odd-clouds-occur.md
+++ b/.changeset/odd-clouds-occur.md
@@ -1,0 +1,9 @@
+---
+'@chainlink/agoric-adapter': major
+---
+
+Agoric \$LINK is now 18 decimal places and serialised as a string
+
+This was done to make fees precise and require no scaling, since they are now represented on the Agoric chain as JavaScript BigInts.
+
+Please update to the latest https://github.com/Agoric/dapp-oracle

--- a/packages/targets/agoric/src/adapter.ts
+++ b/packages/targets/agoric/src/adapter.ts
@@ -19,15 +19,10 @@ const inputParams = {
   payment: ['payment'],
 }
 
-// FIXME: Ideally, these would be the same.
-const LINK_UNIT = BigNumber.from(10).pow(BigNumber.from(18))
-const LINK_AGORIC_UNIT = BigNumber.from(10).pow(BigNumber.from(6))
-
 // Convert the payment in $LINK into Agoric's pegged $LINK token.
-export const getRequiredFee = (value: string | number): number => {
+export const getRequiredFee = (value: string | number): string => {
   const paymentCL = BigNumber.from(value)
-  const paymentAgoricLink = paymentCL.mul(LINK_AGORIC_UNIT).div(LINK_UNIT)
-  return paymentAgoricLink.toNumber()
+  return paymentCL.toString()
 }
 
 export interface PostReply {

--- a/packages/targets/agoric/test/e2e/adapter.test.ts
+++ b/packages/targets/agoric/test/e2e/adapter.test.ts
@@ -49,7 +49,7 @@ describe('execute', () => {
           data: {
             queryId: 'push-3',
             reply: 'abc',
-            requiredFee: 0,
+            requiredFee: '12',
           },
         },
       ],
@@ -68,7 +68,7 @@ describe('execute', () => {
           data: {
             queryId: 'push-3',
             reply: 'abc',
-            requiredFee: 120,
+            requiredFee: '120000000000000',
           },
         },
       ],
@@ -87,7 +87,7 @@ describe('execute', () => {
           data: {
             queryId: 'bad',
             reply: 'abc',
-            requiredFee: 120,
+            requiredFee: '120000000000000',
           },
         },
         {


### PR DESCRIPTION
## Description

At Agoric we have modified the bridged $LINK to use 18 decimal places, so the best way to represent these fee amounts is to use JSON strings. We can and must remove the scaling hack that we needed before to translate between 6 decimals and 18 decimals.

## Changes

- Don't scale Agoric fees from the old 6-decimal-place value; just use 18 decimal places for $LINK on both chains
- Use JSON strings to represent $LINK fee amounts for high precision

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

Follow the steps in https://github.com/Agoric/dapp-oracle#readme to test, following the Chainlink instructions, which requires also smartcontractkit/external-initiator#160

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
