### PR TITLE
[Fix] type label for metrics with error codes

### DIFF
--- a/.changeset/sixty-eels-flash.md
+++ b/.changeset/sixty-eels-flash.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/ea-bootstrap': patch
+---
+
+added 'type' label for metrics for failed requests

--- a/.changeset/sixty-eels-flash.md
+++ b/.changeset/sixty-eels-flash.md
@@ -1,5 +1,5 @@
 ---
-'@chainlink/ea-bootstrap': patch
+'@chainlink/ea-bootstrap': minor
 ---
 
 added 'type' label for metrics for failed requests

--- a/packages/core/bootstrap/src/index.ts
+++ b/packages/core/bootstrap/src/index.ts
@@ -153,6 +153,9 @@ const withMetrics: Middleware = async (execute, context) => async (input: Adapte
     record({
       statusCode: providerStatusCode ? 200 : 500,
       providerStatusCode,
+      type: providerStatusCode
+        ? metrics.HttpRequestType.DATA_PROVIDER_HIT
+        : metrics.HttpRequestType.ADAPTER_ERROR,
     })
     throw error
   }

--- a/packages/core/bootstrap/src/lib/metrics/index.ts
+++ b/packages/core/bootstrap/src/lib/metrics/index.ts
@@ -15,6 +15,7 @@ export const METRICS_ENABLED = parseBool(process.env.EXPERIMENTAL_METRICS_ENABLE
 export enum HttpRequestType {
   CACHE_HIT = 'cacheHit',
   DATA_PROVIDER_HIT = 'dataProviderHit',
+  ADAPTER_ERROR = 'adapterError',
 }
 
 export const httpRequestsTotal = new client.Counter({


### PR DESCRIPTION
Closes #1438



## Changes

- Added new _ADAPTER_ERROR_ option for _HttpRequestType_
- Added `type` label for metrics when adapter or data provider throws an error 



## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
