### PR TITLE
Add from/to input overrides for cfbenchmarks

### DIFF
--- a/.changeset/metal-fishes-heal.md
+++ b/.changeset/metal-fishes-heal.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/cfbenchmarks-adapter': minor
+---
+
+Extend cfbenchmarks values endpoint to support from/to input params

--- a/packages/sources/cfbenchmarks/README.md
+++ b/packages/sources/cfbenchmarks/README.md
@@ -21,9 +21,11 @@
 
 ### Input Params
 
-| Required? |  Name   |     Description     | Options | Defaults to |
-| :-------: | :-----: | :-----------------: | :-----: | :---------: |
-|    ✅     | `index` | The ID of the index |         |             |
+| Required? |  Name   |                                          Description                                           | Options | Defaults to |
+| :-------: | :-----: | :--------------------------------------------------------------------------------------------: | :-----: | :---------: |
+|           | `index` |                                      The ID of the index                                       |         |             |
+|           | `base`  |     The base asset to convert from (if index is not present), aliased to `from` and `coin`     |         |             |
+|           | `quote` | The quote asset to convert to (if index is not present), aliased to `to`, `market`, and `term` |         |             |
 
 ### Sample Input
 
@@ -45,6 +47,31 @@
     "result": 30363.12
   },
   "result": 30363.12,
