### PR TITLE
Additional Anchor EA testing

### DIFF
--- a/packages/composites/anchor/test/integration/prices/__snapshots__/beth.test.ts.snap
+++ b/packages/composites/anchor/test/integration/prices/__snapshots__/beth.test.ts.snap
@@ -13,7 +13,7 @@ Object {
 }
 `;
 
-exports[`price-beth error calls should throw an error if the ETH/USD feed is down 1`] = `
+exports[`price-beth error calls should throw an error if the ETH/USD feed returns 0 1`] = `
 Object {
   "error": Object {
     "feedID": "BETH/ETH",
@@ -26,11 +26,37 @@ Object {
 }
 `;
 
-exports[`price-beth error calls should throw an error if the stETH/ETH Curve pool is having issues 1`] = `
+exports[`price-beth error calls should throw an error if the ETH/USD feed reverts 1`] = `
+Object {
+  "error": Object {
+    "feedID": "BETH/ETH",
+    "message": "Call to ETH-USD Terra feed has reverted",
+    "name": "AdapterError",
+  },
+  "jobRunID": "1",
+  "status": "errored",
+  "statusCode": 500,
+}
+`;
+
+exports[`price-beth error calls should throw an error if the stETH/ETH Curve pool is returns 0 1`] = `
 Object {
   "error": Object {
     "feedID": "BETH/ETH",
     "message": "Invalid result for stETH/ETH Exchange Rate from Curve Pool address error-curve-address",
+    "name": "AdapterError",
+  },
+  "jobRunID": "1",
+  "status": "errored",
+  "statusCode": 500,
+}
+`;
+
+exports[`price-beth error calls should throw an error if the stETH/ETH Curve pool reverts 1`] = `
+Object {
+  "error": Object {
+    "feedID": "BETH/ETH",
+    "message": "Call to Curve pool to fetch stETH/ETH rate reverted",
     "name": "AdapterError",
   },
   "jobRunID": "1",

--- a/packages/composites/anchor/test/integration/prices/__snapshots__/bluna.test.ts.snap
+++ b/packages/composites/anchor/test/integration/prices/__snapshots__/bluna.test.ts.snap
@@ -1,5 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`price-bluna error calls should throw an error if call to the LUNA/USD feed reverts 1`] = `
+Object {
+  "error": Object {
+    "feedID": "BLUNA/USD",
+    "message": "Call to Terra bLUNA/USD feed reverted",
+    "name": "AdapterError",
+  },
+  "jobRunID": "1",
+  "status": "errored",
+  "statusCode": 500,
+}
+`;
+
 exports[`price-bluna error calls should throw an error if the Anchor bLUNA Hub contract returns 0 1`] = `
 Object {
   "error": Object {
@@ -13,11 +26,24 @@ Object {
 }
 `;
 
