### PR TITLE
Remove DEFAULT_QUOTE from set-token-index schema

### DIFF
--- a/packages/composites/set-token-index/schemas/env.json
+++ b/packages/composites/set-token-index/schemas/env.json
@@ -10,10 +10,6 @@
       "description": "Ethereum Mainnet RPC endpoint to get the needed on-chain data",
       "type": "string",
       "format": "uri"
-    },
-    "DEFAULT_QUOTE": {
-      "default": "USD",
-      "description": "Currency for which the price will be fetched"
     }
   },
   "allOf": [


### PR DESCRIPTION
## Changes

- Remove DEFAULT_QUOTE from set-token-index schema

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

Running `yarn ts-node-transpile-only ./packages/scripts/src/gha` should succeed without error

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
