### PR TITLE
Add getReserveValue for Enzyme

### DIFF
--- a/.changeset/hip-lies-walk.md
+++ b/.changeset/hip-lies-walk.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/enzyme-adapter': major
+---
+
+Add getReserveValue endpoint to enzyme EA

--- a/packages/sources/enzyme/src/abis/CollateralManagerV1.json
+++ b/packages/sources/enzyme/src/abis/CollateralManagerV1.json
@@ -1,0 +1,192 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "bytes32", "name": "reserveId", "type": "bytes32" },
+      { "indexed": true, "internalType": "address", "name": "from", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "calculator", "type": "address" }
+    ],
+    "name": "AddTokenReserveVault",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "previousAdmin", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "newAdmin", "type": "address" }
+    ],
+    "name": "AdminChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": true, "internalType": "address", "name": "beacon", "type": "address" }],
+    "name": "BeaconUpgraded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "bytes32", "name": "reserveId", "type": "bytes32" },
+      { "indexed": true, "internalType": "address", "name": "from", "type": "address" },
+      { "indexed": false, "internalType": "string", "name": "name", "type": "string" },
+      { "indexed": false, "internalType": "string", "name": "description", "type": "string" }
+    ],
+    "name": "CreateTokenReserve",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "bytes32", "name": "reserveId", "type": "bytes32" },
+      { "indexed": true, "internalType": "address", "name": "from", "type": "address" },
+      { "indexed": false, "internalType": "string", "name": "name", "type": "string" },
+      { "indexed": false, "internalType": "string", "name": "description", "type": "string" }
+    ],
+    "name": "DeleteTokenReserve",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "previousOwner", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "newOwner", "type": "address" }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "bytes32", "name": "reserveId", "type": "bytes32" },
+      { "indexed": true, "internalType": "address", "name": "from", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "calculator", "type": "address" }
+    ],
+    "name": "RemoveTokenReserveVault",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "implementation", "type": "address" }
+    ],
+    "name": "Upgraded",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "reserveId", "type": "bytes32" },
+      {
+        "components": [
+          { "internalType": "address", "name": "vault", "type": "address" },
+          { "internalType": "address", "name": "calculator", "type": "address" },
+          { "internalType": "uint256", "name": "numerator", "type": "uint256" },
+          { "internalType": "uint256", "name": "denominator", "type": "uint256" }
+        ],
+        "internalType": "struct CollateralManagerV1.Vault",
+        "name": "vault",
+        "type": "tuple"
+      }
+    ],
+    "name": "addReserveVault",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "string", "name": "name", "type": "string" },
+      { "internalType": "string", "name": "description", "type": "string" }
+    ],
+    "name": "createReserve",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "reserveId", "type": "bytes32" }],
+    "name": "deleteReserve",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "reserveId", "type": "bytes32" }],
+    "name": "getReserveValue",
+    "outputs": [{ "internalType": "uint256", "name": "value", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "reserveId", "type": "bytes32" },
+      { "internalType": "uint256", "name": "index", "type": "uint256" }
+    ],
+    "name": "removeReserveVault",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "name": "reserveMap",
+    "outputs": [
+      { "internalType": "string", "name": "name", "type": "string" },
+      { "internalType": "string", "name": "description", "type": "string" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "name": "reserves",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "newOwner", "type": "address" }],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "newImplementation", "type": "address" }],
+    "name": "upgradeTo",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "newImplementation", "type": "address" },
+      { "internalType": "bytes", "name": "data", "type": "bytes" }
+    ],
+    "name": "upgradeToAndCall",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  }
+]

--- a/packages/sources/enzyme/src/endpoint/getReserveValue.ts
+++ b/packages/sources/enzyme/src/endpoint/getReserveValue.ts
@@ -1,0 +1,45 @@
+import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import { ExecuteWithConfig, InputParameters } from '@chainlink/types'
+import { Config } from '../config'
+import { ethers, BigNumber } from 'ethers'
+import CollateralManagerV1ABI from '../abis/CollateralManagerV1.json'
+
+export const supportedEndpoints = ['getReserveValue']
+
+export const inputParameters: InputParameters = {
+  address: true,
+  reserveId: true,
+}
+
+export const execute: ExecuteWithConfig<Config> = async (request, _, config) => {
+  const validator = new Validator(request, inputParameters)
+  if (validator.error) throw validator.error
+
+  const jobRunID = validator.validated.id
+  const address = validator.validated.data.address
+  const reserveId = validator.validated.data.reserveId
+
+  const result = await getReserveValue(address, reserveId, config)
+
+  const response = {
+    status: 200,
+    statusText: 'OK',
+    headers: {},
+    config: {},
+    data: { value: result.toString() },
+  }
+  return Requester.success(
+    jobRunID,
+    Requester.withResult(response, result.toString()),
+    config.verbose,
+  )
+}
+
+const getReserveValue = (
+  address: string,
+  reserveId: string,
+  config: Config,
+): Promise<[denominationAsset: string, netValue: BigNumber]> => {
+  const contract = new ethers.Contract(address, CollateralManagerV1ABI, config.provider)
+  return contract.callStatic.getReserveValue(reserveId)
+}

--- a/packages/sources/enzyme/src/endpoint/index.ts
+++ b/packages/sources/enzyme/src/endpoint/index.ts
@@ -1,3 +1,4 @@
 export * as calcGav from './calcGav'
 export * as calcNav from './calcNav'
 export * as calcNetValueForSharesHolder from './calcNetValueForSharesHolder'
+export * as getReserveValue from './getReserveValue'


### PR DESCRIPTION
## Changes

- Adds ability to call "getReserveValue" for Enzyme

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. Run Enzyme adapter with "getReserveValue" as endpoint

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
