### PR TITLE
Add inverse pairs for amberdata

### DIFF
--- a/.changeset/hungry-lions-breathe.md
+++ b/.changeset/hungry-lions-breathe.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/amberdata-adapter': minor
+---
+
+Add additional inverse pair presets for amberdata

--- a/packages/core/bootstrap/src/lib/external-adapter/overrides/presetIncludes.json
+++ b/packages/core/bootstrap/src/lib/external-adapter/overrides/presetIncludes.json
@@ -154,5 +154,29 @@
         "tokens": true
       }
     ]
+  },
+  {
+    "from": "BTC",
+    "to": "ETH",
+    "includes": [
+      {
+        "from": "ETH",
+        "to": "BTC",
+        "adapters": ["AMBERDATA"],
+        "inverse": true
+      }
+    ]
+  },
+  {
+    "from": "USDC",
+    "to": "ETH",
+    "includes": [
+      {
+        "from": "ETH",
+        "to": "USDC",
+        "adapters": ["AMBERDATA"],
+        "inverse": true
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## Closes #25773

## Description
Add additional presets to amberdata for inverse price pairs.

## Changes

- Add BTC/ETH and USDC/ETH as inverse pairs

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

start `amberdata-adapter` and request `{"jobRunId": 1, "data": {"endpoint": "crypto", "base": "BTC", "quote": "ETH"}}` from it. Answer should return without error.

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
