### PR TITLE
(fix): Ensure Burst Limit's second retry

### DIFF
--- a/.changeset/selfish-carrots-scream.md
+++ b/.changeset/selfish-carrots-scream.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/ea-bootstrap': patch
+---
+
+(fix): Ensure Burst Limit's second retry correctly updates state's sliding window

--- a/packages/core/bootstrap/src/lib/middleware/burst-limit/actions.ts
+++ b/packages/core/bootstrap/src/lib/middleware/burst-limit/actions.ts
@@ -6,5 +6,7 @@ export interface RequestObservedPayload {
 }
 
 export const requestObserved = createAction<RequestObservedPayload>(
-  'RL/SUCCESSFUL_REQUEST_OBSERVED',
+  'BL/SUCCESSFUL_REQUEST_OBSERVED',
 )
+
+export const updateIntervals = createAction('BL/UPDATE_INTERVALS')

--- a/packages/core/bootstrap/src/lib/middleware/burst-limit/index.ts
+++ b/packages/core/bootstrap/src/lib/middleware/burst-limit/index.ts
@@ -23,6 +23,7 @@ const availableSecondLimitCapacity = async (
   burstCapacity1s: number,
 ) => {
   for (let retry = SECOND_LIMIT_RETRIES; retry > 0; retry--) {
+    store.dispatch(actions.updateIntervals())
     const state = store.getState()
     const { requests }: { requests: RequestsState } = state
 
@@ -54,7 +55,7 @@ export const withBurstLimit =
       const availableCapacity = availableSecondLimitCapacity(store, config.burstCapacity1s)
       if (!availableCapacity) {
         logger.warn(
-          `External Adapter backing off. Provider's limit of ${config.burstCapacity1s} requests per second reached.`,
+          `External Adapter backing off. Provider's burst limit of ${config.burstCapacity1s} requests per second reached.`,
         )
         throw new AdapterError({
           jobRunID: input.id,

--- a/packages/core/bootstrap/src/lib/middleware/burst-limit/reducer.ts
+++ b/packages/core/bootstrap/src/lib/middleware/burst-limit/reducer.ts
@@ -43,6 +43,23 @@ export const initialRequestsState: RequestsState = {
 }
 
 export const requestReducer = createReducer<RequestsState>(initialRequestsState, (builder) => {
+  builder.addCase(actions.updateIntervals, (state) => {
+    const time = Date.now()
+
+    const storedIntervals = [IntervalNames.SECOND, IntervalNames.MINUTE]
+
+    for (const intervalName of storedIntervals) {
+      // remove all requests that are older than the current interval
+      const window = time - Intervals[intervalName]
+      const isInWindow = (h: Request) => h.t >= window
+      state.participants[intervalName] = sortedFilter(state.participants[intervalName], isInWindow)
+
+      // update total
+      state.total[intervalName] = state.participants[intervalName].length
+    }
+
+    return state
+  })
   builder.addCase(actions.requestObserved, (state, action) => {
     const request: Request = {
       id: makeId(action.payload.input),

--- a/packages/core/bootstrap/test/unit/burst-limit.test.ts
+++ b/packages/core/bootstrap/test/unit/burst-limit.test.ts
@@ -1,0 +1,73 @@
+import { AdapterContext, APIEndpoint, Execute } from '@chainlink/types'
+import { createStore } from 'redux'
+import { useFakeTimers, SinonFakeTimers } from 'sinon'
+import { reducer as burstLimitReducer, withBurstLimit } from '../../src/lib/middleware/burst-limit'
+
+describe('burst limit', () => {
+  let clock: SinonFakeTimers
+
+  beforeEach(() => {
+    clock = useFakeTimers()
+  })
+
+  afterEach(() => {
+    clock.restore()
+  })
+
+  it('successfully blocks burst of requests', async () => {
+    const execute: Execute = async () => {
+      return {
+        jobRunID: '1',
+        statusCode: 200,
+        data: { result: 1 },
+        result: 1,
+      }
+    }
+
+    const request = {
+      id: '1',
+      data: {
+        endpoint: 'testDownstreamEndpoint',
+        source: 'SOMESOURCEADAPTER',
+      },
+    }
+
+    const context: AdapterContext = {
+      rateLimit: {
+        enabled: true,
+        burstCapacity1s: 5,
+      },
+    }
+
+    const store = createStore(burstLimitReducer.rootReducer, {})
+    const middleware = await withBurstLimit(store)(execute, context)
+
+    // Perform initial requests; these should pass
+    for (let i = 0; i < 6; i++) {
+      await middleware(request, {})
+    }
+    // This next one will fail on the burst limiter.
+    // Wrapped in a custom promise to check state synchronously.
+    let burstLimitedRequestResolved = false
+    // eslint-disable-next-line no-async-promise-executor
+    const promise = new Promise(async (resolve) => {
+      const result = await middleware(request, {})
+      burstLimitedRequestResolved = true
+      resolve(result)
+    })
+
+    // Advance the clock 2s. It will still be retrying, because the total requests are only updated
+    // when the reducer is fired by a successful request.
+    clock.tickAsync(2000)
+    expect(burstLimitedRequestResolved).toBe(false)
+
+    // We can make another request, which should pass.
+    await middleware(request, {})
+
+    // Now the redux store should have been updated, and our promise resolved.
+    const result = await promise
+
+    // NOTE - Doesn't work, because reducer is only triggered on successful request.
+    expect(result).toBeNull()
+  }, 10000)
+})


### PR DESCRIPTION
## Description

Ensure Burst Limit's second retry correctly updates state's sliding window

## Changes

- Add action to update Burst Limit's interval state forward in time, used to check for retries.


## Steps to Test

1. Integration tests added by @alejoberardino 
