### PR TITLE
Added RENFIL overrides

### DIFF
--- a/.changeset/red-tips-know.md
+++ b/.changeset/red-tips-know.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/ea-bootstrap': minor
+---
+
+Added RENFIL -> FIL overrides for coingecko, coinmarketcap, nomics, tiingo, and set override ID for RENFIL on coinpaprika

--- a/packages/core/bootstrap/src/lib/external-adapter/overrides/presetSymbols.json
+++ b/packages/core/bootstrap/src/lib/external-adapter/overrides/presetSymbols.json
@@ -11,15 +11,18 @@
     "grt": "the-graph",
     "BCH": "bitcoin-cash",
     "LEO": "leo-token",
-    "FIL": "filecoin"
+    "FIL": "filecoin",
+    "RENFIL": "FIL"
   },
   "coinmarketcap": {
-    "PAX": "USDP"
+    "PAX": "USDP",
+    "RENFIL": "FIL"
   },
   "coinpaprika": {
     "GRT": "grt-the-graph",
     "PAX": "usdp-paxos-standard-token",
-    "KNC": "knc-kyber-network"
+    "KNC": "knc-kyber-network",
+    "RENFIL": "fil-filecoin"
   },
   "cryptocompare": {
     "PAX": "USDP"
@@ -61,11 +64,13 @@
     "MDX": "MDX2",
     "MIOTA": "IOT",
     "RAI": "RAI3",
-    "WING": "WING2"
+    "WING": "WING2",
+    "RENFIL": "FIL"
   },
   "tiingo": {
     "MIOTA": "IOTA",
-    "WTI": "usoil"
+    "WTI": "usoil",
+    "RENFIL": "FIL"
   },
   "tradermade": {
     "BRENT": "UKOIL",


### PR DESCRIPTION
## Changes

- Added RENFIL -> FIL overrides for coingecko, coinmarketcap, nomics, tiingo
- set override ID for RENFIL on coinpaprika

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. Request RENFIL/USD on all adapters mentioned above and verify it's fetching the price of FIL

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
