### PR TITLE
Change delay function calls into sleep

### DIFF
--- a/.changeset/lucky-numbers-deny.md
+++ b/.changeset/lucky-numbers-deny.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/ea-bootstrap': patch
+---
+
+Change delay functions into using sleep util

--- a/packages/core/bootstrap/src/lib/middleware/burst-limit/index.ts
+++ b/packages/core/bootstrap/src/lib/middleware/burst-limit/index.ts
@@ -9,7 +9,7 @@ import {
 import * as actions from './actions'
 import { WARMUP_BATCH_REQUEST_ID } from '../cache-warmer/config'
 import { AdapterError, logger } from '../../modules'
-import { delay } from '../../util'
+import { sleep } from '../../util'
 
 export * as actions from './actions'
 export * as reducer from './reducer'
@@ -32,7 +32,7 @@ const availableSecondLimitCapacity = async (
       logger.debug(
         `Per Second Burst rate limit cap of ${burstCapacity1s} reached. ${observedRequestsInSecond} requests sent in the last minute. Waiting 1 second. Retry number: ${retry}`,
       )
-      await delay(1000)
+      await sleep(1000)
     } else return true
   }
   return false

--- a/packages/core/bootstrap/src/lib/middleware/cache/index.ts
+++ b/packages/core/bootstrap/src/lib/middleware/cache/index.ts
@@ -10,7 +10,6 @@ import { Store } from 'redux'
 import { reducer } from '../burst-limit'
 import { withBurstLimit } from '../burst-limit'
 import {
-  delay,
   exponentialBackOffMs,
   getEnv,
   getHashOpts,
@@ -18,6 +17,7 @@ import {
   parseBool,
   uuid,
   hash,
+  sleep,
 } from '../../util'
 import { getMaxAgeOverride, getTTL } from './ttl'
 import * as local from './local'
@@ -156,7 +156,7 @@ export class AdapterCache {
           // Add some entropy here because of possible scenario where the key won't be set before multiple
           // other instances in a burst request try to access the coalescing key.
           const randomMs = Math.random() * this.options.requestCoalescing.entropyMax
-          await delay(randomMs)
+          await sleep(randomMs)
         }
         const inFlight = await this.cache.getFlightMarker(this.getCoalescingKey(key))
         logger.debug(`Request coalescing: CHECK inFlight:${inFlight} on retry #${retryCount}`)

--- a/packages/core/bootstrap/src/lib/modules/requester.ts
+++ b/packages/core/bootstrap/src/lib/modules/requester.ts
@@ -8,7 +8,7 @@ import {
 } from '@chainlink/types'
 import { reducer } from '../middleware/cache-warmer'
 import axios, { AxiosResponse } from 'axios'
-import { deepType, getEnv } from '../util'
+import { deepType, getEnv, sleep } from '../util'
 import { getDefaultConfig, logConfig } from '../config'
 import { AdapterError } from './error'
 import { logger } from './logger'
@@ -40,7 +40,7 @@ export class Requester {
     const _retry = async (n: number): Promise<AxiosResponse<T>> => {
       const _delayRetry = async (message: string) => {
         logger.warn(message)
-        await new Promise((resolve) => setTimeout(resolve, delay))
+        await sleep(delay)
         return await _retry(n - 1)
       }
 

--- a/packages/core/bootstrap/src/lib/util.ts
+++ b/packages/core/bootstrap/src/lib/util.ts
@@ -100,9 +100,6 @@ export const uuid = (): string => {
   return process.env.UUID
 }
 
-export const delay = (ms: number): Promise<number> =>
-  new Promise((resolve) => setTimeout(resolve, ms))
-
 /**
  * Return a value used for exponential backoff in milliseconds.
  * @example
@@ -136,7 +133,7 @@ export const getWithCoalescing = async ({
     if (entry) return entry
     const inFlight = await isInFlight(retryCount)
     if (!inFlight) return
-    await delay(interval(retryCount))
+    await sleep(interval(retryCount))
     return await _self(_retries - 1)
   }
   return await _self(retries)


### PR DESCRIPTION
## Description

In #1704 many repeated sleep function declarations were removed, this PR takes out a few remaining ones that were called `delay` instead.
