### PR TITLE
1forge ws integration tests

### DIFF
--- a/.changeset/breezy-dancers-design.md
+++ b/.changeset/breezy-dancers-design.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/1forge-adapter': patch
+---
+
+move WS endpoint into DEFAULT_WS_API_ENDPOINT variable

--- a/.changeset/happy-dolls-pull.md
+++ b/.changeset/happy-dolls-pull.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/ea-test-helpers': minor
+---
+
+add mockWebSocketFlow support for requests and responses with string type

--- a/packages/core/test-helpers/src/websocket.ts
+++ b/packages/core/test-helpers/src/websocket.ts
@@ -46,10 +46,23 @@ export const mockWebSocketFlow = async (
     server.on('connection', async (connection) => {
       connection.on('message', (received) => {
         const { request, response } = flow[currentExchange]
-        const expected = JSON.stringify(request)
+        let expected
+        if (typeof request === 'string') {
+          expected = request
+        } else {
+          expected = JSON.stringify(request)
+        }
+
         if (received === expected) {
           if (Array.isArray(response) && response.length > 0) {
-            response.forEach((r) => connection.send(JSON.stringify(r)))
+            response.forEach((r) => {
+              if (typeof r === 'string') {
+                return connection.send(r)
+              }
+              return connection.send(JSON.stringify(r))
+            })
+          } else if (typeof response === 'string') {
+            connection.send(response)
           } else {
             connection.send(JSON.stringify(response))
           }

--- a/packages/sources/1forge/src/adapter.ts
+++ b/packages/sources/1forge/src/adapter.ts
@@ -7,7 +7,7 @@ import {
   APIEndpoint,
   MakeWSHandler,
 } from '@chainlink/types'
-import { makeConfig } from './config'
+import { DEFAULT_WS_API_ENDPOINT, makeConfig } from './config'
 import * as endpoints from './endpoint'
 
 export const execute: ExecuteWithConfig<Config> = async (request, context, config) => {
@@ -48,7 +48,7 @@ export const makeWSHandler = (config?: Config): MakeWSHandler => {
 
     return {
       connection: {
-        url: 'wss://sockets.1forge.com/socket',
+        url: DEFAULT_WS_API_ENDPOINT,
       },
       subscribe: (input) => getSubscription(getSymbol(input)),
       unsubscribe: (input) => getSubscription(getSymbol(input), false),

--- a/packages/sources/1forge/src/config/index.ts
+++ b/packages/sources/1forge/src/config/index.ts
@@ -5,6 +5,7 @@ export const NAME = 'ADAPTER_1FORGE'
 
 export const DEFAULT_ENDPOINT = 'quotes'
 export const DEFAULT_BASE_URL = 'https://api.1forge.com/'
+export const DEFAULT_WS_API_ENDPOINT = 'wss://sockets.1forge.com/socket'
 
 export const makeConfig = (prefix?: string): Config => {
   const config = Requester.getDefaultConfig(prefix, true)

--- a/packages/sources/1forge/test/integration/adapter.test.ts
+++ b/packages/sources/1forge/test/integration/adapter.test.ts
@@ -4,8 +4,26 @@ import * as process from 'process'
 import { server as startServer } from '../../src'
 import * as nock from 'nock'
 import * as http from 'http'
-import { mockResponseSuccessConvertEndpoint, mockResponseSuccessQuotesEnpoint } from './fixtures'
+import {
+  mockLoginResponse,
+  mockResponseSuccessConvertEndpoint,
+  mockResponseSuccessQuotesEnpoint,
+  mockSubscribeResponse,
+  mockUnsubscribeResponse,
+} from './fixtures'
 import { AddressInfo } from 'net'
+import {
+  mockWebSocketProvider,
+  mockWebSocketServer,
+  MockWsServer,
+  mockWebSocketFlow,
+} from '@chainlink/ea-test-helpers'
+import { WebSocketClassProvider } from '@chainlink/ea-bootstrap/dist/lib/middleware/ws/recorder'
+import { DEFAULT_WS_API_ENDPOINT } from '../../src/config'
+
+const sleep = (ms: number) => {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
 
 describe('execute', () => {
   const id = '1'
@@ -13,7 +31,6 @@ describe('execute', () => {
   let req: SuperTest<Test>
 
   beforeAll(async () => {
-    process.env.CACHE_ENABLED = 'false'
     process.env.API_KEY = process.env.API_KEY || 'fake-api-key'
     if (process.env.RECORD) {
       nock.recorder.rec()
@@ -79,5 +96,91 @@ describe('execute', () => {
         .expect(200)
       expect(response.body).toMatchSnapshot()
     })
+  })
+})
+
+describe('websocket', () => {
+  let mockedWsServer: InstanceType<typeof MockWsServer>
+  let server: http.Server
+  let req: SuperTest<Test>
+
+  let oldEnv: NodeJS.ProcessEnv
+  beforeAll(async () => {
+    if (!process.env.RECORD) {
+      process.env.API_KEY = 'fake-api-key'
+      mockedWsServer = mockWebSocketServer(DEFAULT_WS_API_ENDPOINT)
+      mockWebSocketProvider(WebSocketClassProvider)
+    }
+
+    oldEnv = JSON.parse(JSON.stringify(process.env))
+    process.env.WS_ENABLED = 'true'
+    process.env.WS_SUBSCRIPTION_TTL = '100'
+
+    server = await startServer()
+    req = request(`localhost:${(server.address() as AddressInfo).port}`)
+  })
+
+  afterAll((done) => {
+    process.env = oldEnv
+    nock.restore()
+    nock.cleanAll()
+    nock.enableNetConnect()
+    server.close(done)
+  })
+
+  describe('quotes api', () => {
+    const jobID = '1'
+
+    it('should return success', async () => {
+      const data: AdapterRequest = {
+        id: jobID,
+        data: {
+          endpoint: 'quotes',
+          base: 'USD',
+          quote: 'EUR',
+        },
+      }
+
+      let flowFulfilled: Promise<boolean>
+      if (!process.env.RECORD) {
+        mockResponseSuccessQuotesEnpoint() // For the first response
+
+        flowFulfilled = mockWebSocketFlow(mockedWsServer, [
+          mockLoginResponse,
+          mockSubscribeResponse,
+          mockUnsubscribeResponse,
+          // the second unsubscribe request is needed
+          mockUnsubscribeResponse,
+        ])
+      }
+
+      const makeRequest = () =>
+        req
+          .post('/')
+          .send(data)
+          .set('Accept', '*/*')
+          .set('Content-Type', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(200)
+
+      // We don't care about the first response, coming from http request
+      // This first request will start both batch warmer & websocket
+      await makeRequest()
+
+      // This final request should disable the cache warmer, sleep is used to make sure that the data is  pulled from the websocket
+      // populated cache entries.
+      await sleep(100)
+      const response = await makeRequest()
+
+      expect(response.body).toEqual({
+        jobRunID: '1',
+        result: 0.88935,
+        statusCode: 200,
+        maxAge: 30000,
+        data: { result: 0.88935 },
+      })
+
+      await flowFulfilled
+    }, 30000)
   })
 })

--- a/packages/sources/1forge/test/integration/fixtures.ts
+++ b/packages/sources/1forge/test/integration/fixtures.ts
@@ -53,3 +53,22 @@ export const mockResponseSuccessQuotesEnpoint = (): nock =>
         'Origin',
       ],
     )
+
+export const mockLoginResponse = {
+  request: 'login|fake-api-key',
+  response: [
+    'message|Connected to 1Forge Socket Server. If you need help, please email contact@1forge.com',
+    'message|You are currently using 1 out of 10 sessions',
+    'post_login_success|undefined',
+  ],
+}
+
+export const mockSubscribeResponse = {
+  request: 'subscribe_to|USD/EUR',
+  response: 'update|{"p":0.88935,"a":0.88938,"b":0.88932,"s":"USD/EUR","t":1645811011686}',
+}
+
+export const mockUnsubscribeResponse = {
+  request: 'unsubscribe_from|USD/EUR',
+  response: '',
+}


### PR DESCRIPTION


## Changes

-  modified `mockWebSocketFlow` function to support request and response mocks of string type
- added websocket integration tests for 1forge EA

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

`yarn test packages/sources/1forge/test/integration/
`
## Quality Assurance

- [ ] Ran `yarn changeset` if adapter source code was changed
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [ ] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
