### PR TITLE
Tiingo crypto WS updates and fixes

### DIFF
--- a/.changeset/gold-zebras-prove.md
+++ b/.changeset/gold-zebras-prove.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/tiingo-adapter': minor
+---
+
+Change crypto WS endpoint and fix incorrect WS cache key usage

--- a/packages/sources/tiingo/README.md
+++ b/packages/sources/tiingo/README.md
@@ -8,10 +8,8 @@
 
 #### Websocket support
 
-This adapter has Websocket support. However, the Tiingo WS API only offers price updates from individual exchanges with
-no aggregation. Because of this, Tiingo WS should not be used to provide data to the Chainlink price feeds. To avoid
-node operators accidentally running this with WS enabled, WS will only be enabled when run in development mode. To
-enable WS, set `NODE_ENV=development` in addition to `WS_ENABLED=true`.
+The Tiingo WS does not support aggregated updates for anything other than crypto prices. Enabling WS for anything other
+than this should be proceeded with caution.
 
 ---
 

--- a/packages/sources/tiingo/src/adapter.ts
+++ b/packages/sources/tiingo/src/adapter.ts
@@ -52,10 +52,17 @@ interface TradeUpdateData {
   4: number // The amount of crypto volume done at the last price in the base currency.
   5: number // The last price the last trade was executed at.
 }
+interface SyntheticMessage {
+  0: 'SA'
+  1: string // Ticker
+  2: string // A string representing the datetime this trade quote came in.
+  3: string // The exchange the trade was done one.
+  4: number // The last price the last trade was executed at.
+}
 interface UpdateMessage extends Message {
   messageType: 'A'
   service: 'crypto_data'
-  data: TopOfBookUpdateData | TradeUpdateData
+  data: TopOfBookUpdateData | TradeUpdateData | SyntheticMessage
 }
 
 const customParams = {
@@ -92,7 +99,7 @@ export const makeWSHandler = (config?: Config): MakeWSHandler | undefined => {
     if (isFx(input)) {
       return `${baseURL}/iex`
     }
-    return `${baseURL}/crypto`
+    return `${baseURL}/crypto-synth`
   }
 
   const getSubscription = (input: AdapterRequest, ticker: string | undefined, subscribe = true) => {

--- a/packages/sources/tiingo/src/endpoint/crypto/prices.ts
+++ b/packages/sources/tiingo/src/endpoint/crypto/prices.ts
@@ -2,7 +2,7 @@ import { Requester, Validator } from '@chainlink/ea-bootstrap'
 import { ExecuteWithConfig, Config, InputParameters } from '@chainlink/types'
 import { NAME as AdapterName } from '../../config'
 
-export const supportedEndpoints = ['prices', 'crypto', 'volume']
+export const supportedEndpoints = ['prices', 'crypto', 'volume', 'crypto-synth']
 
 export const endpointResultPaths = {
   prices: 'fxClose',


### PR DESCRIPTION
## Changes

- Made Tiingo use the `crypto-synthetic` WS endpoint for crypto. Doesn't seem to be any differences, but data team requested this.
- Added types for synthetic updates
- Fixed setting of wrong cache key for WS updates, which would cause prices for different pairs to be returned

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. Run adapter with WS enabled
2. Send multiple requests with different pairs
3. Make sure each request gets the appropriate price back

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
