### PR TITLE
Release/v1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/external-adapters-js",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "license": "MIT",
   "private": true,
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/external-adapters-js",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "license": "MIT",
   "private": true,
   "workspaces": [

--- a/packages/composites/apy-finance/CHANGELOG.md
+++ b/packages/composites/apy-finance/CHANGELOG.md
@@ -56,15 +56,17 @@
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/token-allocation-adapter@1.0.11
   - @chainlink/ea-test-helpers@1.0.1
+- Updated dependencies [b78f8e06]
+- Updated dependencies [c93e5654]
+- Updated dependencies [ccff5d7f]
+  - @chainlink/ea-bootstrap@1.3.0
 
 ## 1.0.10
 
 ### Patch Changes
 
-- Updated dependencies [b78f8e06]
-- Updated dependencies [c93e5654]
-- Updated dependencies [ccff5d7f]
-  - @chainlink/ea-bootstrap@1.3.0
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/token-allocation-adapter@1.0.10
   - @chainlink/ea-test-helpers@1.0.1
 

--- a/packages/composites/augur/CHANGELOG.md
+++ b/packages/composites/augur/CHANGELOG.md
@@ -53,13 +53,10 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/sportsdataio-adapter@1.1.6
   - @chainlink/therundown-adapter@1.1.1
-
-## 1.0.7
-
-### Patch Changes
 
 - Updated dependencies [fe8ab13c]
 - Updated dependencies [b78f8e06]
@@ -68,6 +65,15 @@
   - @chainlink/therundown-adapter@1.1.0
   - @chainlink/ea-bootstrap@1.3.0
   - @chainlink/sportsdataio-adapter@1.1.5
+
+## 1.0.7
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
+  - @chainlink/sportsdataio-adapter@1.1.5
+  - @chainlink/therundown-adapter@1.0.6
 
 ## 1.0.6
 

--- a/packages/composites/bitcoin-json-rpc/CHANGELOG.md
+++ b/packages/composites/bitcoin-json-rpc/CHANGELOG.md
@@ -53,18 +53,22 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
   - @chainlink/json-rpc-adapter@1.1.3
-
-## 1.0.7
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.7
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
   - @chainlink/json-rpc-adapter@1.1.2
 

--- a/packages/composites/bob/CHANGELOG.md
+++ b/packages/composites/bob/CHANGELOG.md
@@ -56,15 +56,17 @@
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
   - @chainlink/json-rpc-adapter@1.1.3
+- Updated dependencies [b78f8e06]
+- Updated dependencies [c93e5654]
+- Updated dependencies [ccff5d7f]
+  - @chainlink/ea-bootstrap@1.3.0
 
 ## 1.0.7
 
 ### Patch Changes
 
-- Updated dependencies [b78f8e06]
-- Updated dependencies [c93e5654]
-- Updated dependencies [ccff5d7f]
-  - @chainlink/ea-bootstrap@1.3.0
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
   - @chainlink/json-rpc-adapter@1.1.2
 

--- a/packages/composites/circuit-breaker/CHANGELOG.md
+++ b/packages/composites/circuit-breaker/CHANGELOG.md
@@ -43,16 +43,20 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
 
 ## 1.0.5
 

--- a/packages/composites/crypto-volatility-index/CHANGELOG.md
+++ b/packages/composites/crypto-volatility-index/CHANGELOG.md
@@ -58,19 +58,23 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/token-allocation-adapter@1.0.11
   - @chainlink/ea-reference-data-reader@1.0.7
   - @chainlink/ea-test-helpers@1.0.1
 
-## 1.0.10
-
-### Patch Changes
-
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.10
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/token-allocation-adapter@1.0.10
   - @chainlink/ea-reference-data-reader@1.0.6
   - @chainlink/ea-test-helpers@1.0.1

--- a/packages/composites/defi-dozen/CHANGELOG.md
+++ b/packages/composites/defi-dozen/CHANGELOG.md
@@ -53,18 +53,22 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/token-allocation-adapter@1.0.11
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.10
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.10
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/token-allocation-adapter@1.0.10
   - @chainlink/ea-test-helpers@1.0.1
 

--- a/packages/composites/defi-pulse/CHANGELOG.md
+++ b/packages/composites/defi-pulse/CHANGELOG.md
@@ -53,18 +53,22 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/token-allocation-adapter@1.0.11
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.10
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.10
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/token-allocation-adapter@1.0.10
   - @chainlink/ea-test-helpers@1.0.1
 

--- a/packages/composites/dns-record-check/CHANGELOG.md
+++ b/packages/composites/dns-record-check/CHANGELOG.md
@@ -53,18 +53,22 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
   - @chainlink/dns-query-adapter@1.0.7
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
   - @chainlink/dns-query-adapter@1.0.6
 

--- a/packages/composites/dxdao/CHANGELOG.md
+++ b/packages/composites/dxdao/CHANGELOG.md
@@ -53,18 +53,22 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/token-allocation-adapter@1.0.11
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.10
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.10
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/token-allocation-adapter@1.0.10
   - @chainlink/ea-test-helpers@1.0.1
 

--- a/packages/composites/dydx-rewards/CHANGELOG.md
+++ b/packages/composites/dydx-rewards/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ipfs-adapter@1.0.7
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ipfs-adapter@1.0.6
 
 ## 1.0.5

--- a/packages/composites/google-weather/CHANGELOG.md
+++ b/packages/composites/google-weather/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/google-bigquery-adapter@1.0.7
-
-## 1.0.7
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.7
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/google-bigquery-adapter@1.0.6
 
 ## 1.0.6

--- a/packages/composites/historical-average/CHANGELOG.md
+++ b/packages/composites/historical-average/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/coinmarketcap-adapter@1.2.3
-
-## 1.0.2
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.2
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/coinmarketcap-adapter@1.2.2
 
 ## 1.0.1

--- a/packages/composites/linear-finance/CHANGELOG.md
+++ b/packages/composites/linear-finance/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/token-allocation-adapter@1.0.11
-
-## 1.1.7
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.7
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/token-allocation-adapter@1.0.10
 
 ## 1.1.6

--- a/packages/composites/market-closure/CHANGELOG.md
+++ b/packages/composites/market-closure/CHANGELOG.md
@@ -63,20 +63,24 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-reference-data-reader@1.0.7
   - @chainlink/ea-test-helpers@1.0.1
   - @chainlink/fcsapi-adapter@1.0.7
   - @chainlink/finnhub-adapter@1.0.7
 
-## 1.0.6
-
-### Patch Changes
-
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-reference-data-reader@1.0.6
   - @chainlink/ea-test-helpers@1.0.1
   - @chainlink/fcsapi-adapter@1.0.6

--- a/packages/composites/medianizer/CHANGELOG.md
+++ b/packages/composites/medianizer/CHANGELOG.md
@@ -43,16 +43,20 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
 
 ## 1.0.5
 

--- a/packages/composites/outlier-detection/CHANGELOG.md
+++ b/packages/composites/outlier-detection/CHANGELOG.md
@@ -58,14 +58,11 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea@1.0.14
   - @chainlink/ea-reference-data-reader@1.0.7
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.13
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
@@ -74,6 +71,16 @@
   - @chainlink/ea@1.0.13
   - @chainlink/ea-reference-data-reader@1.0.6
   - @chainlink/ea-test-helpers@1.0.1
+
+## 1.0.13
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
+  - @chainlink/ea-reference-data-reader@1.0.6
+  - @chainlink/ea-test-helpers@1.0.1
+  - @chainlink/ea@1.0.13
 
 ## 1.0.12
 

--- a/packages/composites/proof-of-reserves/CHANGELOG.md
+++ b/packages/composites/proof-of-reserves/CHANGELOG.md
@@ -133,6 +133,7 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/bitcoin-json-rpc-adapter@1.0.8
   - @chainlink/ea-test-helpers@1.0.1
@@ -153,14 +154,17 @@
   - @chainlink/wbtc-address-set-adapter@1.0.7
   - @chainlink/wrapped-adapter@2.0.3
 
-## 1.1.2
-
-### Patch Changes
-
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/bitcoin-json-rpc-adapter@1.0.7
   - @chainlink/ea-test-helpers@1.0.1
   - @chainlink/ada-balance-adapter@1.0.6

--- a/packages/composites/reference-transform/CHANGELOG.md
+++ b/packages/composites/reference-transform/CHANGELOG.md
@@ -53,13 +53,10 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea@1.0.14
   - @chainlink/ea-reference-data-reader@1.0.7
-
-## 1.0.13
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
@@ -67,6 +64,15 @@
   - @chainlink/ea-bootstrap@1.3.0
   - @chainlink/ea@1.0.13
   - @chainlink/ea-reference-data-reader@1.0.6
+
+## 1.0.13
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
+  - @chainlink/ea-reference-data-reader@1.0.6
+  - @chainlink/ea@1.0.13
 
 ## 1.0.12
 

--- a/packages/composites/set-token-index/CHANGELOG.md
+++ b/packages/composites/set-token-index/CHANGELOG.md
@@ -53,18 +53,22 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/token-allocation-adapter@1.0.11
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.10
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.10
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/token-allocation-adapter@1.0.10
   - @chainlink/ea-test-helpers@1.0.1
 

--- a/packages/composites/synth-index/CHANGELOG.md
+++ b/packages/composites/synth-index/CHANGELOG.md
@@ -53,18 +53,22 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/token-allocation-adapter@1.0.11
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.10
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.10
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/token-allocation-adapter@1.0.10
   - @chainlink/ea-test-helpers@1.0.1
 

--- a/packages/composites/the-graph/CHANGELOG.md
+++ b/packages/composites/the-graph/CHANGELOG.md
@@ -58,19 +58,23 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-reference-data-reader@1.0.7
   - @chainlink/ea-test-helpers@1.0.1
   - @chainlink/graphql-adapter@1.0.7
 
-## 1.0.6
-
-### Patch Changes
-
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-reference-data-reader@1.0.6
   - @chainlink/ea-test-helpers@1.0.1
   - @chainlink/graphql-adapter@1.0.6

--- a/packages/composites/token-allocation/CHANGELOG.md
+++ b/packages/composites/token-allocation/CHANGELOG.md
@@ -93,6 +93,7 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
   - @chainlink/amberdata-adapter@1.1.6
@@ -105,14 +106,17 @@
   - @chainlink/nomics-adapter@1.0.7
   - @chainlink/tiingo-adapter@1.2.4
 
-## 1.0.10
-
-### Patch Changes
-
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.10
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
   - @chainlink/amberdata-adapter@1.1.5
   - @chainlink/coinapi-adapter@1.0.6

--- a/packages/composites/vesper/CHANGELOG.md
+++ b/packages/composites/vesper/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/token-allocation-adapter@1.0.11
-
-## 1.0.10
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.10
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/token-allocation-adapter@1.0.10
 
 ## 1.0.9

--- a/packages/composites/xsushi-price/CHANGELOG.md
+++ b/packages/composites/xsushi-price/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/token-allocation-adapter@1.0.11
-
-## 1.0.10
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.10
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/token-allocation-adapter@1.0.10
 
 ## 1.0.9

--- a/packages/core/bootstrap/CHANGELOG.md
+++ b/packages/core/bootstrap/CHANGELOG.md
@@ -50,6 +50,12 @@
 
 - b78f8e06: Print out actual used port when bootstrapping server
 
+## 1.2.2
+
+### Patch Changes
+
+- 34b40ed33: Fix rate limit capacity parsing
+
 ## 1.2.1
 
 ### Patch Changes

--- a/packages/core/factories/CHANGELOG.md
+++ b/packages/core/factories/CHANGELOG.md
@@ -43,16 +43,20 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
 
 ## 1.0.5
 

--- a/packages/core/legos/CHANGELOG.md
+++ b/packages/core/legos/CHANGELOG.md
@@ -616,6 +616,7 @@
 ### Patch Changes
 
 - Updated dependencies [f04c118fe]
+
   - @chainlink/nikkei-adapter@1.1.0
   - @chainlink/1forge-adapter@1.1.4
   - @chainlink/accuweather-adapter@1.0.7
@@ -732,10 +733,6 @@
   - @chainlink/wootrade-adapter@1.0.7
   - @chainlink/wrapped-adapter@2.0.3
   - @chainlink/xbto-adapter@1.1.3
-
-## 1.0.13
-
-### Patch Changes
 
 - Updated dependencies [9e5dc6df]
 - Updated dependencies [fe8ab13c]
@@ -858,6 +855,127 @@
   - @chainlink/wootrade-adapter@1.0.6
   - @chainlink/wrapped-adapter@2.0.2
   - @chainlink/xbto-adapter@1.1.2
+
+## 1.0.13
+
+### Patch Changes
+
+- @chainlink/1forge-adapter@1.1.3
+- @chainlink/accuweather-adapter@1.0.6
+- @chainlink/ada-balance-adapter@1.0.6
+- @chainlink/alphachain-adapter@1.0.6
+- @chainlink/alphavantage-adapter@1.0.6
+- @chainlink/amberdata-adapter@1.1.5
+- @chainlink/anyblock-adapter@1.0.6
+- @chainlink/ap-election-adapter@1.0.6
+- @chainlink/bea-adapter@1.0.6
+- @chainlink/binance-adapter@1.0.6
+- @chainlink/binance-dex-adapter@1.1.2
+- @chainlink/bitex-adapter@1.2.2
+- @chainlink/bitso-adapter@1.1.2
+- @chainlink/blockchain.com-adapter@1.0.6
+- @chainlink/blockchair-adapter@1.0.6
+- @chainlink/blockcypher-adapter@1.1.2
+- @chainlink/blockstream-adapter@1.1.2
+- @chainlink/bravenewcoin-adapter@1.0.6
+- @chainlink/btc.com-adapter@1.0.6
+- @chainlink/cache.gold-adapter@1.1.2
+- @chainlink/cfbenchmarks-adapter@1.0.6
+- @chainlink/chain-reserve-wallet-adapter@1.0.6
+- @chainlink/coinapi-adapter@1.0.6
+- @chainlink/coinbase-adapter@1.1.2
+- @chainlink/coincodex-adapter@1.0.6
+- @chainlink/coingecko-adapter@1.0.7
+- @chainlink/coinlore-adapter@1.1.2
+- @chainlink/coinmarketcap-adapter@1.2.2
+- @chainlink/coinmetrics-adapter@1.1.6
+- @chainlink/coinpaprika-adapter@1.0.7
+- @chainlink/coinranking-adapter@1.0.6
+- @chainlink/covid-tracker-adapter@1.0.7
+- @chainlink/cryptoapis-adapter@1.0.6
+- @chainlink/cryptoapis-v2-adapter@1.0.6
+- @chainlink/cryptocompare-adapter@1.1.6
+- @chainlink/cryptoid-adapter@1.1.2
+- @chainlink/cryptomkt-adapter@1.1.2
+- @chainlink/currencylayer-adapter@1.0.6
+- @chainlink/curve-adapter@1.0.6
+- @chainlink/deribit-adapter@1.0.6
+- @chainlink/dns-query-adapter@1.0.6
+- @chainlink/durin-adapter@1.0.6
+- @chainlink/dwolla-adapter@1.0.6
+- @chainlink/dxfeed-adapter@1.1.3
+- @chainlink/dxfeed-secondary-adapter@1.1.3
+- @chainlink/enzyme-adapter@1.0.6
+- @chainlink/eodhistoricaldata-adapter@1.1.2
+- @chainlink/eth-balance-adapter@1.0.6
+- @chainlink/etherchain-adapter@1.1.2
+- @chainlink/etherscan-adapter@1.1.2
+- @chainlink/ethgasstation-adapter@1.1.2
+- @chainlink/ethgaswatch-adapter@1.1.2
+- @chainlink/expert-car-broker-adapter@1.1.2
+- @chainlink/fcsapi-adapter@1.0.6
+- @chainlink/finage-adapter@1.1.6
+- @chainlink/finnhub-adapter@1.0.6
+- @chainlink/fixer-adapter@1.0.6
+- @chainlink/flightaware-adapter@1.0.6
+- @chainlink/fmpcloud-adapter@1.1.2
+- @chainlink/gemini-adapter@1.0.6
+- @chainlink/genesis-volatility-adapter@1.0.6
+- @chainlink/geodb-adapter@1.0.6
+- @chainlink/google-bigquery-adapter@1.0.6
+- @chainlink/graphql-adapter@1.0.6
+- @chainlink/iex-cloud-adapter@1.0.6
+- @chainlink/intrinio-adapter@1.0.6
+- @chainlink/ipfs-adapter@1.0.6
+- @chainlink/json-rpc-adapter@1.1.2
+- @chainlink/kaiko-adapter@1.0.6
+- @chainlink/layer2-sequencer-health-adapter@1.0.6
+- @chainlink/lcx-adapter@1.1.2
+- @chainlink/linkpool-adapter@1.0.6
+- @chainlink/lition-adapter@1.0.6
+- @chainlink/lotus-adapter@1.0.7
+- @chainlink/marketstack-adapter@1.1.2
+- @chainlink/messari-adapter@1.0.6
+- @chainlink/metalsapi-adapter@1.1.2
+- @chainlink/mycryptoapi-adapter@1.1.2
+- @chainlink/ncfx-adapter@1.0.6
+- @chainlink/nikkei-adapter@1.0.6
+- @chainlink/nomics-adapter@1.0.6
+- @chainlink/oilpriceapi-adapter@1.0.6
+- @chainlink/onchain-adapter@1.0.6
+- @chainlink/onchain-gas-adapter@1.0.6
+- @chainlink/openexchangerates-adapter@1.0.6
+- @chainlink/orchid-bandwidth-adapter@1.0.6
+- @chainlink/paxos-adapter@1.1.2
+- @chainlink/paypal-adapter@1.0.6
+- @chainlink/poa-adapter@1.1.2
+- @chainlink/polygon-adapter@1.1.2
+- @chainlink/reduce-adapter@1.1.2
+- @chainlink/renvm-address-set-adapter@1.0.6
+- @chainlink/satoshitango-adapter@1.1.2
+- @chainlink/sochain-adapter@1.1.2
+- @chainlink/spectral-macro-score-adapter@1.0.6
+- @chainlink/sportsdataio-adapter@1.1.5
+- @chainlink/stasis-adapter@1.0.6
+- @chainlink/synthetix-debt-pool-adapter@1.1.2
+- @chainlink/taapi-adapter@1.0.6
+- @chainlink/terra-view-function-adapter@1.0.6
+- @chainlink/therundown-adapter@1.0.6
+- @chainlink/tiingo-adapter@1.2.3
+- @chainlink/tradermade-adapter@1.2.3
+- @chainlink/tradingeconomics-adapter@1.0.6
+- @chainlink/trueusd-adapter@1.0.6
+- @chainlink/twelvedata-adapter@1.0.6
+- @chainlink/unibit-adapter@1.1.2
+- @chainlink/uniswap-v2-adapter@1.0.6
+- @chainlink/uniswap-v3-adapter@1.0.6
+- @chainlink/upvest-adapter@1.1.2
+- @chainlink/uscpi-one-adapter@1.0.6
+- @chainlink/view-function-adapter@1.0.6
+- @chainlink/wbtc-address-set-adapter@1.0.6
+- @chainlink/wootrade-adapter@1.0.6
+- @chainlink/wrapped-adapter@2.0.2
+- @chainlink/xbto-adapter@1.1.2
 
 ## 1.0.12
 

--- a/packages/core/reference-data-reader/CHANGELOG.md
+++ b/packages/core/reference-data-reader/CHANGELOG.md
@@ -43,16 +43,20 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
 
 ## 1.0.5
 

--- a/packages/examples/composite/CHANGELOG.md
+++ b/packages/examples/composite/CHANGELOG.md
@@ -43,16 +43,20 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
 
 ## 1.0.5
 

--- a/packages/examples/source/CHANGELOG.md
+++ b/packages/examples/source/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/1forge/CHANGELOG.md
+++ b/packages/sources/1forge/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.3
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.3
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.1.2

--- a/packages/sources/accuweather/CHANGELOG.md
+++ b/packages/sources/accuweather/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/ada-balance/CHANGELOG.md
+++ b/packages/sources/ada-balance/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/alphachain/CHANGELOG.md
+++ b/packages/sources/alphachain/CHANGELOG.md
@@ -50,15 +50,17 @@
 - Updated dependencies [97bbbfc69]
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
+- Updated dependencies [b78f8e06]
+- Updated dependencies [c93e5654]
+- Updated dependencies [ccff5d7f]
+  - @chainlink/ea-bootstrap@1.3.0
 
 ## 1.0.6
 
 ### Patch Changes
 
-- Updated dependencies [b78f8e06]
-- Updated dependencies [c93e5654]
-- Updated dependencies [ccff5d7f]
-  - @chainlink/ea-bootstrap@1.3.0
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/alphavantage/CHANGELOG.md
+++ b/packages/sources/alphavantage/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/amberdata/CHANGELOG.md
+++ b/packages/sources/amberdata/CHANGELOG.md
@@ -53,18 +53,22 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-factories@1.0.7
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.5
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.5
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-factories@1.0.6
   - @chainlink/ea-test-helpers@1.0.1
 

--- a/packages/sources/anyblock/CHANGELOG.md
+++ b/packages/sources/anyblock/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/ap-election/CHANGELOG.md
+++ b/packages/sources/ap-election/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/bea/CHANGELOG.md
+++ b/packages/sources/bea/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/binance-dex/CHANGELOG.md
+++ b/packages/sources/binance-dex/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.2
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.1.1

--- a/packages/sources/binance/CHANGELOG.md
+++ b/packages/sources/binance/CHANGELOG.md
@@ -52,17 +52,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/bitex/CHANGELOG.md
+++ b/packages/sources/bitex/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.2.2
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.2.2
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.2.1

--- a/packages/sources/bitso/CHANGELOG.md
+++ b/packages/sources/bitso/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.2
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.1.1

--- a/packages/sources/blockchain.com/CHANGELOG.md
+++ b/packages/sources/blockchain.com/CHANGELOG.md
@@ -53,18 +53,22 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-factories@1.0.7
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-factories@1.0.6
   - @chainlink/ea-test-helpers@1.0.1
 

--- a/packages/sources/blockchair/CHANGELOG.md
+++ b/packages/sources/blockchair/CHANGELOG.md
@@ -53,18 +53,22 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-factories@1.0.7
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-factories@1.0.6
   - @chainlink/ea-test-helpers@1.0.1
 

--- a/packages/sources/blockcypher/CHANGELOG.md
+++ b/packages/sources/blockcypher/CHANGELOG.md
@@ -53,18 +53,22 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-factories@1.0.7
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.2
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-factories@1.0.6
   - @chainlink/ea-test-helpers@1.0.1
 

--- a/packages/sources/blockstream/CHANGELOG.md
+++ b/packages/sources/blockstream/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.2
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.1.1

--- a/packages/sources/bravenewcoin/CHANGELOG.md
+++ b/packages/sources/bravenewcoin/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/btc.com/CHANGELOG.md
+++ b/packages/sources/btc.com/CHANGELOG.md
@@ -53,18 +53,22 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-factories@1.0.7
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-factories@1.0.6
   - @chainlink/ea-test-helpers@1.0.1
 

--- a/packages/sources/cache.gold/CHANGELOG.md
+++ b/packages/sources/cache.gold/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.2
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.1.1

--- a/packages/sources/cfbenchmarks/CHANGELOG.md
+++ b/packages/sources/cfbenchmarks/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/chain-reserve-wallet/CHANGELOG.md
+++ b/packages/sources/chain-reserve-wallet/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/coinapi/CHANGELOG.md
+++ b/packages/sources/coinapi/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/coinbase/CHANGELOG.md
+++ b/packages/sources/coinbase/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.2
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.1.1

--- a/packages/sources/coincodex/CHANGELOG.md
+++ b/packages/sources/coincodex/CHANGELOG.md
@@ -63,6 +63,13 @@
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/coingecko/CHANGELOG.md
+++ b/packages/sources/coingecko/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.7
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.7
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.6

--- a/packages/sources/coinlore/CHANGELOG.md
+++ b/packages/sources/coinlore/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.2
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.1.1

--- a/packages/sources/coinmarketcap/CHANGELOG.md
+++ b/packages/sources/coinmarketcap/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.2.2
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.2.2
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.2.1

--- a/packages/sources/coinmetrics/CHANGELOG.md
+++ b/packages/sources/coinmetrics/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.1.5

--- a/packages/sources/coinpaprika/CHANGELOG.md
+++ b/packages/sources/coinpaprika/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.7
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.7
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.6

--- a/packages/sources/coinranking/CHANGELOG.md
+++ b/packages/sources/coinranking/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/covid-tracker/CHANGELOG.md
+++ b/packages/sources/covid-tracker/CHANGELOG.md
@@ -63,6 +63,13 @@
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.7
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.6

--- a/packages/sources/cryptoapis-v2/CHANGELOG.md
+++ b/packages/sources/cryptoapis-v2/CHANGELOG.md
@@ -53,18 +53,22 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-factories@1.0.7
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-factories@1.0.6
   - @chainlink/ea-test-helpers@1.0.1
 

--- a/packages/sources/cryptoapis/CHANGELOG.md
+++ b/packages/sources/cryptoapis/CHANGELOG.md
@@ -53,18 +53,22 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-factories@1.0.7
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-factories@1.0.6
   - @chainlink/ea-test-helpers@1.0.1
 

--- a/packages/sources/cryptocompare/CHANGELOG.md
+++ b/packages/sources/cryptocompare/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.1.5

--- a/packages/sources/cryptoid/CHANGELOG.md
+++ b/packages/sources/cryptoid/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.2
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.1.1

--- a/packages/sources/cryptomkt/CHANGELOG.md
+++ b/packages/sources/cryptomkt/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.2
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.1.1

--- a/packages/sources/currencylayer/CHANGELOG.md
+++ b/packages/sources/currencylayer/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/curve/CHANGELOG.md
+++ b/packages/sources/curve/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/deribit/CHANGELOG.md
+++ b/packages/sources/deribit/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/dns-query/CHANGELOG.md
+++ b/packages/sources/dns-query/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/durin/CHANGELOG.md
+++ b/packages/sources/durin/CHANGELOG.md
@@ -43,16 +43,20 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
 
 ## 1.0.5
 

--- a/packages/sources/dwolla/CHANGELOG.md
+++ b/packages/sources/dwolla/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/dxfeed-secondary/CHANGELOG.md
+++ b/packages/sources/dxfeed-secondary/CHANGELOG.md
@@ -53,18 +53,22 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
   - @chainlink/dxfeed-adapter@1.1.4
-
-## 1.1.3
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.3
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
   - @chainlink/dxfeed-adapter@1.1.3
 

--- a/packages/sources/dxfeed/CHANGELOG.md
+++ b/packages/sources/dxfeed/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.3
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.3
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.1.2

--- a/packages/sources/enzyme/CHANGELOG.md
+++ b/packages/sources/enzyme/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/eodhistoricaldata/CHANGELOG.md
+++ b/packages/sources/eodhistoricaldata/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.2
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.1.1

--- a/packages/sources/eth-balance/CHANGELOG.md
+++ b/packages/sources/eth-balance/CHANGELOG.md
@@ -53,18 +53,22 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-factories@1.0.7
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-factories@1.0.6
   - @chainlink/ea-test-helpers@1.0.1
 

--- a/packages/sources/etherchain/CHANGELOG.md
+++ b/packages/sources/etherchain/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.2
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.1.1

--- a/packages/sources/etherscan/CHANGELOG.md
+++ b/packages/sources/etherscan/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.2
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.1.1

--- a/packages/sources/ethgasstation/CHANGELOG.md
+++ b/packages/sources/ethgasstation/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.2
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.1.1

--- a/packages/sources/ethgaswatch/CHANGELOG.md
+++ b/packages/sources/ethgaswatch/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.2
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.1.1

--- a/packages/sources/expert-car-broker/CHANGELOG.md
+++ b/packages/sources/expert-car-broker/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.2
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.1.1

--- a/packages/sources/fcsapi/CHANGELOG.md
+++ b/packages/sources/fcsapi/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/finage/CHANGELOG.md
+++ b/packages/sources/finage/CHANGELOG.md
@@ -52,17 +52,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.1.5

--- a/packages/sources/finnhub/CHANGELOG.md
+++ b/packages/sources/finnhub/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/fixer/CHANGELOG.md
+++ b/packages/sources/fixer/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/flightaware/CHANGELOG.md
+++ b/packages/sources/flightaware/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/fmpcloud/CHANGELOG.md
+++ b/packages/sources/fmpcloud/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.2
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.1.1

--- a/packages/sources/gemini/CHANGELOG.md
+++ b/packages/sources/gemini/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/genesis-volatility/CHANGELOG.md
+++ b/packages/sources/genesis-volatility/CHANGELOG.md
@@ -63,6 +63,13 @@
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/geodb/CHANGELOG.md
+++ b/packages/sources/geodb/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/google-bigquery/CHANGELOG.md
+++ b/packages/sources/google-bigquery/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/graphql/CHANGELOG.md
+++ b/packages/sources/graphql/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/iex-cloud/CHANGELOG.md
+++ b/packages/sources/iex-cloud/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/intrinio/CHANGELOG.md
+++ b/packages/sources/intrinio/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/ipfs/CHANGELOG.md
+++ b/packages/sources/ipfs/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/json-rpc/CHANGELOG.md
+++ b/packages/sources/json-rpc/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.2
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.1.1

--- a/packages/sources/kaiko/CHANGELOG.md
+++ b/packages/sources/kaiko/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/layer2-sequencer-health/CHANGELOG.md
+++ b/packages/sources/layer2-sequencer-health/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/lcx/CHANGELOG.md
+++ b/packages/sources/lcx/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.2
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.1.1

--- a/packages/sources/linkpool/CHANGELOG.md
+++ b/packages/sources/linkpool/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/lition/CHANGELOG.md
+++ b/packages/sources/lition/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/lotus/CHANGELOG.md
+++ b/packages/sources/lotus/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/json-rpc-adapter@1.1.3
-
-## 1.0.7
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.7
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/json-rpc-adapter@1.1.2
 
 ## 1.0.6

--- a/packages/sources/marketstack/CHANGELOG.md
+++ b/packages/sources/marketstack/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.2
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.1.1

--- a/packages/sources/messari/CHANGELOG.md
+++ b/packages/sources/messari/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/metalsapi/CHANGELOG.md
+++ b/packages/sources/metalsapi/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.2
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.1.1

--- a/packages/sources/mycryptoapi/CHANGELOG.md
+++ b/packages/sources/mycryptoapi/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.2
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.1.1

--- a/packages/sources/ncfx/CHANGELOG.md
+++ b/packages/sources/ncfx/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/nikkei/CHANGELOG.md
+++ b/packages/sources/nikkei/CHANGELOG.md
@@ -52,17 +52,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/nomics/CHANGELOG.md
+++ b/packages/sources/nomics/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/oilpriceapi/CHANGELOG.md
+++ b/packages/sources/oilpriceapi/CHANGELOG.md
@@ -63,6 +63,13 @@
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/onchain-gas/CHANGELOG.md
+++ b/packages/sources/onchain-gas/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/onchain/CHANGELOG.md
+++ b/packages/sources/onchain/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/openexchangerates/CHANGELOG.md
+++ b/packages/sources/openexchangerates/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/orchid-bandwidth/CHANGELOG.md
+++ b/packages/sources/orchid-bandwidth/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/paxos/CHANGELOG.md
+++ b/packages/sources/paxos/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.2
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.1.1

--- a/packages/sources/paypal/CHANGELOG.md
+++ b/packages/sources/paypal/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/poa/CHANGELOG.md
+++ b/packages/sources/poa/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.2
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.1.1

--- a/packages/sources/polygon/CHANGELOG.md
+++ b/packages/sources/polygon/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.2
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.1.1

--- a/packages/sources/reduce/CHANGELOG.md
+++ b/packages/sources/reduce/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.2
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.1.1

--- a/packages/sources/renvm-address-set/CHANGELOG.md
+++ b/packages/sources/renvm-address-set/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/satoshitango/CHANGELOG.md
+++ b/packages/sources/satoshitango/CHANGELOG.md
@@ -48,17 +48,19 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.2
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.2
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.1.1

--- a/packages/sources/sochain/CHANGELOG.md
+++ b/packages/sources/sochain/CHANGELOG.md
@@ -53,18 +53,22 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-factories@1.0.7
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.2
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-factories@1.0.6
   - @chainlink/ea-test-helpers@1.0.1
 

--- a/packages/sources/spectral-macro-score/CHANGELOG.md
+++ b/packages/sources/spectral-macro-score/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/sportsdataio/CHANGELOG.md
+++ b/packages/sources/sportsdataio/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.5
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.5
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.1.4

--- a/packages/sources/stasis/CHANGELOG.md
+++ b/packages/sources/stasis/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/synthetix-debt-pool/CHANGELOG.md
+++ b/packages/sources/synthetix-debt-pool/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.2
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.1.1

--- a/packages/sources/taapi/CHANGELOG.md
+++ b/packages/sources/taapi/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/terra-view-function/CHANGELOG.md
+++ b/packages/sources/terra-view-function/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/therundown/CHANGELOG.md
+++ b/packages/sources/therundown/CHANGELOG.md
@@ -63,6 +63,20 @@
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.7
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/tiingo/CHANGELOG.md
+++ b/packages/sources/tiingo/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.2.3
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.2.3
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.2.2

--- a/packages/sources/tradermade/CHANGELOG.md
+++ b/packages/sources/tradermade/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.2.3
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.2.3
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.2.2

--- a/packages/sources/tradingeconomics/CHANGELOG.md
+++ b/packages/sources/tradingeconomics/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/trueusd/CHANGELOG.md
+++ b/packages/sources/trueusd/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/twelvedata/CHANGELOG.md
+++ b/packages/sources/twelvedata/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/unibit/CHANGELOG.md
+++ b/packages/sources/unibit/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.2
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.1.1

--- a/packages/sources/uniswap-v2/CHANGELOG.md
+++ b/packages/sources/uniswap-v2/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/uniswap-v3/CHANGELOG.md
+++ b/packages/sources/uniswap-v3/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/upvest/CHANGELOG.md
+++ b/packages/sources/upvest/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.2
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.1.1

--- a/packages/sources/uscpi-one/CHANGELOG.md
+++ b/packages/sources/uscpi-one/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/view-function/CHANGELOG.md
+++ b/packages/sources/view-function/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/wbtc-address-set/CHANGELOG.md
+++ b/packages/sources/wbtc-address-set/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/wootrade/CHANGELOG.md
+++ b/packages/sources/wootrade/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/sources/wrapped/CHANGELOG.md
+++ b/packages/sources/wrapped/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 2.0.2
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 2.0.2
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 2.0.1

--- a/packages/sources/xbto/CHANGELOG.md
+++ b/packages/sources/xbto/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.1.2
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.1.1

--- a/packages/targets/agoric/CHANGELOG.md
+++ b/packages/targets/agoric/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/targets/conflux/CHANGELOG.md
+++ b/packages/targets/conflux/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/targets/dydx-stark/CHANGELOG.md
+++ b/packages/targets/dydx-stark/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/targets/ethwrite/CHANGELOG.md
+++ b/packages/targets/ethwrite/CHANGELOG.md
@@ -50,15 +50,17 @@
 - Updated dependencies [97bbbfc69]
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
+- Updated dependencies [b78f8e06]
+- Updated dependencies [c93e5654]
+- Updated dependencies [ccff5d7f]
+  - @chainlink/ea-bootstrap@1.3.0
 
 ## 1.0.6
 
 ### Patch Changes
 
-- Updated dependencies [b78f8e06]
-- Updated dependencies [c93e5654]
-- Updated dependencies [ccff5d7f]
-  - @chainlink/ea-bootstrap@1.3.0
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5

--- a/packages/targets/harmony/CHANGELOG.md
+++ b/packages/targets/harmony/CHANGELOG.md
@@ -48,17 +48,21 @@
 - Updated dependencies [9e3e1cbb6]
 - Updated dependencies [a3b352bb5]
 - Updated dependencies [97bbbfc69]
+
   - @chainlink/ea-bootstrap@1.3.1
   - @chainlink/ea-test-helpers@1.0.1
-
-## 1.0.6
-
-### Patch Changes
 
 - Updated dependencies [b78f8e06]
 - Updated dependencies [c93e5654]
 - Updated dependencies [ccff5d7f]
   - @chainlink/ea-bootstrap@1.3.0
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies [34b40ed33]
+  - @chainlink/ea-bootstrap@1.2.2
   - @chainlink/ea-test-helpers@1.0.1
 
 ## 1.0.5


### PR DESCRIPTION
## Changelog

### New Adapters

 - Anchor adapter to pull `bETH/USD` and `bLuna/USD` feeds
 - Snowflake covid adapter
 - Alpine

### Features
 
 - Upgrade `node-redis` to v4
 - Cache warmer metric feed ID labelled as `cacheWarmer`
 - Finage WS crypto endpoint
 - Double amount of allowed entries in local cache
 - Add `coingecko` KNC ticker override

### Bug Fixes

 - Cachewarmer count metric no longer goes negative
 - Correction to Redis logging.  Issue was that the adapter was not logging expected data but instead logged an object that was not spread.
