### PR TITLE
Cfbenchmarks websocket tests

### DIFF
--- a/packages/core/test-helpers/src/websocket.ts
+++ b/packages/core/test-helpers/src/websocket.ts
@@ -11,8 +11,15 @@ import { Server, WebSocket } from 'mock-socket'
  * @param provider singleton WebSocketClassProvider
  */
 export const mockWebSocketProvider = (provider: typeof WebSocketClassProvider): void => {
+  // Extend mock WebSocket class to bypass protocol headers error
+  class MockWebSocket extends WebSocket {
+    constructor(url: string, protocol: string | string[] | Record<string, string> | undefined) {
+      super(url, protocol instanceof Object ? undefined : protocol)
+    }
+  }
+
   // Need to disable typing, the mock-socket impl does not implement the ws interface fully
-  provider.set(WebSocket as any) // eslint-disable-line @typescript-eslint/no-explicit-any
+  provider.set(MockWebSocket as any) // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 export const mockWebSocketServer = (url: string): Server => {

--- a/packages/sources/cfbenchmarks/test/integration/adapter.test.ts
+++ b/packages/sources/cfbenchmarks/test/integration/adapter.test.ts
@@ -4,8 +4,21 @@ import * as process from 'process'
 import { server as startServer } from '../../src'
 import * as nock from 'nock'
 import * as http from 'http'
-import { mockResponseSuccess } from './fixtures'
+import { mockResponseSuccess, mockSubscribeResponse, mockUnsubscribeResponse } from './fixtures'
 import { AddressInfo } from 'net'
+import {
+  mockWebSocketProvider,
+  mockWebSocketServer,
+  MockWsServer,
+  mockWebSocketFlow,
+} from '@chainlink/ea-test-helpers'
+import { WebSocketClassProvider } from '@chainlink/ea-bootstrap/dist/lib/middleware/ws/recorder'
+import { DEFAULT_WS_API_ENDPOINT } from '../../src/config'
+
+const sleep = (ms: number) => {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
 describe('execute', () => {
   const id = '1'
   let server: http.Server
@@ -50,5 +63,86 @@ describe('execute', () => {
         .expect(200)
       expect(response.body).toMatchSnapshot()
     })
+  })
+})
+
+describe('websocket', () => {
+  let mockedWsServer: InstanceType<typeof MockWsServer>
+  let server: http.Server
+  let req: SuperTest<Test>
+
+  let oldEnv: NodeJS.ProcessEnv
+  beforeAll(async () => {
+    if (!process.env.RECORD) {
+      process.env.API_USERNAME = process.env.API_USERNAME || 'fake-api-username'
+      process.env.API_PASSWORD = process.env.API_PASSWORD || 'fake-api-password'
+      mockedWsServer = mockWebSocketServer(DEFAULT_WS_API_ENDPOINT)
+      mockWebSocketProvider(WebSocketClassProvider)
+    }
+
+    oldEnv = JSON.parse(JSON.stringify(process.env))
+    process.env.WS_ENABLED = 'true'
+    process.env.WS_SUBSCRIPTION_TTL = '300'
+
+    server = await startServer()
+    req = request(`localhost:${(server.address() as AddressInfo).port}`)
+  })
+
+  afterAll((done) => {
+    process.env = oldEnv
+    nock.restore()
+    nock.cleanAll()
+    nock.enableNetConnect()
+    server.close(done)
+  })
+
+  describe('values endpoint', () => {
+    const jobID = '1'
+
+    it('should return success', async () => {
+      const data: AdapterRequest = {
+        id: jobID,
+        data: {
+          index: 'BRTI',
+        },
+      }
+
+      let flowFulfilled: Promise<boolean>
+      if (!process.env.RECORD) {
+        mockResponseSuccess() // For the first response
+
+        flowFulfilled = mockWebSocketFlow(mockedWsServer, [
+          mockSubscribeResponse,
+          mockUnsubscribeResponse,
+        ])
+      }
+
+      const makeRequest = () =>
+        req
+          .post('/')
+          .send(data)
+          .set('Accept', '*/*')
+          .set('Content-Type', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(200)
+
+      // This first request will start both batch warmer & websocket
+      await makeRequest()
+
+      // This final request should disable the cache warmer, sleep is used to make sure that the data is  pulled from the websocket
+      // populated cache entries.
+      await sleep(10)
+      const response = await makeRequest()
+
+      expect(response.body).toEqual({
+        jobRunID: '1',
+        result: 40067,
+        statusCode: 200,
+        maxAge: 30000,
+        data: { result: 40067 },
+      })
+
+      await flowFulfilled
+    }, 30000)
   })
 })

--- a/packages/sources/cfbenchmarks/test/integration/adapter.test.ts
+++ b/packages/sources/cfbenchmarks/test/integration/adapter.test.ts
@@ -6,6 +6,7 @@ import * as nock from 'nock'
 import * as http from 'http'
 import { mockResponseSuccess, mockSubscribeResponse, mockUnsubscribeResponse } from './fixtures'
 import { AddressInfo } from 'net'
+import { util } from '@chainlink/ea-bootstrap'
 import {
   mockWebSocketProvider,
   mockWebSocketServer,
@@ -14,10 +15,6 @@ import {
 } from '@chainlink/ea-test-helpers'
 import { WebSocketClassProvider } from '@chainlink/ea-bootstrap/dist/lib/middleware/ws/recorder'
 import { DEFAULT_WS_API_ENDPOINT } from '../../src/config'
-
-const sleep = (ms: number) => {
-  return new Promise((resolve) => setTimeout(resolve, ms))
-}
 
 describe('execute', () => {
   const id = '1'
@@ -131,7 +128,7 @@ describe('websocket', () => {
 
       // This final request should disable the cache warmer, sleep is used to make sure that the data is  pulled from the websocket
       // populated cache entries.
-      await sleep(10)
+      await util.sleep(10)
       const response = await makeRequest()
 
       expect(response.body).toEqual({

--- a/packages/sources/cfbenchmarks/test/integration/fixtures.ts
+++ b/packages/sources/cfbenchmarks/test/integration/fixtures.ts
@@ -27,3 +27,37 @@ export const mockResponseSuccess = (): nock =>
         'Origin',
       ],
     )
+
+export const mockSubscribeResponse = {
+  request: {
+    type: 'subscribe',
+    id: 'BRTI',
+    stream: 'value',
+    cacheID: 'BRTI',
+  },
+  response: [
+    {
+      type: 'value',
+      time: 1645203822000,
+      id: 'BRTI',
+      value: '40067.00',
+    },
+  ],
+}
+
+export const mockUnsubscribeResponse = {
+  request: {
+    type: 'unsubscribe',
+    id: 'BRTI',
+    stream: 'value',
+    cacheID: 'BRTI',
+  },
+  response: [
+    {
+      type: 'unsubscribe',
+      id: 'BRTI',
+      stream: 'value',
+      success: true,
+    },
+  ],
+}


### PR DESCRIPTION


## Changes

-  Added websocket integration test for cfbechmarks EA
- Modified websocket testing framework to bypass the complex headers

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

` yarn test packages/sources/cfbenchmarks/test/integration
`
## Quality Assurance

- [ ] Ran `yarn changeset` if adapter source code was changed
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [ ] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
