### PR TITLE
Override commit parent in codecov actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,10 @@ jobs:
         with:
           flags: integration
           fail_ci_if_error: true
-          override_commit: ${{ github.sha }} # PR merge commit, what checkout@v2 uses by default
+          # PR merge commit for PRs, current commit for push events, what checkout@v2 uses by default
+          override_commit: ${{ github.sha }}
+          # Base branch SHA for PRs, previous commit for push events
+          commit_parent: ${{ github.event.pull_request.base.sha || github.event.before }}
 
   run-unit-tests:
     name: Run unit tests
@@ -57,7 +60,10 @@ jobs:
         with:
           flags: unit
           fail_ci_if_error: true
-          override_commit: ${{ github.sha }} # PR merge commit, what checkout@v2 uses by default
+          # PR merge commit for PRs, current commit for push events, what checkout@v2 uses by default
+          override_commit: ${{ github.sha }}
+          # Base branch SHA for PRs, previous commit for push events
+          commit_parent: ${{ github.event.pull_request.base.sha || github.event.before }}
 
   run-basic-checks:
     name: Run linters and unit tests


### PR DESCRIPTION
## Description

Now codecov is using the proper commit SHA in theory, but there are still inconsistencies reported from coverage. One of them is that it takes as a base commit the latest base branch in the PR tree, but the checkout action merges the latest from the base branch at origin. This PR overrides the commit parent so that now codecov will know to report against the latest from the base branch.

## Changes

- Overrides commit parent in codecov action to use the latest from target branch

## Steps to Test

1. Verify that the codecov action sucessfully uses the latest commit from target branch as the commit parent

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
