### PR TITLE
cfbenchmarks intetegration tests

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -4475,6 +4475,9 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@chainlink/types", "workspace:packages/core/types/@chainlink"],
             ["@types/jest", "npm:27.0.3"],
             ["@types/node", "npm:16.11.19"],
+            ["@types/supertest", "npm:2.0.11"],
+            ["nock", "npm:13.1.3"],
+            ["supertest", "npm:6.1.6"],
             ["tslib", "npm:2.3.1"],
             ["typescript", "patch:typescript@npm%3A4.3.5#~builtin<compat/typescript>::version=4.3.5&hash=d8b4e7"]
           ],

--- a/packages/sources/cfbenchmarks/package.json
+++ b/packages/sources/cfbenchmarks/package.json
@@ -36,6 +36,9 @@
     "@chainlink/types": "workspace:*",
     "@types/jest": "27.0.3",
     "@types/node": "16.11.19",
+    "@types/supertest": "2.0.11",
+    "nock": "13.1.3",
+    "supertest": "6.1.6",
     "typescript": "4.3.5"
   }
 }

--- a/packages/sources/cfbenchmarks/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/cfbenchmarks/test/integration/__snapshots__/adapter.test.ts.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`execute values endpoint should return success 1`] = `
+Object {
+  "data": Object {
+    "result": 39829.3,
+  },
+  "jobRunID": "1",
+  "providerStatusCode": 200,
+  "result": 39829.3,
+  "statusCode": 200,
+}
+`;

--- a/packages/sources/cfbenchmarks/test/integration/adapter.test.ts
+++ b/packages/sources/cfbenchmarks/test/integration/adapter.test.ts
@@ -1,0 +1,54 @@
+import { AdapterRequest } from '@chainlink/types'
+import request, { SuperTest, Test } from 'supertest'
+import * as process from 'process'
+import { server as startServer } from '../../src'
+import * as nock from 'nock'
+import * as http from 'http'
+import { mockResponseSuccess } from './fixtures'
+import { AddressInfo } from 'net'
+describe('execute', () => {
+  const id = '1'
+  let server: http.Server
+  let req: SuperTest<Test>
+
+  beforeAll(async () => {
+    process.env.API_USERNAME = process.env.API_USERNAME || 'fake-api-username'
+    process.env.API_PASSWORD = process.env.API_PASSWORD || 'fake-api-password'
+    if (process.env.RECORD) {
+      nock.recorder.rec()
+    }
+    server = await startServer()
+    req = request(`localhost:${(server.address() as AddressInfo).port}`)
+  })
+
+  afterAll((done) => {
+    if (process.env.RECORD) {
+      nock.recorder.play()
+    }
+
+    nock.restore()
+    nock.cleanAll()
+    nock.enableNetConnect()
+    server.close(done)
+  })
+
+  describe('values endpoint', () => {
+    const data: AdapterRequest = {
+      id,
+      data: { index: 'BRTI' },
+    }
+
+    it('should return success', async () => {
+      mockResponseSuccess()
+
+      const response = await req
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+      expect(response.body).toMatchSnapshot()
+    })
+  })
+})

--- a/packages/sources/cfbenchmarks/test/integration/fixtures.ts
+++ b/packages/sources/cfbenchmarks/test/integration/fixtures.ts
@@ -1,0 +1,29 @@
+import nock from 'nock'
+
+export const mockResponseSuccess = (): nock =>
+  nock('https://www.cfbenchmarks.com/api', {
+    reqheaders: {
+      Authorization: 'Basic ZmFrZS1hcGktdXNlcm5hbWU6ZmFrZS1hcGktcGFzc3dvcmQ=',
+    },
+  })
+    .get('/v1/values?id=BRTI')
+    .reply(
+      200,
+      (_, request) => ({
+        serverTime: '2022-02-18T16:53:55.772Z',
+        payload: [
+          { value: '39829.42', time: 1645199636000 },
+          { value: '39829.30', time: 1645199637000 },
+        ],
+      }),
+      [
+        'Content-Type',
+        'application/json',
+        'Connection',
+        'close',
+        'Vary',
+        'Accept-Encoding',
+        'Vary',
+        'Origin',
+      ],
+    )

--- a/yarn.lock
+++ b/yarn.lock
@@ -2223,6 +2223,9 @@ __metadata:
     "@chainlink/types": "workspace:*"
     "@types/jest": 27.0.3
     "@types/node": 16.11.19
+    "@types/supertest": 2.0.11
+    nock: 13.1.3
+    supertest: 6.1.6
     tslib: ^2.3.1
     typescript: 4.3.5
   languageName: unknown


### PR DESCRIPTION


## Changes

- Added integration tests (not websocket) for cfbenchmarks EA

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

`yarn test packages/sources/cfbenchmarks/test/integration`

## Quality Assurance

- [ ] Ran `yarn changeset` if adapter source code was changed
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [ ] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
