### PR TITLE
Improve Anchor EA

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -4074,6 +4074,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/jest", "npm:27.0.3"],
             ["@types/node", "npm:16.11.19"],
             ["@types/supertest", "npm:2.0.11"],
+            ["bignumber.js", "npm:9.0.1"],
             ["ethers", "npm:5.5.1"],
             ["nock", "npm:13.2.1"],
             ["supertest", "npm:6.1.6"],

--- a/packages/composites/anchor/README.md
+++ b/packages/composites/anchor/README.md
@@ -6,10 +6,11 @@ This composite adapter fetches the price of a given token from the Anchor protoc
 
 The adapter takes the following environment variables:
 
-| Required? |              Name               |               Description                |                                             Options                                             | Defaults to |
-| :-------: | :-----------------------------: | :--------------------------------------: | :---------------------------------------------------------------------------------------------: | :---------: |
-|    ✅     |            `RPC_URL`            |   The RPC URL to connect to the chain    |                                                                                                 |             |
-|    ✅     | `ANCHOR_VAULT_CONTRACT_ADDRESS` | The address of the anchor vault contract | Address can be found [here](https://docs.anchorprotocol.com/smart-contracts/deployed-contracts) |             |
+| Required? |              Name               |               Description                |                                             Options                                             |                  Defaults to                   |
+| :-------: | :-----------------------------: | :--------------------------------------: | :---------------------------------------------------------------------------------------------: | :--------------------------------------------: |
+|    ✅     |            `RPC_URL`            |   The RPC URL to connect to the chain    |                                                                                                 |                                                |
+|           | `ANCHOR_VAULT_CONTRACT_ADDRESS` | The address of the anchor vault contract | Address can be found [here](https://docs.anchorprotocol.com/smart-contracts/deployed-contracts) |  `0xA2F987A546D4CD1c607Ee8141276876C26b72Bdf`  |
+|           | `TERRA_BLUNA_CONTRACT_ADDRESS`  |  The address of bLuna contract in Terra  | Address can be found [here](https://docs.anchorprotocol.com/smart-contracts/deployed-contracts) | `terra1mtwph2juhj0rvjz7dy92gvl6xvukaxu8rfv8ts` |
 
 **Additional environment variables must be set according to the Token Allocation adapter.**
 This composite adapter executes the code from the Token Allocation composite adapter. As such the same configuration and input parameters apply to this adapter. See [../token-allocation/README.md](../token-allocation/README.md) for more details.

--- a/packages/composites/anchor/package.json
+++ b/packages/composites/anchor/package.json
@@ -34,6 +34,7 @@
     "@chainlink/ea-test-helpers": "workspace:*",
     "@chainlink/terra-view-function-adapter": "workspace:*",
     "@chainlink/token-allocation-adapter": "workspace:*",
+    "bignumber.js": "^9.0.0",
     "ethers": "^5.5.1",
     "tslib": "^2.3.1"
   },

--- a/packages/composites/anchor/schemas/env.json
+++ b/packages/composites/anchor/schemas/env.json
@@ -1,7 +1,7 @@
 {
   "$id": "https://external-adapters.chainlinklabs.com/schemas/anchor-adapter.json",
   "title": "@chainlink/anchor-adapter env var schema",
-  "required": ["RPC_URL", "ANCHOR_VAULT_CONTRACT_ADDRESS"],
+  "required": ["RPC_URL", "ANCHOR_VAULT_CONTRACT_ADDRESS", "TERRA_BLUNA_CONTRACT_ADDRESS"],
   "type": "object",
   "properties": {
     "RPC_URL": {
@@ -9,8 +9,10 @@
       "required": true
     },
     "ANCHOR_VAULT_CONTRACT_ADDRESS": {
-      "type": "string",
-      "required": true
+      "type": "string"
+    },
+    "TERRA_BLUNA_CONTRACT_ADDRESS": {
+      "type": "string"
     }
   },
   "allOf": [

--- a/packages/composites/anchor/src/config.ts
+++ b/packages/composites/anchor/src/config.ts
@@ -4,17 +4,22 @@ import { Config as DefaultConfig } from '@chainlink/types'
 export const DEFAULT_ENDPOINT = 'price'
 export const DEFAULT_TOKEN_DECIMALS = 18
 
+export const DEFAULT_ANCHOR_VAULT_CONTRACT_ADDRESS = '0xA2F987A546D4CD1c607Ee8141276876C26b72Bdf'
+export const DEFAULT_TERRA_BLUNA_CONTRACT_ADDRESS = 'terra1mtwph2juhj0rvjz7dy92gvl6xvukaxu8rfv8ts'
+
 export interface Config extends DefaultConfig {
   anchorVaultContractAddress: string
+  terraBLunaContractAddress: string
 }
 
 export const makeConfig = (prefix?: string): Config => {
-  const config = Requester.getDefaultConfig(prefix)
-  config.rpcUrl = util.getRequiredEnv('RPC_URL', prefix)
-  config.defaultEndpoint = DEFAULT_ENDPOINT
-
   return {
-    ...config,
-    anchorVaultContractAddress: util.getRequiredEnv('ANCHOR_VAULT_CONTRACT_ADDRESS', prefix),
+    ...Requester.getDefaultConfig(prefix),
+    rpcUrl: util.getRequiredEnv('RPC_URL', prefix),
+    defaultEndpoint: util.getEnv('API_ENDPOINT', prefix) || DEFAULT_ENDPOINT,
+    anchorVaultContractAddress:
+      util.getEnv('ANCHOR_VAULT_CONTRACT_ADDRESS', prefix) || DEFAULT_ANCHOR_VAULT_CONTRACT_ADDRESS,
+    terraBLunaContractAddress:
+      util.getEnv('TERRA_BLUNA_CONTRACT_ADDRESS', prefix) || DEFAULT_TERRA_BLUNA_CONTRACT_ADDRESS,
   }
 }

--- a/packages/composites/anchor/src/endpoint/price/beth.ts
+++ b/packages/composites/anchor/src/endpoint/price/beth.ts
@@ -1,5 +1,6 @@
-import { BigNumber, ethers } from 'ethers'
+import { ethers } from 'ethers'
 import { PriceExecute } from '.'
+import BigNumber from 'bignumber.js'
 
 export const FROM = 'BETH'
 export const INTERMEDIARY_TOKEN_DECIMALS = 8
@@ -24,7 +25,11 @@ export const execute: PriceExecute = async (input, _, config, taAdapterResponse)
     provider,
   )
   const bEthExchangeRateBigNum = await anchorVaultContract.get_rate()
-  const stEthPerBEth = bEthExchangeRateBigNum.div(BigNumber.from(10).pow(18)).toNumber()
+
+  // Need to convert to BigNumber JS from ethers BigNumber as the latter will remove all decimals
+  const stEthPerBEth = new BigNumber(bEthExchangeRateBigNum.toString())
+    .dividedBy(new BigNumber(10).pow(18))
+    .toNumber()
   const usdPerStEth = taAdapterResponse.data.result
   const result = usdPerStEth * stEthPerBEth
   return {

--- a/packages/composites/anchor/src/endpoint/price/bluna.ts
+++ b/packages/composites/anchor/src/endpoint/price/bluna.ts
@@ -1,4 +1,4 @@
-import { AdapterContext, AdapterRequest, AdapterResponse, InputParameters } from '@chainlink/types'
+import { AdapterContext, AdapterRequest, AdapterResponse } from '@chainlink/types'
 import { Config } from '../../config'
 import * as view from '@chainlink/terra-view-function-adapter'
 import { Validator } from '@chainlink/ea-bootstrap'
@@ -6,27 +6,21 @@ import { Validator } from '@chainlink/ea-bootstrap'
 export const FROM = 'BLUNA'
 export const INTERMEDIARY_TOKEN_DECIMALS = 8
 export const INTERMEDIARY_TOKEN = 'LUNA'
-export const DEFAULT_TERRA_BLUNA_CONTRACT_ADDRESS = 'terra1mtwph2juhj0rvjz7dy92gvl6xvukaxu8rfv8ts'
-
-export const inputParameters: InputParameters = {
-  terraBLunaContractAddress: false,
-}
 
 export const execute = async (
   input: AdapterRequest,
   context: AdapterContext,
-  _: Config,
+  config: Config,
   taAdapterResponse: AdapterResponse,
 ): Promise<AdapterResponse> => {
-  const validator = new Validator(input, inputParameters)
-
+  const validator = new Validator(input)
+  if (validator.error) throw validator.error
   const _config = view.makeConfig()
   const _execute = view.makeExecute(_config)
   const viewFunctionAdapterRequest: AdapterRequest = {
     id: input.id,
     data: {
-      address:
-        validator.validated.data.terraBLunaContractAddress || DEFAULT_TERRA_BLUNA_CONTRACT_ADDRESS,
+      address: config.terraBLunaContractAddress,
       query: {
         state: {},
       },

--- a/packages/composites/anchor/src/endpoint/price/index.ts
+++ b/packages/composites/anchor/src/endpoint/price/index.ts
@@ -57,7 +57,7 @@ export const execute: ExecuteWithConfig<Config> = async (input, context, config)
   const taResponse = await getTokenPrice(input, context, intermediaryTokenSymbol, taDecimals)
   const resultInUSD = await priceExecute(input, context, config, taResponse)
 
-  if (to === 'USD') return resultInUSD
+  if (to.toUpperCase() === 'USD') return resultInUSD
   const convertedResult = await convertUSDQuote(
     input,
     context,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1871,6 +1871,7 @@ __metadata:
     "@types/jest": 27.0.3
     "@types/node": 16.11.19
     "@types/supertest": 2.0.11
+    bignumber.js: ^9.0.0
     ethers: ^5.5.1
     nock: 13.2.1
     supertest: 6.1.6


### PR DESCRIPTION
## Closes 29226

## Description

Minor improvements to the Anchor EA to fetch `bLuna` and `bETH` prices

## Changes

- Set default environment variable for `ANCHOR_VAULT_CONTRACT_ADDRESS`
- Create new environment variable named `TERRA_BLUNA_CONTRACT_ADDRESS` and set default value for it
- Address rounding issue when calculating `bLuna` price

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. Run EA 
2. Send request bodies below and verify successful responses.

`bLuna`
```
{
  "id": "1",
  "data": {
    "from": "BLuna",
    "to": "USD",
    "source": "tiingo"
  }
}
```

`bETH`
```
{
  "id": "1",
  "data": {
    "from": "BETH",
    "to": "USD",
    "source": "tiingo"
  }
}
```
## Quality Assurance

- [x] Ran `yarn changeset` if adapter source code was changed
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
