### PR TITLE
Fix markdown syntax highlighting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Starting from the root of the repository:
 
 1. Ensure that the project is setup and that the docker-compose file has been generated
 
-   ```json
+   ```
    yarn && yarn setup && yarn generate:docker-compose
    ```
 
@@ -187,7 +187,7 @@ The adapter will have the format of `[[ADAPTER NAME]]-adapter`.
 
 For example:
 
-```json
+```
 cd grafana && ./scripts/compose.sh coingecko-adapter coinmarketcap-adapter
 ```
 
@@ -195,7 +195,7 @@ cd grafana && ./scripts/compose.sh coingecko-adapter coinmarketcap-adapter
 
 - External Adapters - search `docker-compose.generated.yaml` for the name of your EA. The port it is running on will be found as the first number before the colon under `ports`.
 
-```json
+```yml
 coincodex-adapter:
     image: coincodex-adapter:0.0.4
     ports:
@@ -339,19 +339,19 @@ The External Adapters are being tagged with semantic releases to allow for autom
 
 The EA container image can be download by using the [docker pull command](https://docs.docker.com/engine/reference/commandline/pull/). For example:
 
-```json
+```
 docker pull public.ecr.aws/chainlink/adapters/1forge-adapter:latest
 ```
 
 To run the image use the [docker run command](https://docs.docker.com/engine/reference/run/). For example:
 
-```json
+```
 docker run -p 8080:8080 -e API_KEY='YOUR_API_KEY' public.ecr.aws/chainlink/adapters/1forge-adapter:latest
 ```
 
 It can be helpful to pass a text file to the container to handle giving multiple environment variables:
 
-```json
+```
 docker run -p 8080:8080 --env-file=[[path to your env file]] public.ecr.aws/chainlink/adapters/1forge-adapter:latest
 ```
 
@@ -403,7 +403,7 @@ Optionally `data` parameters can also be passed via a query string added to the 
 
 The External Adapter will do some processing, often request data from an API, and return the following response structure:
 
-```json
+```javascript
   {
     "jobRunID": "2cae6a10e5184aa685c3428964b02418",
     "statusCode": 200,


### PR DESCRIPTION
<!-- Employees: Please use Clubhouse/Shortcuts's "Open PR" button from the relevant story or include links to relevant Clubhouse/Shortcut stories in your branch name, commit messages, or pull request comments. Do not add links to your pull request description, they will be ignored. https://help.clubhouse.io/hc/en-us/articles/207540323-Using-The-Clubhouse-GitHub-Integration -->

<!-- Employees: Delete this section. -->

## Closes #ISSUE_NUMBER_GOES_HERE

## Description

All the reds in README are now gone, and appropriate syntax highlighting language is applied to code blocks.

Before:

<img width="841" alt="Screenshot 2021-12-21 at 23 12 46" src="https://user-images.githubusercontent.com/89800081/147004444-3fd3fce1-35ef-417e-b22e-393e1af42f88.png">

After:

<img width="841" alt="Screenshot 2021-12-21 at 23 13 30" src="https://user-images.githubusercontent.com/89800081/147004469-4288eaa4-2d9a-4e47-99e3-206706bf47a0.png">


## Changes

- Fix for markdown syntax highlighting in README

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

See the before/after screenshots above.

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [ ] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
