### PR TITLE
Override commit in codecov actions to use PR merge commit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           flags: integration
           fail_ci_if_error: true
+          override_commit: ${{ github.sha }} # PR merge commit, what checkout@v2 uses by default
 
   run-unit-tests:
     name: Run unit tests
@@ -56,6 +57,7 @@ jobs:
         with:
           flags: unit
           fail_ci_if_error: true
+          override_commit: ${{ github.sha }} # PR merge commit, what checkout@v2 uses by default
 
   run-basic-checks:
     name: Run linters and unit tests


### PR DESCRIPTION
## Description
We've been getting inconsistent codecov reports, most noticeably deltas in coverage for PRs that don't modify any tests or source code, e.g. README updates. After investigating possible causes, one promising lead is that the `checkout@v2` action in the unit & integration test jobs [pulls the PR merge commit by default](https://github.com/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit) (PR HEAD SHA, merged with latest base branch). This conflicts with the codecov action default behavior, which uses the PR HEAD SHA [as seen here](https://github.com/codecov/codecov-action/blob/f32b3a3741e1053eb607407145bc9619351dc93b/src/buildExec.ts#L120). This might be the cause of the inconsistencies, so this PR overrides the commit SHA for codecov to use the PR merge commit.

## Changes

- Overrides codecov actions to use PR merge commit SHA.

## Steps to Test

1. Merge these changes.
2. Codecov action should now use the same SHA that the checkout action pulls.

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
