### PR TITLE
Add confirmations param to eth-balance adapter

### DIFF
--- a/.changeset/slimy-rings-cheat.md
+++ b/.changeset/slimy-rings-cheat.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/eth-balance-adapter': minor
+---
+
+Add confirmations param to balance endpoint

--- a/packages/sources/eth-balance/src/endpoint/balance.ts
+++ b/packages/sources/eth-balance/src/endpoint/balance.ts
@@ -15,9 +15,9 @@ export const inputParameters: InputParameters = {
     description:
       'An array of addresses to get the balances of (as an object with string `address` as an attribute)',
   },
-  confirmations: {
+  minConfirmations: {
     required: false,
-    aliases: ['minConfirmations'],
+    aliases: ['confirmations'],
     type: 'number',
     default: 0,
     description:
@@ -39,7 +39,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
 
   const jobRunID = validator.validated.id
   const addresses = validator.validated.data.addresses as Address[]
-  const confirmations = validator.validated.data.confirmations
+  const minConfirmations = validator.validated.data.minConfirmations
 
   if (!Array.isArray(addresses) || addresses.length === 0) {
     throw new AdapterError({
@@ -50,7 +50,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
   }
 
   // The limitation of 64 is to make it work with both full and light/fast sync nodes
-  if (!Number.isInteger(confirmations) || confirmations < 0 || confirmations > 64) {
+  if (!Number.isInteger(minConfirmations) || minConfirmations < 0 || minConfirmations > 64) {
     throw new AdapterError({
       jobRunID,
       message: `Min confirmations must be an integer between 0 and 64`,
@@ -59,9 +59,9 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
   }
 
   let targetBlockTag: string | number = 'latest'
-  if (confirmations !== 0) {
+  if (minConfirmations !== 0) {
     const lastBlockNumber = await config.provider.getBlockNumber()
-    targetBlockTag = lastBlockNumber - confirmations
+    targetBlockTag = lastBlockNumber - minConfirmations
   }
 
   const balances = await Promise.all(

--- a/packages/sources/eth-balance/src/endpoint/balance.ts
+++ b/packages/sources/eth-balance/src/endpoint/balance.ts
@@ -15,6 +15,14 @@ export const inputParameters: InputParameters = {
     description:
       'An array of addresses to get the balances of (as an object with string `address` as an attribute)',
   },
+  confirmations: {
+    required: false,
+    aliases: ['minConfirmations'],
+    type: 'number',
+    default: 0,
+    description:
+      'Number (integer, min 0, max 64) of blocks that must have been confirmed after the point against which the balance is checked (i.e. balance will be sourced from {latestBlockNumber - minConfirmations}',
+  },
 }
 
 interface AddressWithBalance {
@@ -31,6 +39,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
 
   const jobRunID = validator.validated.id
   const addresses = validator.validated.data.addresses as Address[]
+  const confirmations = validator.validated.data.confirmations
 
   if (!Array.isArray(addresses) || addresses.length === 0) {
     throw new AdapterError({
@@ -40,7 +49,24 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
     })
   }
 
-  const balances = await Promise.all(addresses.map((addr) => getBalance(addr.address, config)))
+  // The limitation of 64 is to make it work with both full and light/fast sync nodes
+  if (!Number.isInteger(confirmations) || confirmations < 0 || confirmations > 64) {
+    throw new AdapterError({
+      jobRunID,
+      message: `Min confirmations must be an integer between 0 and 64`,
+      statusCode: 400,
+    })
+  }
+
+  let targetBlockTag: string | number = 'latest'
+  if (confirmations !== 0) {
+    const lastBlockNumber = await config.provider.getBlockNumber()
+    targetBlockTag = lastBlockNumber - confirmations
+  }
+
+  const balances = await Promise.all(
+    addresses.map((addr) => getBalance(addr.address, targetBlockTag, config)),
+  )
 
   const response = {
     jobRunID,
@@ -57,7 +83,11 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
   )
 }
 
-const getBalance = async (address: string, config: Config): Promise<AddressWithBalance> => ({
+const getBalance = async (
+  address: string,
+  targetBlockTag: string | number,
+  config: Config,
+): Promise<AddressWithBalance> => ({
   address,
-  balance: (await config.provider.getBalance(address)).toString(),
+  balance: (await config.provider.getBalance(address, targetBlockTag)).toString(),
 })

--- a/packages/sources/eth-balance/test/integration/__snapshots__/balance.test.ts.snap
+++ b/packages/sources/eth-balance/test/integration/__snapshots__/balance.test.ts.snap
@@ -1,5 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`execute with explicit minConfirmations should return success 1`] = `
+Object {
+  "data": Object {
+    "result": Array [
+      Object {
+        "address": "0x6a1544F72A2A275715e8d5924e6D8A017F0e41ed",
+        "balance": "15671674977708000",
+      },
+    ],
+  },
+  "jobRunID": "1",
+  "providerStatusCode": 200,
+  "result": Array [
+    Object {
+      "address": "0x6a1544F72A2A275715e8d5924e6D8A017F0e41ed",
+      "balance": "15671674977708000",
+    },
+  ],
+  "statusCode": 200,
+}
+`;
+
 exports[`execute with multiple addresses should return success 1`] = `
 Object {
   "data": Object {

--- a/packages/sources/eth-balance/test/integration/balance.test.ts
+++ b/packages/sources/eth-balance/test/integration/balance.test.ts
@@ -2,7 +2,7 @@ import { AdapterRequest } from '@chainlink/types'
 import request, { SuperTest, Test } from 'supertest'
 import * as process from 'process'
 import { server as startServer } from '../../src'
-import { mockETHBalanceResponseSuccess } from './fixtures'
+import { mockETHBalanceResponseSuccess, mockETHBalanceAtBlockResponseSuccess } from './fixtures'
 import * as nock from 'nock'
 import * as http from 'http'
 import { AddressInfo } from 'net'
@@ -75,6 +75,29 @@ describe('execute', () => {
 
     it('should return success', async () => {
       mockETHBalanceResponseSuccess()
+
+      const response = await req
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+      expect(response.body).toMatchSnapshot()
+    })
+  })
+
+  describe('with explicit minConfirmations', () => {
+    const data: AdapterRequest = {
+      id,
+      data: {
+        result: [{ address: '0x6a1544F72A2A275715e8d5924e6D8A017F0e41ed' }],
+        minConfirmations: 20,
+      },
+    }
+
+    it('should return success', async () => {
+      mockETHBalanceAtBlockResponseSuccess()
 
       const response = await req
         .post('/')

--- a/packages/sources/eth-balance/test/integration/fixtures.ts
+++ b/packages/sources/eth-balance/test/integration/fixtures.ts
@@ -56,3 +56,45 @@ export const mockETHBalanceResponseSuccess = (): nock =>
         'Origin',
       ],
     )
+
+export const mockETHBalanceAtBlockResponseSuccess = (): nock =>
+  nock('http://localhost:8545', {
+    encodedQueryParams: true,
+  })
+    .persist()
+    .post('/', {
+      method: 'eth_blockNumber',
+      params: [],
+      id: /^\d+$/,
+      jsonrpc: '2.0',
+    })
+    .reply(200, (_, request) => ({ jsonrpc: '2.0', id: request['id'], result: '0xddae3f' }), [
+      'Content-Type',
+      'application/json',
+      'Connection',
+      'close',
+      'Vary',
+      'Accept-Encoding',
+      'Vary',
+      'Origin',
+    ])
+    .post('/', {
+      method: 'eth_getBalance',
+      params: ['0x6a1544f72a2a275715e8d5924e6d8a017f0e41ed', '0xddae2b'],
+      id: /^\d+$/,
+      jsonrpc: '2.0',
+    })
+    .reply(
+      200,
+      (_, request) => ({ jsonrpc: '2.0', id: request['id'], result: '0x37ad4e2c14e7e0' }),
+      [
+        'Content-Type',
+        'application/json',
+        'Connection',
+        'close',
+        'Vary',
+        'Accept-Encoding',
+        'Vary',
+        'Origin',
+      ],
+    )

--- a/packages/sources/eth-balance/test/unit/balance.test.ts
+++ b/packages/sources/eth-balance/test/unit/balance.test.ts
@@ -21,6 +21,46 @@ describe('execute', () => {
         name: 'empty result',
         testData: { id: jobID, data: { result: [] } },
       },
+      {
+        name: 'invalid confirmations (string)',
+        testData: {
+          id: jobID,
+          data: {
+            addresses: [{ address: '0xEF9FFcFbeCB6213E5903529c8457b6F61141140d' }],
+            confirmations: 'asd',
+          },
+        },
+      },
+      {
+        name: 'invalid confirmations (float)',
+        testData: {
+          id: jobID,
+          data: {
+            addresses: [{ address: '0xEF9FFcFbeCB6213E5903529c8457b6F61141140d' }],
+            confirmations: 12.3,
+          },
+        },
+      },
+      {
+        name: 'invalid confirmations (negative)',
+        testData: {
+          id: jobID,
+          data: {
+            addresses: [{ address: '0xEF9FFcFbeCB6213E5903529c8457b6F61141140d' }],
+            confirmations: -1,
+          },
+        },
+      },
+      {
+        name: 'invalid confirmations (over 64)',
+        testData: {
+          id: jobID,
+          data: {
+            addresses: [{ address: '0xEF9FFcFbeCB6213E5903529c8457b6F61141140d' }],
+            confirmations: 65,
+          },
+        },
+      },
     ]
 
     requests.forEach((req) => {


### PR DESCRIPTION
## Description

Adds `confirmations` parameter to the `eth-balance` adapter to specify the number of confirmed blocks that must have passed to fetch the balance.

## Changes

- Add confirmations param to balance endpoint in eth-balance adapter

## Steps to Test

1. Run eth-balance adapter
2. Fetch balance from a known address with a very recent transaction
3. Specify confirmations param to a number of blocks higher than the ones that have passed since that transaction
4. Check that the balance received does not include the recent tx, as it does not have enough confirmaitons in the chain

## Quality Assurance

- [x] Ran `yarn changeset` if adapter source code was changed
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
