### PR TITLE
[Perf] Deterministic Cache keys

### DIFF
--- a/.changeset/weak-melons-taste.md
+++ b/.changeset/weak-melons-taste.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/ea-bootstrap': major
+---
+
+Change to deterministic cache key generation

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -7874,7 +7874,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@ethereumjs/tx", "npm:3.5.0"],
             ["async-eventemitter", "npm:0.2.4"],
             ["core-js-pure", "npm:3.16.0"],
-            ["debug", "virtual:f92816622f12a682efedc01f1da20281c4ed3ab0d1858943fa583f464413255415b0d58f4e477fba1231a5b80c3207c40b52c5cfccd9a508e7310ddae63ea7df#npm:4.3.3"],
+            ["debug", "virtual:59206ab6494fcf87afedf322312213fa8ec8d4b68ffaa4891fb721746a43f127c90c15a0f13a3370ed56e7ee6f4829d99c14a8c620abb41edeb7abf7d1f432a6#npm:4.3.3"],
             ["ethereumjs-util", "npm:7.1.4"],
             ["functional-red-black-tree", "npm:1.0.1"],
             ["mcl-wasm", "npm:0.7.8"],
@@ -16215,6 +16215,20 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "linkType": "SOFT",
         }],
+        ["virtual:59206ab6494fcf87afedf322312213fa8ec8d4b68ffaa4891fb721746a43f127c90c15a0f13a3370ed56e7ee6f4829d99c14a8c620abb41edeb7abf7d1f432a6#npm:4.3.3", {
+          "packageLocation": "./.yarn/__virtual__/debug-virtual-1b42834cde/0/cache/debug-npm-4.3.3-710fd4cc7f-14472d56fe.zip/node_modules/debug/",
+          "packageDependencies": [
+            ["debug", "virtual:59206ab6494fcf87afedf322312213fa8ec8d4b68ffaa4891fb721746a43f127c90c15a0f13a3370ed56e7ee6f4829d99c14a8c620abb41edeb7abf7d1f432a6#npm:4.3.3"],
+            ["@types/supports-color", null],
+            ["ms", "npm:2.1.2"],
+            ["supports-color", null]
+          ],
+          "packagePeers": [
+            "@types/supports-color",
+            "supports-color"
+          ],
+          "linkType": "HARD",
+        }],
         ["virtual:612e500d6d9d9c332d8475cbf619d8fa9fe7de63ec445b4de39cc68ccfbc77429a4327f46d9b5572a19ca0de9f285af134301bc8843c271b7712b6d1256451cc#npm:3.2.6", {
           "packageLocation": "./.yarn/__virtual__/debug-virtual-d84ce13359/0/cache/debug-npm-3.2.6-6214e40f12-07bc8b3a13.zip/node_modules/debug/",
           "packageDependencies": [
@@ -16278,20 +16292,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/supports-color", null],
             ["ms", "npm:2.1.2"],
             ["supports-color", "npm:8.1.1"]
-          ],
-          "packagePeers": [
-            "@types/supports-color",
-            "supports-color"
-          ],
-          "linkType": "HARD",
-        }],
-        ["virtual:f92816622f12a682efedc01f1da20281c4ed3ab0d1858943fa583f464413255415b0d58f4e477fba1231a5b80c3207c40b52c5cfccd9a508e7310ddae63ea7df#npm:4.3.3", {
-          "packageLocation": "./.yarn/__virtual__/debug-virtual-b35c953d93/0/cache/debug-npm-4.3.3-710fd4cc7f-14472d56fe.zip/node_modules/debug/",
-          "packageDependencies": [
-            ["debug", "virtual:f92816622f12a682efedc01f1da20281c4ed3ab0d1858943fa583f464413255415b0d58f4e477fba1231a5b80c3207c40b52c5cfccd9a508e7310ddae63ea7df#npm:4.3.3"],
-            ["@types/supports-color", null],
-            ["ms", "npm:2.1.2"],
-            ["supports-color", null]
           ],
           "packagePeers": [
             "@types/supports-color",
@@ -31106,7 +31106,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["superagent", "npm:7.1.1"],
             ["component-emitter", "npm:1.3.0"],
             ["cookiejar", "npm:2.1.3"],
-            ["debug", "virtual:f92816622f12a682efedc01f1da20281c4ed3ab0d1858943fa583f464413255415b0d58f4e477fba1231a5b80c3207c40b52c5cfccd9a508e7310ddae63ea7df#npm:4.3.3"],
+            ["debug", "virtual:59206ab6494fcf87afedf322312213fa8ec8d4b68ffaa4891fb721746a43f127c90c15a0f13a3370ed56e7ee6f4829d99c14a8c620abb41edeb7abf7d1f432a6#npm:4.3.3"],
             ["fast-safe-stringify", "npm:2.1.1"],
             ["form-data", "npm:4.0.0"],
             ["formidable", "npm:2.0.1"],

--- a/packages/core/bootstrap/src/index.ts
+++ b/packages/core/bootstrap/src/index.ts
@@ -20,7 +20,7 @@ import * as ioLogger from './lib/middleware/io-logger'
 import * as statusCode from './lib/middleware/status-code'
 import * as debug from './lib/middleware/debugger'
 import * as normalize from './lib/middleware/normalize'
-import * as cacheKey from './lib/middleware/cache-key'
+import * as CacheKey from './lib/middleware/cache-key'
 import * as server from './lib/server'
 import { configureStore } from './lib/store'
 import * as util from './lib/util'
@@ -65,7 +65,7 @@ export const makeMiddleware = <C extends Config>(
     withCache(storeSlice('burstLimit')),
     RateLimit.withRateLimit(storeSlice('rateLimit')),
     statusCode.withStatusCode,
-    cacheKey.withCacheKey(endpointSelector),
+    CacheKey.withCacheKey(endpointSelector),
     normalize.withNormalizedInput(endpointSelector),
   ].concat(metrics.METRICS_ENABLED ? [metrics.withMetrics] : [])
 
@@ -79,7 +79,7 @@ export const makeMiddleware = <C extends Config>(
     ws.withWebSockets(storeSlice('ws'), makeWsHandler),
     RateLimit.withRateLimit(storeSlice('rateLimit')),
     statusCode.withStatusCode,
-    cacheKey.withCacheKey(endpointSelector),
+    CacheKey.withCacheKey(endpointSelector),
     normalize.withNormalizedInput(endpointSelector),
   ].concat(metrics.METRICS_ENABLED ? [metrics.withMetrics, debug.withDebug] : [debug.withDebug])
 }
@@ -144,4 +144,15 @@ export const expose = <C extends Config>(
   }
 }
 
-export { Requester, Validator, AdapterError, Builder, Logger, util, server, Cache, RateLimit }
+export {
+  Requester,
+  Validator,
+  AdapterError,
+  CacheKey,
+  Builder,
+  Logger,
+  util,
+  server,
+  Cache,
+  RateLimit,
+}

--- a/packages/core/bootstrap/src/index.ts
+++ b/packages/core/bootstrap/src/index.ts
@@ -20,6 +20,7 @@ import * as ioLogger from './lib/middleware/io-logger'
 import * as statusCode from './lib/middleware/status-code'
 import * as debug from './lib/middleware/debugger'
 import * as normalize from './lib/middleware/normalize'
+import * as cacheKey from './lib/middleware/cache-key'
 import * as server from './lib/server'
 import { configureStore } from './lib/store'
 import * as util from './lib/util'
@@ -64,6 +65,7 @@ export const makeMiddleware = <C extends Config>(
     withCache(storeSlice('burstLimit')),
     RateLimit.withRateLimit(storeSlice('rateLimit')),
     statusCode.withStatusCode,
+    cacheKey.withCacheKey(endpointSelector),
     normalize.withNormalizedInput(endpointSelector),
   ].concat(metrics.METRICS_ENABLED ? [metrics.withMetrics] : [])
 
@@ -77,6 +79,7 @@ export const makeMiddleware = <C extends Config>(
     ws.withWebSockets(storeSlice('ws'), makeWsHandler),
     RateLimit.withRateLimit(storeSlice('rateLimit')),
     statusCode.withStatusCode,
+    cacheKey.withCacheKey(endpointSelector),
     normalize.withNormalizedInput(endpointSelector),
   ].concat(metrics.METRICS_ENABLED ? [metrics.withMetrics, debug.withDebug] : [debug.withDebug])
 }

