### PR TITLE
Remove /dist when cleaning directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "versions": "ts-node-transpile-only ./packages/scripts/src/versions",
     "new": "ts-node-transpile-only ./packages/scripts/src/new",
     "bundle": "ncc build",
-    "clean": "tsc -b --clean  ./packages/tsconfig.json",
+    "clean": "rm -rf **/dist || tsc -b --clean ./packages/tsconfig.json",
     "lint": "eslint --ext ts .",
     "lint:fix": "yarn lint --fix",
     "format:check": "prettier --check .",


### PR DESCRIPTION
## Description
Some developers encountered issues with the recent [EA config refactor](https://github.com/smartcontractkit/external-adapters-js/pull/1542) where the `/dist` folders would not clear all the right files since `tsconfig.tsbuildinfo` for each EA was out of sync. In order to clear these, we need to remove all `/dist` folders in a separate command before running `tsc -b --clean`.

## Changes
- Update `yarn clean` command with `rm -rf **/dist`

## Steps to Test
1. `yarn && yarn build` -> See `/dist` folders in each EA
2. `yarn clean` -> `/dist` folders removed entirely (not just the folder contents)

## Quality Assurance

- [x] Ran `yarn changeset` if adapter source code was changed
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
