### PR TITLE
Add endpointSelector for metalsapi

### DIFF
--- a/.changeset/sixty-feet-rest.md
+++ b/.changeset/sixty-feet-rest.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/metalsapi-adapter': minor
+---
+
+Add endpointSelector to expose method inputs

--- a/packages/sources/metalsapi/src/index.ts
+++ b/packages/sources/metalsapi/src/index.ts
@@ -1,6 +1,6 @@
 import { expose } from '@chainlink/ea-bootstrap'
-import { makeExecute } from './adapter'
+import { endpointSelector, makeExecute } from './adapter'
 import { makeConfig, NAME } from './config'
 
-const { server } = expose(NAME, makeExecute())
+const { server } = expose(NAME, makeExecute(), undefined, endpointSelector)
 export { NAME, makeExecute, makeConfig, server }


### PR DESCRIPTION
## Description
Add `endpointSelector` to metalsapi `expose` so that the `withNormalizedInputs` method can execute correctly. This will likely need to be added to other EAs as well that are missing it, but I didn't want to make too many changes ahead of release.

## Changes
- Add `endpointSelector` as input to `expose` method.

## Steps to Test

Start the `metalsapi` EA and query `{"jobRunId": 1, "data": {"from": "CHF", "to": "USD"}}` multiple times. Existing setup will error-out the process after the second request, but with the fix it continues as expected.

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
