### PR TITLE
18580 (PR 2) - URL Path Builder (adapters E-M)

### DIFF
--- a/.changeset/afraid-books-tap.md
+++ b/.changeset/afraid-books-tap.md
@@ -1,0 +1,19 @@
+---
+'@chainlink/ea-bootstrap': minor
+'@chainlink/eodhistoricaldata-adapter': patch
+'@chainlink/expert-car-broker-adapter': patch
+'@chainlink/fcsapi-adapter': patch
+'@chainlink/finage-adapter': patch
+'@chainlink/finnhub-adapter': patch
+'@chainlink/fmpcloud-adapter': patch
+'@chainlink/gemini-adapter': patch
+'@chainlink/geodb-adapter': patch
+'@chainlink/iex-cloud-adapter': patch
+'@chainlink/intrinio-adapter': patch
+'@chainlink/kaiko-adapter': patch
+'@chainlink/linkpool-adapter': patch
+'@chainlink/lition-adapter': patch
+'@chainlink/messari-adapter': patch
+---
+
+Added buildUrl & buildUrlPath methods to util. Updated source adapters to use these methods for building URLs with user input.

--- a/packages/core/bootstrap/src/lib/util.ts
+++ b/packages/core/bootstrap/src/lib/util.ts
@@ -373,3 +373,101 @@ export const getRequiredEnvWithFallback = (
 
   throw new RequiredEnvError(getEnvName(primary, prefix))
 }
+
+//  URL Encoding
+
+const charsToEncode = {
+  ':': '%3A',
+  '/': '%2F',
+  '?': '%3F',
+  '#': '%23',
+  '[': '%5B',
+  ']': '%5D',
+  '@': '%40',
+  '!': '%21',
+  $: '%24',
+  '&': '%26',
+  "'": '%27',
+  '(': '%28',
+  ')': '%29',
+  '*': '%2A',
+  '+': '%2B',
+  ',': '%2C',
+  ';': '%3B',
+  '=': '%3D',
+  '%': '%25',
+  ' ': '%20',
+  '"': '%22',
+  '<': '%3C',
+  '>': '%3E',
+  '{': '%7B',
+  '}': '%7D',
+  '|': '%7C',
+  '^': '%5E',
+  '`': '%60',
+  '\\': '%5C',
+}
+
+/**
+ * Check whether the given string contains characters in the given whitelist.
+ * @param str The string to check.
+ * @param whitelist The string array of whitelist entries. Returns true if any of these are found in 'str', otherwise returns false.
+ * @returns {boolean}
+ */
+const stringHasWhitelist = (str: string, whitelist: string[]): boolean =>
+  whitelist.some((el) => str.includes(el))
+
+/**
+ * Manually iterate through a given string and replace unsafe/reserved characters with encoded values (unless a character is whitelisted)
+ * @param str The string to encode.
+ * @param whitelist The string array of whitelist entries.
+ * @returns {string}
+ */
+const percentEncodeString = (str: string, whitelist: string[]): string =>
+  str
+    .split('')
+    .map((char) => {
+      const encodedValue = charsToEncode[char as keyof typeof charsToEncode]
+      return encodedValue && !whitelist.includes(char) ? encodedValue : char
+    })
+    .join('')
+
+/**
+ * Build a URL path using the given pathTemplate and params. If a param is found in pathTemplate, it will be inserted there; otherwise, it will be ignored.
+ * eg.) pathTemplate = "/from/:from/to/:to" and params = { from: "ETH", to: "BTC", note: "hello" } will become "/from/ETH/to/BTC"
+ * @param pathTemplate The path template for the URL path. Each param to include in the path should have a prefix of ':'.
+ * @param params The object containing keys & values to be added to the URL path.
+ * @param whitelist The list of characters to whitelist for the URL path (if a param contains one of your whitelisted characters, it will not be encoded).
+ * @returns {string}
+ */
+export const buildUrlPath = (pathTemplate = '', params = {}, whitelist = ''): string => {
+  const allowedChars = whitelist.split('')
+
+  for (const param in params) {
+    const value = params[param as keyof typeof params]
+    if (!value) continue
+
+    // If string contains a whitelisted character: manually replace any non-whitelisted characters with percent encoded values. Otherwise, encode the string as usual.
+    const encodedValue = stringHasWhitelist(value, allowedChars)
+      ? percentEncodeString(value, allowedChars)
+      : encodeURIComponent(value)
+
+    if (pathTemplate.includes(`:${param}`))
+      pathTemplate = pathTemplate.replace(`:${param}`, encodedValue)
+  }
+
+  return pathTemplate
+}
+
+/**
+ * Build a full URL using the given baseUrl, pathTemplate and params. Uses buildUrlPath to add path & params.
+ * @param baseUrl The base URL to add the pathTemplate & params to.
+ * @param pathTemplate The path template for the URL path. Leave empty if only searchParams are required.
+ * @param params The object containing keys & values to be added to the URL path.
+ * @param whitelist The list of characters to whitelist for the URL path.
+ * @returns {string}
+ */
+export const buildUrl = (baseUrl: string, pathTemplate = '', params = {}, whitelist = ''): string =>
+  new URL(buildUrlPath(pathTemplate, params, whitelist), baseUrl).toString()
+
+//  URL Encoding

