### PR TITLE
Cfbenchmarks secondary endpoint

### DIFF
--- a/.changeset/stupid-dancers-notice.md
+++ b/.changeset/stupid-dancers-notice.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/cfbenchmarks-adapter': minor
+---
+
+Added support for a secondary API endpoint

--- a/packages/sources/cfbenchmarks/README.md
+++ b/packages/sources/cfbenchmarks/README.md
@@ -2,10 +2,11 @@
 
 ### Environment variables
 
-| Required? |      Name      | Description | Options | Defaults to |
-| :-------: | :------------: | :---------: | :-----: | :---------: |
-|    ✅     | `API_USERNAME` |             |         |             |
-|    ✅     | `API_PASSWORD` |             |         |             |
+| Required? |      Name       |                 Description                  |   Options    | Defaults to |
+| :-------: | :-------------: | :------------------------------------------: | :----------: | :---------: |
+|    ✅     | `API_USERNAME`  |                                              |              |             |
+|    ✅     | `API_PASSWORD`  |                                              |              |             |
+|           | `API_SECONDARY` | Use the secondary endpoint from cfbenchmarks | true / false |    false    |
 
 ---
 

--- a/packages/sources/cfbenchmarks/schemas/env.json
+++ b/packages/sources/cfbenchmarks/schemas/env.json
@@ -11,6 +11,11 @@
     "API_PASSWORD": {
       "type": "string",
       "required": true
+    },
+    "API_SECONDARY": {
+      "type": "boolean",
+      "required": false,
+      "default": "false"
     }
   },
   "allOf": [

--- a/packages/sources/cfbenchmarks/src/adapter.ts
+++ b/packages/sources/cfbenchmarks/src/adapter.ts
@@ -1,20 +1,19 @@
 import { Builder, Requester, Validator } from '@chainlink/ea-bootstrap'
 import {
-  Config,
   ExecuteWithConfig,
   ExecuteFactory,
   AdapterRequest,
   APIEndpoint,
   MakeWSHandler,
 } from '@chainlink/types'
-import { AUTHORIZATION_HEADER, makeConfig } from './config'
+import { AUTHORIZATION_HEADER, Config, makeConfig } from './config'
 import * as endpoints from './endpoint'
 
 export const execute: ExecuteWithConfig<Config> = async (request, context, config) => {
   return Builder.buildSelector(request, context, config, endpoints)
 }
 
-export const endpointSelector = (request: AdapterRequest): APIEndpoint =>
+export const endpointSelector = (request: AdapterRequest): APIEndpoint<Config> =>
   Builder.selectEndpoint(request, makeConfig(), endpoints)
 
 export const makeExecute: ExecuteFactory<Config> = (config) => {
@@ -37,7 +36,7 @@ export const makeWSHandler = (config?: Config): MakeWSHandler => {
       { shouldThrowError: false },
     )
     if (validator.error) return
-    return endpoints.values.getIdFromInputs(validator, false)
+    return endpoints.values.getIdFromInputs(config || makeConfig(), validator, false)
   }
   const getSubscription = (type: 'subscribe' | 'unsubscribe', id?: string) => {
     if (!id) return

--- a/packages/sources/cfbenchmarks/src/config.ts
+++ b/packages/sources/cfbenchmarks/src/config.ts
@@ -1,5 +1,5 @@
 import { Requester, util } from '@chainlink/ea-bootstrap'
-import { Config } from '@chainlink/types'
+import { Config as BaseConfig } from '@chainlink/types'
 
 export const NAME = 'CFBENCHMARKS'
 
@@ -7,15 +7,29 @@ export const AUTHORIZATION_HEADER = 'Authorization'
 
 export const ENV_API_USERNAME = 'API_USERNAME'
 export const ENV_API_PASSWORD = 'API_PASSWORD'
+export const ENV_API_SECONDARY = 'API_SECONDARY'
 
 export const DEFAULT_ENDPOINT = 'values'
 export const DEFAULT_API_ENDPOINT = 'https://www.cfbenchmarks.com/api'
 export const DEFAULT_WS_API_ENDPOINT = 'wss://www.cfbenchmarks.com/ws/v4'
+export const SECONDARY_API_ENDPOINT = 'https://unregprod.cfbenchmarks.com/api'
+export const SECONDARY_WS_API_ENDPOINT = 'wss://unregprod.cfbenchmarks.com/ws/v4'
+
+export type Config = BaseConfig & {
+  useSecondary: boolean
+}
 
 export const makeConfig = (prefix?: string): Config => {
-  const config = Requester.getDefaultConfig(prefix)
-  config.api.baseURL = config.api.baseURL || DEFAULT_API_ENDPOINT
-  config.api.baseWsURL = config.api.baseWsURL || DEFAULT_WS_API_ENDPOINT
+  const config = {
+    ...Requester.getDefaultConfig(prefix),
+    useSecondary: util.parseBool(util.getEnv(ENV_API_SECONDARY)),
+  }
+
+  config.api.baseURL =
+    config.api.baseURL || (config.useSecondary ? SECONDARY_API_ENDPOINT : DEFAULT_API_ENDPOINT)
+  config.api.baseWsURL =
+    config.api.baseWsURL ||
+    (config.useSecondary ? SECONDARY_WS_API_ENDPOINT : DEFAULT_WS_API_ENDPOINT)
 
   const username = util.getRequiredEnv(ENV_API_USERNAME, prefix)
   const password = util.getRequiredEnv(ENV_API_PASSWORD, prefix)


### PR DESCRIPTION
## Changes

- Cfbenchmarks now supports pointing to a secondary API endpoint

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. Run EA with no special env vars set, try requesting things like ETH/USD
2. Run the EA with `API_SECONDARY`, try requesting things like SOL/USD

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
