### PR TITLE
18580 - URL Path Builder (adapters B-C) 

### DIFF
--- a/.changeset/afraid-books-tap.md
+++ b/.changeset/afraid-books-tap.md
@@ -1,0 +1,46 @@
+---
+'@chainlink/ea-bootstrap': minor
+'@chainlink/accuweather-adapter': minor
+'@chainlink/amberdata-adapter': minor
+'@chainlink/ap-election-adapter': minor
+'@chainlink/bitex-adapter': minor
+'@chainlink/blockchain.com-adapter': minor
+'@chainlink/blockchair-adapter': minor
+'@chainlink/btc.com-adapter': minor
+'@chainlink/coinapi-adapter': minor
+'@chainlink/coinbase-adapter': minor
+'@chainlink/coincodex-adapter': minor
+'@chainlink/coinmetrics-adapter': minor
+'@chainlink/coinpaprika-adapter': minor
+'@chainlink/covid-tracker-adapter': minor
+'@chainlink/cryptoapis-adapter': minor
+'@chainlink/cryptoapis-v2-adapter': minor
+'@chainlink/cryptomkt-adapter': minor
+'@chainlink/eodhistoricaldata-adapter': minor
+'@chainlink/expert-car-broker-adapter': minor
+'@chainlink/fcsapi-adapter': minor
+'@chainlink/finage-adapter': minor
+'@chainlink/finnhub-adapter': minor
+'@chainlink/fmpcloud-adapter': minor
+'@chainlink/gemini-adapter': minor
+'@chainlink/geodb-adapter': minor
+'@chainlink/iex-cloud-adapter': minor
+'@chainlink/intrinio-adapter': minor
+'@chainlink/kaiko-adapter': minor
+'@chainlink/linkpool-adapter': minor
+'@chainlink/lition-adapter': minor
+'@chainlink/messari-adapter': minor
+'@chainlink/oilpriceapi-adapter': minor
+'@chainlink/paxos-adapter': minor
+'@chainlink/polygon-adapter': minor
+'@chainlink/satoshitango-adapter': minor
+'@chainlink/sochain-adapter': minor
+'@chainlink/sportsdataio-adapter': minor
+'@chainlink/therundown-adapter': minor
+'@chainlink/tiingo-adapter': minor
+'@chainlink/tradingeconomics-adapter': minor
+'@chainlink/uscpi-one-adapter': minor
+'@chainlink/xbto-adapter': minor
+---
+
+Added buildUrl & buildUrlPath methods to util. Updated source adapters to use these methods for building URLs with user input.

--- a/packages/core/bootstrap/src/lib/util.ts
+++ b/packages/core/bootstrap/src/lib/util.ts
@@ -373,3 +373,103 @@ export const getRequiredEnvWithFallback = (
 
   throw new RequiredEnvError(getEnvName(primary, prefix))
 }
