### PR TITLE
Disable Codecov CI check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: codecov/codecov-action@v2
         with:
           flags: integration
-          fail_ci_if_error: true
+          fail_ci_if_error: false # TODO: Set back to true once coverage reports are consistent
           override_commit: ${{ github.sha }} # PR merge commit, what checkout@v2 uses by default
 
   run-unit-tests:
@@ -56,7 +56,7 @@ jobs:
       - uses: codecov/codecov-action@v2
         with:
           flags: unit
-          fail_ci_if_error: true
+          fail_ci_if_error: false # TODO: Set back to true once coverage reports are consistent
           override_commit: ${{ github.sha }} # PR merge commit, what checkout@v2 uses by default
 
   run-basic-checks:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,16 +1,17 @@
+# TODO: Reenable once coverage reports are consistent
 comment:
-  layout: 'reach, diff, flags, files'
-  behavior: default
-
-  coverage:
-    status:
-      project:
-        default:
-          target: auto
-          threshold: 1%
-      patch:
-        default:
-          target: 90%
+  false
+  # layout: 'reach, diff, flags, files'
+  # behavior: default
+  # coverage:
+  #   status:
+  #     project:
+  #       default:
+  #         target: auto
+  #         threshold: 1%
+  #     patch:
+  #       default:
+  #         target: 90%
 
 ignore:
   - '.yarn'
@@ -35,7 +36,11 @@ flag_management:
         type: project
         target: auto
         threshold: 1%
+        informational: true # TODO: Delete once coverage reports are consistent
+        if_ci_fails: success # TODO: Delete once coverage reports are consistent
       # Every PR must have a minimum of 90% coverage on adjusted lines
       - name_prefix: patch-
         type: patch
         target: 90%
+        informational: true # TODO: Delete once coverage reports are consistent
+        if_ci_fails: success # TODO: Delete once coverage reports are consistent


### PR DESCRIPTION
## Description

Codecov still presents inconsistent reports, reasons yet to be determined / fixed. This PR disables the CI check, so the tool will still run and output the calculated coverage, but won't fail the checks for PRs.

## Changes

- Disable codecov CI check

## Steps to Test

1. PRs should no longer get a codecov CI failure

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
