### PR TITLE
Fix 1forge name

### DIFF
--- a/.changeset/long-trainers-jog.md
+++ b/.changeset/long-trainers-jog.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/1forge-adapter': minor
+---
+
+Changed adapter name to fit the right format

--- a/packages/sources/1forge/src/config.ts
+++ b/packages/sources/1forge/src/config.ts
@@ -1,7 +1,7 @@
 import { Requester } from '@chainlink/ea-bootstrap'
 import { Config } from '@chainlink/types'
 
-export const NAME = 'ADAPTER_1FORGE'
+export const NAME = '1FORGE'
 
 export const DEFAULT_ENDPOINT = 'forex'
 export const DEFAULT_BASE_URL = 'https://api.1forge.com/'


### PR DESCRIPTION
## Changes

- Changed the 1Forge adapter name to fit the format we use

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. Run the 1forge adapter
2. Verify that it doesn't log the following error message: `Rate Limit: Provider: \"adapter_1forge\" doesn't match any provider spec in limits.json`

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [ ] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
