### PR TITLE
cryptocompare websocket integration tests

### DIFF
--- a/.changeset/fluffy-cougars-develop.md
+++ b/.changeset/fluffy-cougars-develop.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/cryptocompare-adapter': patch
+---
+
+removed websocket protocol for connection

--- a/packages/sources/cryptocompare/src/adapter.ts
+++ b/packages/sources/cryptocompare/src/adapter.ts
@@ -82,7 +82,6 @@ export const makeWSHandler = (config?: Config): MakeWSHandler => {
           defaultConfig.api.baseWsURL || DEFAULT_WS_API_ENDPOINT,
           defaultConfig.apiKey || '',
         ),
-        protocol: { query: { api_key: defaultConfig.apiKey } },
       },
       subscribe: (input) => getSubscription('SubAdd', getPair(input)),
       unsubscribe: (input) => getSubscription('SubRemove', getPair(input)),

--- a/packages/sources/cryptocompare/test/integration/adapter.test.ts
+++ b/packages/sources/cryptocompare/test/integration/adapter.test.ts
@@ -4,8 +4,25 @@ import * as process from 'process'
 import { server as startServer } from '../../src'
 import * as nock from 'nock'
 import * as http from 'http'
-import { mockPriceResponseFailure, mockPriceResponseSuccess } from './fixtures'
+import {
+  mockPriceResponseFailure,
+  mockPriceResponseSuccess,
+  mockSubscribeResponse,
+  mockUnsubscribeResponse,
+} from './fixtures'
 import { AddressInfo } from 'net'
