### PR TITLE
(Fix): Coinpaprika coinlist sorting

### DIFF
--- a/.changeset/cuddly-actors-cover.md
+++ b/.changeset/cuddly-actors-cover.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/coinpaprika-adapter': minor
+---
+
+Fixed bug which caused the last ranked coinid to be used instead of the first

--- a/packages/core/bootstrap/src/lib/modules/overrider.ts
+++ b/packages/core/bootstrap/src/lib/modules/overrider.ts
@@ -53,11 +53,11 @@ export class Overrider {
     const alreadyWarned: { [symbol: string]: boolean } = {}
     for (const coinResponse of coinsResponse) {
       if (remainingSyms.includes(coinResponse.symbol)) {
-        if (isOverridden[coinResponse.symbol] === true && !alreadyWarned[coinResponse.symbol]) {
+        if (isOverridden[coinResponse.symbol] === true) {
+          if (!alreadyWarned[coinResponse.symbol]) alreadyWarned[coinResponse.symbol] = true
           logger.warn(
             `Overrider: The symbol "${coinResponse.symbol}" has a duplicate coin id and no override.`,
           )
-          alreadyWarned[coinResponse.symbol] = true
         } else {
           overriddenCoins[coinResponse.symbol] = coinResponse.id
         }


### PR DESCRIPTION
## Changes

- Fixed bug which caused the last ranked coinid to be used instead of the first

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

`yarn test coinpaprika`

## Quality Assurance

- [x] Ran `yarn changeset` if adapter source code was changed
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
