### PR TITLE
[test] symbol overrides 

### DIFF
--- a/packages/core/bootstrap/test/unit/overrides.test.ts
+++ b/packages/core/bootstrap/test/unit/overrides.test.ts
@@ -1,0 +1,12 @@
+import presetSymbols from '../../src/lib/external-adapter/overrides/presetSymbols.json'
+
+describe('presetSymbols', () => {
+  it('Should not contain any overrides that lead to another override', () => {
+    for (const adapter in presetSymbols) {
+      for (const symbol in presetSymbols[adapter]) {
+        const override = presetSymbols[adapter][symbol]
+        expect(presetSymbols[adapter][override]).toBeFalsy
+      }
+    }
+  })
+})


### PR DESCRIPTION
### Description
Add unit test to avoid the situation where a symbol override leads to another override.