+import {
+  mockWebSocketProvider,
+  mockWebSocketServer,
+  MockWsServer,
+  mockWebSocketFlow,
+} from '@chainlink/ea-test-helpers'
+import { WebSocketClassProvider } from '@chainlink/ea-bootstrap/dist/lib/middleware/ws/recorder'
+import { DEFAULT_WS_API_ENDPOINT } from '../../src/config'
+
+const sleep = (ms: number) => {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
 
 describe('execute', () => {
   const id = '1'
@@ -13,7 +30,6 @@ describe('execute', () => {
   let req: SuperTest<Test>
 
   beforeAll(async () => {
-    process.env.CACHE_ENABLED = 'false'
     process.env.API_KEY = process.env.API_KEY || 'fake-api-key'
     if (process.env.RECORD) {
       nock.recorder.rec()
@@ -29,7 +45,6 @@ describe('execute', () => {
 
     nock.restore()
     nock.cleanAll()
-    nock.enableNetConnect()
     server.close(done)
   })
 
@@ -149,5 +164,90 @@ describe('execute', () => {
         .expect(200)
       expect(response.body).toMatchSnapshot()
     })
+  })
+})
+
+describe('websocket', () => {
+  let mockedWsServer: InstanceType<typeof MockWsServer>
+  let server: http.Server
+  let req: SuperTest<Test>
+
+  let oldEnv: NodeJS.ProcessEnv
+  beforeAll(async () => {
+    if (!process.env.RECORD) {
+      process.env.API_KEY = 'fake-api-key'
+      mockedWsServer = mockWebSocketServer(
+        `${DEFAULT_WS_API_ENDPOINT}?api_key=${process.env.API_KEY}`,
+      )
+      mockWebSocketProvider(WebSocketClassProvider)
+    }
+
+    oldEnv = JSON.parse(JSON.stringify(process.env))
+    process.env.WS_ENABLED = 'true'
+    process.env.WS_SUBSCRIPTION_TTL = '300'
+
+    server = await startServer()
+    req = request(`localhost:${(server.address() as AddressInfo).port}`)
+  })
+
+  afterAll((done) => {
+    process.env = oldEnv
+    nock.restore()
+    nock.cleanAll()
+    nock.enableNetConnect()
+    server.close(done)
+  })
+
+  describe('crypto endpoint', () => {
+    const jobID = '1'
+
+    it('should return success', async () => {
+      const data: AdapterRequest = {
+        id: jobID,
+        data: {
+          endpoint: 'crypto',
+          base: 'ETH',
+          quote: 'BTC',
+        },
+      }
+
+      let flowFulfilled: Promise<boolean>
+      if (!process.env.RECORD) {
+        mockPriceResponseSuccess() // For the first response
+
+        flowFulfilled = mockWebSocketFlow(mockedWsServer, [
+          mockSubscribeResponse,
+          mockUnsubscribeResponse,
+        ])
+      }
+
+      const makeRequest = () =>
+        req
+          .post('/')
+          .send(data)
+          .set('Accept', '*/*')
+          .set('Content-Type', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(200)
+
+      // We don't care about the first response, coming from http request
+      // This first request will start both batch warmer & websocket
+      await makeRequest()
+
+      // This final request should disable the cache warmer, sleep is used to make sure that the data is  pulled from the websocket
+      // populated cache entries.
+      await sleep(10)
+      const response = await makeRequest()
+
+      expect(response.body).toEqual({
+        jobRunID: '1',
+        result: 0.07038,
+        statusCode: 200,
+        maxAge: 30000,
+        data: { result: 0.07038 },
+      })
+
+      await flowFulfilled
+    }, 30000)
   })
 })

--- a/packages/sources/cryptocompare/test/integration/adapter.test.ts
+++ b/packages/sources/cryptocompare/test/integration/adapter.test.ts
@@ -4,6 +4,7 @@ import * as process from 'process'
 import { server as startServer } from '../../src'
 import * as nock from 'nock'
 import * as http from 'http'
+import { util } from '@chainlink/ea-bootstrap'
 import {
   mockPriceResponseFailure,
   mockPriceResponseSuccess,
@@ -19,10 +20,6 @@ import {
 } from '@chainlink/ea-test-helpers'
 import { WebSocketClassProvider } from '@chainlink/ea-bootstrap/dist/lib/middleware/ws/recorder'
 import { DEFAULT_WS_API_ENDPOINT } from '../../src/config'
-
-const sleep = (ms: number) => {
-  return new Promise((resolve) => setTimeout(resolve, ms))
-}
 
 describe('execute', () => {
   const id = '1'
@@ -236,7 +233,7 @@ describe('websocket', () => {
 
       // This final request should disable the cache warmer, sleep is used to make sure that the data is  pulled from the websocket
       // populated cache entries.
-      await sleep(10)
+      await util.sleep(10)
       const response = await makeRequest()
 
       expect(response.body).toEqual({

--- a/packages/sources/cryptocompare/test/integration/fixtures.ts
+++ b/packages/sources/cryptocompare/test/integration/fixtures.ts
@@ -159,3 +159,72 @@ export const mockPriceResponseFailure = (): nock =>
       'Vary',
       'Origin',
     ])
+
+export const mockSubscribeResponse = {
+  request: {
+    action: 'SubAdd',
+    subs: ['5~CCCAGG~ETH~BTC'],
+  },
+  response: [
+    {
+      TYPE: '16',
+      MESSAGE: 'SUBSCRIBECOMPLETE',
+      SUB: '5~CCCAGG~ETH~BTC',
+    },
+    {
+      TYPE: '3',
+      MESSAGE: 'LOADCOMPLETE',
+      INFO: 'All your valid subs have been loaded.',
+    },
+    {
+      TYPE: '5',
+      MARKET: 'CCCAGG',
+      FROMSYMBOL: 'ETH',
+      TOSYMBOL: 'BTC',
+      FLAGS: 2,
+      PRICE: 0.07038,
+      LASTUPDATE: 1645027932,
+      MEDIAN: 0.07038,
+      LASTVOLUME: 0.045,
+      LASTVOLUMETO: 0.00316565955,
+      LASTTRADEID: '16450279320001',
+      VOLUMEDAY: 253257.38626818382,
+      VOLUMEDAYTO: 11398.462174583636,
+      VOLUME24HOUR: 78687.65999060342,
+      VOLUME24HOURTO: 5583.496196776957,
+      OPENDAY: 0.07148,
+      HIGHDAY: 0.07187,
+      LOWDAY: 0.07014,
+      OPEN24HOUR: 0.07057,
+      HIGH24HOUR: 0.0719,
+      LOW24HOUR: 0.07013,
+      LASTMARKET: 'aax',
+      VOLUMEHOUR: 9845.973204030126,
+      VOLUMEHOURTO: 406.67115535224315,
+      OPENHOUR: 0.07033,
+      HIGHHOUR: 0.07043,
+      LOWHOUR: 0.07021,
+      TOPTIERVOLUME24HOUR: 78687.39639060342,
+      TOPTIERVOLUME24HOURTO: 5583.4778180780095,
+      CURRENTSUPPLY: 119524383.0615,
+      CIRCULATINGSUPPLY: 119524383.0615,
+      MAXSUPPLY: -1,
+      MKTCAPPENALTY: 0,
+      CURRENTSUPPLYMKTCAP: 8412126.079868369,
+      CIRCULATINGSUPPLYMKTCAP: 8412126.079868369,
+      MAXSUPPLYMKTCAP: -1,
+    },
+  ],
+}
+
+export const mockUnsubscribeResponse = {
+  request: {
+    action: 'SubRemove',
+    subs: ['5~CCCAGG~ETH~BTC'],
+  },
+  response: {
+    TYPE: '17',
+    MESSAGE: 'UNSUBSCRIBECOMPLETE',
+    SUB: '5~CCCAGG~ETH~BTC',
+  },
+}


### PR DESCRIPTION


## Changes

- Removed websocket connection protocol. API_KEY was in connection url
- Added websocket integration tests for cryptocompare EA

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

`yarn test packages/sources/cryptocompare/test/integration`

## Quality Assurance

- [x] Ran `yarn changeset` if adapter source code was changed
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [ ] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
