### PR TITLE
Fix consume-release workflow

### DIFF
--- a/.github/workflows/consume-release.yml
+++ b/.github/workflows/consume-release.yml
@@ -5,7 +5,7 @@
 on:
   workflow_run:
     workflows: [Release]
-    types: [Completed]
+    types: [completed]
 
 jobs:
   on-success:


### PR DESCRIPTION
A capitalization error within the types of workflow run filter made it
so that all workflow_run events were filtered out.
