### PR TITLE
Update Anchor EA to new way of deriving USD/bETH price price

### DIFF
--- a/.changeset/five-parents-float.md
+++ b/.changeset/five-parents-float.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/anchor-adapter': minor
+---
+
+update anchor EA to derive the USD/bETH price using the new method. This new method relies on pulling the stETH/ETH price from the pool's Curve contract. Because of this, a new optional environment variable named 'STETH_POOL_CONTRACT_ADDRESS' has been added with a default of '0xdc24316b9ae028f1497c275eb9192a3ea0f67022'

--- a/packages/composites/anchor/README.md
+++ b/packages/composites/anchor/README.md
@@ -11,6 +11,7 @@ The adapter takes the following environment variables:
 |    ✅     |            `RPC_URL`            |   The RPC URL to connect to the chain    |                                                                                                 |                                                |
 |           | `ANCHOR_VAULT_CONTRACT_ADDRESS` | The address of the Anchor Vault contract | Address can be found [here](https://docs.anchorprotocol.com/smart-contracts/deployed-contracts) |  `0xA2F987A546D4CD1c607Ee8141276876C26b72Bdf`  |
 |           | `TERRA_BLUNA_CONTRACT_ADDRESS`  |  The address of bLuna contract in Terra  | Address can be found [here](https://docs.anchorprotocol.com/smart-contracts/deployed-contracts) | `terra1mtwph2juhj0rvjz7dy92gvl6xvukaxu8rfv8ts` |
+|           |  `STETH_POOL_CONTRACT_ADDRESS`  |      The address of stEth contract       |                   Address can be found by finding the stETH/ETH pool in Curve                   |  `0xdc24316b9ae028f1497c275eb9192a3ea0f67022`  |
 
 **Additional environment variables must be set according to the Token Allocation adapter.**
 This composite adapter executes the code from the Token Allocation composite adapter. As such the same configuration and input parameters apply to this adapter. See [../token-allocation/README.md](../token-allocation/README.md) for more details.

--- a/packages/composites/anchor/schemas/env.json
+++ b/packages/composites/anchor/schemas/env.json
@@ -13,6 +13,9 @@
     },
     "TERRA_BLUNA_CONTRACT_ADDRESS": {
       "type": "string"
+    },
+    "STETH_POOL_CONTRACT_ADDRESS": {
+      "type": "string"
     }
   },
   "allOf": [

--- a/packages/composites/anchor/src/config/index.ts
+++ b/packages/composites/anchor/src/config/index.ts
@@ -7,10 +7,12 @@ export const NAME = 'ANCHOR'
 
 export const DEFAULT_ANCHOR_VAULT_CONTRACT_ADDRESS = '0xA2F987A546D4CD1c607Ee8141276876C26b72Bdf'
 export const DEFAULT_TERRA_BLUNA_CONTRACT_ADDRESS = 'terra1mtwph2juhj0rvjz7dy92gvl6xvukaxu8rfv8ts'
+export const DEFAULT_STETH_POOL_CONTRACT_ADDRESS = '0xdc24316b9ae028f1497c275eb9192a3ea0f67022'
 
 export interface Config extends DefaultConfig {
   anchorVaultContractAddress: string
   terraBLunaContractAddress: string
+  stEthPoolContractAddress: string
 }
 
 export const makeConfig = (prefix?: string): Config => {
@@ -22,5 +24,7 @@ export const makeConfig = (prefix?: string): Config => {
       util.getEnv('ANCHOR_VAULT_CONTRACT_ADDRESS', prefix) || DEFAULT_ANCHOR_VAULT_CONTRACT_ADDRESS,
     terraBLunaContractAddress:
       util.getEnv('TERRA_BLUNA_CONTRACT_ADDRESS', prefix) || DEFAULT_TERRA_BLUNA_CONTRACT_ADDRESS,
+    stEthPoolContractAddress:
+      util.getEnv('STETH_POOL_CONTRACT_ADDRESS', prefix) || DEFAULT_STETH_POOL_CONTRACT_ADDRESS,
   }
 }

--- a/packages/composites/anchor/src/endpoint/price/abi.ts
+++ b/packages/composites/anchor/src/endpoint/price/abi.ts
@@ -1,0 +1,19 @@
+export const anchorVaultAbi = [
+  {
+    stateMutability: 'view',
+    type: 'function',
+    name: 'get_rate',
+    inputs: [],
+    outputs: [{ name: '', type: 'uint256' }],
+  },
+]
+
+export const curvePoolAbi = [
+  {
+    name: 'balances',
+    outputs: [{ type: 'uint256', name: '' }],
+    inputs: [{ type: 'uint256', name: 'i' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+]

--- a/packages/composites/anchor/src/endpoint/price/beth.ts
+++ b/packages/composites/anchor/src/endpoint/price/beth.ts
@@ -1,37 +1,22 @@
 import { ethers } from 'ethers'
 import { PriceExecute } from '.'
 import BigNumber from 'bignumber.js'
+import { Config } from '../../config'
+import { anchorVaultAbi, curvePoolAbi } from './abi'
 
 export const FROM = 'BETH'
 export const INTERMEDIARY_TOKEN_DECIMALS = 8
-export const INTERMEDIARY_TOKEN = 'stETH'
+export const INTERMEDIARY_TOKEN = 'ETH'
 
-export const anchorVaultAbi = [
-  {
-    stateMutability: 'view',
-    type: 'function',
-    name: 'get_rate',
-    inputs: [],
-    outputs: [{ name: '', type: 'uint256' }],
-  },
-]
-
+// USD / ETH * stETH / bETH * ETH / stETH
 export const execute: PriceExecute = async (input, _, config, taAdapterResponse) => {
   const rpcUrl = config.rpcUrl
   const provider = new ethers.providers.JsonRpcProvider(rpcUrl)
-  const anchorVaultContract = new ethers.Contract(
-    config.anchorVaultContractAddress,
-    anchorVaultAbi,
-    provider,
-  )
-  const bEthExchangeRateBigNum = await anchorVaultContract.get_rate()
 
-  // Need to convert to BigNumber JS from ethers BigNumber as the latter will remove all decimals
-  const stEthPerBEth = new BigNumber(bEthExchangeRateBigNum.toString())
-    .dividedBy(new BigNumber(10).pow(18))
-    .toNumber()
-  const usdPerStEth = taAdapterResponse.data.result
-  const result = usdPerStEth * stEthPerBEth
+  const stEthPerBEth = await getStEthBEthExchangeRate(config, provider)
+  const ethPerStEth = await getStETHExchangeRate(config, provider)
+  const usdPerEth = taAdapterResponse.data.result
+  const result = usdPerEth * stEthPerBEth * ethPerStEth
   return {
     jobRunID: input.id,
     statusCode: 200,
@@ -40,4 +25,34 @@ export const execute: PriceExecute = async (input, _, config, taAdapterResponse)
       result,
     },
   }
+}
+
+const getStETHExchangeRate = async (
+  config: Config,
+  provider: ethers.providers.JsonRpcProvider,
+): Promise<number> => {
+  const stEthPoolContract = new ethers.Contract(
+    config.stEthPoolContractAddress,
+    curvePoolAbi,
+    provider,
+  )
+  const ethBal = await stEthPoolContract.balances(0)
+  const stEthBal = await stEthPoolContract.balances(1)
+  return new BigNumber(ethBal.toString()).dividedBy(new BigNumber(stEthBal.toString())).toNumber()
+}
+
+const getStEthBEthExchangeRate = async (
+  config: Config,
+  provider: ethers.providers.JsonRpcProvider,
+): Promise<number> => {
+  const anchorVaultContract = new ethers.Contract(
+    config.anchorVaultContractAddress,
+    anchorVaultAbi,
+    provider,
+  )
+  const bEthExchangeRateBigNum = await anchorVaultContract.get_rate()
+  // Need to convert to BigNumber JS from ethers BigNumber as the latter will remove all decimals
+  return new BigNumber(bEthExchangeRateBigNum.toString())
+    .dividedBy(new BigNumber(10).pow(18))
+    .toNumber()
 }

--- a/packages/composites/anchor/src/endpoint/price/beth.ts
+++ b/packages/composites/anchor/src/endpoint/price/beth.ts
@@ -8,7 +8,6 @@ export const FROM = 'BETH'
 export const INTERMEDIARY_TOKEN_DECIMALS = 8
 export const INTERMEDIARY_TOKEN = 'ETH'
 
-// USD / ETH * stETH / bETH * ETH / stETH
 export const execute: PriceExecute = async (input, _, config, taAdapterResponse) => {
   const rpcUrl = config.rpcUrl
   const provider = new ethers.providers.JsonRpcProvider(rpcUrl)
@@ -16,7 +15,7 @@ export const execute: PriceExecute = async (input, _, config, taAdapterResponse)
   const stEthPerBEth = await getStEthBEthExchangeRate(config, provider)
   const ethPerStEth = await getStETHExchangeRate(config, provider)
   const usdPerEth = taAdapterResponse.data.result
-  const result = usdPerEth * stEthPerBEth * ethPerStEth
+  const result = usdPerEth * ethPerStEth * stEthPerBEth
   return {
     jobRunID: input.id,
     statusCode: 200,

--- a/packages/composites/anchor/src/utils.ts
+++ b/packages/composites/anchor/src/utils.ts
@@ -14,7 +14,7 @@ export const getTokenPrice = async (
   const allocations = [
     {
       symbol,
-      balance: BigNumber.from(10).pow(decimals),
+      balance: BigNumber.from(10).pow(decimals).toString(),
       decimals,
     },
   ]

--- a/packages/composites/anchor/test/integration/fixtures.ts
+++ b/packages/composites/anchor/test/integration/fixtures.ts
@@ -40,7 +40,7 @@ export function mockLunaUSDPrice() {
 export function mockSTEthUSDPrice() {
   nock('http://localhost:5000', { encodedQueryParams: true })
     .persist(true)
-    .post('/', { id: '1', data: { base: 'STETH', quote: 'USD', endpoint: 'crypto' } })
+    .post('/', { id: '1', data: { base: 'ETH', quote: 'USD', endpoint: 'crypto' } })
     .reply(
       200,
       {

--- a/packages/composites/anchor/test/integration/prices/__snapshots__/beth.test.ts.snap
+++ b/packages/composites/anchor/test/integration/prices/__snapshots__/beth.test.ts.snap
@@ -3,10 +3,10 @@
 exports[`price-beth successful calls return success when fetching the USD/BEth price 1`] = `
 Object {
   "data": Object {
-    "result": 4507.32,
+    "result": 4430.014752502817,
   },
   "jobRunID": "1",
-  "result": 4507.32,
+  "result": 4430.014752502817,
   "statusCode": 200,
 }
 `;
@@ -14,10 +14,10 @@ Object {
 exports[`price-beth successful calls returns success when fetching the BTC/BEth price 1`] = `
 Object {
   "data": Object {
-    "result": 0.07962618803660389,
+    "result": 0.07826051571393168,
   },
   "jobRunID": "1",
-  "result": 0.07962618803660389,
+  "result": 0.07826051571393168,
   "statusCode": 200,
 }
 `;
@@ -25,10 +25,10 @@ Object {
 exports[`price-beth successful calls returns success when fetching the ETH/BEth price 1`] = `
 Object {
   "data": Object {
-    "result": 0.9931255122815366,
+    "result": 0.9828489551447018,
   },
   "jobRunID": "1",
-  "result": 0.9931255122815366,
+  "result": 0.9828489551447018,
   "statusCode": 200,
 }
 `;

--- a/packages/composites/anchor/test/integration/prices/beth.test.ts
+++ b/packages/composites/anchor/test/integration/prices/beth.test.ts
@@ -9,6 +9,8 @@ import { ethers, BigNumber } from 'ethers'
 import { AddressInfo } from 'net'
 
 const mockBigNum = BigNumber.from(10).pow(18)
+const mockEthBalance = BigNumber.from('600035129129882344513625')
+const mockStEthBalance = BigNumber.from('610505943959151982581203')
 
 jest.mock('ethers', () => ({
   ...jest.requireActual('ethers'),
@@ -22,6 +24,13 @@ jest.mock('ethers', () => ({
       return {
         get_rate: (____: string) => {
           return mockBigNum
+        },
+        balances: (id: number): BigNumber => {
+          if (id === 0) {
+            return mockEthBalance
+          } else {
+            return mockStEthBalance
+          }
         },
       }
     },

--- a/packages/sources/cfbenchmarks/src/endpoint/values.ts
+++ b/packages/sources/cfbenchmarks/src/endpoint/values.ts
@@ -32,7 +32,6 @@ const getIdFromBaseQuoteSymbols = (config: Config, base: string, quote: string) 
   const baseQuote = `${base}/${quote}`
 
   let id = idFromBaseQuoteSymbol[baseQuote] // Check hardcoded conversions first
-  console.log(config.useSecondary)
   if (!id) {
     // If not hardcoded, use template
     if (config.useSecondary) {

--- a/packages/sources/cfbenchmarks/src/endpoint/values.ts
+++ b/packages/sources/cfbenchmarks/src/endpoint/values.ts
@@ -32,7 +32,7 @@ const getIdFromBaseQuoteSymbols = (config: Config, base: string, quote: string) 
   const baseQuote = `${base}/${quote}`
 
   let id = idFromBaseQuoteSymbol[baseQuote] // Check hardcoded conversions first
-
+  console.log(config.useSecondary)
   if (!id) {
     // If not hardcoded, use template
     if (config.useSecondary) {


### PR DESCRIPTION
## Closes 30353

## Description

This PR updates the way the `USD/bETH` price is derived.  The high level calculation is outlined below

```
bETH = ETHPrice * StETHETHRate / StETHbETHExchangeRate
```

ETHPrice: Pulled from a the token allocation EA
StETHETHRate: `ETH / stETH` price on Curve - Pulled from curve smart contract
StETHbETHExchangeRate - pulled from Lido's AnchorVault contract by calling get_rate() 

## Changes

 - Update composite Anchor EA to calculate the `bETH` price using the method above
 - Update tests to reflect changes
 - Add new environment variable `STETH_POOL_CONTRACT_ADDRESS` for the `stETH-ETH` pool in Curve with a default of `0xdc24316b9ae028f1497c275eb9192a3ea0f67022` 

## Steps to Test

1. Set the Token Allocation EA required environment variables
2. Run the EA
3. Verify that the EA returns a successful response with the following sources

* tiingo
* coinmetrics
* cryptoompare
* ncfx
* cfbenchmarks
* finage

Sample request

```
{
  "id": "1",
  "data": {
    "from": "BETH",
    "to": "USD",
    "source": "ncfx"
  }
}
```

## Quality Assurance

- [x] Ran `yarn changeset` if adapter source code was changed
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