--- a/packages/core/bootstrap/test/unit/utils.test.ts
+++ b/packages/core/bootstrap/test/unit/utils.test.ts
@@ -1,4 +1,4 @@
-import { getEnv } from '../../src/lib/util'
+import { getEnv, buildUrlPath, buildUrl } from '../../src/lib/util'
 
 describe('utils', () => {
   let oldEnv
@@ -22,6 +22,104 @@ describe('utils', () => {
       process.env.TEST = ''
       const actual = getEnv('TEST')
       expect(actual).toBeUndefined()
+    })
+  })
+
+  describe(`buildUrlPath`, () => {
+    it(`builds path with valid characters`, () => {
+      const actual = buildUrlPath('/from/:from/to/:to', {
+        from: 'ETH',
+        to: 'USD',
+      })
+      expect(actual).toEqual('/from/ETH/to/USD')
+    })
+
+    it(`builds path with whitelisted & non-whitelisted characters`, () => {
+      const actual = buildUrlPath(
+        '/from/:from/to/:to',
+        {
+          from: 'E:T?H',
+          to: 'U%S\\D !',
+        },
+        ':%^ !',
+      )
+      expect(actual).toEqual('/from/E:T%3FH/to/U%S%5CD !')
+    })
+
+    it(`returns empty string from empty path`, () => {
+      const actual = buildUrlPath('', { from: 'ETH', to: 'USD', message: 'hello_world' })
+      expect(actual).toEqual('')
+    })
+
+    it(`builds path with no params`, () => {
+      const actual = buildUrlPath('/from/to')
+      expect(actual).toEqual('/from/to')
+    })
+
+    it(`builds path with reserved characters`, () => {
+      const actual = buildUrlPath('/from/:from/to/:to', {
+        from: 'ETH:USD',
+        to: 'USD/?ETH=USD',
+      })
+      expect(actual).toEqual('/from/ETH%3AUSD/to/USD%2F%3FETH%3DUSD')
+    })
+
+    it(`builds path with unsafe characters`, () => {
+      const actual = buildUrlPath('/from/:from/to/:to', {
+        from: 'ETH"USD"',
+        to: '{U|S|D>',
+      })
+      expect(actual).toEqual('/from/ETH%22USD%22/to/%7BU%7CS%7CD%3E')
+      expect(decodeURI(actual)).toEqual('/from/ETH"USD"/to/{U|S|D>')
+    })
+
+    it(`builds path with non-latin characters`, () => {
+      const actual = buildUrlPath('/from/:from/to/:to', {
+        from: 'abcÂÃ',
+        to: '你好世界',
+      })
+      expect(actual).toEqual('/from/abc%C3%82%C3%83/to/%E4%BD%A0%E5%A5%BD%E4%B8%96%E7%95%8C')
+      expect(decodeURI(actual)).toEqual('/from/abcÂÃ/to/你好世界')
+    })
+  })
+
+  describe(`buildUrl`, () => {
+    it(`builds URL with a given base, path & params`, () => {
+      const baseWsURL = 'wss://example.com:8000'
+      const asset = 'BTC'
+      const metrics = 'hello'
+      const key = 123456
+
+      const expected = `${baseWsURL}/timeseries-stream/asset-metrics/assets/${asset}/metrics/${metrics}/frequency/1s/api_key/${key}`
+      const actual = buildUrl(
+        baseWsURL,
+        '/timeseries-stream/asset-metrics/assets/:assets/metrics/:metrics/frequency/:frequency/api_key/:api_key',
+        {
+          assets: asset,
+          metrics: metrics,
+          frequency: '1s',
+          api_key: key,
+        },
+      )
+
+      expect(actual).toEqual(expected)
+    })
+
+    it(`builds URL with a given base & path only`, () => {
+      const baseWsURL = 'wss://example.com:8000'
+      const expected = `${baseWsURL}/timeseries-stream/asset-metrics`
+      const actual = buildUrl(baseWsURL, '/timeseries-stream/asset-metrics')
+
+      expect(actual).toEqual(expected)
+    })
+
+    it(`builds URL with basic auth (key:secret)`, () => {
+      const withApiKey = (url: string, key: string, secret: string) =>
+        buildUrl(url, '/client/:client', { client: `${key}:${secret}` }, ':')
+      const expected = `wss://stream.tradingeconomics.com/client/keystring:secretstring`
+      const actual = withApiKey('wss://stream.tradingeconomics.com', 'keystring', 'secretstring')
+
+      expect(actual).toEqual(expected)
     })
   })
 })

