### PR TITLE
Stop batching Coinpaprika quotes

### DIFF
--- a/.changeset/three-bobcats-count.md
+++ b/.changeset/three-bobcats-count.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/coinpaprika-adapter': patch
+---
+
+Coinpaprika - stop batching crypto quotes

--- a/packages/sources/coinpaprika/src/endpoint/crypto.ts
+++ b/packages/sources/coinpaprika/src/endpoint/crypto.ts
@@ -11,7 +11,7 @@ import { getCoin } from '../util'
 import overrides from '../config/symbols.json'
 
 export const supportedEndpoints = ['crypto', 'price', 'marketcap', 'volume']
-export const batchablePropertyPath = [{ name: 'base' }, { name: 'quote' }]
+export const batchablePropertyPath = [{ name: 'base' }]
 
 export interface ResponseSchema {
   id: string


### PR DESCRIPTION
## Closes sc-30383

## Description
Disable batching by quotes for Coinpaprika.

This will increase the number of batch warmers running and requests per minute by N, where N is the number of unique quotes on Coinpaprika feeds. (currently estimated to be 4).

## Changes
Disable batching by quotes for Coinpaprika.

## Steps to Test

1. Run Coinpaprika along with redux dev tools
2. Request with one quote
```
{
    "data": {
        "from": "LINK",
        "to": "USD"
    }
}
```
3. Request the same base ticker with a different quote
```
{
    "data": {
        "from": "LINK",
        "to": "BTC"
    }
}
```
4. In redux dev tools there should be two batch warmers running

## Quality Assurance

- [x] Ran `yarn changeset` if adapter source code was changed
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