+
+//  URL Encoding
+
+const charsToEncode = {
+  ':': '%3A',
+  '/': '%2F',
+  '?': '%3F',
+  '#': '%23',
+  '[': '%5B',
+  ']': '%5D',
+  '@': '%40',
+  '!': '%21',
+  $: '%24',
+  '&': '%26',
+  "'": '%27',
+  '(': '%28',
+  ')': '%29',
+  '*': '%2A',
+  '+': '%2B',
+  ',': '%2C',
+  ';': '%3B',
+  '=': '%3D',
+  '%': '%25',
+  ' ': '%20',
+  '"': '%22',
+  '<': '%3C',
+  '>': '%3E',
+  '{': '%7B',
+  '}': '%7D',
+  '|': '%7C',
+  '^': '%5E',
+  '`': '%60',
+  '\\': '%5C',
+}
+
+/**
+ * Check whether the given string contains characters in the given whitelist.
+ * @param str The string to check.
+ * @param whitelist The string array of whitelist entries. Returns true if any of these are found in 'str', otherwise returns false.
+ * @returns {boolean}
+ */
+const stringHasWhitelist = (str: string, whitelist: string[]): boolean =>
+  whitelist.some((el) => str.includes(el))
+
+/**
+ * Manually iterate through a given string and replace unsafe/reserved characters with encoded values (unless a character is whitelisted)
+ * @param str The string to encode.
+ * @param whitelist The string array of whitelist entries.
+ * @returns {boolean}
+ */
+const percentEncodeString = (str: string, whitelist: string[]): string =>
+  str
+    .split('')
+    .map((char) => {
+      const encodedValue = charsToEncode[char as keyof typeof charsToEncode]
+      return encodedValue && !whitelist.includes(char) ? encodedValue : char
+    })
+    .join('')
+
+/**
+ * Build a URL path using the given pathTemplate and params. If a param is found in pathTemplate, it will be inserted there; otherwise, it will be added as a searchParam.
+ * eg.) pathTemplate = "/from/:from/to/:to" and params = { from: "ETH", to: "BTC", note: "hello" } will become "/from/ETH/to/BTC?note=hello"
+ * @param pathTemplate The path template for the URL path. Each param to include in the path should have a prefix of ':'. Leave empty if only searchParams are required.
+ * @param params The object containing keys & values to be added to the URL path. Each value can be either a string or an object of { value: string, skipEncoding: boolean }.
+ * @param whitelist The list of characters to whitelist for the URL path (if a param contains one of your whitelisted characters, it will not be encoded).
+ * @returns {string}
+ */
+export const buildUrlPath = (pathTemplate = '', params = {}, whitelist = ''): string => {
+  const allowedChars = whitelist.split('')
+  let searchParams = ''
+
+  for (const param in params) {
+    const value = params[param as keyof typeof params]
+    if (!value) continue
+
+    // If string contains a whitelisted character: manually replace any non-whitelisted characters with percent encoded values. Otherwise, encode the string as usual.
+    const encodedValue = stringHasWhitelist(value, allowedChars)
+      ? percentEncodeString(value, allowedChars)
+      : encodeURIComponent(value)
+
+    if (pathTemplate.includes(`:${param}`))
+      pathTemplate = pathTemplate.replace(`:${param}`, encodedValue)
+    else searchParams += `${searchParams ? '&' : '?'}${param}=${encodedValue}`
+  }
+
+  return pathTemplate + searchParams
+}
+
+/**
+ * Build a full URL using the given baseUrl, pathTemplate and params. Uses buildUrlPath to add path & params.
+ * @param baseUrl The base URL to add the pathTemplate & params to.
+ * @param pathTemplate The path template for the URL path. Leave empty if only searchParams are required.
+ * @param params The object containing keys & values to be added to the URL path.
+ * @param whitelist The list of characters to whitelist for the URL path (if a param contains one of your whitelisted characters, it will not be encoded).
+ * @returns {string}
+ */
+export const buildUrl = (baseUrl: string, pathTemplate = '', params = {}, whitelist = ''): string =>
+  new URL(buildUrlPath(pathTemplate, params, whitelist), baseUrl).toString()
+
+//  URL Encoding

