### PR TITLE
Fix/skipped integration tests

### DIFF
--- a/.changeset/unlucky-tools-bow.md
+++ b/.changeset/unlucky-tools-bow.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/amberdata-adapter': patch
+---
+
+Remove console.log

--- a/packages/composites/anchor/test/unit/price.test.ts
+++ b/packages/composites/anchor/test/unit/price.test.ts
@@ -32,7 +32,6 @@ describe('execute', () => {
         try {
           await execute(req.testData as AdapterRequest, {})
         } catch (error) {
-          console.log(error)
           const errorResp = Requester.errored(jobID, error)
           assertError({ expected: 400, actual: errorResp.statusCode }, errorResp, jobID)
         }

--- a/packages/composites/apy-finance/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/composites/apy-finance/test/integration/__snapshots__/adapter.test.ts.snap
@@ -4,21 +4,21 @@ exports[`execute with request properly formatted should return success 1`] = `
 Object {
   "data": Object {
     "payload": Object {
-      "USDC": Object {
+      "DAI": Object {
         "quote": Object {
           "USD": Object {
-            "price": 2000,
+            "price": 1,
           },
         },
       },
     },
-    "result": 200000,
+    "result": 0,
     "sources": Array [],
   },
   "debug": undefined,
   "jobRunID": "1",
   "providerStatusCode": 200,
-  "result": 200000,
+  "result": 0,
   "statusCode": 200,
 }
 `;

--- a/packages/composites/apy-finance/test/integration/adapter.test.ts
+++ b/packages/composites/apy-finance/test/integration/adapter.test.ts
@@ -8,8 +8,8 @@ describe('execute', () => {
   let execute: Execute
   const id = '1'
 
-  beforeAll(() => {
-    execute = apyFinanceAdapter.makeExecute()
+  beforeAll(async () => {
+    execute = await apyFinanceAdapter.makeExecute()
     oldEnv = JSON.parse(JSON.stringify(process.env))
     process.env.CACHE_ENABLED = 'false'
     process.env.REGISTRY_ADDRESS =
@@ -18,13 +18,13 @@ describe('execute', () => {
       process.env.TIINGO_DATA_PROVIDER_URL || 'http://localhost:3000'
     process.env.ETHEREUM_RPC_URL =
       process.env.ETHEREUM_RPC_URL || 'https://geth-main.eth.devnet.tools'
+
+    if (process.env.RECORD) nock.recorder.rec()
   })
 
   afterAll(() => {
     process.env = oldEnv
-    if (process.env.RECORD) {
-      nock.recorder.play()
-    }
+    if (process.env.RECORD) nock.recorder.play()
 
     nock.restore()
     nock.cleanAll()
@@ -41,7 +41,7 @@ describe('execute', () => {
       },
     }
 
-    it.skip('should return success', async () => {
+    it('should return success', async () => {
       const resp = await execute(data, {})
       expect(resp).toMatchSnapshot()
     })

--- a/packages/composites/apy-finance/test/integration/fixtures.ts
+++ b/packages/composites/apy-finance/test/integration/fixtures.ts
@@ -1,61 +1,131 @@
 import nock from 'nock'
 
 export function mockEthereumCalls() {
-  nock('http://localhost:8545')
+  nock('https://geth-main.eth.devnet.tools:443', { encodedQueryParams: true })
     .persist()
-    .post('/v3/4d97c9da8e764ff3b1d466e1e091724f', {
+    .post('/', {
       method: 'eth_chainId',
       params: [],
       id: /^\d+$/,
       jsonrpc: '2.0',
     })
-    .reply(200, (_, request) => ({ jsonrpc: '2.0', id: request['id'], result: '0x1' }), [
-      'Date',
-      'Thu, 26 Aug 2021 19:32:18 GMT',
-      'Content-Type',
-      'application/json',
-      'Content-Length',
-      '40',
-      'Connection',
-      'close',
-      'Vary',
-      'Accept-Encoding',
-      'Vary',
-      'Origin',
-    ])
-    .post('/*', {
+    .reply(200, (_, request) => ({ jsonrpc: '2.0', id: request['id'], result: '0x1' }), [])
+    .post('/', {
       method: 'eth_call',
-      params: [
-        {
-          to: '0x00000000000c2e074ec69a0dfb2997ba6c7d2e1e',
-          data: '0x0178b8bf5dbc4a41e3633cb8fb4fe64b14f15ba82b7d15b34fdc239d4fc96a9610b03b92',
-        },
-        'latest',
-      ],
-      id: 45,
+      params: [{ to: '0x7ec81b7035e91f8435bdeb2787dcbd51116ad303', data: '0xfcbf6ef8' }, 'latest'],
+      id: /^\d+$/,
       jsonrpc: '2.0',
     })
     .reply(
       200,
-      {
+      (_, request) => ({
         jsonrpc: '2.0',
-        id: 45,
-        result: '0x0000000000000000000000000000000000000000000000000000000000000000',
-      },
-      [
-        'Date',
-        'Thu, 26 Aug 2021 19:32:19 GMT',
-        'Content-Type',
-        'application/json',
-        'Content-Length',
-        '103',
-        'Connection',
-        'close',
-        'Vary',
-        'Accept-Encoding',
-        'Vary',
-        'Origin',
+        id: request['id'],
+        result: '0x00000000000000000000000074a07a137e347590b7d6fa63b70c2c331af94a8b',
+      }),
+      [],
+    )
+    .post('/', {
+      method: 'eth_call',
+      params: [{ to: '0x74a07a137e347590b7d6fa63b70c2c331af94a8b', data: '0xd8de0947' }, 'latest'],
+      id: /^\d+$/,
+      jsonrpc: '2.0',
+    })
+    .reply(
+      200,
+      (_, request) => ({
+        jsonrpc: '2.0',
+        id: request['id'],
+        result:
+          '0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000011893e362eeaefe364facfb30daa986746b65eb67000000000000000000000000',
+      }),
+      [],
+    )
+    .post('/', {
+      method: 'eth_call',
+      params: [
+        {
+          to: '0x74a07a137e347590b7d6fa63b70c2c331af94a8b',
+          data: '0xd87e053c1893e362eeaefe364facfb30daa986746b65eb67060000000000000000000000',
+        },
+        'latest',
       ],
+      id: /^\d+$/,
+      jsonrpc: '2.0',
+    })
+    .reply(
+      200,
+      (_, request) => ({
+        jsonrpc: '2.0',
+        id: request['id'],
+        result:
+          '0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000044652415800000000000000000000000000000000000000000000000000000000',
+      }),
+      [],
+    )
+    .post('/', {
+      method: 'eth_call',
+      params: [
+        {
+          to: '0x74a07a137e347590b7d6fa63b70c2c331af94a8b',
+          data: '0xd87e053c1893e362eeaefe364facfb30daa986746b65eb67000000000000000000000000',
+        },
+        'latest',
+      ],
+      id: /^\d+$/,
+      jsonrpc: '2.0',
+    })
+    .reply(
+      200,
+      (_, request) => ({
+        jsonrpc: '2.0',
+        id: request['id'],
+        result:
+          '0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000034441490000000000000000000000000000000000000000000000000000000000',
+      }),
+      [],
+    )
+    .post('/', {
+      method: 'eth_call',
+      params: [
+        {
+          to: '0x74a07a137e347590b7d6fa63b70c2c331af94a8b',
+          data: '0x6c7f15421893e362eeaefe364facfb30daa986746b65eb67000000000000000000000000',
+        },
+        'latest',
+      ],
+      id: /^\d+$/,
+      jsonrpc: '2.0',
+    })
+    .reply(
+      200,
+      (_, request) => ({
+        jsonrpc: '2.0',
+        id: request['id'],
+        result: '0x0000000000000000000000000000000000000000000000000000000000000000',
+      }),
+      [],
+    )
+    .post('/', {
+      method: 'eth_call',
+      params: [
+        {
+          to: '0x74a07a137e347590b7d6fa63b70c2c331af94a8b',
+          data: '0xdab09d9f1893e362eeaefe364facfb30daa986746b65eb67000000000000000000000000',
+        },
+        'latest',
+      ],
+      id: /^\d+$/,
+      jsonrpc: '2.0',
+    })
+    .reply(
+      200,
+      (_, request) => ({
+        jsonrpc: '2.0',
+        id: request['id'],
+        result: '0x0000000000000000000000000000000000000000000000000000000000000012',
+      }),
+      [],
     )
 }
 
@@ -90,31 +160,24 @@ export function mockTiingoResponse() {
     })
 
   nock('http://localhost:3000')
-    .post('/', { id: '1', data: { base: 'WETH', quote: 'USD', endpoint: 'price' } })
+    .post('/', { id: '1', data: { base: 'DAI', quote: 'USD', endpoint: 'crypto' } })
     .reply(200, {
       jobRunID: '1',
       providerStatusCode: 200,
       data: {
         sources: [],
         payload: {
-          WETH: {
+          DAI: {
             quote: {
               USD: {
-                price: '1800',
-              },
-            },
-          },
-          LINK: {
-            quote: {
-              USD: {
-                price: '2000',
+                price: '1.0',
               },
             },
           },
         },
-        result: 2000,
+        result: 1.0,
       },
-      result: 2000,
+      result: 1.0,
       statusCode: 200,
     })
 }

--- a/packages/composites/historical-average/test/unit/adapter.test.ts
+++ b/packages/composites/historical-average/test/unit/adapter.test.ts
@@ -129,19 +129,19 @@ describe('execute', () => {
 describe('getFromToDates', () => {
   it('should ignore days when both to- and from-dates are provided', () => {
     const { fromDate, toDate } = getFromToDates('2021-11-01', '2021-11-02', 100)
-    expect(fromDate.toISOString()).toBe('2021-11-01T00:00:00.000Z')
-    expect(toDate.toISOString()).toBe('2021-11-02T00:00:00.000Z')
+    expect(fromDate.toDateString()).toBe(new Date('2021-11-01').toDateString())
+    expect(toDate.toDateString()).toBe(new Date('2021-11-02').toDateString())
   })
 
   it('should add days to fromDate when toDate is omitted', () => {
     const { fromDate, toDate } = getFromToDates('2021-11-01', undefined, 7)
-    expect(fromDate.toISOString()).toBe('2021-11-01T00:00:00.000Z')
-    expect(toDate.toISOString()).toBe('2021-11-08T00:00:00.000Z')
+    expect(fromDate.toDateString()).toBe(new Date('2021-11-01').toDateString())
+    expect(toDate.toDateString()).toBe(new Date('2021-11-08').toDateString())
   })
 
   it('should subtract days from toDate when fromDate is omitted', () => {
     const { fromDate, toDate } = getFromToDates(undefined, '2021-11-08', 7)
-    expect(fromDate.toISOString()).toBe('2021-11-01T00:00:00.000Z')
-    expect(toDate.toISOString()).toBe('2021-11-08T00:00:00.000Z')
+    expect(fromDate.toDateString()).toBe(new Date('2021-11-01').toDateString())
+    expect(toDate.toDateString()).toBe(new Date('2021-11-08').toDateString())
   })
 })

--- a/packages/composites/synth-index/test/integration/adapter.test.ts
+++ b/packages/composites/synth-index/test/integration/adapter.test.ts
@@ -87,7 +87,7 @@ describe('synth-index X coingecko', () => {
       })
     })
     describe('and coingecko replies with a failure repeatedly', () => {
-      it.only('should try 3 times and then fail', async () => {
+      it('should try 3 times and then fail', async () => {
         mockCoingeckoConnectionFailure((server.address() as AddressInfo).port, 4)
 
         const response = await req

--- a/packages/scripts/src/new/lib.ts
+++ b/packages/scripts/src/new/lib.ts
@@ -81,7 +81,6 @@ async function generate(type: string) {
   // add to packages/tsconfig.json
   const tsconfigPath = 'packages/tsconfig.json'
   const tsconfig = JSON.parse(JSON.stringify(require(path.relative(__dirname, tsconfigPath))))
-  console.log(tsconfig)
   tsconfig.references = tsconfGenerate(currentWorkspace, tsconfigPath, 1)
   writeData = { ...writeData, [tsconfigPath]: tsconfig }
 

--- a/packages/sources/amberdata/src/endpoint/volume.ts
+++ b/packages/sources/amberdata/src/endpoint/volume.ts
@@ -54,7 +54,6 @@ export const execute: ExecuteWithConfig<Config> = async (input, _, config) => {
   const reqConfig = { ...config.api, params, url }
 
   const response = await Requester.request(reqConfig, customError)
-  console.log(response.data.payload.data)
   response.data.result = Requester.validateResultNumber(
     response.data,
     ['payload', 'data', 0, 'volume'],

--- a/packages/sources/ap-election/test/e2e/election.test.ts
+++ b/packages/sources/ap-election/test/e2e/election.test.ts
@@ -26,7 +26,6 @@ describe('execute', () => {
     requests.forEach((req) => {
       it(`${req.name}`, async () => {
         const adapterResponse = await execute(req.testData as AdapterRequest)
-        console.log(adapterResponse)
         assertSuccess(adapterResponse.statusCode, adapterResponse, jobID)
       })
     })

--- a/packages/sources/view-function/test/unit/function.test.ts
+++ b/packages/sources/view-function/test/unit/function.test.ts
@@ -19,7 +19,6 @@ describe('execute', () => {
         try {
           await execute(req.testData as AdapterRequest)
         } catch (error) {
-          console.log(error)
           const errorResp = Requester.errored(jobID, error)
           assertError({ expected: 400, actual: errorResp.statusCode }, errorResp, jobID)
         }


### PR DESCRIPTION
## Closes #16514

## Description
- Fix `apy-finance` integration test so we don't skip it
- Remove `only` from `synth-index` test so it also isn't skpped
- Remove some console log statements

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

`yarn && yarn setup && yarn test:integration` => All tests should pass, and none should be skipped

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