--- a/packages/core/bootstrap/src/lib/metrics/util.ts
+++ b/packages/core/bootstrap/src/lib/metrics/util.ts
@@ -1,6 +1,6 @@
 import { AdapterRequest } from '@chainlink/types'
 import { logger, Validator } from '../modules'
-import { excludableAdapterRequestProperties } from '../util'
+import { excludableAdapterRequestProperties } from '../middleware/cache-key/util'
 import * as crypto from 'crypto'
 
 /**

--- a/packages/core/bootstrap/src/lib/middleware/burst-limit/reducer.ts
+++ b/packages/core/bootstrap/src/lib/middleware/burst-limit/reducer.ts
@@ -44,7 +44,7 @@ export const initialRequestsState: RequestsState = {
 export const requestReducer = createReducer<RequestsState>(initialRequestsState, (builder) => {
   builder.addCase(actions.requestObserved, (state, action) => {
     const request: Request = {
-      id: makeId(action.payload.input),
+      id: action.payload.input?.debug?.cacheKey ?? makeId(action.payload.input),
       t: Date.now(),
     }
     const storedIntervals = [IntervalNames.SECOND, IntervalNames.MINUTE]

--- a/packages/core/bootstrap/src/lib/middleware/cache-key/index.ts
+++ b/packages/core/bootstrap/src/lib/middleware/cache-key/index.ts
@@ -1,0 +1,48 @@
+import type { Middleware, AdapterRequest, Config, APIEndpoint } from '@chainlink/types'
+import { Validator } from '../../modules'
+import { getHashOpts, hash, excludableInternalAdapterRequestProperties } from './util'
+import crypto from 'crypto'
+import { baseInputParameters } from '../../modules/selector'
+
+const baseInputParametersCachable = Object.keys(baseInputParameters).filter(
+  (inputParam) => !excludableInternalAdapterRequestProperties.includes(inputParam),
+)
+
+export const withCacheKey: <C extends Config>(
+  endpointSelector?: (request: AdapterRequest) => APIEndpoint<C>,
+) => Middleware = (endpointSelector) => async (execute, context) => async (input: AdapterRequest) => {
+  const cacheKey = endpointSelector
+    ? getCacheKey(input, endpointSelector(input))
+    : hash(input, getHashOpts())
+  const inputWithCacheKey = { ...input, debug: { ...input.debug, cacheKey } }
+  return execute(inputWithCacheKey, context)
+}
+
+export function getCacheKey<C extends Config>(
+  request: AdapterRequest,
+  apiEndpoint: APIEndpoint<C>,
+): string {
+  const inputParameterKeys = Object.keys(apiEndpoint.inputParameters ?? {}).concat(
+    baseInputParametersCachable,
+  )
+  const validator = new Validator(
+    request,
+    apiEndpoint.inputParameters,
+    {},
+    { shouldThrowError: false },
+  )
+
+  let cacheKey = ''
+
+  for (const key of inputParameterKeys) {
+    const data = JSON.stringify(validator.validated.data[key])
+    if (!data) continue
+    const shasum = crypto.createHash('sha1')
+    shasum.update(data)
+    const hash = shasum.digest('base64')
+    cacheKey += hash
+  }
+
+  const hashedCacheKey = crypto.createHash('sha1').update(cacheKey).digest('base64')
+  return hashedCacheKey
+}

--- a/packages/core/bootstrap/src/lib/middleware/cache-key/util.ts
+++ b/packages/core/bootstrap/src/lib/middleware/cache-key/util.ts
@@ -53,7 +53,6 @@ export const hash = (
   hashOptions: Required<Parameters<typeof objectHash>>['1'],
   mode: HashMode = 'include',
 ): string => {
-  console.log('AHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHhhh')
   return mode === 'include' || !data
     ? objectHash(getKeyData(data), hashOptions)
     : objectHash(data, getHashOpts())

--- a/packages/core/bootstrap/src/lib/middleware/cache-key/util.ts
+++ b/packages/core/bootstrap/src/lib/middleware/cache-key/util.ts
@@ -1,0 +1,70 @@
+import { AdapterRequest } from '@chainlink/types'
+import { pick, omit } from 'lodash'
+import objectHash from 'object-hash'
+
+/** Common keys within adapter requests that should be ignored to generate a stable key*/
+export const excludableAdapterRequestProperties: Record<string, true> = [
+  'id',
+  'maxAge',
+  'meta',
+  'debug',
+  'rateLimitMaxAge',
+  'metricsMeta',
+]
+  .concat((process.env.CACHE_KEY_IGNORED_PROPS || '').split(',').filter((k) => k))
+  .reduce((prev, next) => {
+    prev[next] = true
+    return prev
+  }, {} as Record<string, true>)
+
+/** Common keys within adapter requests that should be used to generate a stable key*/
+export const includableAdapterRequestProperties: string[] = ['data'].concat(
+  (process.env.CACHE_KEY_INCLUDED_PROPS || '').split(',').filter((k) => k),
+)
+
+/** Common keys within adapter requests that should be ignored within "data" to create a stable key*/
+export const excludableInternalAdapterRequestProperties = [
+  'resultPath', // TODO: this too?
+  'overrides',
+  'tokenOverrides',
+  'includes',
+]
+
+export const getKeyData = (data: AdapterRequest) =>
+  omit(
+    pick(data, includableAdapterRequestProperties),
+    excludableInternalAdapterRequestProperties.map((property) => `data.${property}`),
+  )
+
+export type HashMode = 'include' | 'exclude'
+/**
+ * Generates a key by hashing input data
+ *
+ * @param data Adapter request input data
+ * @param hashOptions Additional configuration for the objectHash package
+ * @param mode Which behavior to use:
+ *    include (default) - hash only selected properties throwing out everything else
+ *    exclude           - hash the entire data object after excluding certain properties
+ *
+ * @returns string
+ */
+export const hash = (
+  data: AdapterRequest,
+  hashOptions: Required<Parameters<typeof objectHash>>['1'],
+  mode: HashMode = 'include',
+): string => {
+  console.log('AHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHhhh')
+  return mode === 'include' || !data
+    ? objectHash(getKeyData(data), hashOptions)
+    : objectHash(data, getHashOpts())
+}
+
+export const getHashOpts = (): Required<Parameters<typeof objectHash>>['1'] => ({
+  algorithm: 'sha1',
+  encoding: 'hex',
+  unorderedSets: false,
+  respectType: false,
+  respectFunctionProperties: false,
+  respectFunctionNames: false,
+  excludeKeys: (props: string) => excludableAdapterRequestProperties[props],
+})

