### PR TITLE
Add limits for 1forge adapter following name change

### DIFF
--- a/.changeset/ninety-carpets-beam.md
+++ b/.changeset/ninety-carpets-beam.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/1forge-adapter': patch
+---
+
+Uses new limits from core

--- a/packages/core/bootstrap/src/lib/provider-limits/limits.json
+++ b/packages/core/bootstrap/src/lib/provider-limits/limits.json
@@ -2,7 +2,8 @@
   "1forge": {
     "http": {
       "starter": {
-        "rateLimit1h": 208.33
+        "rateLimit1h": 208.33,
+        "note": "https://1forge.com/pricing"
       },
       "premium": {
         "rateLimit1h": 4166.66
@@ -19,7 +20,8 @@
   "adapter_1forge": {
     "http": {
       "starter": {
-        "rateLimit1h": 208.33
+        "rateLimit1h": 208.33,
+        "note": "https://1forge.com/pricing"
       },
       "premium": {
         "rateLimit1h": 4166.66

--- a/packages/core/bootstrap/src/lib/provider-limits/limits.json
+++ b/packages/core/bootstrap/src/lib/provider-limits/limits.json
@@ -16,6 +16,23 @@
     },
     "ws": {}
   },
+  "adapter_1forge": {
+    "http": {
+      "starter": {
+        "rateLimit1h": 208.33
+      },
+      "premium": {
+        "rateLimit1h": 4166.66
+      },
+      "business": {
+        "rateLimit1h": 41666.66
+      },
+      "business+": {
+        "rateLimit1h": 416666.66
+      }
+    },
+    "ws": {}
+  },
   "alphachain": {
     "http": {
       "basic": {


### PR DESCRIPTION
## Description

PR #1056 changed the `1forge` adapter name to `adapter_1forge`, enforcing a convention that adapter names start with a letter. This meant that limits were no longer automatically fetched, since in the `limits.json` file the key was still `1forge`.

This PR _copies_ the limits into another `adapter_1forge` key, which on release will allow NOPs to remove the `RATE_LIMIT_API_PROVIDER=1forge` env var. After that happens, a subsequent PR will remove the `1forge` key.

## Changes

- Copy `1forge` limits into `adapter_1forge`

## Steps to Test

1. Run `1forge` adapter with `RATE_LIMIT_API_PROVIDER=1forge`
2. Run `1forge` adapter without setting that env var
3. In both cases, rate limits should be found

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
