### PR TITLE
Remove option sets from ncfx

### DIFF
--- a/.changeset/great-stingrays-drive.md
+++ b/.changeset/great-stingrays-drive.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/ncfx-adapter': minor
+---
+
+Remove token option limits on ncfx forex endpoint

--- a/packages/sources/ncfx/src/endpoint/forex.ts
+++ b/packages/sources/ncfx/src/endpoint/forex.ts
@@ -7,13 +7,11 @@ export const inputParameters: InputParameters = {
   base: {
     aliases: ['from', 'coin'],
     description: 'The symbol of the currency to query',
-    options: ['BTC', 'ETH', 'USD'],
     required: true,
   },
   quote: {
     aliases: ['to', 'market'],
     description: 'The symbol of the currency to convert to',
-    options: ['BTC', 'ETH', 'USD'],
     required: true,
   },
 }


### PR DESCRIPTION
## Description

Remove `option` limitations for `NCFX` input parameters (akin to https://github.com/smartcontractkit/external-adapters-js/pull/1373)

## Changes

Remove `option` attribute from input parameters

## Steps to Test

Query NCFX `forex` endpoint with asset symbols other than `BTC`, `ETH` or `USD`, like `LINK/USD` or `ADA/BTC`

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
