### PR TITLE
[Fix] coinpaprika alchemixusd

### DIFF
--- a/.changeset/flat-coins-accept.md
+++ b/.changeset/flat-coins-accept.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/coinpaprika-adapter': patch
+---
+
+Add label for 'crypto-single' and add ALUSD kludge

--- a/packages/sources/coinpaprika/src/endpoint/crypto-single.ts
+++ b/packages/sources/coinpaprika/src/endpoint/crypto-single.ts
@@ -4,7 +4,7 @@ import { NAME as AdapterName } from '../config'
 import { getCoinIds, getSymbolToId } from '../util'
 import overrides from '../config/symbols.json'
 
-export const supportedEndpoints = []
+export const supportedEndpoints = ['crypto-single']
 
 const buildPath =
   (path: string) =>
@@ -16,9 +16,7 @@ const buildPath =
   }
 
 export const endpointResultPaths = {
-  crypto: buildPath('price'),
-  price: buildPath('price'),
-  marketcap: buildPath('market_cap'),
+  'crypto-single': buildPath('price'),
 }
 
 export const inputParameters: InputParameters = {

--- a/packages/sources/coinpaprika/src/endpoint/crypto.ts
+++ b/packages/sources/coinpaprika/src/endpoint/crypto.ts
@@ -76,6 +76,22 @@ export const inputParameters: InputParameters = {
   },
 }
 
+export const endpointOverride = (request: AdapterRequest): string | null => {
+  /*
+     WARNING:
+     ALUSD has been removed from /tickers. Coinpaprika is adding a custom /tickers endpoint.
+     Remove this kludge once the new endpoint is available.
+  */
+
+  const validator = new Validator(request, inputParameters)
+  if (
+    !Array.isArray(validator.validated.data.base) &&
+    validator.validated.data.base?.toUpperCase() === 'ALUSD'
+  )
+    return 'crypto-single'
+  return null
+}
+
 interface RequestedData {
   symbol?: string
   coinid?: string


### PR DESCRIPTION
## Description
Coinpaprika removed `alusd-alchemixusd` from the `/tickers` endpoint, which we use for batching.

They will be adding a custom `/tickers` endpoint that supports it, but in the mean time we need a quick fix.
......

## Changes
- Adds label for `crypto-single` , which is the non-batched crypto data endpoint
- Adds endpoint override to `crypto-single` when base is `ALUSD`

## Steps to Test

1. Run Coinpaprika and redux remote devtools
2. Request `ALUSD/USD`
3. It should use `crypto-single` endpoint without batching
4. Request any other pair
5. It should use batching

## Quality Assurance

- [x] Ran `yarn changeset` if adapter source code was changed
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
