### PR TITLE
Add endpoint to base inputParameters

### DIFF
--- a/.changeset/wild-rabbits-love.md
+++ b/.changeset/wild-rabbits-love.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/ea-bootstrap': patch
+---
+
+Include 'endpoint' as a base input parameter

--- a/packages/core/bootstrap/src/lib/external-adapter/builder.ts
+++ b/packages/core/bootstrap/src/lib/external-adapter/builder.ts
@@ -11,13 +11,34 @@ import {
 import { logger } from '../external-adapter'
 
 export const baseInputParameters: InputParameters = {
-  endpoint: false,
+  endpoint: {
+    description: 'The External Adapter "endpoint" name to use.',
+    required: false,
+    type: 'string',
+  },
 
-  resultPath: false,
+  resultPath: {
+    description: 'The path to key into the API response the retrieve the result',
+    required: false,
+    // type: 'string', TODO: Once multiple types are supported this could be string or array of strings
+  },
 
-  overrides: false,
-  tokenOverrides: false,
-  includes: false,
+  overrides: {
+    description: 'Override the mapping of token symbols to another token symbol',
+    required: false,
+    // type: 'string', TODO: Once complex types are supported this could be { [adapter: string]: { [token: string]: string } }
+  },
+  tokenOverrides: {
+    description: 'Override the mapping of token symbols to smart contract address',
+    required: false,
+    // type: 'string', TODO: Once complex types are supported this could be { [network: string]: { [token: string]: string } }
+  },
+  includes: {
+    description:
+      'Override the array of includes that holds additional input parameters when matching a pair of symbols',
+    required: false,
+    // type: 'string', TODO: Once complex types are supported this could be { from: string, to: string, includes: [{ from: string, to: string, adapters: string[], inverse: boolean, tokens: boolean }] } }[]
+  },
 }
 
 const findSupportedEndpoint = <C extends Config>(

--- a/packages/core/bootstrap/src/lib/external-adapter/builder.ts
+++ b/packages/core/bootstrap/src/lib/external-adapter/builder.ts
@@ -10,8 +10,14 @@ import {
 } from '@chainlink/types'
 import { logger } from '../external-adapter'
 
-export const inputParameters: InputParameters = {
+export const baseInputParameters: InputParameters = {
   endpoint: false,
+
+  resultPath: false,
+
+  overrides: false,
+  tokenOverrides: false,
+  includes: false,
 }
 
 const findSupportedEndpoint = <C extends Config>(
@@ -35,7 +41,7 @@ const selectEndpoint = <C extends Config>(
   apiEndpoints: Record<string, APIEndpoint<C>>,
   customParams?: InputParameters,
 ): APIEndpoint<C> => {
-  const params = customParams || inputParameters
+  const params = customParams || baseInputParameters
   const validator = new Validator(request, params)
 
   const jobRunID = validator.validated.id

--- a/packages/core/bootstrap/src/lib/external-adapter/validator.ts
+++ b/packages/core/bootstrap/src/lib/external-adapter/validator.ts
@@ -10,22 +10,14 @@ import {
   Config,
 } from '@chainlink/types'
 import { merge } from 'lodash'
-import { isArray, isObject, excludableInternalAdapterRequestProperties } from '../util'
+import { isArray, isObject } from '../util'
 import { AdapterError } from './errors'
 import { logger } from './logger'
 import presetSymbols from './overrides/presetSymbols.json'
 import presetTokens from './overrides/presetTokens.json'
 import presetIncludes from './overrides/presetIncludes.json'
 import { Requester } from './requester'
-import { inputParameters } from './builder'
-
-const sharedInputConfig = excludableInternalAdapterRequestProperties.reduce<Record<string, false>>(
-  (config, name) => {
-    config[name] = false
-    return config
-  },
-  {},
-)
+import { baseInputParameters } from './builder'
 
 export type OverrideType = 'overrides' | 'tokenOverrides' | 'includes'
 
@@ -51,7 +43,7 @@ export class Validator {
     this.input = { ...input }
     if (!this.input.id) this.input.id = '1' //TODO Please remove these once "no any" strict typing is enabled
     if (!this.input.data) this.input.data = {}
-    this.inputConfigs = { ...inputConfigs, ...sharedInputConfig }
+    this.inputConfigs = { ...inputConfigs, ...baseInputParameters }
     this.options = { ...options }
     this.shouldLogError = shouldLogError
     this.validated = { id: this.input.id, data: {} }
@@ -328,7 +320,7 @@ export function normalizeInput<C extends Config>(
   if (!apiEndpoint.supportedEndpoints.includes(input.data.endpoint))
     input.data.endpoint = apiEndpoint.supportedEndpoints[0]
 
-  const fullParameters = { ...inputParameters, ...apiEndpoint.inputParameters }
+  const fullParameters = { ...baseInputParameters, ...apiEndpoint.inputParameters }
   const validator = new Validator(request, fullParameters)
 
   // remove undefined values

--- a/packages/core/bootstrap/src/lib/external-adapter/validator.ts
+++ b/packages/core/bootstrap/src/lib/external-adapter/validator.ts
@@ -43,7 +43,7 @@ export class Validator {
     this.input = { ...input }
     if (!this.input.id) this.input.id = '1' //TODO Please remove these once "no any" strict typing is enabled
     if (!this.input.data) this.input.data = {}
-    this.inputConfigs = { ...inputConfigs, ...baseInputParameters }
+    this.inputConfigs = { ...baseInputParameters, ...inputConfigs }
     this.options = { ...options }
     this.shouldLogError = shouldLogError
     this.validated = { id: this.input.id, data: {} }

--- a/packages/core/bootstrap/test/unit/validator.test.ts
+++ b/packages/core/bootstrap/test/unit/validator.test.ts
@@ -84,7 +84,13 @@ describe('Validator', () => {
 
       const validator = new Validator(input, params, {}, false)
       expect(validator.validated.id).toEqual(input.id)
-      expect(validator.validated.data).toEqual({})
+      expect(validator.validated.data).toEqual({
+        endpoint: 'test',
+        includes: undefined,
+        overrides: undefined,
+        resultPath: undefined,
+        tokenOverrides: undefined,
+      })
       expect(validator?.error).toBeTruthy()
       expect(validator?.error?.statusCode).toEqual(400)
       expect(validator?.error?.status).toEqual('errored')

--- a/packages/sources/ap-election/src/endpoint/election.ts
+++ b/packages/sources/ap-election/src/endpoint/election.ts
@@ -98,7 +98,8 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
   validateRequest(request)
 
   const jobRunID = validator.validated.id
-  const { raceType, date, resultsType, ...rest } = validator.validated.data
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { raceType, date, resultsType, endpoint, ...rest } = validator.validated.data
   const url = `/elections/${date}`
 
   const params = {

--- a/packages/sources/binance-dex/src/config.ts
+++ b/packages/sources/binance-dex/src/config.ts
@@ -5,7 +5,6 @@ export const NAME = 'BINANCE_DEX'
 export const DEFAULT_ENDPOINT = 'price'
 
 export const DEFAULT_API_ENDPOINT = 'dex-asiapacific'
-export const DEFAULT_DATA_ENDPOINT = 'v1/ticker/24hr'
 
 // TODO: this usage of the process.env.API_ENDPOINT differs from most other adapters and should be changed
 const getBaseURL = (region: string) => `https://${region}.binance.org`

--- a/packages/sources/binance-dex/src/endpoint/price.ts
+++ b/packages/sources/binance-dex/src/endpoint/price.ts
@@ -1,6 +1,5 @@
 import { Requester, Validator, AdapterError } from '@chainlink/ea-bootstrap'
 import { ExecuteWithConfig, Config, InputParameters } from '@chainlink/types'
-import { DEFAULT_DATA_ENDPOINT } from '../config'
 
 export const NAME = 'price'
 
@@ -54,8 +53,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
   if (validator.error) throw validator.error
 
   const jobRunID = validator.validated.id
-  const endpoint = validator.validated.data.endpoint || DEFAULT_DATA_ENDPOINT
-  const url = `/api/${endpoint}`
+  const url = `/api/v1/ticker/24hr`
   const base = validator.validated.data.base.toUpperCase()
   const quote = validator.validated.data.quote.toUpperCase()
   const symbol = `${base}_${quote}`

--- a/packages/sources/coingecko/src/endpoint/crypto.ts
+++ b/packages/sources/coingecko/src/endpoint/crypto.ts
@@ -50,11 +50,6 @@ export const inputParameters: InputParameters = {
     description: 'The symbol of the currency to convert to',
     required: true,
   },
-  endpoint: {
-    description: 'Name of the endpoint to use',
-    required: false,
-    type: 'string',
-  },
 }
 
 const handleBatchedRequest = (

--- a/packages/sources/cryptoapis-v2/src/config.ts
+++ b/packages/sources/cryptoapis-v2/src/config.ts
@@ -8,6 +8,7 @@ export const makeConfig = (prefix?: string): Config => {
   const config = Requester.getDefaultConfig(prefix, true)
   config.api.headers['X-API-Key'] = config.apiKey
   config.api.baseURL = 'https://rest.cryptoapis.io'
+  config.defaultEndpoint = DEFAULT_ENDPOINT
   return config
 }
 

--- a/packages/sources/cryptoapis-v2/src/endpoint/bc_info.ts
+++ b/packages/sources/cryptoapis-v2/src/endpoint/bc_info.ts
@@ -1,8 +1,13 @@
 import { AdapterError, Requester, Validator } from '@chainlink/ea-bootstrap'
 import { ExecuteWithConfig, Config, InputParameters } from '@chainlink/types'
-import { DEFAULT_ENDPOINT, BLOCKCHAIN_NAME_BY_TICKER, BlockchainTickers } from '../config'
+import { BLOCKCHAIN_NAME_BY_TICKER, BlockchainTickers } from '../config'
 
 export const supportedEndpoints = ['height', 'difficulty']
+
+export const endpointResultPaths = {
+  height: ['data', 'item', 'height'],
+  difficulty: ['data', 'item', 'blockchainSpecific', 'difficulty'],
+}
 
 export interface ResponseSchema {
   apiVersion: string
@@ -46,14 +51,10 @@ export const inputParameters: InputParameters = {
   },
 }
 
-const payloadDataPaths: { [key: string]: string[] } = {
-  height: ['data', 'item', 'height'],
-  difficulty: ['data', 'item', 'blockchainSpecific', 'difficulty'],
-}
-
 export const execute: ExecuteWithConfig<Config> = async (request, _, config) => {
   const validator = new Validator(request, inputParameters)
   if (validator.error) throw validator.error
+
   const jobRunID = validator.validated.id
   const blockchain = validator.validated.data.blockchain
   if (blockchain.toLowerCase() !== 'btc')
@@ -63,17 +64,14 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
       statusCode: 400,
     })
   const network = validator.validated.data.network || 'mainnet'
-  const endpoint = validator.validated.data.endpoint || DEFAULT_ENDPOINT
-  const payloadDataPath = payloadDataPaths[endpoint]
-  if (!payloadDataPath) {
-    throw new Error(`${endpoint} has no payload data path and is invalid`)
-  }
+  const resultPath = validator.validated.data.resultPath
+
   const url = `/v2/blockchain-data/${
     BLOCKCHAIN_NAME_BY_TICKER[blockchain.toLowerCase() as BlockchainTickers]
   }-specific/${network.toLowerCase()}/blocks/last`
   const options = { ...config.api, url }
   const response = await Requester.request<ResponseSchema>(options)
-  const result = Requester.validateResultNumber(response.data, payloadDataPath)
+  const result = Requester.validateResultNumber(response.data, resultPath)
   const responseWithCost = { ...response, data: { ...response.data } }
   return Requester.success(jobRunID, Requester.withResult(responseWithCost, result), config.verbose)
 }

--- a/packages/sources/cryptocompare/src/adapter.ts
+++ b/packages/sources/cryptocompare/src/adapter.ts
@@ -39,12 +39,7 @@ export const makeWSHandler = (config?: Config): MakeWSHandler => {
     aggregate: 5,
   }
   const getPair = (input: AdapterRequest) => {
-    const validator = new Validator(
-      input,
-      { endpoint: false, ...crypto.inputParameters },
-      {},
-      false,
-    )
+    const validator = new Validator(input, crypto.inputParameters, {}, false)
     if (validator.error) return false
     const endpoint = validator.validated.data.endpoint?.toLowerCase()
     if (endpoint == 'marketcap') return false

--- a/packages/sources/cryptocompare/src/endpoint/crypto.ts
+++ b/packages/sources/cryptocompare/src/endpoint/crypto.ts
@@ -136,9 +136,6 @@ export const inputParameters: InputParameters = {
     description: 'The symbol of the currency to convert to',
     required: true,
   },
-  endpoint: {
-    type: 'string',
-  },
 }
 
 const handleBatchedRequest = (


### PR DESCRIPTION
<!-- Employees: Please use Clubhouse/Shortcuts's "Open PR" button from the relevant story or include links to relevant Clubhouse/Shortcut stories in your branch name, commit messages, or pull request comments. Do not add links to your pull request description, they will be ignored. https://help.clubhouse.io/hc/en-us/articles/207540323-Using-The-Clubhouse-GitHub-Integration -->

<!-- Employees: Delete this section. -->

## Description

Fix for `cryptoapis-v2` that used `endpoint` within its adapter's code.
`endpoint` is shared as a base input parameter by all EAs.
Previously it would only be used in `builder` to select the endpoint and resultPath.
Because cryptoapis-v2 hadn't been moved over to using the pattern of `endpointResultPaths`, it had no endpoint and had no resultPath to key through the API response.

## Changes

- Adds endpoint to baseInputParameters, now every `validator.validated.data` will have access to it.
- Changes cryptoapis-v2 `payloadDataPaths` :arrow_right: `endpointResultPaths`

## Steps to Test

1. Run `cryptoapis-v2`
2. Request
```
{
    "data": {
        "endpoint": "height",
        "blockchain": "BTC",
        "network": "mainnet"
    }
}
```
3. It should correctly return a result

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
