### PR TITLE
Refactored Terra RPC_URL environment variables

### DIFF
--- a/.changeset/ten-hounds-pull.md
+++ b/.changeset/ten-hounds-pull.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/terra-view-function-adapter': minor
+---
+
+Changed the environment variables that were formerly RPC_URLs to now be LCD_URLs

--- a/packages/sources/terra-view-function/README.md
+++ b/packages/sources/terra-view-function/README.md
@@ -4,11 +4,13 @@ This external adapter allows querying contracts on the Terra blockchain.
 
 ### Environment Variables
 
+- Note: The old `RPC_URL` environment variables are still supported, however, please the `LCD_URL` ones below instead.
+
 | Required? |        Name        |                               Description                                | Options | Defaults to  |
 | :-------: | :----------------: | :----------------------------------------------------------------------: | :-----: | :----------: |
-|    ✅     | COLUMBUS_5_RPC_URL | The URL to a Terra `columbus-5` full node to query on-chain mainnet data |         |              |
-|    ✅     | BOMBAY_12_RPC_URL  | The URL to a Terra `bombay-12` full node to query on-chain testnet data  |         |              |
-|    ✅     | LOCALTERRA_RPC_URL |   The URL to a locally running Terra full node to query on-chain data    |         |              |
+|    ✅     | COLUMBUS_5_LCD_URL | The URL to a Terra `columbus-5` full node to query on-chain mainnet data |         |              |
+|    ✅     | BOMBAY_12_LCD_URL  | The URL to a Terra `bombay-12` full node to query on-chain testnet data  |         |              |
+|    ✅     | LOCALTERRA_LCD_URL |   The URL to a locally running Terra full node to query on-chain data    |         |              |
 |           |  DEFAULT_CHAIN_ID  |         The default `chainId` value to use as an input parameter         |         | `columbus-5` |
 
 A list of public endpoints can be found [here](https://docs.terra.money/Reference/endpoints.html). Please only use these for testing, not in production, as they are not secure.

--- a/packages/sources/terra-view-function/schemas/env.json
+++ b/packages/sources/terra-view-function/schemas/env.json
@@ -2,20 +2,20 @@
   "$id": "https://external-adapters.chainlinklabs.com/schemas/terra-view-function-adapter.json",
   "title": "Chainlink External Adapter for querying Terra view functions",
   "description": "This external adapter allows querying contracts on the Terra blockchain. A list of public endpoints can be found [here](https://docs.terra.money/Reference/endpoints.html). Please only use these for testing, not in production, as they are not secure.",
-  "required": ["COLUMBUS_5_RPC_URL", "BOMBAY_12_RPC_URL", "LOCALTERRA_RPC_URL"],
+  "required": ["COLUMBUS_5_LCD_URL", "BOMBAY_12_LCD_URL", "LOCALTERRA_LCD_URL"],
   "type": "object",
   "properties": {
-    "COLUMBUS_5_RPC_URL": {
+    "COLUMBUS_5_LCD_URL": {
       "type": "string",
       "description": "The URL to a Terra `columbus-5` full node to query on-chain mainnet data",
       "required": true
     },
-    "BOMBAY_12_RPC_URL": {
+    "BOMBAY_12_LCD_URL": {
       "type": "string",
       "description": "The URL to a Terra `bombay-12` full node to query on-chain testnet data",
       "required": true
     },
-    "LOCALTERRA_RPC_URL": {
+    "LOCALTERRA_LCD_URL": {
       "type": "string",
       "description": "The URL to a locally running Terra full node to query on-chain data",
       "required": true

--- a/packages/sources/terra-view-function/src/config/index.ts
+++ b/packages/sources/terra-view-function/src/config/index.ts
@@ -11,10 +11,11 @@ export type ChainId = typeof SUPPORTED_CHAIN_IDS[number]
 export const ENV_DEFAULT_CHAIN_ID = 'DEFAULT_CHAIN_ID'
 export const DEFAULT_CHAIN_ID = 'columbus-5'
 
+export const ENV_LCD_URL = 'LCD_URL'
 export const ENV_RPC_URL = 'RPC_URL'
 
 export type Config = BaseConfig & {
-  rpcUrls: Partial<Record<ChainId, string>>
+  lcdUrls: Partial<Record<ChainId, string>>
   defaultChainId: string
 }
 
@@ -23,26 +24,32 @@ export const makeConfig = (prefix?: string): Config => {
 
   return {
     ...baseConfig,
-    rpcUrls: buildRpcUrlMapping(),
+    lcdUrls: buildLcdUrlMapping(),
     defaultChainId: util.getEnv(ENV_DEFAULT_CHAIN_ID, prefix) || DEFAULT_CHAIN_ID,
     defaultEndpoint: DEFAULT_ENDPOINT,
   }
 }
 
-const buildRpcUrlMapping = () => {
+const buildLcdUrlMapping = () => {
   const output: Partial<Record<ChainId, string>> = {}
   let hasAtLeastOneURL = false
   for (const chainId of SUPPORTED_CHAIN_IDS) {
     // Underscore-ize and capitalize to format for environment variables
     const prefix = chainId.replace('-', '_').toUpperCase()
-    const envVar = util.getEnv(ENV_RPC_URL, prefix)
+    const envVar = util.getEnv(ENV_LCD_URL, prefix)
+    const legacyEnvVar = util.getEnv(ENV_RPC_URL, prefix)
     if (envVar) {
       output[chainId] = envVar
       hasAtLeastOneURL = true
+    } else if (legacyEnvVar) {
+      console.log(
+        'The RPC_URL environment variable is being deprecated, please use an LCD_URL instead. See README for more information.',
+      )
+      output[chainId] = legacyEnvVar
+      hasAtLeastOneURL = true
     }
   }
-
-  if (!hasAtLeastOneURL) throw new Error('At least one RPC URL must be defined')
+  if (!hasAtLeastOneURL) throw new Error('At least one LCD URL must be defined')
 
   return output
 }

--- a/packages/sources/terra-view-function/src/endpoint/view.ts
+++ b/packages/sources/terra-view-function/src/endpoint/view.ts
@@ -38,7 +38,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
   const chainID = (validator.validated.data.chainId || config.defaultChainId) as ChainId
   const resultPath = validator.validated.data.resultPath as string
 
-  const URL = config.rpcUrls[chainID]
+  const URL = config.lcdUrls[chainID]
   if (!URL)
     throw new AdapterError({
       jobRunID,

--- a/packages/sources/terra-view-function/test/e2e/view.test.ts
+++ b/packages/sources/terra-view-function/test/e2e/view.test.ts
@@ -9,7 +9,7 @@ let oldEnv: NodeJS.ProcessEnv
 beforeAll(() => {
   oldEnv = JSON.parse(JSON.stringify(process.env))
   process.env.CACHE_ENABLED = 'false'
-  process.env.BOMBAY_12_RPC_URL = process.env.BOMBAY_12_RPC_URL || 'https://bombay-lcd.terra.dev'
+  process.env.BOMBAY_12_LCD_URL = process.env.BOMBAY_12_LCD_URL || 'https://bombay-lcd.terra.dev'
 })
 
 afterAll(() => {


### PR DESCRIPTION
## Closes #24483

## Description
What is provided is actually a LCD url, we should reflect this in the name and documentation, while still supported the legacy name of RPC URL.
......

## Changes
Made slight changes to terra-view-controller adadpter and the documentation to prefer an LCD_URL environment variable over an RPC_URL one. 

## Steps to Test

1. Ensure the Adapter still works as normal using both LCD_URL and RPC_URL environment variables

## Quality Assurance

- [x] Ran `yarn changeset` if adapter source code was changed
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
