### PR TITLE
Fix/rate limit ignore health chceks

### DIFF
--- a/.changeset/quiet-apples-heal.md
+++ b/.changeset/quiet-apples-heal.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/ea-bootstrap': minor
+---
+
+Ignore health checks in rate limiter

--- a/packages/core/bootstrap/src/lib/server.ts
+++ b/packages/core/bootstrap/src/lib/server.ts
@@ -150,9 +150,13 @@ function initExpressMiddleware(app: express.Express) {
     windowMs,
     max, // limit each IP's requests per windowMs
     keyGenerator: () => '*', // use one key for all incoming requests
-    handler: ((_, res) => {
-      httpRateLimit.inc()
-      res.status(429).send('Too many requests, please try again later.')
+    handler: ((req, res) => {
+      if (req.url === '/health') {
+        res.status(200).send({ message: 'OK', version })
+      } else {
+        httpRateLimit.inc()
+        res.status(429).send('Too many requests, please try again later.')
+      }
     }) as express.RequestHandler,
   })
   app.use(rateLimiter)


### PR DESCRIPTION
## Closes #25942

## Description
Ignore health checks in rate limiter and return the usual health check response instead.

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

`export SERVER_RATE_LIMIT_MAX=1`, then query `localhost:8080/health` while an adapter is running at `localhost:8080`. The health check should succeed even when sending multiple requests within seconds of each other.

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
