### PR TITLE
[Fix] CC batch limits

### DIFF
--- a/packages/composites/anchor/CHANGELOG.md
+++ b/packages/composites/anchor/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chainlink/anchor-adapter
 
+## 1.1.7
+
+### Patch Changes
+
+- @chainlink/token-allocation-adapter@1.0.18
+
 ## 1.1.6
 
 ### Patch Changes

--- a/packages/composites/anchor/package.json
+++ b/packages/composites/anchor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/anchor-adapter",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Chainlink anchor adapter.",
   "keywords": [
     "Chainlink",

--- a/packages/composites/apy-finance/CHANGELOG.md
+++ b/packages/composites/apy-finance/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chainlink/apy-finance-adapter
 
+## 1.0.18
+
+### Patch Changes
+
+- @chainlink/token-allocation-adapter@1.0.18
+
 ## 1.0.17
 
 ### Patch Changes

--- a/packages/composites/apy-finance/package.json
+++ b/packages/composites/apy-finance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/apy-finance-adapter",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "Chainlink APY Finance TVL adapter",
   "keywords": [
     "Chainlink",

--- a/packages/composites/crypto-volatility-index/CHANGELOG.md
+++ b/packages/composites/crypto-volatility-index/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chainlink/crypto-volatility-index-adapter
 
+## 1.0.18
+
+### Patch Changes
+
+- @chainlink/token-allocation-adapter@1.0.18
+
 ## 1.0.17
 
 ### Patch Changes

--- a/packages/composites/crypto-volatility-index/package.json
+++ b/packages/composites/crypto-volatility-index/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/crypto-volatility-index-adapter",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "The Crypto volatility index (CVI)",
   "keywords": [
     "Chainlink",

--- a/packages/composites/defi-dozen/CHANGELOG.md
+++ b/packages/composites/defi-dozen/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chainlink/defi-dozen-adapter
 
+## 1.0.18
+
+### Patch Changes
+
+- @chainlink/token-allocation-adapter@1.0.18
+
 ## 1.0.17
 
 ### Patch Changes

--- a/packages/composites/defi-dozen/package.json
+++ b/packages/composites/defi-dozen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/defi-dozen-adapter",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "Chainlink defi-dozen adapter.",
   "keywords": [
     "Chainlink",

--- a/packages/composites/defi-pulse/CHANGELOG.md
+++ b/packages/composites/defi-pulse/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chainlink/defi-pulse-adapter
 
+## 1.0.18
+
+### Patch Changes
+
+- @chainlink/token-allocation-adapter@1.0.18
+
 ## 1.0.17
 
 ### Patch Changes

--- a/packages/composites/defi-pulse/package.json
+++ b/packages/composites/defi-pulse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/defi-pulse-adapter",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "Chainlink defi pulse adapter",
   "keywords": [
     "Chainlink",

--- a/packages/composites/dxdao/CHANGELOG.md
+++ b/packages/composites/dxdao/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chainlink/dxdao-adapter
 
+## 1.0.18
+
+### Patch Changes
+
+- @chainlink/token-allocation-adapter@1.0.18
+
 ## 1.0.17
 
 ### Patch Changes

--- a/packages/composites/dxdao/package.json
+++ b/packages/composites/dxdao/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/dxdao-adapter",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "Chainlink dxdao adapter.",
   "keywords": [
     "Chainlink",

--- a/packages/composites/linear-finance/CHANGELOG.md
+++ b/packages/composites/linear-finance/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chainlink/linear-finance-adapter
 
+## 1.1.15
+
+### Patch Changes
+
+- @chainlink/token-allocation-adapter@1.0.18
+
 ## 1.1.14
 
 ### Patch Changes

--- a/packages/composites/linear-finance/package.json
+++ b/packages/composites/linear-finance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/linear-finance-adapter",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "description": "Chainlink linear-finance adapter.",
   "keywords": [
     "Chainlink",

--- a/packages/composites/outlier-detection/CHANGELOG.md
+++ b/packages/composites/outlier-detection/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chainlink/outlier-detection-adapter
 
+## 1.0.22
+
+### Patch Changes
+
+- @chainlink/ea@1.0.22
+
 ## 1.0.21
 
 ### Patch Changes

--- a/packages/composites/outlier-detection/package.json
+++ b/packages/composites/outlier-detection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/outlier-detection-adapter",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "description": "Chainlink Outlier Detection adapter.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/composites/reference-transform/CHANGELOG.md
+++ b/packages/composites/reference-transform/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chainlink/reference-transform-adapter
 
+## 1.0.22
+
+### Patch Changes
+
+- @chainlink/ea@1.0.22
+
 ## 1.0.21
 
 ### Patch Changes

--- a/packages/composites/reference-transform/package.json
+++ b/packages/composites/reference-transform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/reference-transform-adapter",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "description": "Transform external adapter results from an on-chain reference.",
   "keywords": [
     "Chainlink",

--- a/packages/composites/set-token-index/CHANGELOG.md
+++ b/packages/composites/set-token-index/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chainlink/set-token-index-adapter
 
+## 1.0.18
+
+### Patch Changes
+
+- @chainlink/token-allocation-adapter@1.0.18
+
 ## 1.0.17
 
 ### Patch Changes

--- a/packages/composites/set-token-index/package.json
+++ b/packages/composites/set-token-index/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/set-token-index-adapter",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "Chainlink set-token-index adapter.",
   "keywords": [
     "Chainlink",

--- a/packages/composites/synth-index/CHANGELOG.md
+++ b/packages/composites/synth-index/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chainlink/synth-index-adapter
 
+## 1.0.18
+
+### Patch Changes
+
+- @chainlink/token-allocation-adapter@1.0.18
+
 ## 1.0.17
 
 ### Patch Changes

--- a/packages/composites/synth-index/package.json
+++ b/packages/composites/synth-index/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/synth-index-adapter",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "Chainlink Synth Index adapter",
   "keywords": [
     "Chainlink",

--- a/packages/composites/token-allocation/CHANGELOG.md
+++ b/packages/composites/token-allocation/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @chainlink/token-allocation-adapter
 
+## 1.0.18
+
+### Patch Changes
+
+- Updated dependencies
+  - @chainlink/cryptocompare-adapter@1.1.14
+
 ## 1.0.17
 
 ### Patch Changes

--- a/packages/composites/token-allocation/package.json
+++ b/packages/composites/token-allocation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/token-allocation-adapter",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "Chainlink token allocation adapter",
   "keywords": [
     "Chainlink",

--- a/packages/composites/vesper/CHANGELOG.md
+++ b/packages/composites/vesper/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chainlink/vesper-adapter
 
+## 1.0.18
+
+### Patch Changes
+
+- @chainlink/token-allocation-adapter@1.0.18
+
 ## 1.0.17
 
 ### Patch Changes

--- a/packages/composites/vesper/package.json
+++ b/packages/composites/vesper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/vesper-adapter",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "Chainlink vesper adapter.",
   "keywords": [
     "Chainlink",

--- a/packages/composites/xsushi-price/CHANGELOG.md
+++ b/packages/composites/xsushi-price/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chainlink/xsushi-price-adapter
 
+## 1.0.18
+
+### Patch Changes
+
+- @chainlink/token-allocation-adapter@1.0.18
+
 ## 1.0.17
 
 ### Patch Changes

--- a/packages/composites/xsushi-price/package.json
+++ b/packages/composites/xsushi-price/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/xsushi-price-adapter",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "Chainlink xsushi-price adapter.",
   "keywords": [
     "Chainlink",

--- a/packages/core/legos/CHANGELOG.md
+++ b/packages/core/legos/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @chainlink/ea
 
+## 1.0.22
+
+### Patch Changes
+
+- Updated dependencies
+  - @chainlink/cryptocompare-adapter@1.1.14
+
 ## 1.0.21
 
 ### Patch Changes

--- a/packages/core/legos/package.json
+++ b/packages/core/legos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/ea",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "description": "Build with composable Chainlink External Adapters",
   "keywords": [
     "Chainlink",

--- a/packages/sources/cryptocompare/CHANGELOG.md
+++ b/packages/sources/cryptocompare/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chainlink/cryptocompare-adapter
 
+## 1.1.14
+
+### Patch Changes
+
+- Lower batch property limits to reflect character limit
+
 ## 1.1.13
 
 ### Patch Changes

--- a/packages/sources/cryptocompare/package.json
+++ b/packages/sources/cryptocompare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/cryptocompare-adapter",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "description": "Chainlink cryptocompare adapter.",
   "keywords": [
     "Chainlink",

--- a/packages/sources/cryptocompare/src/endpoint/crypto.ts
+++ b/packages/sources/cryptocompare/src/endpoint/crypto.ts
@@ -10,8 +10,10 @@ import { NAME as AdapterName } from '../config'
 
 export const supportedEndpoints = ['crypto', 'price', 'marketcap', 'volume']
 export const batchablePropertyPath = [
-  { name: 'base', limit: 1000 },
-  { name: 'quote', limit: 100 },
+  // NOTE: Cryptocompare limits by character length of fsyms
+  { name: 'base', limit: 200 }, // actual limit: 1000 characters
+  { name: 'quote', limit: 20 }, // actual limit: 100 characters
+  // TODO handle character length limits
 ]
 
 export const endpointResultPaths = {


### PR DESCRIPTION
<!-- Employees: Please use Clubhouse/Shortcuts's "Open PR" button from the relevant story or include links to relevant Clubhouse/Shortcut stories in your branch name, commit messages, or pull request comments. Do not add links to your pull request description, they will be ignored. https://help.clubhouse.io/hc/en-us/articles/207540323-Using-The-Clubhouse-GitHub-Integration -->

<!-- Employees: Delete this section. -->

## Description
Cryptocompare has a limit on the number of from symbols and to symbols.
We currently have those in the code assumed to be the number of symbols, but it is actually the character limit.

## Changes
- Lowers CryptoCompare batch property limits to reflect character limits (divided by 5)