### PR TITLE
Fix codecov yaml, add validation script

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -37,10 +37,10 @@ flag_management:
         target: auto
         threshold: 1%
         informational: true # TODO: Delete once coverage reports are consistent
-        if_ci_fails: success # TODO: Delete once coverage reports are consistent
+        if_ci_failed: success # TODO: Delete once coverage reports are consistent
       # Every PR must have a minimum of 90% coverage on adjusted lines
       - name_prefix: patch-
         type: patch
         target: 90%
         informational: true # TODO: Delete once coverage reports are consistent
-        if_ci_fails: success # TODO: Delete once coverage reports are consistent
+        if_ci_failed: success # TODO: Delete once coverage reports are consistent

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "cm": "cz",
     "qa:adapter": "ts-node-transpile-only ./packages/scripts/src/ephemeral-adapters",
     "qa:flux:configure": "ts-node-transpile-only ./packages/scripts/src/flux-emulator",
-    "get-changed-adapters": "ts-node-transpile-only ./packages/scripts/src/get-changed-adapters"
+    "get-changed-adapters": "ts-node-transpile-only ./packages/scripts/src/get-changed-adapters",
+    "validate-codecov": "curl --data-binary @codecov.yml https://codecov.io/validate"
   },
   "dependencies": {
     "@babel/core": "7.16.0",


### PR DESCRIPTION
## Description
 
Last PR to disable codecov had a typo in one of the fields, and codecov yaml silently passes using the previous valid config file. This PR fixes the issues, adding a script to validate the file as well.

## Changes

- Fix `codecov.yml` issues
- Add script to validate `codecov.yml` file

## Steps to Test

1. Run `yarn validate-codecov`
2. Should return valid in response

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
