### PR TITLE
intrino websocket integration tests

### DIFF
--- a/.changeset/loud-mangos-type.md
+++ b/.changeset/loud-mangos-type.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/intrinio-adapter': minor
+---
+
+changed util.ts to use axios instead of native https module

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -6067,6 +6067,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/jest", "npm:27.0.3"],
             ["@types/node", "npm:16.11.19"],
             ["@types/supertest", "npm:2.0.11"],
+            ["axios", "npm:0.24.0"],
             ["express", "npm:4.17.1"],
             ["intrinio-realtime", "npm:2.3.0"],
             ["nock", "npm:13.2.4"],

--- a/packages/sources/intrinio/package.json
+++ b/packages/sources/intrinio/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@chainlink/ea-bootstrap": "workspace:*",
     "@chainlink/ea-test-helpers": "workspace:*",
+    "axios": "^0.24.0",
     "express": "^4.17.1",
     "intrinio-realtime": "^2.3.0",
     "tslib": "^2.3.1"

--- a/packages/sources/intrinio/test/integration/adapter.test.ts
+++ b/packages/sources/intrinio/test/integration/adapter.test.ts
@@ -4,8 +4,24 @@ import * as process from 'process'
 import { server as startServer } from '../../src'
 import * as nock from 'nock'
 import * as http from 'http'
-import { mockRateResponseSuccess } from './fixtures'
+import {
+  mockAuthResponse,
+  mockRateResponseSuccess,
+  mockSubscribeResponse,
+  mockUnsubscribeResponse,
+} from './fixtures'
 import { AddressInfo } from 'net'