--- a/packages/core/bootstrap/test/unit/utils.test.ts
+++ b/packages/core/bootstrap/test/unit/utils.test.ts
@@ -1,4 +1,4 @@
-import { getEnv } from '../../src/lib/util'
+import { getEnv, buildUrlPath, buildUrl } from '../../src/lib/util'
 
 describe('utils', () => {
   let oldEnv
@@ -22,6 +22,124 @@ describe('utils', () => {
       process.env.TEST = ''
       const actual = getEnv('TEST')
       expect(actual).toBeUndefined()
+    })
+  })
+
+  describe(`buildUrlPath`, () => {
+    it(`builds path with valid characters`, () => {
+      const actual = buildUrlPath('/from/:from/to/:to', {
+        from: 'ETH',
+        to: 'USD',
+        message: 'hello_world',
+      })
+      expect(actual).toEqual('/from/ETH/to/USD?message=hello_world')
+    })
+
+    it(`builds path with whitelisted & non-whitelisted characters`, () => {
+      const actual = buildUrlPath(
+        '/from/:from/to/:to',
+        {
+          from: 'E:T?H',
+          to: 'U%S\\D',
+          message: 'hello world!',
+        },
+        ':%^ !',
+      )
+      expect(actual).toEqual('/from/E:T%3FH/to/U%S%5CD?message=hello world!')
+    })
+
+    it(`builds path from empty string`, () => {
+      const actual = buildUrlPath('', { from: 'ETH', to: 'USD', message: 'hello_world' })
+      expect(actual).toEqual('?from=ETH&to=USD&message=hello_world')
+    })
+
+    it(`builds path with no params`, () => {
+      const actual = buildUrlPath('/from/to')
+      expect(actual).toEqual('/from/to')
+    })
+
+    it(`builds path with reserved characters`, () => {
+      const actual = buildUrlPath('/from/:from/to/:to', {
+        from: 'ETH:USD',
+        to: 'USD/?ETH=USD',
+        message: 'hello;+world',
+      })
+      expect(actual).toEqual('/from/ETH%3AUSD/to/USD%2F%3FETH%3DUSD?message=hello%3B%2Bworld')
+    })
+
+    it(`builds path with unsafe characters`, () => {
+      const actual = buildUrlPath('/from/:from/to/:to', {
+        from: 'ETH"USD"',
+        to: '{U|S|D>',
+        message: 'hello world',
+      })
+      expect(actual).toEqual('/from/ETH%22USD%22/to/%7BU%7CS%7CD%3E?message=hello%20world')
+      expect(decodeURI(actual)).toEqual('/from/ETH"USD"/to/{U|S|D>?message=hello world')
+    })
+
+    it(`builds path with non-latin characters`, () => {
+      const actual = buildUrlPath('/from/:from/to/:to', {
+        from: 'abcÂÃ',
+        to: 'доллар_США',
+        message: '你好世界',
+      })
+      expect(actual).toEqual(
+        '/from/abc%C3%82%C3%83/to/%D0%B4%D0%BE%D0%BB%D0%BB%D0%B0%D1%80_%D0%A1%D0%A8%D0%90?message=%E4%BD%A0%E5%A5%BD%E4%B8%96%E7%95%8C',
+      )
+      expect(decodeURI(actual)).toEqual('/from/abcÂÃ/to/доллар_США?message=你好世界')
+    })
+  })
+
+  describe(`buildUrl`, () => {
+    it(`builds URL with a given base, path & params`, () => {
+      const baseWsURL = 'wss://example.com:8000'
+      const asset = 'BTC'
+      const metrics = 'hello'
+      const key = 123456
+
+      const expected = `${baseWsURL}/timeseries-stream/asset-metrics?assets=${asset}&metrics=${metrics}&frequency=1s&api_key=${key}`
+      const actual = buildUrl(baseWsURL, '/timeseries-stream/asset-metrics', {
+        assets: asset,
+        metrics: metrics,
+        frequency: '1s',
+        api_key: key,
+      })
+
+      expect(actual).toEqual(expected)
+    })
+
+    it(`builds URL with a given base & path only`, () => {
+      const baseWsURL = 'wss://example.com:8000'
+      const expected = `${baseWsURL}/timeseries-stream/asset-metrics`
+      const actual = buildUrl(baseWsURL, '/timeseries-stream/asset-metrics')
+
+      expect(actual).toEqual(expected)
+    })
+
+    it(`builds URL with a given base & params only`, () => {
+      const baseWsURL = 'wss://example.com:8000'
+      const asset = 'BTC'
+      const metrics = 'hello'
+      const key = 123456
+
+      const expected = `${baseWsURL}/?assets=${asset}&metrics=${metrics}&frequency=1s&api_key=${key}`
+      const actual = buildUrl(baseWsURL, '', {
+        assets: asset,
+        metrics: metrics,
+        frequency: '1s',
+        api_key: key,
+      })
+
+      expect(actual).toEqual(expected)
+    })
+
+    it(`builds URL with basic auth (key:secret)`, () => {
+      const withApiKey = (url: string, key: string, secret: string) =>
+        buildUrl(url, '', { client: `${key}:${secret}` }, ':')
+      const expected = `wss://stream.tradingeconomics.com/?client=keystring:secretstring`
+      const actual = withApiKey('wss://stream.tradingeconomics.com', 'keystring', 'secretstring')
+
+      expect(actual).toEqual(expected)
     })
   })
 })

--- a/packages/sources/accuweather/src/endpoint/current-conditions.ts
+++ b/packages/sources/accuweather/src/endpoint/current-conditions.ts
@@ -1,4 +1,4 @@
-import { AdapterError, Requester, Validator } from '@chainlink/ea-bootstrap'
+import { AdapterError, Requester, util, Validator } from '@chainlink/ea-bootstrap'
 import { AxiosResponse, Config, ExecuteWithConfig, InputParameters } from '@chainlink/types'
 import { utils } from 'ethers'
 
@@ -221,7 +221,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
 
   validateUnitsParameter(jobRunID, units)
 
-  const url = `currentconditions/v1/${locationKey}.json`
+  const url = util.buildUrlPath('currentconditions/v1/:locationKey.json', { locationKey })
   const params = {
     details: true,
     apikey: config.apiKey,

--- a/packages/sources/amberdata/src/endpoint/balance.ts
+++ b/packages/sources/amberdata/src/endpoint/balance.ts
@@ -1,4 +1,4 @@
-import { Requester } from '@chainlink/ea-bootstrap'
+import { Requester, util } from '@chainlink/ea-bootstrap'
 import { balance } from '@chainlink/ea-factories'
 import { Config, ExecuteFactory, RequestConfig } from '@chainlink/types'
 import { BLOCKCHAINS, isChainType, isCoinType } from '../config'
@@ -21,7 +21,8 @@ export interface ResponseSchema {
   }
 }
 