--- a/packages/core/bootstrap/src/lib/middleware/cache-warmer/config.ts
+++ b/packages/core/bootstrap/src/lib/middleware/cache-warmer/config.ts
@@ -1,5 +1,5 @@
 import objectHash from 'object-hash'
-import { getHashOpts } from '../../util'
+import { getHashOpts } from '../../middleware/cache-key/util'
 import { logger } from '../../modules'
 
 export const WARMUP_REQUEST_ID = '9001'

--- a/packages/core/bootstrap/src/lib/middleware/cache-warmer/epics.ts
+++ b/packages/core/bootstrap/src/lib/middleware/cache-warmer/epics.ts
@@ -83,7 +83,7 @@ export const executeHandler: Epic<AnyAction, AnyAction, RootState, EpicDependenc
       // If result was from a batch request
       if (payload.result?.data?.results) {
         const members = []
-        for (const [request] of Object.values<[AdapterRequest, number]>(
+        for (const [childKey, request] of Object.values<[string, AdapterRequest, number]>(
           payload.result.data.results,
         )) {
           const warmupSubscribedPayloadChild = {
@@ -91,8 +91,8 @@ export const executeHandler: Epic<AnyAction, AnyAction, RootState, EpicDependenc
             ...request,
             parent: batchWarmerSubscriptionKey,
             batchablePropertyPath,
+            key: childKey,
           }
-          const childKey = getSubscriptionKey(warmupSubscribedPayloadChild)
           childLastSeenById[childKey] = Date.now()
           members.push(warmupSubscribedPayloadChild)
         }
@@ -103,7 +103,8 @@ export const executeHandler: Epic<AnyAction, AnyAction, RootState, EpicDependenc
           parent: batchWarmerSubscriptionKey,
           batchablePropertyPath,
         }
-        const childKey = getSubscriptionKey(warmupSubscribedPayloadChild)
+        // TODO: check this
+        const childKey = payload.debug?.cacheKey ?? getSubscriptionKey(warmupSubscribedPayloadChild)
         childLastSeenById[childKey] = Date.now()
         actionsToDispatch.push(warmupSubscribed(warmupSubscribedPayloadChild))
       }

--- a/packages/core/bootstrap/src/lib/middleware/cache-warmer/epics.ts
+++ b/packages/core/bootstrap/src/lib/middleware/cache-warmer/epics.ts
@@ -162,7 +162,7 @@ export const warmupSubscriber: Epic<AnyAction, AnyAction, any, EpicDependencies>
     filter(warmupSubscribed.match),
     map(({ payload }) => ({
       payload,
-      key: payload.key || getSubscriptionKey(payload),
+      key: payload.key || payload.debug?.cacheKey || getSubscriptionKey(payload),
     })),
     withLatestFrom(state$),
     // check if the subscription already exists, then noop
@@ -312,7 +312,10 @@ export const warmupUnsubscriber: Epic<AnyAction, AnyAction, any, EpicDependencie
   // used as a helper stream for the timeout limit stream
   const keyedSubscription$ = action$.pipe(
     filter(warmupSubscribed.match),
-    map(({ payload }) => ({ payload, key: getSubscriptionKey(payload) })),
+    map(({ payload }) => ({
+      payload,
+      key: payload.debug?.cacheKey || getSubscriptionKey(payload),
+    })),
   )
 
   const unsubscribeOnTimeout$ = keyedSubscription$.pipe(

--- a/packages/core/bootstrap/src/lib/middleware/cache-warmer/reducer.ts
+++ b/packages/core/bootstrap/src/lib/middleware/cache-warmer/reducer.ts
@@ -70,7 +70,6 @@ export const subscriptionsReducer = createReducer<SubscriptionState>({}, (builde
   builder.addCase(actions.warmupSubscribedMultiple, (state, { payload }) => {
     for (const member of payload.members) {
       const key = member.key || getSubscriptionKey(member)
-      // TODO
       state[key] = {
         origin: member.data,
         executeFn: member.executeFn,

--- a/packages/core/bootstrap/src/lib/middleware/cache-warmer/reducer.ts
+++ b/packages/core/bootstrap/src/lib/middleware/cache-warmer/reducer.ts
@@ -55,7 +55,7 @@ export interface SubscriptionState {
 
 export const subscriptionsReducer = createReducer<SubscriptionState>({}, (builder) => {
   builder.addCase(actions.warmupSubscribed, (state, { payload }) => {
-    const key = payload.key || getSubscriptionKey(payload)
+    const key = payload.key || payload.debug?.cacheKey || getSubscriptionKey(payload)
     state[key] = {
       origin: payload.data,
       executeFn: payload.executeFn,
@@ -70,6 +70,7 @@ export const subscriptionsReducer = createReducer<SubscriptionState>({}, (builde
   builder.addCase(actions.warmupSubscribedMultiple, (state, { payload }) => {
     for (const member of payload.members) {
       const key = member.key || getSubscriptionKey(member)
+      // TODO
       state[key] = {
         origin: member.data,
         executeFn: member.executeFn,

--- a/packages/core/bootstrap/src/lib/middleware/cache-warmer/util.ts
+++ b/packages/core/bootstrap/src/lib/middleware/cache-warmer/util.ts
@@ -9,7 +9,6 @@ const conf = get()
 export function getSubscriptionKey(
   request: WarmupSubscribedPayload | WarmupExecutePayload,
 ): string {
-  console.log(1)
   return hash(
     omit(request, ['id', 'parent', 'children', 'result', 'batchablePropertyPath']),
     conf.hashOpts,

--- a/packages/core/bootstrap/src/lib/middleware/cache-warmer/util.ts
+++ b/packages/core/bootstrap/src/lib/middleware/cache-warmer/util.ts
@@ -3,12 +3,13 @@ import { WarmupExecutePayload, WarmupSubscribedPayload } from './actions'
 import { get } from './config'
 import { BatchableProperty, SubscriptionData } from './reducer'
 import { AdapterRequest, AdapterResponse } from '@chainlink/types'
-import { hash } from '../../util'
+import { hash } from '../../middleware/cache-key/util'
 
 const conf = get()
 export function getSubscriptionKey(
   request: WarmupSubscribedPayload | WarmupExecutePayload,
 ): string {
+  console.log(1)
   return hash(
     omit(request, ['id', 'parent', 'children', 'result', 'batchablePropertyPath']),
     conf.hashOpts,

--- a/packages/core/bootstrap/src/lib/middleware/cache/index.ts
+++ b/packages/core/bootstrap/src/lib/middleware/cache/index.ts
@@ -9,15 +9,7 @@ import { logger } from '../../modules'
 import { Store } from 'redux'
 import { reducer } from '../burst-limit'
 import { withBurstLimit } from '../burst-limit'
-import {
-  delay,
-  exponentialBackOffMs,
-  getHashOpts,
-  getWithCoalescing,
-  parseBool,
-  uuid,
-  hash,
-} from '../../util'
+import { delay, exponentialBackOffMs, getWithCoalescing, parseBool, uuid } from '../../util'
 import { getMaxAgeOverride, getTTL } from './ttl'
 import * as local from './local'
 import { LocalOptions } from './local'
@@ -116,7 +108,6 @@ export const redactOptions = (options: CacheOptions): CacheOptions => ({
 export class AdapterCache {
   private readonly options: CacheOptions
   private cache: Cache
-  private hashOptions = getHashOpts()
 
   constructor(context: AdapterContext) {
     if (!context?.cache?.instance) throw Error(`cache not initiated`)
@@ -130,7 +121,7 @@ export class AdapterCache {
   }
 
   public getKey(data: AdapterRequest): string {
-    return `${this.options.key.group}:${hash(data, this.hashOptions)}`
+    return `${this.options.key.group}:${data.debug?.cacheKey}`
   }
 
   public get instance(): Cache {

--- a/packages/core/bootstrap/src/lib/middleware/rate-limit/index.ts
+++ b/packages/core/bootstrap/src/lib/middleware/rate-limit/index.ts
@@ -1,6 +1,6 @@
 import { AdapterRequest, Middleware } from '@chainlink/types'
 import { Store } from 'redux'
-import { getHashOpts, hash } from '../../util'
+import { getHashOpts, hash } from '../../middleware/cache-key/util'
 import { successfulResponseObserved } from './actions'
 import { Config } from './config'
 import * as metrics from './metrics'
@@ -74,7 +74,7 @@ export const withRateLimit =
     if (!config.enabled) return await execute(input, context)
     let state = store.getState()
     const { heartbeats } = state
-    const requestTypeId = makeId(input)
+    const requestTypeId = input?.debug?.cacheKey ?? makeId(input)
     const maxThroughput = computeThroughput(config, heartbeats, IntervalNames.HOUR, requestTypeId)
     const maxAge = maxAgeFor(maxThroughput, Intervals[IntervalNames.MINUTE])
     const result = await execute({ ...input, rateLimitMaxAge: maxAge }, context)

--- a/packages/core/bootstrap/src/lib/middleware/rate-limit/reducer.ts
+++ b/packages/core/bootstrap/src/lib/middleware/rate-limit/reducer.ts
@@ -51,7 +51,7 @@ const DEFAULT_COST = 1
 const heartbeatReducer = createReducer<Heartbeats>(initialHeartbeatsState, (builder) => {
   builder.addCase(successfulResponseObserved, (state, action) => {
     const heartbeat: Heartbeat = {
-      id: makeId(action.payload.input),
+      id: action.payload.input?.debug?.cacheKey ?? makeId(action.payload.input),
       c: action.payload.response.data.cost || DEFAULT_COST,
       t: Date.parse(action.payload.createdAt),
       h: !!action.payload.response.maxAge,

--- a/packages/core/bootstrap/src/lib/middleware/ws/reducer.ts
+++ b/packages/core/bootstrap/src/lib/middleware/ws/reducer.ts
@@ -1,7 +1,7 @@
 import { AdapterContext, AdapterRequest } from '@chainlink/types'
 import { combineReducers, createReducer, isAnyOf } from '@reduxjs/toolkit'
 import { logger } from '../../modules'
-import { getHashOpts, hash } from '../../util'
+import { getHashOpts, hash } from '../../middleware/cache-key/util'
 import * as actions from './actions'
 
 /**

--- a/packages/core/bootstrap/src/lib/modules/requester.ts
+++ b/packages/core/bootstrap/src/lib/modules/requester.ts
@@ -5,6 +5,7 @@ import {
   AdapterRequest,
   AdapterRequestData,
   ResultPath,
+  AdapterBatchResponse,
 } from '@chainlink/types'
 import { reducer } from '../middleware/cache-warmer'
 import axios, { AxiosResponse } from 'axios'
@@ -134,7 +135,7 @@ export class Requester {
   static withResult<T>(
     response: AxiosResponse<T>,
     result?: number | string,
-    results?: [AdapterRequest, number][],
+    results?: [string, AdapterRequest, number][],
   ): AxiosResponseWithLiftedResult<T> | AxiosResponseWithPayloadAndLiftedResult<T> {
     const isObj = deepType(response.data) === 'object'
     const output = isObj
@@ -248,7 +249,7 @@ interface BatchedResult {
    *    its result
    * ]
    */
-  results?: [AdapterRequest, number][]
+  results?: AdapterBatchResponse
 }
 
 /**

--- a/packages/core/bootstrap/src/lib/util.ts
+++ b/packages/core/bootstrap/src/lib/util.ts
@@ -1,7 +1,6 @@
-import { AdapterImplementation, AdapterRequest } from '@chainlink/types'
+import { AdapterImplementation } from '@chainlink/types'
 import { Decimal } from 'decimal.js'
-import { flatMap, values, pick, omit } from 'lodash'
-import objectHash from 'object-hash'
+import { flatMap, values } from 'lodash'
 import { v4 as uuidv4 } from 'uuid'
 import { CacheEntry } from './middleware/cache/types'
 
@@ -178,72 +177,6 @@ export const toFixedMax = (num: number | string | Decimal, decimals: number): st
     .replace(/(\.\d*?[1-9])0+$/g, '$1')
     // remove decimal part if all zeros (or only decimal point)
     .replace(/\.0*$/g, '')
-
-/** Common keys within adapter requests that should be ignored to generate a stable key*/
-export const excludableAdapterRequestProperties: Record<string, true> = [
-  'id',
-  'maxAge',
-  'meta',
-  'debug',
-  'rateLimitMaxAge',
-  'metricsMeta',
-]
-  .concat((process.env.CACHE_KEY_IGNORED_PROPS || '').split(',').filter((k) => k))
-  .reduce((prev, next) => {
-    prev[next] = true
-    return prev
-  }, {} as Record<string, true>)
-
-/** Common keys within adapter requests that should be used to generate a stable key*/
-export const includableAdapterRequestProperties: string[] = ['data'].concat(
-  (process.env.CACHE_KEY_INCLUDED_PROPS || '').split(',').filter((k) => k),
-)
-
-/** Common keys within adapter requests that should be ignored within "data" to create a stable key*/
-export const excludableInternalAdapterRequestProperties = [
-  'resultPath',
-  'overrides',
-  'tokenOverrides',
-  'includes',
-]
-
-export const getKeyData = (data: AdapterRequest) =>
-  omit(
-    pick(data, includableAdapterRequestProperties),
-    excludableInternalAdapterRequestProperties.map((property) => `data.${property}`),
-  )
-
-export type HashMode = 'include' | 'exclude'
-/**
- * Generates a key by hashing input data
- *
- * @param data Adapter request input data
- * @param hashOptions Additional configuration for the objectHash package
- * @param mode Which behavior to use:
- *    include (default) - hash only selected properties throwing out everything else
- *    exclude           - hash the entire data object after excluding certain properties
- *
- * @returns string
- */
-export const hash = (
-  data: AdapterRequest,
-  hashOptions: Required<Parameters<typeof objectHash>>['1'],
-  mode: HashMode = 'include',
-): string => {
-  return mode === 'include' || !data
-    ? objectHash(getKeyData(data), hashOptions)
-    : objectHash(data, getHashOpts())
-}
-
-export const getHashOpts = (): Required<Parameters<typeof objectHash>>['1'] => ({
-  algorithm: 'sha1',
-  encoding: 'hex',
-  unorderedSets: false,
-  respectType: false,
-  respectFunctionProperties: false,
-  respectFunctionNames: false,
-  excludeKeys: (props: string) => excludableAdapterRequestProperties[props],
-})
 
 // Helper to identify if debug mode is running
 export const isDebug = (): boolean => {

--- a/packages/core/types/@chainlink/index.d.ts
+++ b/packages/core/types/@chainlink/index.d.ts
@@ -104,6 +104,8 @@ declare module '@chainlink/types' {
     error: ErrorBasic | ErrorFull
   }
 
+  export type AdapterBatchResponse = [string, AdapterRequest, number][]
+
   /* BOOTSTRAP */
   export type Middleware = (
     execute: Execute,

--- a/packages/core/types/@chainlink/index.d.ts
+++ b/packages/core/types/@chainlink/index.d.ts
@@ -22,6 +22,7 @@ declare module '@chainlink/types' {
   }
 
   export type AdapterDebug = {
+    cacheKey?: string
     ws?: boolean
     warmer?: boolean
     cacheHit?: boolean

--- a/packages/k6/src/test.ts
+++ b/packages/k6/src/test.ts
@@ -51,7 +51,7 @@ function getLoadTestGroupsUrls(): LoadTestGroupUrls {
      */
     return {
       local: {
-        [__ENV.LOCAL_ADAPTER_NAME]: 'http://host.docker.internal:8080',
+        [__ENV.LOCAL_ADAPTER_NAME]: 'http://localhost:8080',
       },
     }
   } else {
@@ -144,6 +144,7 @@ function buildRequests() {
 }
 
 const batchRequests = buildRequests()
+console.log(JSON.stringify(batchRequests))
 
 export default (): void => {
   currIteration++

--- a/packages/sources/fixer/src/endpoint/latest.ts
+++ b/packages/sources/fixer/src/endpoint/latest.ts
@@ -1,10 +1,11 @@
-import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import { Requester, Validator, CacheKey } from '@chainlink/ea-bootstrap'
 import {
   ExecuteWithConfig,
   Config,
   InputParameters,
   AdapterRequest,
   AxiosResponse,
+  AdapterBatchResponse,
 } from '@chainlink/types'
 import { NAME as AdapterName } from '../config'
 
@@ -39,17 +40,31 @@ const handleBatchedRequest = (
   resultPath: string,
   symbols: string[],
 ) => {
-  const payload: [AdapterRequest, number][] = []
+  const payload: AdapterBatchResponse = []
+
   for (const symbol of symbols) {
     const from = response.data.base
+
+    const individualRequest = {
+      ...request,
+      data: { ...request.data, base: from.toUpperCase(), quote: symbol.toUpperCase() },
+    }
+
+    const result = Requester.validateResultNumber(response.data, [resultPath, symbol])
+
     payload.push([
-      {
-        ...request,
-        data: { ...request.data, base: from.toUpperCase(), quote: symbol.toUpperCase() },
-      },
-      Requester.validateResultNumber(response.data, [resultPath, symbol]),
+      CacheKey.getCacheKey(individualRequest, inputParameters),
+      individualRequest,
+      result,
+    ])
+
+    payload.push([
+      CacheKey.getCacheKey(individualRequest, inputParameters),
+      individualRequest,
+      result,
     ])
   }
+
   return Requester.success(
     jobRunID,
     Requester.withResult(response, undefined, payload),

--- a/packages/sources/openexchangerates/src/endpoint/forex.ts
+++ b/packages/sources/openexchangerates/src/endpoint/forex.ts
@@ -1,10 +1,11 @@
-import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import { Requester, Validator, CacheKey } from '@chainlink/ea-bootstrap'
 import {
   ExecuteWithConfig,
   Config,
   InputParameters,
   AdapterRequest,
   AxiosResponse,
+  AdapterBatchResponse,
 } from '@chainlink/types'
 import { NAME as AdapterName } from '../config'
 
@@ -44,17 +45,25 @@ const handleBatchedRequest = (
   resultPath: string,
   symbols: string[],
 ) => {
-  const payload: [AdapterRequest, number][] = []
+  const payload: AdapterBatchResponse = []
+
   for (const symbol of symbols) {
     const from = response.data.base
+
+    const individualRequest = {
+      ...request,
+      data: { ...request.data, base: from.toUpperCase(), quote: symbol.toUpperCase() },
+    }
+
+    const result = Requester.validateResultNumber(response.data, [resultPath, symbol])
+
     payload.push([
-      {
-        ...request,
-        data: { ...request.data, base: from.toUpperCase(), quote: symbol.toUpperCase() },
-      },
-      Requester.validateResultNumber(response.data, [resultPath, symbol]),
+      CacheKey.getCacheKey(individualRequest, inputParameters),
+      individualRequest,
+      result,
     ])
   }
+
   return Requester.success(
     jobRunID,
     Requester.withResult(response, undefined, payload),


### PR DESCRIPTION
<!-- Employees: Please use Clubhouse/Shortcuts's "Open PR" button from the relevant story or include links to relevant Clubhouse/Shortcut stories in your branch name, commit messages, or pull request comments. Do not add links to your pull request description, they will be ignored. https://help.clubhouse.io/hc/en-us/articles/207540323-Using-The-Clubhouse-GitHub-Integration -->

<!-- Employees: Delete this section. -->

## Description
To avoid `object-hash` sorts we can instead use the `inputParameters` of a request to generate a deterministic cache key by hashing together the values.

## Changes

- Introduces a new middleware `cache-key` that is used to generate the cache key one time, then add it to the `AdapterContext` for re-use across the EA framework's execution.
- Modifies the structure of batch data `.results` to include the child data's cache key. Updates batchable EAs with this change.

## Caveats
- WS cache keys still use `object-hash`ing

## TODO:
- [ ] WS cache keys
- [ ] Additional unit tests
- [ ] Profiling

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test
Single pair
1. Run any external adapter with batch warming
2. Send un-batched single pair request
3. Request again. It should be cached from the request on step 2.

Single pair from warmer
1. Run any external adapter with batch warming
2. Send un-batched single pair request
3. Request again after ~1 minute. It should be cached after being topped up from the cache warmer.

Batch request
1. Run any external adapter with batch warming
2. Send batched request (e.g. `base: ["BTC", "ETH"], quote: "USD"`)
3. Request again. It should be cached from the request on step 2.

Batch request from warmer
1. Run any external adapter with batch warming
2. Send batched request (e.g. `base: ["BTC", "ETH"], quote: "USD"`)
3. Request again after ~1 minute. It should be cached after being topped up from the cache warmer.

Single pairs fulfilled from warmer
1. Run any external adapter with batch warming
2. Send multiple single pair requests
3. Request each of them again after ~1 minute. It should be cached after being topped up from the cache warmer.

## Quality Assurance

- [x] Ran `yarn changeset` if adapter source code was changed
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
