### PR TITLE
[Release] v1.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/external-adapters-js",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "license": "MIT",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
External Adapters v1.7.0

## Changelog Notes

### New Adapters

- N/A

### Features
 
 - Tiingo WS switched to the crypto-synth endpoint for synthetic cryptocurrency data streams

- Add the ability to rate limit WS messages for performance reasons. Limit added to the Tiingo adapter.

- Batching support added to forex adapters (polygon, openexchangerates, 1forge, tradermade, metalsapi, currencylayer, fixer)

- Redis falls back to using local cache on failures

- To allow more granular monitoring status code has been changed to reflect the status of the execution of the External Adapter itself. `providerStatusCode` has been added to show what response the data provider's API returned. In the example where the data provider's API goes down the EA would return statusCode 200 to show that the EA is functioning and providerStatusCode of 500 to show that the provider request failed. The request body will still contain a status of `errored`.

- Source maps removed from builds, giving substantial performance improvements. This may affect stack traces of errors, but with logging and metrics issues should still be easy to debug.

### Bug Fixes

 - Fix NCFX not  allowing most input tickers through

- Security fix to remove an APY-finance adapter's dependency

- Amendment to Agoric's fees decimal places

### Refactors

- Non-BTC Proof of Reserves adapters changed to have a consistent interface and typing

- Many more source adapter TypeScript types added for API response structures