### PR TITLE
Change status code in metrics

### DIFF
--- a/.changeset/sweet-steaks-notice.md
+++ b/.changeset/sweet-steaks-notice.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/ea-bootstrap': minor
+---
+
+Modify the way metrics are calculated on DP errors for the http_total_requests metric

--- a/packages/core/bootstrap/src/index.ts
+++ b/packages/core/bootstrap/src/index.ts
@@ -124,9 +124,14 @@ const withMetrics: Middleware = async (execute, context) => async (input: Adapte
     }
     const end = metrics.httpRequestDurationSeconds.startTimer()
 
-    return (statusCode?: number, type?: metrics.HttpRequestType) => {
-      labels.type = type
-      labels.status_code = metrics.util.normalizeStatusCode(statusCode)
+    return (props: {
+      providerStatusCode?: number
+      statusCode?: number
+      type?: metrics.HttpRequestType
+    }) => {
+      labels.type = props.type
+      labels.status_code = metrics.util.normalizeStatusCode(props.statusCode)
+      labels.provider_status_code = metrics.util.normalizeStatusCode(props.providerStatusCode)
       end()
       metrics.httpRequestsTotal.labels(labels).inc()
     }
@@ -135,15 +140,20 @@ const withMetrics: Middleware = async (execute, context) => async (input: Adapte
   const record = recordMetrics()
   try {
     const result = await execute({ ...input, metricsMeta }, context)
-    record(
-      result.statusCode,
-      result.data.maxAge || (result as any).maxAge
-        ? metrics.HttpRequestType.CACHE_HIT
-        : metrics.HttpRequestType.DATA_PROVIDER_HIT,
-    )
+    record({
+      statusCode: result.statusCode,
+      type:
+        result.data.maxAge || (result as any).maxAge
+          ? metrics.HttpRequestType.CACHE_HIT
+          : metrics.HttpRequestType.DATA_PROVIDER_HIT,
+    })
     return { ...result, metricsMeta: { ...result.metricsMeta, ...metricsMeta } }
   } catch (error) {
-    record()
+    const providerStatusCode: number | undefined = error.cause?.response?.status
+    record({
+      statusCode: providerStatusCode ? 200 : 500,
+      providerStatusCode,
+    })
     throw error
   }
 }

--- a/packages/core/bootstrap/src/lib/metrics/index.ts
+++ b/packages/core/bootstrap/src/lib/metrics/index.ts
@@ -20,7 +20,15 @@ export enum HttpRequestType {
 export const httpRequestsTotal = new client.Counter({
   name: 'http_requests_total',
   help: 'The number of http requests this external adapter has serviced for its entire uptime',
-  labelNames: ['method', 'status_code', 'retry', 'type', 'is_cache_warming', 'feed_id'] as const,
+  labelNames: [
+    'method',
+    'status_code',
+    'retry',
+    'type',
+    'is_cache_warming',
+    'feed_id',
+    'provider_status_code',
+  ] as const,
 })
 
 export const httpRequestDurationSeconds = new client.Histogram({

--- a/packages/core/bootstrap/src/lib/metrics/util.ts
+++ b/packages/core/bootstrap/src/lib/metrics/util.ts
@@ -13,11 +13,7 @@ import * as crypto from 'crypto'
  * @returns {string} the normalized status code.
  */
 export function normalizeStatusCode(status?: number): string {
-  if (!status) {
-    return '5XX'
-  }
-
-  if (status >= 200 && status < 300) {
+  if (!status || (status >= 200 && status < 300)) {
     return '2XX'
   }
 


### PR DESCRIPTION
## Description

A common occurrence with EAs is that the Data Provider sources fail, and we currently surface their status code as the response from the EA itself. Since EAs are not a completely clean proxy by design, the end result is that it's not possible to discern in metrics whether the failing point is the EA or the DP.

This PR changes only the metrics published in the optional `/metrics` endpoint, so that a failing request to a DP results in metric labels of `status_code="2XX",provider_status_code="5XX"` for example. 

## Changes

- Changed metric labels calculation to modify cases with failing DP requests only.

## Steps to Test

1. Run an adapter of choice with `EXPERIMENTAL_METRICS_ENABLED=true`
2. Make a request so that the DP request succeeds
3. Make another so that the DP request fails
4. You should see entries for `http_total_requests` in the `/metrics` endpoint with `status_code="2XX",provider_status_code="2XX"` and `status_code="2XX",provider_status_code="5XX"` respectively

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
