### PR TITLE
Add coinpaprika ALUSD override

### DIFF
--- a/.changeset/nine-otters-greet.md
+++ b/.changeset/nine-otters-greet.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/coinpaprika-adapter': patch
+---
+
+Add ALUSD symbol to id override

--- a/packages/sources/coinpaprika/src/config/symbols.json
+++ b/packages/sources/coinpaprika/src/config/symbols.json
@@ -3,6 +3,7 @@
     "GRT": "grt-the-graph",
     "PAX": "usdp-paxos-standard-token",
     "KNC": "knc-kyber-network",
-    "RENFIL": "fil-filecoin"
+    "RENFIL": "fil-filecoin",
+    "ALUSD": "alusd-alchemixusd"
   }
 }


### PR DESCRIPTION
### Description
Bringing ALUSD override into hardcoded overrides for nops who do not have `ALUSD/USD` on Coinpaprika.