### PR TITLE
Move market alias back to base param in tradermade adapter

### DIFF
--- a/.changeset/quiet-timers-know.md
+++ b/.changeset/quiet-timers-know.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/tradermade-adapter': patch
+---
+
+Move market alias back to base parameter

--- a/packages/sources/tradermade/src/endpoint/live.ts
+++ b/packages/sources/tradermade/src/endpoint/live.ts
@@ -6,13 +6,13 @@ export const supportedEndpoints = ['live', 'commodities', 'stock']
 
 export const inputParameters: InputParameters = {
   base: {
-    aliases: ['from', 'symbol'],
+    aliases: ['from', 'symbol', 'market'],
     required: true,
     description: 'The symbol of the currency to query',
     type: 'string',
   },
   quote: {
-    aliases: ['to', 'market', 'convert'],
+    aliases: ['to', 'convert'],
     required: false,
     description: 'The quote currency',
     type: 'string',


### PR DESCRIPTION
## Description
Turns out a PR to change the market alias from base to quote to be inline with most of the other adapters caused this to fail: #1466
The problem is that we cannot simply instruct NOPs to change their jobs, because there are many other adapters following this inconsistent behavior. For now, the mitigation is to roll back the specific tradermade changes, and create stories that will be linked to this one to correct inconsistencies in one go moving forward.

## Changes

- Move back `market` alias to `base` param.

## Steps to Test

1. Run tradermade adapter
2. Request using payload in the description
3. The request should succeed

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
