### PR TITLE
Refactor/satoshitango types

### DIFF
--- a/.changeset/little-lemons-sell.md
+++ b/.changeset/little-lemons-sell.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/satoshitango-adapter': patch
+---
+
+added response types for crypto endpoint

--- a/packages/sources/satoshitango/src/endpoint/crypto.ts
+++ b/packages/sources/satoshitango/src/endpoint/crypto.ts
@@ -14,6 +14,23 @@ export const inputParameters: InputParameters = {
   resultPath: false,
 }
 
+export interface ResponseSchema {
+  data: {
+    ticker: {
+      [key: string]: {
+        date: string
+        timestamp: number
+        bid: number
+        ask: number
+        high: number
+        low: number
+        volume: number
+      }
+    }
+    code: 'success'
+  }
+}
+
 export const execute: ExecuteWithConfig<Config> = async (request, _, config) => {
   const validator = new Validator(request, inputParameters)
   if (validator.error) throw validator.error
@@ -29,13 +46,8 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
     url,
   }
 
-  const response = await Requester.request(options)
-  response.data.result = Requester.validateResultNumber(response.data, [
-    'data',
-    'ticker',
-    base,
-    resultPath,
-  ])
+  const response = await Requester.request<ResponseSchema>(options)
+  const result = Requester.validateResultNumber(response.data, ['data', 'ticker', base, resultPath])
 
-  return Requester.success(jobRunID, response, config.verbose)
+  return Requester.success(jobRunID, Requester.withResult(response, result), config.verbose)
 }


### PR DESCRIPTION


## Changes

- Adds _crypto_ endpoint ResponseSchema



## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [ ] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
