### PR TITLE
Use static private key in L2 health check

### DIFF
--- a/.changeset/hot-actors-do.md
+++ b/.changeset/hot-actors-do.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/layer2-sequencer-health-adapter': patch
+---
+
+Use static private key instead of randomly generating one

--- a/packages/sources/layer2-sequencer-health/src/network.ts
+++ b/packages/sources/layer2-sequencer-health/src/network.ts
@@ -2,6 +2,8 @@ import { Logger, Requester } from '@chainlink/ea-bootstrap'
 import { HEALTH_ENDPOINTS, Networks, RPC_ENDPOINTS } from './config'
 import { BigNumber, ethers } from 'ethers'
 
+const DEFAULT_PRIVATE_KEY = '0x0000000000000000000000000000000000000000000000000000000000000001'
+
 export interface NetworkHealthCheck {
   (network: Networks, delta: number, deltaBlocks: number): Promise<undefined | boolean>
 }
@@ -58,7 +60,7 @@ export const getStatusByTransaction = async (
 ): Promise<boolean> => {
   const rpcEndpoint = RPC_ENDPOINTS[network]
   const provider = new ethers.providers.JsonRpcProvider(rpcEndpoint)
-  const wallet = new ethers.Wallet(ethers.Wallet.createRandom()?.privateKey, provider)
+  const wallet = new ethers.Wallet(DEFAULT_PRIVATE_KEY, provider)
 
   // These errors come from the Sequencer when submitting an empty transaction
   const sequencerOnlineErrors: Record<Networks, string[]> = {


### PR DESCRIPTION
## Changes

- Use static private key instead of randomly generating one in L2 health check

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. Run L2 health check EA
2. Disconnect Internet connection
3. EA should respond to requests with a `1` result

## Quality Assurance

- [x] Ran `yarn changeset` if adapter source code was changed
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