+import {
+  mockWebSocketProvider,
+  mockWebSocketServer,
+  MockWsServer,
+  mockWebSocketFlow,
+} from '@chainlink/ea-test-helpers'
+import { WebSocketClassProvider } from '@chainlink/ea-bootstrap/dist/lib/middleware/ws/recorder'
+
+const sleep = (ms: number) => {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
 
 describe('execute', () => {
   const id = '1'
@@ -26,9 +42,6 @@ describe('execute', () => {
       nock.recorder.play()
     }
 
-    nock.restore()
-    nock.cleanAll()
-    nock.enableNetConnect()
     server.close(done)
   })
 
@@ -36,7 +49,7 @@ describe('execute', () => {
     const data: AdapterRequest = {
       id,
       data: {
-        base: 'ETH',
+        base: 'AAPL',
       },
     }
 
@@ -52,5 +65,90 @@ describe('execute', () => {
         .expect(200)
       expect(response.body).toMatchSnapshot()
     })
+  })
+})
+
+describe('websocket', () => {
+  let mockedWsServer: InstanceType<typeof MockWsServer>
+  let server: http.Server
+  let req: SuperTest<Test>
+
+  let oldEnv: NodeJS.ProcessEnv
+  beforeAll(async () => {
+    if (!process.env.RECORD) {
+      process.env.API_KEY = 'fake-api-key'
+      mockedWsServer = mockWebSocketServer(
+        `wss://realtime.intrinio.com/socket/websocket?vsn=1.0.0&token=fake-api-token`,
+      )
+      mockWebSocketProvider(WebSocketClassProvider)
+    }
+
+    oldEnv = JSON.parse(JSON.stringify(process.env))
+    process.env.WS_ENABLED = 'true'
+    process.env.WS_SUBSCRIPTION_TTL = '300'
+
+    server = await startServer()
+    req = request(`localhost:${(server.address() as AddressInfo).port}`)
+  })
+
+  afterAll((done) => {
+    process.env = oldEnv
+    nock.restore()
+    nock.cleanAll()
+    nock.enableNetConnect()
+    server.close(done)
+  })
+
+  describe('iex endpoint', () => {
+    const jobID = '1'
+
+    it('should return success', async () => {
+      const data: AdapterRequest = {
+        id: jobID,
+        data: {
+          endpoint: 'iex',
+          base: 'AAPL',
+        },
+      }
+
+      let flowFulfilled: Promise<boolean>
+      if (!process.env.RECORD) {
+        mockAuthResponse()
+        mockRateResponseSuccess()
+
+        flowFulfilled = mockWebSocketFlow(mockedWsServer, [
+          mockSubscribeResponse,
+          mockUnsubscribeResponse,
+        ])
+      }
+
+      const makeRequest = () =>
+        req
+          .post('/')
+          .send(data)
+          .set('Accept', '*/*')
+          .set('Content-Type', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(200)
+
+      // We don't care about the first response, coming from http request
+      // This first request will start both batch warmer & websocket
+      await makeRequest()
+
+      // This final request should disable the cache warmer, sleep is used to make sure that the data is  pulled from the websocket
+      // populated cache entries.
+      await sleep(100)
+      const response = await makeRequest()
+
+      expect(response.body).toEqual({
+        jobRunID: '1',
+        result: 166.91,
+        statusCode: 200,
+        maxAge: 30000,
+        data: { result: 166.91 },
+      })
+
+      await flowFulfilled
+    }, 30000)
   })
 })

--- a/packages/sources/intrinio/test/integration/adapter.test.ts
+++ b/packages/sources/intrinio/test/integration/adapter.test.ts
@@ -4,6 +4,7 @@ import * as process from 'process'
 import { server as startServer } from '../../src'
 import * as nock from 'nock'
 import * as http from 'http'
+import { util } from '@chainlink/ea-bootstrap'
 import {
   mockAuthResponse,
   mockRateResponseSuccess,
@@ -18,10 +19,6 @@ import {
   mockWebSocketFlow,
 } from '@chainlink/ea-test-helpers'
 import { WebSocketClassProvider } from '@chainlink/ea-bootstrap/dist/lib/middleware/ws/recorder'
-
-const sleep = (ms: number) => {
-  return new Promise((resolve) => setTimeout(resolve, ms))
-}
 
 describe('execute', () => {
   const id = '1'
@@ -137,7 +134,7 @@ describe('websocket', () => {
 
       // This final request should disable the cache warmer, sleep is used to make sure that the data is  pulled from the websocket
       // populated cache entries.
-      await sleep(100)
+      await util.sleep(100)
       const response = await makeRequest()
 
       expect(response.body).toEqual({

--- a/packages/sources/intrinio/test/integration/fixtures.ts
+++ b/packages/sources/intrinio/test/integration/fixtures.ts
@@ -1,10 +1,10 @@
 import nock from 'nock'
 
 export const mockRateResponseSuccess = (): nock =>
-  nock('https://api-v2.intrinio.com/', {
+  nock('https://api-v2.intrinio.com', {
     encodedQueryParams: true,
   })
-    .get('/securities/ETH/prices/realtime')
+    .get('/securities/AAPL/prices/realtime')
     .query({ api_key: 'fake-api-key' })
     .reply(
       200,
@@ -43,3 +43,44 @@ export const mockRateResponseSuccess = (): nock =>
         'Origin',
       ],
     )
+
+export const mockAuthResponse = (): nock =>
+  nock('https://realtime.intrinio.com', {
+    encodedQueryParams: true,
+  })
+    .get('/auth')
+    .query({ api_key: 'fake-api-key' })
+    .reply(200, 'fake-api-token', ['Transfer-Encoding', 'chunked'])
+
+export const mockSubscribeResponse = {
+  request: {
+    topic: 'iex:securities:AAPL',
+    event: 'phx_join',
+    payload: {},
+    ref: null,
+  },
+  response: [
+    {
+      topic: 'iex:securities:AAPL',
+      payload: {
+        type: 'last',
+        timestamp: 1646336888.345325,
+        ticker: 'AAPL',
+        size: 100,
+        price: 166.91,
+      },
+      event: 'quote',
+    },
+  ],
+}
+
+export const mockUnsubscribeResponse = {
+  request: {
+    topic: 'iex:securities:AAPL',
+    event: 'phx_leave',
+    payload: {},
+    ref: null,
+  },
+
+  response: '',
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3647,6 +3647,7 @@ __metadata:
     "@types/jest": 27.0.3
     "@types/node": 16.11.19
     "@types/supertest": 2.0.11
+    axios: ^0.24.0
     express: ^4.17.1
     intrinio-realtime: ^2.3.0
     nock: 13.2.4


### PR DESCRIPTION


## Changes

- Added websocket integration tests for Intrino EA
- Modified util.ts to use axios instead of native https module (in order nock to work)


<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

` yarn test packages/sources/intrinio/test/integration`

## Quality Assurance

- [x] Ran `yarn changeset` if adapter source code was changed
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [ ] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
