### PR TITLE
Add assets endpoint integration test to coinapi

### DIFF
--- a/packages/sources/coinapi/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/coinapi/test/integration/__snapshots__/adapter.test.ts.snap
@@ -1,5 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`coinapi assets endpoint when sending well-formed request should reply with success 1`] = `
+Object {
+  "data": Object {
+    "result": 3043.673871176232,
+  },
+  "jobRunID": "1",
+  "providerStatusCode": 200,
+  "result": 3043.673871176232,
+  "statusCode": 200,
+}
+`;
+
 exports[`coinapi crypto endpoint when sending well-formed request should reply with success 1`] = `
 Object {
   "data": Object {

--- a/packages/sources/coinapi/test/integration/adapter.test.ts
+++ b/packages/sources/coinapi/test/integration/adapter.test.ts
@@ -4,7 +4,7 @@ import http from 'http'
 import nock from 'nock'
 import request, { SuperTest, Test } from 'supertest'
 import { server as startServer } from '../../src/index'
-import { mockCryptoEndpoint } from './cryptoFixtures'
+import { mockAssetEndpoint, mockCryptoEndpoint } from './fixtures'
 import { AddressInfo } from 'net'
 
 describe('coinapi', () => {
@@ -51,6 +51,29 @@ describe('coinapi', () => {
         const response = await req
           .post('/')
           .send(cryptoRequest)
+          .set('Accept', '*/*')
+          .set('Content-Type', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(200)
+        expect(response.body).toMatchSnapshot()
+      })
+    })
+  })
+
+  describe('assets endpoint', () => {
+    describe('when sending well-formed request', () => {
+      it('should reply with success', async () => {
+        const assetRequest: AdapterRequest = {
+          id: '1',
+          data: {
+            endpoint: 'assets',
+            base: 'ETH',
+          },
+        }
+        mockAssetEndpoint()
+        const response = await req
+          .post('/')
+          .send(assetRequest)
           .set('Accept', '*/*')
           .set('Content-Type', 'application/json')
           .expect('Content-Type', /json/)

--- a/packages/sources/coinapi/test/integration/fixtures.ts
+++ b/packages/sources/coinapi/test/integration/fixtures.ts
@@ -170,3 +170,59 @@ export function mockCryptoEndpoint() {
       ],
     )
 }
+
+export function mockAssetEndpoint() {
+  nock('https://rest.coinapi.io:443', { encodedQueryParams: true })
+    .get('/v1/assets')
+    .query({ apikey: 'mock-api-key', filter_asset_id: 'ETH' })
+    .reply(
+      200,
+      [
+        {
+          asset_id: 'ETH',
+          name: 'Ethereum',
+          type_is_crypto: 1,
+          data_quote_start: '2015-08-07T14:50:38.1774950Z',
+          data_quote_end: '2022-01-10T18:45:03.3682903Z',
+          data_orderbook_start: '2015-08-07T14:50:38.1774950Z',
+          data_orderbook_end: '2020-08-05T14:38:33.4327540Z',
+          data_trade_start: '2015-08-07T15:21:48.1062520Z',
+          data_trade_end: '2022-01-10T18:44:24.5080000Z',
+          data_symbols_count: 61012,
+          volume_1hrs_usd: 298165681760.79,
+          volume_1day_usd: 6964865921209.1,
+          volume_1mth_usd: 6100863678584647,
+          price_usd: 3043.673871176232,
+          id_icon: '604ae453-3d9f-4ad0-9a48-9905cce617c2',
+          data_start: '2015-08-07',
+          data_end: '2022-01-10',
+        },
+      ],
+      [
+        'date',
+        'Mon, 10 Jan 2022 19:02:51 GMT',
+        'content-type',
+        'application/json; charset=utf-8',
+        'transfer-encoding',
+        'chunked',
+        'x-concurrencylimit-limit',
+        '10',
+        'x-concurrencylimit-remaining',
+        '10',
+        'x-ratelimit-used',
+        '2',
+        'x-ratelimit-overage',
+        'disabled',
+        'x-ratelimit-limit',
+        '10000',
+        'x-ratelimit-remaining',
+        '9998',
+        'x-ratelimit-reset',
+        '2022-01-11T19:02:51.0913704Z',
+        'x-ratelimit-request-cost',
+        '1',
+        'connection',
+        'close',
+      ],
+    )
+}


### PR DESCRIPTION
## Description
`coinapi` source adapter was missing integration tests for the `assets` endpoint.

## Changes

- Add integration test for `assets` endpoint of `coinapi` adapter

<!-- Acceptance testing steps, automated tests should _always_ be included -->

`yarn && yarn setup && yarn test packages/sources/coinapi/test/integration/*`

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
