### PR TITLE
Fill input param with default endpoint when not given

### DIFF
--- a/.changeset/proud-numbers-sip.md
+++ b/.changeset/proud-numbers-sip.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/ea-bootstrap': patch
+---
+
+Fill endpoint input parameter with default when not given

--- a/packages/core/bootstrap/src/lib/modules/selector.ts
+++ b/packages/core/bootstrap/src/lib/modules/selector.ts
@@ -102,6 +102,9 @@ const selectEndpoint = <C extends Config>(
       })
   }
 
+  // Fill in default endpoint
+  if (!request?.data?.endpoint) request.data.endpoint = config.defaultEndpoint
+
   // Allow adapter endpoints to dynamically query different endpoint resultPaths
   if (apiEndpoint.endpointResultPaths && request.data && !request.data.resultPath) {
     const resultPath = apiEndpoint.endpointResultPaths[endpoint]


### PR DESCRIPTION
## Description
Fills in default endpoint input parameter when no endpoint is given.

## Steps to Test

1. Start an EA and remote-dev-tools. Turn on LOG_LEVEL=debug
2. Request an EA without an endpoint
3. The cache warmer state should show the endpoint filled
4. The logs should show the endpoint filled

## Quality Assurance

- [x] Ran `yarn changeset` if adapter source code was changed
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
