### PR TITLE
close ws connection to node after ada balance adapter finishes making…

### DIFF
--- a/.changeset/flat-pandas-play.md
+++ b/.changeset/flat-pandas-play.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/ada-balance-adapter': minor
+---
+
+close ws connection after completing request

--- a/packages/sources/ada-balance/src/endpoint/ogmios/index.ts
+++ b/packages/sources/ada-balance/src/endpoint/ogmios/index.ts
@@ -47,7 +47,8 @@ export const createInteractionContext = async (
     })
 
     const afterEach = (cb: () => void) => {
-      cb()
+      socket.once('close', cb)
+      socket.close()
     }
 
     const onInitialError = (error: Error) => {


### PR DESCRIPTION
## Closes 27500

## Description

This PR fixes an issue in the `ada-balance` adapter where it continually made new WS connections until it crashes

## Steps to Test

1) Run adapter and send requests to it every 30s
2) Ensure that the WS connection is closed by verifying that `Cardano Ogmios WS connection closed.  Code: 1000.  Reason ""` gets closed in the logs.

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
