### PR TITLE
Remove hardcoded timeout

### DIFF
--- a/.changeset/healthy-hornets-march.md
+++ b/.changeset/healthy-hornets-march.md
@@ -1,5 +1,0 @@
----
-'@chainlink/ethgasstation-adapter': patch
----
-
-Make sure API timeout is not hardcoded

--- a/.changeset/healthy-hornets-march.md
+++ b/.changeset/healthy-hornets-march.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/ethgasstation-adapter': patch
+---
+
+Make sure API timeout is not hardcoded

--- a/packages/composites/outlier-detection/CHANGELOG.md
+++ b/packages/composites/outlier-detection/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chainlink/outlier-detection-adapter
 
+## 1.0.20
+
+### Patch Changes
+
+- @chainlink/ea@1.0.20
+
 ## 1.0.19
 
 ### Patch Changes

--- a/packages/composites/outlier-detection/package.json
+++ b/packages/composites/outlier-detection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/outlier-detection-adapter",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "Chainlink Outlier Detection adapter.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/composites/reference-transform/CHANGELOG.md
+++ b/packages/composites/reference-transform/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chainlink/reference-transform-adapter
 
+## 1.0.20
+
+### Patch Changes
+
+- @chainlink/ea@1.0.20
+
 ## 1.0.19
 
 ### Patch Changes

--- a/packages/composites/reference-transform/package.json
+++ b/packages/composites/reference-transform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/reference-transform-adapter",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "Transform external adapter results from an on-chain reference.",
   "keywords": [
     "Chainlink",

--- a/packages/core/legos/CHANGELOG.md
+++ b/packages/core/legos/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @chainlink/ea
 
+## 1.0.20
+
+### Patch Changes
+
+- Updated dependencies [1cda142a3]
+  - @chainlink/ethgasstation-adapter@1.1.9
+
 ## 1.0.19
 
 ### Patch Changes

--- a/packages/core/legos/package.json
+++ b/packages/core/legos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/ea",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "Build with composable Chainlink External Adapters",
   "keywords": [
     "Chainlink",

--- a/packages/sources/ethgasstation/CHANGELOG.md
+++ b/packages/sources/ethgasstation/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chainlink/ethgasstation-adapter
 
+## 1.1.9
+
+### Patch Changes
+
+- 1cda142a3: Make sure API timeout is not hardcoded
+
 ## 1.1.8
 
 ### Patch Changes

--- a/packages/sources/ethgasstation/package.json
+++ b/packages/sources/ethgasstation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/ethgasstation-adapter",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "Chainlink ethgasstation adapter.",
   "keywords": [
     "Chainlink",

--- a/packages/sources/ethgasstation/src/endpoint/gasprice.ts
+++ b/packages/sources/ethgasstation/src/endpoint/gasprice.ts
@@ -20,7 +20,6 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
   const options = {
     ...config.api,
     url,
-    timeout: 10000,
   }
 
   const response = await Requester.request(options, customError)


### PR DESCRIPTION
## Changes

- Make sure ethgasstation API timeout is not hardcoded

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. Run ethgasstation with API_TIMEOUT env var

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