--- a/packages/sources/eodhistoricaldata/src/endpoint/stock.ts
+++ b/packages/sources/eodhistoricaldata/src/endpoint/stock.ts
@@ -1,4 +1,4 @@
-import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import { Requester, util, Validator } from '@chainlink/ea-bootstrap'
 import { ExecuteWithConfig, Config, InputParameters } from '@chainlink/types'
 
 export const supportedEndpoints = ['price', 'stock']
@@ -44,7 +44,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
   if (commonKeys[symbol]) {
     symbol = commonKeys[symbol]
   }
-  const url = `/api/real-time/${symbol}`
+  const url = util.buildUrlPath('/api/real-time/:symbol', { symbol })
 
   const params = {
     ...config.api.params,

--- a/packages/sources/expert-car-broker/src/endpoint/feed.ts
+++ b/packages/sources/expert-car-broker/src/endpoint/feed.ts
@@ -1,4 +1,4 @@
-import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import { Requester, util, Validator } from '@chainlink/ea-bootstrap'
 import { Config, ExecuteWithConfig, InputParameters } from '@chainlink/types'
 
 export const supportedEndpoints = ['feed']
@@ -26,7 +26,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
   const jobRunID = validator.validated.id
   const product = validator.validated.data.product
   const feedId = validator.validated.data.feedId
-  const url = `${product}/feed-${feedId}`
+  const url = util.buildUrlPath(':product/feed-:feedId', { product, feedId })
 
   const params = {
     api_key: config.apiKey,

--- a/packages/sources/fcsapi/src/endpoint/common.ts
+++ b/packages/sources/fcsapi/src/endpoint/common.ts
@@ -68,7 +68,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
   const options = {
     ...config.api,
     params,
-    url: endpoint,
+    url: util.buildUrlPath(':endpoint', { endpoint }, '/'),
   }
 
   const response = await Requester.request<ResponseSchema>(options, customError)

--- a/packages/sources/finage/src/endpoint/crypto.ts
+++ b/packages/sources/finage/src/endpoint/crypto.ts
@@ -1,5 +1,5 @@
 import { Config, ExecuteWithConfig, InputParameters } from '@chainlink/types'
-import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import { Requester, util, Validator } from '@chainlink/ea-bootstrap'
 import { NAME } from '../config'
 import overrides from '../config/symbols.json'
 import { ResponseSchema } from './forex'
@@ -27,7 +27,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
   const from = (validator.overrideSymbol(NAME) as string).toUpperCase()
   const to = validator.validated.data.quote.toUpperCase()
 
-  const url = `/last/crypto/${from}${to}`
+  const url = util.buildUrlPath('/last/crypto/:from:to', { from, to })
   const params = {
     apikey: config.apiKey,
   }

--- a/packages/sources/finage/src/endpoint/eod.ts
+++ b/packages/sources/finage/src/endpoint/eod.ts
@@ -1,5 +1,5 @@
 import { AxiosResponse, Config, ExecuteWithConfig, InputParameters } from '@chainlink/types'
-import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import { Requester, util, Validator } from '@chainlink/ea-bootstrap'
 import { NAME } from '../config'
 import overrides from '../config/symbols.json'
 
@@ -34,7 +34,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
     ? base.map((symbol) => symbol.toUpperCase()).join(',')
     : (validator.overrideSymbol(NAME) as string).toUpperCase()
 
-  const url = `/agg/stock/prev-close/${symbol}`
+  const url = util.buildUrlPath('/agg/stock/prev-close/:symbol', { symbol })
   const params = {
     apikey: config.apiKey,
   }

--- a/packages/sources/finage/src/endpoint/forex.ts
+++ b/packages/sources/finage/src/endpoint/forex.ts
@@ -1,5 +1,5 @@
 import { Config, ExecuteWithConfig, InputParameters } from '@chainlink/types'
-import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import { Requester, util, Validator } from '@chainlink/ea-bootstrap'
 import { NAME } from '../config'
 import overrides from '../config/symbols.json'
 
@@ -37,7 +37,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
   const from = (validator.overrideSymbol(NAME) as string).toUpperCase()
   const to = validator.validated.data.quote.toUpperCase()
 
-  const url = `/last/forex/${from}${to}`
+  const url = util.buildUrlPath('/last/forex/:from:to', { from, to })
   const params = {
     apikey: config.apiKey,
   }

--- a/packages/sources/finage/src/endpoint/stock.ts
+++ b/packages/sources/finage/src/endpoint/stock.ts
@@ -5,7 +5,7 @@ import {
   ExecuteWithConfig,
   InputParameters,
 } from '@chainlink/types'
-import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import { Requester, util, Validator } from '@chainlink/ea-bootstrap'
 import { NAME } from '../config'
 import overrides from '../config/symbols.json'
 
@@ -44,6 +44,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
   const url = getStockURL(base, symbol)
   const params = {
     apikey: config.apiKey,
+    ...(Array.isArray(base) ? { symbols: symbol } : null),
   }
 
   const options = {
@@ -63,9 +64,9 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
 
 const getStockURL = (base: string | string[], symbol: string) => {
   if (Array.isArray(base)) {
-    return `/last/stocks/?symbols=${symbol}`
+    return util.buildUrlPath('/last/stocks')
   }
-  return `/last/stock/${symbol}`
+  return util.buildUrlPath('/last/stock/:symbol', { symbol })
 }
 
 const handleBatchedRequest = (

--- a/packages/sources/finnhub/src/endpoint/quote.ts
+++ b/packages/sources/finnhub/src/endpoint/quote.ts
@@ -55,7 +55,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
   const options = {
     ...config.api,
     params,
-    url: endpoint,
+    url: util.buildUrlPath(':endpoint', { endpoint }, ':^'),
   }
 
   const response = await Requester.request<ResponseSchema>(options)

--- a/packages/sources/fmpcloud/src/endpoint/stock.ts
+++ b/packages/sources/fmpcloud/src/endpoint/stock.ts
@@ -1,4 +1,4 @@
-import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import { Requester, util, Validator } from '@chainlink/ea-bootstrap'
 import { ExecuteWithConfig, Config, InputParameters } from '@chainlink/types'
 
 export const supportedEndpoints = ['quote', 'price', 'stock']
@@ -60,7 +60,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
   if (commonKeys[symbol]) {
     symbol = commonKeys[symbol]
   }
-  const url = `/api/v3/quote/${symbol}`
+  const url = util.buildUrlPath('/api/v3/quote/:symbol', { symbol }, '^')
 
   const options = {
     ...config.api,

--- a/packages/sources/gemini/src/endpoint/reserves.ts
+++ b/packages/sources/gemini/src/endpoint/reserves.ts
@@ -1,4 +1,4 @@
-import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import { Requester, util, Validator } from '@chainlink/ea-bootstrap'
 import { Config, ExecuteWithConfig, InputParameters } from '@chainlink/types'
 
 export const supportedEndpoints = ['reserves']
@@ -37,7 +37,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
   const token = validator.validated.data.token
   const network = validator.validated.data.network || 'filecoin'
   const chainId = validator.validated.data.chainId || 'mainnet'
-  const url = `/v1/tokens/${token.toLowerCase()}/reserves`
+  const url = util.buildUrlPath('/v1/tokens/:token/reserves', { token: token.toLowerCase() })
 
   const options = { ...config.api, url }
 

--- a/packages/sources/geodb/src/endpoint/matches.ts
+++ b/packages/sources/geodb/src/endpoint/matches.ts
@@ -1,4 +1,4 @@
-import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import { Requester, util, Validator } from '@chainlink/ea-bootstrap'
 import { ExecuteWithConfig, Config, InputParameters } from '@chainlink/types'
 
 export const supportedEndpoints = ['matches']
@@ -47,11 +47,12 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
   const radius = validator.validated.data.radius
   const start = validator.validated.data.start
   const end = validator.validated.data.end
-  const url = encodeURI(`/matches?start=${start}&end=${end}&lat=${lat}&lng=${lng}&radius=${radius}`)
+  const url = util.buildUrlPath('/matches')
 
   const reqConfig = {
     ...config.api,
     url,
+    params: { start, end, lat, lng, radius },
   }
 
   const response = await Requester.request<ResponseSchema>(reqConfig)

--- a/packages/sources/iex-cloud/src/endpoint/crypto.ts
+++ b/packages/sources/iex-cloud/src/endpoint/crypto.ts
@@ -1,4 +1,4 @@
-import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import { Requester, util, Validator } from '@chainlink/ea-bootstrap'
 import { ExecuteWithConfig, Config, InputParameters } from '@chainlink/types'
 import { NAME as AdapterName } from '../config'
 
@@ -39,7 +39,10 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
   const jobRunID = validator.validated.id
   const base = validator.overrideSymbol(AdapterName) as string
   const quote = validator.validated.data.quote
-  const url = `crypto/${base.toUpperCase()}${quote.toUpperCase()}/quote`
+  const url = util.buildUrlPath(`crypto/:base:quote/quote`, {
+    base: base.toUpperCase(),
+    quote: quote.toUpperCase(),
+  })
 
   const params = {
     token: config.apiKey,

--- a/packages/sources/iex-cloud/src/endpoint/eod.ts
+++ b/packages/sources/iex-cloud/src/endpoint/eod.ts
@@ -1,4 +1,4 @@
-import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import { Requester, util, Validator } from '@chainlink/ea-bootstrap'
 import { ExecuteWithConfig, Config, InputParameters } from '@chainlink/types'
 import { NAME as AdapterName } from '../config'
 
@@ -77,7 +77,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
 
   const jobRunID = validator.validated.id
   const base = validator.overrideSymbol(AdapterName) as string
-  const url = `stock/${base.toUpperCase()}/quote`
+  const url = util.buildUrlPath('stock/:base/quote', { base: base.toUpperCase() })
 
   const params = {
     token: config.apiKey,

--- a/packages/sources/iex-cloud/src/endpoint/stock.ts
+++ b/packages/sources/iex-cloud/src/endpoint/stock.ts
@@ -1,4 +1,4 @@
-import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import { Requester, util, Validator } from '@chainlink/ea-bootstrap'
 import { ExecuteWithConfig, Config, InputParameters } from '@chainlink/types'
 import { NAME as AdapterName } from '../config'
 import { ResponseSchema } from './eod'
@@ -19,7 +19,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
 
   const jobRunID = validator.validated.id
   const base = validator.overrideSymbol(AdapterName) as string
-  const url = `stock/${base.toUpperCase()}/quote`
+  const url = util.buildUrlPath('stock/:base/quote', { base: base.toUpperCase() })
 
   const params = {
     token: config.apiKey,

--- a/packages/sources/intrinio/src/adapter.ts
+++ b/packages/sources/intrinio/src/adapter.ts
@@ -1,4 +1,4 @@
-import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import { Requester, util, Validator } from '@chainlink/ea-bootstrap'
 import {
   AdapterRequest,
   AdapterResponse,
@@ -24,7 +24,7 @@ export const execute = async (input: AdapterRequest, config: Config) => {
   const jobRunID = validator.validated.id
   const symbol = validator.validated.data.base.toUpperCase()
 
-  const url = `securities/${symbol}/prices/realtime`
+  const url = util.buildUrlPath('securities/:symbol/prices/realtime', { symbol })
   const params = {
     api_key: config.apiKey,
   }

--- a/packages/sources/kaiko/src/endpoint/trades.ts
+++ b/packages/sources/kaiko/src/endpoint/trades.ts
@@ -1,4 +1,4 @@
-import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import { Requester, util, Validator } from '@chainlink/ea-bootstrap'
 import { Config, ExecuteWithConfig, Includes, IncludePair, InputParameters } from '@chainlink/types'
 import {
   DEFAULT_INTERVAL,
@@ -51,10 +51,16 @@ export const inputParameters: InputParameters = {
 const symbolUrl = (from: string, to: string) =>
   to.toLowerCase() === 'eth'
     ? directUrl(from, to)
-    : `/spot_exchange_rate/${from.toLowerCase()}/${to.toLowerCase()}`
+    : util.buildUrlPath('/spot_exchange_rate/:from/:to', {
+        from: from.toLowerCase(),
+        to: to.toLowerCase(),
+      })
 
 const directUrl = (from: string, to: string) =>
-  `/spot_direct_exchange_rate/${from.toLowerCase()}/${to.toLowerCase()}`
+  util.buildUrlPath('/spot_direct_exchange_rate/:from/:to', {
+    from: from.toLowerCase(),
+    to: to.toLowerCase(),
+  })
 
 export interface ResponseSchema {
   query: {

--- a/packages/sources/linkpool/src/endpoint/futures.ts
+++ b/packages/sources/linkpool/src/endpoint/futures.ts
@@ -22,7 +22,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
   let market = validator.validated.data.market.toLowerCase()
   if (market in commonKeys) market = commonKeys[market]
 
-  const url = `/futures/${market.toUpperCase()}/sip62`
+  const url = util.buildUrlPath('/futures/:market/sip62', { market: market.toUpperCase() })
 
   const headers = {
     'x-api-key': util.getRandomRequiredEnv('API_KEY'),

--- a/packages/sources/lition/src/endpoint/energy.ts
+++ b/packages/sources/lition/src/endpoint/energy.ts
@@ -1,4 +1,4 @@
-import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import { Requester, util, Validator } from '@chainlink/ea-bootstrap'
 import { ExecuteWithConfig, Config, InputParameters } from '@chainlink/types'
 
 export const supportedEndpoints = ['energy']
@@ -39,7 +39,11 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
   const date = validator.validated.data.date || `${currentTime.toISOString().slice(0, 10)}` // YYYY-MM-DD
   const hour = validator.validated.data.hour || currentTime.getUTCHours()
 
-  const url = `energy/source/${source}/date/${date}/hour/${hour}/`
+  const url = util.buildUrlPath('energy/source/:source/date/:date/hour/:hour/', {
+    source,
+    date,
+    hour,
+  })
 
   const options = {
     ...config.api,

--- a/packages/sources/messari/src/endpoint/assets.ts
+++ b/packages/sources/messari/src/endpoint/assets.ts
@@ -1,4 +1,4 @@
-import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import { Requester, util, Validator } from '@chainlink/ea-bootstrap'
 import { ExecuteWithConfig, Config, InputParameters } from '@chainlink/types'
 
 export const supportedEndpoints = ['assets', 'dominance']
@@ -55,7 +55,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
   const jobRunID = validator.validated.id
   const base = validator.validated.data.base.toLowerCase()
   const resultPath = validator.validated.data.resultPath
-  const url = `assets/${base}/metrics`
+  const url = util.buildUrlPath('assets/:base/metrics', { base })
 
   const options = {
     ...config.api,


### PR DESCRIPTION
## Closes #18580

## Description
Updated the following adapters to use buildUrlPath: eodhistoricaldata, expert-car-broker, fcsapi, finage, finnhub, fmpcloud, gemeni, geodb, iex-cloud, intrino, kaiko, linkpool, lition, messari
......

## Steps to Test

1. yarn test:unit
2. yarn test:integration
3. Run an adapter with user input included in a url and check the URL it attempts to call.

## Quality Assurance

- [x] Ran `yarn changeset` if adapter source code was changed
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
