### PR TITLE
Chore/merge master

### DIFF
--- a/packages/composites/proof-of-reserves/CHANGELOG.md
+++ b/packages/composites/proof-of-reserves/CHANGELOG.md
@@ -164,14 +164,14 @@
 
 ### Patch Changes
 
-- Updated dependencies [4d3c0a79]
-- Updated dependencies [4d3c0a79]
-- Updated dependencies [4d3c0a79]
-- Updated dependencies [4d3c0a79]
-- Updated dependencies [4d3c0a79]
-- Updated dependencies [4d3c0a79]
-- Updated dependencies [4d3c0a79]
-- Updated dependencies [4d3c0a79]
+- Updated dependencies [e50223f49]
+- Updated dependencies [e50223f49]
+- Updated dependencies [e50223f49]
+- Updated dependencies [e50223f49]
+- Updated dependencies [e50223f49]
+- Updated dependencies [e50223f49]
+- Updated dependencies [e50223f49]
+- Updated dependencies [e50223f49]
   - @chainlink/ada-balance-adapter@2.0.0
   - @chainlink/chain-reserve-wallet-adapter@2.0.0
   - @chainlink/renvm-address-set-adapter@1.1.0

--- a/packages/core/legos/CHANGELOG.md
+++ b/packages/core/legos/CHANGELOG.md
@@ -744,6 +744,8 @@
 
 ### Patch Changes
 
+### Patch Changes
+
 - Updated dependencies [4d3c0a79]
 - Updated dependencies [cd01b0c5]
 - Updated dependencies [4d3c0a79]
@@ -765,11 +767,15 @@
 
 ### Patch Changes
 
-- Updated dependencies [56be0406]
-- Updated dependencies [e6700270]
-- Updated dependencies [d1c5127a]
-  - @chainlink/tiingo-adapter@1.3.0
-  - @chainlink/ncfx-adapter@1.1.0
+- Updated dependencies [e50223f49]
+- Updated dependencies [e50223f49]
+- Updated dependencies [e50223f49]
+- Updated dependencies [e50223f49]
+- Updated dependencies [e50223f49]
+- Updated dependencies [e50223f49]
+- Updated dependencies [e50223f49]
+- Updated dependencies [e50223f49]
+  - @chainlink/ada-balance-adapter@2.0.0
 
 ## 1.0.23
 

--- a/packages/sources/ada-balance/CHANGELOG.md
+++ b/packages/sources/ada-balance/CHANGELOG.md
@@ -49,7 +49,7 @@
 
 ### Major Changes
 
-- 4d3c0a79: changed 'addresses' input param which now expects an array of objects, instead of array of strings
+- e50223f49: changed 'addresses' input param which now expects an array of objects, instead of array of strings
 
 ## 1.0.13
 

--- a/packages/sources/chain-reserve-wallet/CHANGELOG.md
+++ b/packages/sources/chain-reserve-wallet/CHANGELOG.md
@@ -49,11 +49,11 @@
 
 ### Major Changes
 
-- 4d3c0a79: added new required input parameters, 'chainId' and 'network'. changed the response schema from array of strings to array of objects
+- e50223f49: added new required input parameters, 'chainId' and 'network'. changed the response schema from array of strings to array of objects
 
 ### Patch Changes
 
-- 4d3c0a79: added type checks
+- e50223f49: added type checks
 
 ## 1.0.13
 

--- a/packages/sources/gemini/CHANGELOG.md
+++ b/packages/sources/gemini/CHANGELOG.md
@@ -49,11 +49,11 @@
 
 ### Major Changes
 
-- 4d3c0a79: added new input parameters, changed response schema
+- e50223f49: added new input parameters, changed response schema
 
 ### Patch Changes
 
-- 4d3c0a79: changed default network
+- e50223f49: changed default network
 
 ## 1.0.13
 

--- a/packages/sources/lotus/CHANGELOG.md
+++ b/packages/sources/lotus/CHANGELOG.md
@@ -49,7 +49,7 @@
 
 ### Major Changes
 
-- 4d3c0a79: changed 'addresses' input param which now expects an array of objects, instead of array of strings
+- e50223f49: changed 'addresses' input param which now expects an array of objects, instead of array of strings
 
 ## 1.0.14
 

--- a/packages/sources/renvm-address-set/CHANGELOG.md
+++ b/packages/sources/renvm-address-set/CHANGELOG.md
@@ -45,7 +45,7 @@
 
 ### Minor Changes
 
-- 4d3c0a79: added 'chainId' and 'network' in the response, removed 'chain' from the response
+- e50223f49: added 'chainId' and 'network' in the response, removed 'chain' from the response
 
 ## 1.0.13
 

--- a/packages/sources/wbtc-address-set/CHANGELOG.md
+++ b/packages/sources/wbtc-address-set/CHANGELOG.md
@@ -49,7 +49,7 @@
 
 ### Minor Changes
 
-- 4d3c0a79: added 'network' and 'chainId' to the response
+- e50223f49: added 'network' and 'chainId' to the response
 
 ## 1.0.13
 


### PR DESCRIPTION
Hotfix release 1.6.1 introduced some conflicting changelogs because both `develop` and the hotfix release had separately consumed changesets.
This PR resolves those to bring both branches back into sync.