+  "statusCode": 200
+}
+```
+
+### Sample Input
+
+```json
+{
+  "id": "1",
+  "data": {
+    "base": "ETH",
+    "quote": "USD"
+  }
+}
+```
+
+### Sample Output
+
+```json
+{
+  "jobRunID": "1",
+  "data": {
+    "result": 3000.12
+  },
+  "result": 3000.12,
   "statusCode": 200
 }
 ```

--- a/packages/sources/cfbenchmarks/src/adapter.ts
+++ b/packages/sources/cfbenchmarks/src/adapter.ts
@@ -37,7 +37,7 @@ export const makeWSHandler = (config?: Config): MakeWSHandler => {
       { shouldThrowError: false },
     )
     if (validator.error) return
-    return validator.overrideSymbol(NAME, validator.validated.data.index) as string
+    return endpoints.values.getIdFromInputs(validator)
   }
   const getSubscription = (type: 'subscribe' | 'unsubscribe', id?: string) => {
     if (!id) return

--- a/packages/sources/cfbenchmarks/src/adapter.ts
+++ b/packages/sources/cfbenchmarks/src/adapter.ts
@@ -7,7 +7,7 @@ import {
   APIEndpoint,
   MakeWSHandler,
 } from '@chainlink/types'
-import { AUTHORIZATION_HEADER, makeConfig, NAME } from './config'
+import { AUTHORIZATION_HEADER, makeConfig } from './config'
 import * as endpoints from './endpoint'
 
 export const execute: ExecuteWithConfig<Config> = async (request, context, config) => {
@@ -37,7 +37,7 @@ export const makeWSHandler = (config?: Config): MakeWSHandler => {
       { shouldThrowError: false },
     )
     if (validator.error) return
-    return endpoints.values.getIdFromInputs(validator)
+    return endpoints.values.getIdFromInputs(validator, false)
   }
   const getSubscription = (type: 'subscribe' | 'unsubscribe', id?: string) => {
     if (!id) return

--- a/packages/sources/cfbenchmarks/src/endpoint/values.ts
+++ b/packages/sources/cfbenchmarks/src/endpoint/values.ts
@@ -1,15 +1,69 @@
-import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import { AdapterError, Requester, Validator } from '@chainlink/ea-bootstrap'
 import { ExecuteWithConfig, Config, InputParameters } from '@chainlink/types'
 import { NAME } from '../config'
 
 export const supportedEndpoints = ['values', 'crypto', 'price']
 
+const idFromBaseQuoteSymbol: { [baseQuote: string]: string } = {}
+
 export const inputParameters: InputParameters = {
   index: {
     description: 'The ID of the index',
     type: 'string',
-    required: true,
+    required: false,
   },
+  base: {
+    aliases: ['from', 'coin'],
+    description: 'The base asset to convert from (if index is not present)',
+    type: 'string',
+    required: false,
+  },
+  quote: {
+    aliases: ['to', 'market', 'term'],
+    description: 'The quote asset to convert to (if index is not present)',
+    type: 'string',
+    required: false,
+  },
+}
+
+const getIdFromBaseQuoteSymbols = (base: string, quote: string) => {
+  const baseQuote = `${base}/${quote}`
+
+  let id = idFromBaseQuoteSymbol[baseQuote] // Check hardcoded conversions first
+
+  if (!id) {
+    // If not hardcoded, use template
+    id = `${base}${quote}_RTI`
+  }
+
+  return id
+}
+
+export const getIdFromInputs = (
+  validator: Validator,
+  shouldThrowError = true,
+): string | undefined => {
+  if (
+    !(
+      validator.validated.data.index ||
+      (validator.validated.data.base && validator.validated.data.quote)
+    )
+  ) {
+    const missingInput = !validator.validated.data.index ? 'index' : 'base /or quote'
+    if (shouldThrowError) {
+      throw new AdapterError({
+        jobRunID: validator.validated.id,
+        statusCode: 400,
+        message: `Error: missing ${missingInput} input parameters`,
+      })
+    } else {
+      return
+    }
+  }
+
+  return validator.validated.data.index
+    ? (validator.overrideSymbol(NAME, validator.validated.data.index) as string)
+    : getIdFromBaseQuoteSymbols(validator.validated.data.base, validator.validated.data.quote)
 }
 
 interface PayloadValue {
@@ -25,7 +79,9 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
   const validator = new Validator(request, inputParameters)
 
   const jobRunID = validator.validated.id
-  const id = validator.overrideSymbol(NAME, validator.validated.data.index)
+
+  const id = getIdFromInputs(validator)
+
   const url = `/v1/values`
 
   const params = {

--- a/packages/sources/cfbenchmarks/src/endpoint/values.ts
+++ b/packages/sources/cfbenchmarks/src/endpoint/values.ts
@@ -6,8 +6,8 @@ export const supportedEndpoints = ['values', 'crypto', 'price']
 
 const idFromBaseQuoteSymbol: { [baseQuote: string]: string } = {
   'BTC/USD': 'BRTI',
-  'SOL/USD': 'U_SOLUSD_RTI',
-  'USDC/USD': 'U_USDCUSD_RTI',
+  'SOL/USD': 'U_SOLUSD_RTI', //Unconfirmed, may need to query different server
+  'USDC/USD': 'U_USDCUSD_RTI', //Unconfirmed, may need to query different server
 }
 
 export const inputParameters: InputParameters = {

--- a/packages/sources/cfbenchmarks/src/endpoint/values.ts
+++ b/packages/sources/cfbenchmarks/src/endpoint/values.ts
@@ -4,7 +4,11 @@ import { NAME } from '../config'
 
 export const supportedEndpoints = ['values', 'crypto', 'price']
 
-const idFromBaseQuoteSymbol: { [baseQuote: string]: string } = {}
+const idFromBaseQuoteSymbol: { [baseQuote: string]: string } = {
+  'BTC/USD': 'BRTI',
+  'SOL/USD': 'U_SOLUSD_RTI',
+  'USDC/USD': 'U_USDCUSD_RTI',
+}
 
 export const inputParameters: InputParameters = {
   index: {

--- a/packages/sources/cfbenchmarks/test/unit/adapter.test.ts
+++ b/packages/sources/cfbenchmarks/test/unit/adapter.test.ts
@@ -57,6 +57,16 @@ describe('execute', () => {
         input: { id, data: { index: 'LINKUSD_RTI', from: 'ETH', to: 'USD' } },
         output: 'LINKUSD_RTI',
       },
+      {
+        name: 'maps BTC/USD to BRTI',
+        input: { id, data: { from: 'BTC', to: 'USD' } },
+        output: 'BRTI',
+      },
+      {
+        name: 'maps SOL/USD to U_SOLUSD_RTI',
+        input: { id, data: { from: 'SOL', to: 'USD' } },
+        output: 'U_SOLUSD_RTI',
+      },
     ]
 
     tests.forEach((test) => {

--- a/packages/sources/cfbenchmarks/test/unit/adapter.test.ts
+++ b/packages/sources/cfbenchmarks/test/unit/adapter.test.ts
@@ -1,7 +1,8 @@
-import { Requester } from '@chainlink/ea-bootstrap'
+import { Requester, Validator } from '@chainlink/ea-bootstrap'
 import { assertError } from '@chainlink/ea-test-helpers'
 import { AdapterRequest } from '@chainlink/types'
 import { makeExecute } from '../../src/adapter'
+import { getIdFromInputs, inputParameters } from '../../src/endpoint/values'
 
 let oldEnv: NodeJS.ProcessEnv
 
@@ -17,7 +18,7 @@ afterAll(() => {
 })
 
 describe('execute', () => {
-  const jobID = '1'
+  const id = '1'
   const execute = makeExecute()
 
   describe('validation error', () => {
@@ -31,9 +32,37 @@ describe('execute', () => {
         try {
           await execute(req.testData as AdapterRequest, {})
         } catch (error) {
-          const errorResp = Requester.errored(jobID, error)
-          assertError({ expected: 400, actual: errorResp.statusCode }, errorResp, jobID)
+          const errorResp = Requester.errored(id, error)
+          assertError({ expected: 400, actual: errorResp.statusCode }, errorResp, id)
         }
+      })
+    })
+  })
+
+  describe('getIdFromInputs', () => {
+    const tests: { name: string; input: AdapterRequest; output: string }[] = [
+      { name: 'uses index if present', input: { id, data: { index: 'BRTI' } }, output: 'BRTI' },
+      {
+        name: 'uses from/to if present',
+        input: { id, data: { from: 'ETH', to: 'USD' } },
+        output: 'ETHUSD_RTI',
+      },
+      {
+        name: 'uses aliases base/quote if present',
+        input: { id, data: { base: 'USDT', quote: 'USD' } },
+        output: 'USDTUSD_RTI',
+      },
+      {
+        name: 'ignores from/to if index present',
+        input: { id, data: { index: 'LINKUSD_RTI', from: 'ETH', to: 'USD' } },
+        output: 'LINKUSD_RTI',
+      },
+    ]
+
+    tests.forEach((test) => {
+      it(`${test.name}`, async () => {
+        const validator = new Validator(test.input, inputParameters)
+        expect(getIdFromInputs(validator)).toEqual(test.output)
       })
     })
   })


### PR DESCRIPTION
## Description
Still need to add tests to confirm behavior, but the input parameters now default to the `index` if provided, but if not then it uses the `from,to` symbol pair to come up with the `index` for the request to cfbenchmarks. The `from,to` pair is first checked for a hardcoded symbol (currently empty), but if not the default action is to construct the index symbol from the inputs.

## Changes
 - Add `getIdFromInputs` which is used in the HTTP and WS request methods.

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test
1. Build and start cfbenchmarks adapter
2. Pass in any of the following as inputs and confirm the result:
As base, quote pairs:
`BTC / USD`, `ETH / USD`, `USDT / USD`, and `LINK / USD`
As individual symbols:
`BRTI`, `ETHUSD_RTI`, `USDTUSD_RTI` and `LINKUSD_RTI`

**NOTE: The following are still unconfirmed:**
`SOL / USD`,   `USDC / USD`

## Quality Assurance
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