-const getBalanceURI = (address: string) => `/api/v2/addresses/${address}/account-balances/latest`
+const getBalanceURI = (address: string) =>
+  util.buildUrlPath('/api/v2/addresses/:address/account-balances/latest', { address })
 
 const getBlockchainHeader = (coin?: string) => {
   const network = Requester.toVendorName(coin, BLOCKCHAINS)

--- a/packages/sources/amberdata/src/endpoint/crypto.ts
+++ b/packages/sources/amberdata/src/endpoint/crypto.ts
@@ -1,4 +1,4 @@
-import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import { Requester, util, Validator } from '@chainlink/ea-bootstrap'
 import { ExecuteWithConfig, Config, Includes, IncludePair, InputParameters } from '@chainlink/types'
 import { NAME as AdapterName } from '../config'
 import includes from './../config/includes.json'
@@ -10,12 +10,18 @@ const customError = (data: ResponseSchema) => {
 }
 
 const symbolOptions = (from: string, to: string) => ({
-  url: `/api/v2/market/spot/prices/pairs/${from.toLowerCase()}_${to.toLowerCase()}/latest`,
+  url: util.buildUrlPath('/api/v2/market/spot/prices/pairs/:from_:to/latest', {
+    from: from.toLowerCase(),
+    to: to.toLowerCase(),
+  }),
   params: { includeCrossRates: true },
 })
 
 const tokenOptions = (from: string, to: string) => ({
-  url: `/api/v2/market/defi/prices/pairs/bases/${from}/quotes/${to}/latest`,
+  url: util.buildUrlPath('/api/v2/market/defi/prices/pairs/bases/:from/quotes/:to/latest', {
+    from,
+    to,
+  }),
   params: {},
 })
 

--- a/packages/sources/amberdata/src/endpoint/token.ts
+++ b/packages/sources/amberdata/src/endpoint/token.ts
@@ -1,4 +1,4 @@
-import { AdapterError, Requester, Validator } from '@chainlink/ea-bootstrap'
+import { AdapterError, Requester, util, Validator } from '@chainlink/ea-bootstrap'
 import { ExecuteWithConfig, Config, InputParameters } from '@chainlink/types'
 import includes from './../config/includes.json'
 
@@ -48,7 +48,9 @@ export const execute: ExecuteWithConfig<Config> = async (input, _, config) => {
   const jobRunID = validator.validated.id
   const coin = validator.validated.data.base
   const resultPath = validator.validated.data.resultPath || 'marketCapUSD'
-  const url = `/api/v2/market/tokens/prices/${coin.toLowerCase()}/latest`
+  const url = util.buildUrlPath(`/api/v2/market/tokens/prices/:coin/latest`, {
+    coin: coin.toLowerCase(),
+  })
 
   const reqConfig = { ...config.api, url }
 

--- a/packages/sources/amberdata/src/endpoint/volume.ts
+++ b/packages/sources/amberdata/src/endpoint/volume.ts
@@ -1,4 +1,4 @@
-import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import { Requester, util, Validator } from '@chainlink/ea-bootstrap'
 import { ExecuteWithConfig, Config, Includes, IncludePair, InputParameters } from '@chainlink/types'
 import { NAME as AdapterName } from '../config'
 import includes from './../config/includes.json'
@@ -13,7 +13,10 @@ const today = new Date()
 const yesterday = new Date(today)
 
 const symbolOptions = (from: string, to: string) => ({
-  url: `/api/v2/market/spot/prices/pairs/${from.toLowerCase()}_${to.toLowerCase()}/historical`,
+  url: util.buildUrlPath('/api/v2/market/spot/prices/pairs/:from_:to/historical', {
+    from: from.toLowerCase(),
+    to: to.toLowerCase(),
+  }),
   params: {
     timeInterval: 'd',
     startDate: yesterday.setDate(yesterday.getDate() - 1),
@@ -23,7 +26,10 @@ const symbolOptions = (from: string, to: string) => ({
 })
 
 const tokenOptions = (from: string, to: string) => ({
-  url: `/api/v2/market/defi/prices/pairs/bases/${from}/quotes/${to}/historical`,
+  url: util.buildUrlPath('/api/v2/market/defi/prices/pairs/bases/:from/quotes/:to/historical', {
+    from,
+    to,
+  }),
   params: {
     timeInterval: 'd',
     startDate: yesterday.setDate(yesterday.getDate() - 1),

--- a/packages/sources/ap-election/src/endpoint/election.ts
+++ b/packages/sources/ap-election/src/endpoint/election.ts
@@ -1,4 +1,4 @@
-import { AdapterError, Requester, Validator } from '@chainlink/ea-bootstrap'
+import { AdapterError, Requester, util, Validator } from '@chainlink/ea-bootstrap'
 import { AdapterRequest, Config, ExecuteWithConfig, InputParameters } from '@chainlink/types'
 import { utils } from 'ethers'
 
@@ -102,7 +102,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
   const jobRunID = validator.validated.id
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { raceType, date, resultsType, endpoint, ...rest } = validator.validated.data
-  const url = `/elections/${date}`
+  const url = util.buildUrlPath(`/elections/:date`, { date })
 
   const params = {
     ...rest,

--- a/packages/sources/bitex/src/endpoint/crypto.ts
+++ b/packages/sources/bitex/src/endpoint/crypto.ts
@@ -1,4 +1,4 @@
-import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import { Requester, util, Validator } from '@chainlink/ea-bootstrap'
 import { ExecuteWithConfig, Config, InputParameters } from '@chainlink/types'
 
 export const supportedEndpoints = ['crypto', 'tickers']
@@ -46,7 +46,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
   const base = validator.validated.data.base
   const quote = validator.validated.data.quote
   const resultPath = validator.validated.data.resultPath || 'vwap'
-  const url = `tickers/${base}_${quote}`
+  const url = util.buildUrlPath(`tickers/:base_:quote`, { base, quote })
 
   const options = {
     ...config.api,

--- a/packages/sources/blockchain.com/src/endpoint/balance.ts
+++ b/packages/sources/blockchain.com/src/endpoint/balance.ts
@@ -1,5 +1,5 @@
 import { balance } from '@chainlink/ea-factories'
-import { Requester } from '@chainlink/ea-bootstrap'
+import { Requester, util } from '@chainlink/ea-bootstrap'
 import { Config, ExecuteFactory } from '@chainlink/types'
 import { getBaseURL, ChainType, isCoinType, isChainType } from '../config'
 
@@ -8,7 +8,7 @@ export const supportedEndpoints = ['balance']
 export const inputParameters = balance.inputParameters
 
 const getBalanceURI = (address: string, confirmations: number) =>
-  `/q/addressbalance/${address}?confirmations=${confirmations}`
+  util.buildUrlPath(`/q/addressbalance/:address`, { address, confirmations })
 
 const getBalance: balance.GetBalance = async (account, config) => {
   const reqConfig = {

--- a/packages/sources/blockchair/src/endpoint/balance.ts
+++ b/packages/sources/blockchair/src/endpoint/balance.ts
@@ -1,5 +1,5 @@
 import { balance } from '@chainlink/ea-factories'
-import { Requester } from '@chainlink/ea-bootstrap'
+import { Requester, util } from '@chainlink/ea-bootstrap'
 import { Config, Account, ExecuteFactory, RequestConfig } from '@chainlink/types'
 import { COINS, isCoinType, isChainType } from '../config'
 
@@ -12,7 +12,7 @@ export const inputParameters = balance.inputParameters
 const getBalanceURI = (addresses: string[], coin: string, chain: string) => {
   coin = Requester.toVendorName(coin, COINS)
   if (chain === 'testnet') coin = `${coin}-${chain}`
-  return `/${coin}/addresses/balances?addresses=${addresses.join(',')}`
+  return util.buildUrlPath(`/:coin/addresses/balances`, { coin, addresses: addresses.join(',') })
 }
 
 const getBalances: balance.GetBalances = async (accounts, config) => {
@@ -24,7 +24,9 @@ const getBalances: balance.GetBalances = async (accounts, config) => {
     url: getBalanceURI(addresses, coin as string, chain as string),
   }
 
+  console.log({ reqConfig })
   const response = await Requester.request(reqConfig)
+  console.log({ response })
 
   const toResultWithBalance = (acc: Account) => {
     // NOTE: Blockchair does not return 0 balances

--- a/packages/sources/blockchair/src/endpoint/stats.ts
+++ b/packages/sources/blockchair/src/endpoint/stats.ts
@@ -1,4 +1,4 @@
-import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import { Requester, util, Validator } from '@chainlink/ea-bootstrap'
 import { ExecuteWithConfig, Config, InputParameters } from '@chainlink/types'
 import { COINS } from '../config'
 
@@ -35,7 +35,7 @@ export const execute: ExecuteWithConfig<Config> = async (input, _, config) => {
     validator.validated.data.blockchain.toLowerCase(),
     COINS,
   )
-  const url = `/${blockchain}/stats`
+  const url = util.buildUrlPath(`/:blockchain/stats`, { blockchain })
 
   const reqConfig = { ...config.api, url }
 

--- a/packages/sources/btc.com/src/endpoint/balance.ts
+++ b/packages/sources/btc.com/src/endpoint/balance.ts
@@ -1,5 +1,5 @@
 import { balance } from '@chainlink/ea-factories'
-import { Requester } from '@chainlink/ea-bootstrap'
+import { Requester, util } from '@chainlink/ea-bootstrap'
 import { Config, ExecuteFactory } from '@chainlink/types'
 import { isChainType, isCoinType } from '../config'
 
@@ -9,7 +9,7 @@ export const description = '[Address](https://btc.com/api-doc#Address)'
 
 export const inputParameters = balance.inputParameters
 
-const getBalanceURI = (address: string) => `/v3/address/${address}`
+const getBalanceURI = (address: string) => util.buildUrlPath('/v3/address/:address', { address })
 
 const getBalance: balance.GetBalance = async (account, config) => {
   const reqConfig = {

--- a/packages/sources/coinapi/src/endpoint/crypto.ts
+++ b/packages/sources/coinapi/src/endpoint/crypto.ts
@@ -1,4 +1,4 @@
-import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import { Requester, util, Validator } from '@chainlink/ea-bootstrap'
 import { ExecuteWithConfig, Config, AdapterRequest, InputParameters } from '@chainlink/types'
 import { NAME as AdapterName } from '../config'
 
@@ -60,7 +60,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
   const symbol = (validator.overrideSymbol(AdapterName) as string).toUpperCase()
   const quote = validator.validated.data.quote.toUpperCase()
 
-  const url = `exchangerate/${symbol}/${quote}`
+  const url = util.buildUrlPath('exchangerate/:symbol/:quote', { symbol, quote })
 
   const options = {
     ...config.api,

--- a/packages/sources/coinbase/src/endpoint/crypto.ts
+++ b/packages/sources/coinbase/src/endpoint/crypto.ts
@@ -1,4 +1,4 @@
-import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import { Requester, util, Validator } from '@chainlink/ea-bootstrap'
 import { ExecuteWithConfig, Config, InputParameters } from '@chainlink/types'
 
 export const supportedEndpoints = ['crypto', 'price']
@@ -32,7 +32,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
   const symbol = validator.validated.data.symbol
   const convert = validator.validated.data.convert
   const currencyPair = `${symbol}-${convert}`.toUpperCase()
-  const url = `/v2/prices/${currencyPair}/spot`
+  const url = util.buildUrlPath('/v2/prices/:currencyPair/spot', { currencyPair })
 
   const params = {
     symbol,

--- a/packages/sources/coincodex/src/endpoint/getcoin.ts
+++ b/packages/sources/coincodex/src/endpoint/getcoin.ts
@@ -1,4 +1,4 @@
-import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import { Requester, util, Validator } from '@chainlink/ea-bootstrap'
 import { ExecuteWithConfig, Config, InputParameters } from '@chainlink/types'
 
 export const supportedEndpoints = ['getcoin']
@@ -20,7 +20,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
 
   const options = {
     ...config.api,
-    url: `get_coin/${base}`,
+    url: util.buildUrlPath('get_coin/:base', { base }),
   }
 
   const response = await Requester.request(options)

--- a/packages/sources/coinmetrics/src/adapter.ts
+++ b/packages/sources/coinmetrics/src/adapter.ts
@@ -1,4 +1,4 @@
-import { AdapterError, Builder, Requester, Validator, Logger } from '@chainlink/ea-bootstrap'
+import { AdapterError, Builder, Requester, Validator, Logger, util } from '@chainlink/ea-bootstrap'
 import {
   Config,
   ExecuteWithConfig,
@@ -81,7 +81,12 @@ export const makeWSHandler = (config?: Config): MakeWSHandler => {
       programmaticConnectionInfo: (input) => {
         const { asset, metrics } = getSubKeyInfo(input)
         const key = `${asset}${metrics}`
-        const url = `${defaultConfig.api.baseWsURL}/timeseries-stream/asset-metrics?assets=${asset}&metrics=${metrics}&frequency=1s&api_key=${defaultConfig.apiKey}`
+        const url = util.buildUrl(defaultConfig.api.baseWsURL, '/timeseries-stream/asset-metrics', {
+          assets: asset,
+          metrics: metrics,
+          frequency: '1s',
+          api_key: defaultConfig.apiKey,
+        })
         return {
           key,
           url,

--- a/packages/sources/coinpaprika/src/endpoint/crypto-single.ts
+++ b/packages/sources/coinpaprika/src/endpoint/crypto-single.ts
@@ -1,4 +1,4 @@
-import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import { Requester, util, Validator } from '@chainlink/ea-bootstrap'
 import { ExecuteWithConfig, Config, AdapterRequest, InputParameters } from '@chainlink/types'
 import { NAME as AdapterName } from '../config'
 import { getCoinIds, getSymbolToId } from '../util'
@@ -88,7 +88,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, context, confi
     coin = getSymbolToId(symbol, coinIds)
   }
 
-  const url = `v1/tickers/${coin.toLowerCase()}`
+  const url = util.buildUrlPath('v1/tickers/:coin', { coin: coin.toLowerCase() })
   const resultPath = validator.validated.data.resultPath
 
   const params = {

--- a/packages/sources/coinpaprika/src/endpoint/vwap.ts
+++ b/packages/sources/coinpaprika/src/endpoint/vwap.ts
@@ -1,4 +1,4 @@
-import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import { Requester, util, Validator } from '@chainlink/ea-bootstrap'
 import { ExecuteWithConfig, Config, InputParameters } from '@chainlink/types'
 import { NAME as AdapterName } from '../config'
 import { getCoinIds, getSymbolToId } from '../util'
@@ -53,7 +53,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, context, confi
     coin = getSymbolToId(symbol, coinIds)
   }
 
-  const url = `v1/tickers/${coin.toLowerCase()}/historical`
+  const url = util.buildUrlPath('v1/tickers/:coin/historical', { coin: coin.toLowerCase() })
   const resultPath = validator.validated.data.resultPath
   const hours = validator.validated.data.hours
 

--- a/packages/sources/covid-tracker/src/endpoint/us.ts
+++ b/packages/sources/covid-tracker/src/endpoint/us.ts
@@ -1,4 +1,4 @@
-import { Requester, Validator, AdapterError } from '@chainlink/ea-bootstrap'
+import { Requester, Validator, AdapterError, util } from '@chainlink/ea-bootstrap'
 import { ExecuteWithConfig, Config, InputParameters } from '@chainlink/types'
 
 export const supportedEndpoints = ['us']
@@ -77,7 +77,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
       statusCode: 400,
     })
   const suffix = date ? 'daily' : 'current'
-  const url = `us/${suffix}.json`
+  const url = util.buildUrlPath('us/:suffix.json', { suffix })
 
   const options = {
     ...config.api,

--- a/packages/sources/cryptoapis-v2/src/endpoint/balance.ts
+++ b/packages/sources/cryptoapis-v2/src/endpoint/balance.ts
@@ -1,5 +1,5 @@
 import { balance } from '@chainlink/ea-factories'
-import { Requester } from '@chainlink/ea-bootstrap'
+import { Requester, util } from '@chainlink/ea-bootstrap'
 import { Config, ExecuteFactory } from '@chainlink/types'
 import {
   isCoinType,
@@ -43,7 +43,11 @@ interface ResponseSchema {
 const getBalanceURI = (address: string, chain: string, coin: string) => {
   if (chain === 'testnet')
     chain = Requester.toVendorName(coin, TESTNET_BLOCKCHAINS_BY_PLATFORM) || chain
-  return `/v2/blockchain-data/${coin}/${chain}/addresses/${address}`
+  return util.buildUrlPath('/v2/blockchain-data/:coin/:chain/addresses/:address', {
+    coin,
+    chain,
+    address,
+  })
 }
 
 const getBalance: balance.GetBalance = async (account, config) => {

--- a/packages/sources/cryptoapis-v2/src/endpoint/bc_info.ts
+++ b/packages/sources/cryptoapis-v2/src/endpoint/bc_info.ts
@@ -1,4 +1,4 @@
-import { AdapterError, Requester, Validator } from '@chainlink/ea-bootstrap'
+import { AdapterError, Requester, util, Validator } from '@chainlink/ea-bootstrap'
 import { ExecuteWithConfig, Config, InputParameters } from '@chainlink/types'
 import { BLOCKCHAIN_NAME_BY_TICKER, BlockchainTickers } from '../config'
 
@@ -68,9 +68,14 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
   const network = validator.validated.data.network || 'mainnet'
   const resultPath = validator.validated.data.resultPath
 
-  const url = `/v2/blockchain-data/${
-    BLOCKCHAIN_NAME_BY_TICKER[blockchain.toLowerCase() as BlockchainTickers]
-  }-specific/${network.toLowerCase()}/blocks/last`
+  const url = util.buildUrlPath(
+    `/v2/blockchain-data/:blockchain_name-specific/:network_name/blocks/last`,
+    {
+      blockchain_name: BLOCKCHAIN_NAME_BY_TICKER[blockchain.toLowerCase() as BlockchainTickers],
+      network_name: network.toLowerCase(),
+    },
+  )
+
   const options = { ...config.api, url }
   const response = await Requester.request<ResponseSchema>(options)
   const result = Requester.validateResultNumber(response.data, resultPath)

--- a/packages/sources/cryptoapis-v2/src/endpoint/price.ts
+++ b/packages/sources/cryptoapis-v2/src/endpoint/price.ts
@@ -1,4 +1,4 @@
-import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import { Requester, util, Validator } from '@chainlink/ea-bootstrap'
 import { ExecuteWithConfig, Config, InputParameters } from '@chainlink/types'
 
 export const supportedEndpoints = ['price']
@@ -41,7 +41,10 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
   const jobRunID = validator.validated.id
   const coin = validator.validated.data.base
   const market = validator.validated.data.quote
-  const url = `/v2/market-data/exchange-rates/by-symbols/${coin}/${market}`
+  const url = util.buildUrlPath('/v2/market-data/exchange-rates/by-symbols/:coin/:market', {
+    coin,
+    market,
+  })
   const reqConfig = { ...config.api, url }
   const response = await Requester.request<ResponseSchema>(reqConfig)
   const result = Requester.validateResultNumber(response.data, ['data', 'item', 'rate'])

--- a/packages/sources/cryptoapis/src/endpoint/balance.ts
+++ b/packages/sources/cryptoapis/src/endpoint/balance.ts
@@ -1,6 +1,6 @@
 import { ethers } from 'ethers'
 import { balance } from '@chainlink/ea-factories'
-import { Requester } from '@chainlink/ea-bootstrap'
+import { Requester, util } from '@chainlink/ea-bootstrap'
 import { Config, ExecuteFactory } from '@chainlink/types'
 import { isCoinType, isChainType, TESTNET_BLOCKCHAINS } from '../config'
 
@@ -13,7 +13,7 @@ export const inputParameters = balance.inputParameters
 
 const getBalanceURI = (address: string, chain: string, coin: string) => {
   if (chain === 'testnet') chain = Requester.toVendorName(coin, TESTNET_BLOCKCHAINS) || chain
-  return `/v1/bc/${coin}/${chain}/address/${address}`
+  return util.buildUrlPath('/v1/bc/:coin/:chain/address/:address', { coin, chain, address })
 }
 
 const getBalance: balance.GetBalance = async (account, config) => {

--- a/packages/sources/cryptoapis/src/endpoint/bc_info.ts
+++ b/packages/sources/cryptoapis/src/endpoint/bc_info.ts
@@ -1,4 +1,4 @@
-import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import { Requester, util, Validator } from '@chainlink/ea-bootstrap'
 import { ExecuteWithConfig, Config, InputParameters } from '@chainlink/types'
 
 export const supportedEndpoints = ['height', 'difficulty']
@@ -49,7 +49,10 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
   const blockchain = validator.validated.data.blockchain
   const network = validator.validated.data.network || 'mainnet'
   const resultPath = validator.validated.data.resultPath
-  const url = `/v1/bc/${blockchain.toLowerCase()}/${network.toLowerCase()}/info`
+  const url = util.buildUrlPath('/v1/bc/:blockchain/:network/info', {
+    blockchain: blockchain.toLowerCase(),
+    network: network.toLowerCase(),
+  })
 
   const reqConfig = { ...config.api, url }
 

--- a/packages/sources/cryptoapis/src/endpoint/crypto.ts
+++ b/packages/sources/cryptoapis/src/endpoint/crypto.ts
@@ -1,4 +1,4 @@
-import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import { Requester, util, Validator } from '@chainlink/ea-bootstrap'
 import { ExecuteWithConfig, Config, InputParameters } from '@chainlink/types'
 
 export const supportedEndpoints = ['crypto', 'price']
@@ -38,7 +38,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
   const jobRunID = validator.validated.id
   const coin = validator.validated.data.base
   const market = validator.validated.data.quote
-  const url = `/v1/exchange-rates/${coin}/${market}`
+  const url = util.buildUrlPath('/v1/exchange-rates/:coin/:market', { coin, market })
 
   const reqConfig = { ...config.api, url }
 

--- a/packages/sources/cryptocompare/src/adapter.ts
+++ b/packages/sources/cryptocompare/src/adapter.ts
@@ -1,4 +1,4 @@
-import { Builder, Requester, Validator } from '@chainlink/ea-bootstrap'
+import { Builder, Requester, util, Validator } from '@chainlink/ea-bootstrap'
 import {
   AdapterRequest,
   Config,
@@ -70,7 +70,7 @@ export const makeWSHandler = (config?: Config): MakeWSHandler => {
     if (!pair) return false
     return { action, subs: [`${subscriptions.aggregate}~CCCAGG~${pair}`] }
   }
-  const withApiKey = (url: string, apiKey: string) => `${url}?api_key=${apiKey}`
+  const withApiKey = (url: string, apiKey: string) => util.buildUrl(url, '', { api_key: apiKey })
   const shouldNotRetryAfterError = (error: WSErrorType): boolean => {
     return error.MESSAGE === INVALID_SUB
   }

--- a/packages/sources/cryptomkt/src/endpoint/crypto.ts
+++ b/packages/sources/cryptomkt/src/endpoint/crypto.ts
@@ -1,4 +1,4 @@
-import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import { Requester, util, Validator } from '@chainlink/ea-bootstrap'
 import { ExecuteWithConfig, Config, InputParameters } from '@chainlink/types'
 
 export const supportedEndpoints = ['crypto', 'ticker']
@@ -46,7 +46,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
   const quote = validator.validated.data.quote.toUpperCase()
   const resultPath = validator.validated.data.resultPath
   const market = base + quote
-  const url = `public/ticker/${market}`
+  const url = util.buildUrlPath('public/ticker/:market', { market })
 
   const options = {
     ...config.api,


### PR DESCRIPTION
## Closes #18580

## Description
 Added buildUrlPath methods & unit tests to util. Updated the following adapters to use buildUrlPath: bitex, blockchain.com, blockchair, btc.com, coinapi, coinbase, coincodex, coinmetrics, coinpaprika, covidtracker, cryptoapis, cryptoapis-v2, cryptocompare, cryptomkt
......

## Steps to Test

1. yarn test:unit
2. yarn test:integration
3. Run an adapter with user input included in a url and check the URL it attempts to call.

## Quality Assurance

- [x] Ran `yarn changeset` if adapter source code was changed
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
