### PR TITLE
Pin README test adapter versions to prevent upgrades

### DIFF
--- a/packages/scripts/src/generate-readme/test/integration/__snapshots__/script.test.ts.snap
+++ b/packages/scripts/src/generate-readme/test/integration/__snapshots__/script.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`readme generation script when generating readme for readme-test-adapter should successfully generate readme 1`] = `
 "# README Test Adapter
 
-Version: 1.2.3
+Version: 1.2.4
 
 This is a fake adapter for testing, and should not be used as a template for adapters.
 

--- a/packages/scripts/src/generate-readme/test/integration/readme-test-adapter/README.md
+++ b/packages/scripts/src/generate-readme/test/integration/readme-test-adapter/README.md
@@ -1,6 +1,6 @@
 # README Test Adapter
 
-Version: 1.2.3
+Version: 1.2.4
 
 This is a fake adapter for testing, and should not be used as a template for adapters.
 

--- a/packages/scripts/src/generate-readme/test/integration/readme-test-adapter/package.json
+++ b/packages/scripts/src/generate-readme/test/integration/readme-test-adapter/package.json
@@ -2,12 +2,12 @@
   "name": "@chainlink/readme-test-adapter",
   "version": "1.2.4",
   "dependencies": {
-    "@chainlink/ea-bootstrap": "workspace:*",
-    "@chainlink/ea-factories": "*",
-    "tslib": "^2.3.1"
+    "@chainlink/ea-bootstrap": "1.13.0",
+    "@chainlink/ea-factories": "1.0.34",
+    "tslib": "2.3.1"
   },
   "devDependencies": {
-    "@chainlink/types": "workspace:*",
+    "@chainlink/types": "1.0.2",
     "@types/supertest": "2.0.11",
     "nock": "13.1.3",
     "supertest": "6.1.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2900,7 +2900,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@chainlink/ea-bootstrap@*, @chainlink/ea-bootstrap@workspace:*, @chainlink/ea-bootstrap@workspace:packages/core/bootstrap":
+"@chainlink/ea-bootstrap@*, @chainlink/ea-bootstrap@1.13.0, @chainlink/ea-bootstrap@workspace:*, @chainlink/ea-bootstrap@workspace:packages/core/bootstrap":
   version: 0.0.0-use.local
   resolution: "@chainlink/ea-bootstrap@workspace:packages/core/bootstrap"
   dependencies:
@@ -2954,7 +2954,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@chainlink/ea-factories@*, @chainlink/ea-factories@workspace:*, @chainlink/ea-factories@workspace:packages/core/factories":
+"@chainlink/ea-factories@1.0.34, @chainlink/ea-factories@workspace:*, @chainlink/ea-factories@workspace:packages/core/factories":
   version: 0.0.0-use.local
   resolution: "@chainlink/ea-factories@workspace:packages/core/factories"
   dependencies:
@@ -4229,13 +4229,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@chainlink/readme-test-adapter@workspace:packages/scripts/src/generate-readme/test/integration/readme-test-adapter"
   dependencies:
-    "@chainlink/ea-bootstrap": "workspace:*"
-    "@chainlink/ea-factories": "*"
-    "@chainlink/types": "workspace:*"
+    "@chainlink/ea-bootstrap": 1.13.0
+    "@chainlink/ea-factories": 1.0.34
+    "@chainlink/types": 1.0.2
     "@types/supertest": 2.0.11
     nock: 13.1.3
     supertest: 6.1.6
-    tslib: ^2.3.1
+    tslib: 2.3.1
   languageName: unknown
   linkType: soft
 
@@ -4681,7 +4681,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@chainlink/types@workspace:*, @chainlink/types@workspace:packages/core/types/@chainlink":
+"@chainlink/types@1.0.2, @chainlink/types@workspace:*, @chainlink/types@workspace:packages/core/types/@chainlink":
   version: 0.0.0-use.local
   resolution: "@chainlink/types@workspace:packages/core/types/@chainlink"
   languageName: unknown


### PR DESCRIPTION
## Description
Pin README test adapter dependency versions so it doesn't upgrade when we consume changesets

## Changes
- Pin dependencies from `@chainlink`
- Update integration snapshot to match current version

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test
`yarn && yarn setup && yarn test packages/scripts/src/generate-readme/test/integration/*`

## Quality Assurance

- [x] Ran `yarn changeset` if adapter source code was changed
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