-exports[`price-bluna error calls should throw an error if the LUNA/USD feed is down 1`] = `
+exports[`price-bluna error calls should throw an error if the LUNA/USD feed returns 0 1`] = `
 Object {
   "error": Object {
     "feedID": "BLUNA/USD",
     "message": "Invalid result for Chainlink Terra feed error-luna-feed-address",
+    "name": "AdapterError",
+  },
+  "jobRunID": "1",
+  "status": "errored",
+  "statusCode": 500,
+}
+`;
+
+exports[`price-bluna error calls should throw an error if the call to the Anchor bLUNA Hub reverts 1`] = `
+Object {
+  "error": Object {
+    "feedID": "BLUNA/USD",
+    "message": "Call to Terra bLuna HUB contract reverted",
     "name": "AdapterError",
   },
   "jobRunID": "1",

--- a/packages/composites/anchor/test/integration/prices/bluna.test.ts
+++ b/packages/composites/anchor/test/integration/prices/bluna.test.ts
@@ -65,7 +65,7 @@ describe('price-bluna', () => {
   })
 
   describe('error calls', () => {
-    it('should throw an error if the LUNA/USD feed is down', async () => {
+    it('should throw an error if the LUNA/USD feed returns 0', async () => {
       process.env.LUNA_TERRA_FEED_ADDRESS = ERROR_LUNA_FEED
       const data: AdapterRequest = {
         id: jobID,

--- a/packages/composites/anchor/test/integration/prices/bluna.test.ts
+++ b/packages/composites/anchor/test/integration/prices/bluna.test.ts
@@ -12,7 +12,9 @@ import {
 } from '../fixtures'
 
 const ERROR_LUNA_FEED = 'error-luna-feed-address'
+const FAILED_LUNA_FEED = 'failed-luna-feed-address'
 const ERROR_TERRA_BLUNA_HUB_CONTRACT_ADDRESS = 'error-terra-bluna-hub-contract-address'
+const FAILED_TERRA_BLUNA_HUB_CONTRACT_ADDRESS = 'failed-terra-bluna-hub-contract-address'
 
 jest.mock('@chainlink/terra-view-function-adapter', () => {
   return {
@@ -21,11 +23,23 @@ jest.mock('@chainlink/terra-view-function-adapter', () => {
       jest.fn().mockImplementation((input: AdapterRequest) => {
         const { address, query } = input.data
         if (query === 'latest_round_data') {
-          return address === ERROR_LUNA_FEED ? mockErrorFeedResponse : mockSuccessfulLunaFeedResp
+          switch (address) {
+            case ERROR_LUNA_FEED:
+              return mockErrorFeedResponse
+            case FAILED_LUNA_FEED:
+              throw new Error('Call to Terra bLUNA/USD feed reverted')
+            default:
+              return mockSuccessfulLunaFeedResp
+          }
         } else if (query.state) {
-          return address === ERROR_TERRA_BLUNA_HUB_CONTRACT_ADDRESS
-            ? mockErrorAnchorHubContractResp
-            : mockSuccessfulAnchorHubContractAddress
+          switch (address) {
+            case ERROR_TERRA_BLUNA_HUB_CONTRACT_ADDRESS:
+              return mockErrorAnchorHubContractResp
+            case FAILED_TERRA_BLUNA_HUB_CONTRACT_ADDRESS:
+              throw new Error('Call to Terra bLuna HUB contract reverted')
+            default:
+              return mockSuccessfulAnchorHubContractAddress
+          }
         }
       }),
     ),
@@ -85,8 +99,49 @@ describe('price-bluna', () => {
       expect(response.body).toMatchSnapshot()
     })
 
+    it('should throw an error if call to the LUNA/USD feed reverts', async () => {
+      process.env.LUNA_TERRA_FEED_ADDRESS = FAILED_LUNA_FEED
+      const data: AdapterRequest = {
+        id: jobID,
+        data: {
+          from: 'BLuna',
+          to: 'USD',
+        },
+      }
+
+      const response = await req
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(500)
+      expect(response.body).toMatchSnapshot()
+    })
+
     it('should throw an error if the Anchor bLUNA Hub contract returns 0', async () => {
       process.env.TERRA_BLUNA_HUB_CONTRACT_ADDRESS = ERROR_TERRA_BLUNA_HUB_CONTRACT_ADDRESS
+
+      const data: AdapterRequest = {
+        id: jobID,
+        data: {
+          from: 'BLuna',
+          to: 'USD',
+        },
+      }
+
+      const response = await req
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(500)
+      expect(response.body).toMatchSnapshot()
+    })
+
+    it('should throw an error if the call to the Anchor bLUNA Hub reverts', async () => {
+      process.env.TERRA_BLUNA_HUB_CONTRACT_ADDRESS = FAILED_TERRA_BLUNA_HUB_CONTRACT_ADDRESS
 
       const data: AdapterRequest = {
         id: jobID,


### PR DESCRIPTION
## Closes 31406

## Description

Adds extra integration tests for the Anchor EA

 - test if the call to the curve pool reverts
 - test behavior if reading ETH/USD feed errors out
 - test behavior if reading LUNA/USD feed errors out
 - test if reading Anchor bLUNA Hub errors out
 - reword description for test to see if EA errors when `stETH/ETH` curve pool returns 0 to "should throw an error if the stETH/ETH Curve pool is returning zero"
 - reword description for test to see if EA errors when fetching the `LUNA/USD` from the Terra feed to "should throw an error if the LUNA/USD feed is returning zero"

## Changes

- Update `bEth` and `bLuna` Anchor EA integration tests
- Update snapshots

## Steps to Test

1. Run Anchor integration tests and verify that they pass

## Quality Assurance

- [N/A] Ran `yarn changeset` if adapter source code was changed
- [N/A] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [N/A] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
