### PR TITLE
Fix WS issues with CF Benchmarks adapter

### DIFF
--- a/.changeset/chilly-cycles-confess.md
+++ b/.changeset/chilly-cycles-confess.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/cfbenchmarks-adapter': minor
+---
+
+Bugfix for broken adapter WS

--- a/packages/sources/cfbenchmarks/src/adapter.ts
+++ b/packages/sources/cfbenchmarks/src/adapter.ts
@@ -29,7 +29,7 @@ export const makeWSHandler = (config?: Config): MakeWSHandler => {
   }
   const getSubscription = (type: 'subscribe' | 'unsubscribe', id?: string) => {
     if (!id) return
-    return { type, id, stream: 'value' }
+    return { type, id, stream: 'value', cacheID: id } // Temporarily add another key named cacheID that won't be ignored when generating the subscription key in getSubsID
   }
   return () => {
     const defaultConfig = config || makeConfig()

--- a/packages/sources/cfbenchmarks/src/config.ts
+++ b/packages/sources/cfbenchmarks/src/config.ts
@@ -9,7 +9,7 @@ export const ENV_API_USERNAME = 'API_USERNAME'
 export const ENV_API_PASSWORD = 'API_PASSWORD'
 
 export const DEFAULT_ENDPOINT = 'values'
-export const DEFAULT_API_ENDPOINT = 'https://oracleprod1.cfbenchmarks.com/api'
+export const DEFAULT_API_ENDPOINT = 'https://www.cfbenchmarks.com/api'
 export const DEFAULT_WS_API_ENDPOINT = 'wss://www.cfbenchmarks.com/ws/v4'
 
 export const makeConfig = (prefix?: string): Config => {


### PR DESCRIPTION
## Closes 24692

## Description

 - Address failing HTTP requests to CF Benchmarks
 - Fix bug where sending requests for different feeds always returned the price of the first one.  This issue was caused due to the WS `subscriptionKey` always being the same as the `id` field in the WS subscription message was always being ignored.  We should come up with a better solution for this in the future.  I've created a ticket for this here https://app.shortcut.com/chainlinklabs/story/24721/gracefully-handle-cases-where-ws-subscription-payload-messages-contains-ignored-key

## Changes

- Update adapter HTTP endpoint
- Add a `cacheID` field to ensure different feeds use different keys

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

Make sure you enable websockets before testing.  

1. Send this payload and get a successful response.  Additionally verify that websockets is running from the adapter logs.

```
{
  "id": "1",
  "data": {
    "index": "ETHUSD_RTI"
  }
}
```
2. Send below payload and verify response
```
{
  "id": "1",
  "data": {
    "index": "BRTI"
  }
}
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
