### PR TITLE
Release/1.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/external-adapters-js",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "license": "MIT",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Changelog

### New Adapters
- Add Celsius Address List adapter support to Proof of Reserve composite adapter

#### Notable changes
|    Adapter    | Version |
| :-----------: | :-----: |
| @chainlink/celsius-address-list-wallet-adapter | 1.0.2 |
| @chainlink/proof-of-reserves-adapter | 1.5.0 |

### Features
-  Update CoinGecko and CoinPaprika to use IDs instead of tickers when an ID is available
- Allow individual EAs to override framework defaults
  - Cache is enabled by default for the `layer2-sequencer-health-adapter` EA
  - Turn on WebSockets on by default for `NCFX` and `onchain-gas` EAs

#### Notable changes
|    Adapter    | Version |
| :-----------: | :-----: |
| @chainlink/coingecko-adapter | 1.4.0 |
| @chainlink/coinpaprika-adapter | 1.5.0 |
| @chainlink/layer2-sequencer-health-adapter-adapter | 1.2.0 |
| @chainlink/ncfx-adapter | 1.2.0 |
| @chainlink/onchain-gas-adapter | 1.2.0 |
| @chainlink/coinranking-adapter | 1.2.0 |
| @chainlink/coinpaprika-adapter | 1.6.0 |
   
### Bug Fixes
 - Fix issues related to `bETH/USD` calculation. Issues were mainly due to token pair exchange rates being flipped the wrong way around for the Anchor EA
 - Fix issue with per second rate limits not being enforced

#### Notable changes
|    Adapter    | Version |
| :-----------: | :-----: |
| @chainlink/anchor-adapter | 3.2.0 |

Note:  The fix for the per second rate limit affects all EAs.  Refer to ECR for the latest version numbers