### PR TITLE
ws reset on server close

### DIFF
--- a/packages/core/bootstrap/src/lib/middleware/ws/actions.ts
+++ b/packages/core/bootstrap/src/lib/middleware/ws/actions.ts
@@ -97,6 +97,8 @@ export const onConnectComplete = createAction(
   asAction<WSSubscriptionPayload>(),
 )
 
+export const WSReset = createAction('WS/RESET')
+
 /** SUBSCRIPTIONS */
 export interface WSSubscriptionPayload {
   connectionInfo: WSConnectionInfo

--- a/packages/core/bootstrap/src/lib/middleware/ws/reducer.ts
+++ b/packages/core/bootstrap/src/lib/middleware/ws/reducer.ts
@@ -112,6 +112,8 @@ export const connectionsReducer = createReducer<ConnectionsState>(
       state.all[key].shouldNotRetryConnecting = action.payload.shouldNotRetryConnection
     })
 
+    builder.addCase(actions.WSReset, () => initConnectionsState)
+
     builder.addMatcher(
       isAnyOf(
         actions.connectRequested,
@@ -223,6 +225,8 @@ export const subscriptionsReducer = createReducer<SubscriptionsState>(
       const key = action.payload.subscriptionKey
       state.all[key].lastUpdatedAt = action.payload.timestamp
     })
+
+    builder.addCase(actions.WSReset, () => initSubscriptionsState)
 
     builder.addMatcher(
       isAnyOf(actions.subscribeRequested, actions.subscribeFulfilled, actions.unsubscribeFulfilled),

--- a/packages/core/bootstrap/src/lib/server.ts
+++ b/packages/core/bootstrap/src/lib/server.ts
@@ -19,6 +19,7 @@ import { getEnv, toObjectWithNumbers } from './util'
 import { warmupShutdown } from './middleware/cache-warmer/actions'
 import { shutdown } from './middleware/error-backoff/actions'
 import { AddressInfo } from 'net'
+import { WSReset } from './middleware/ws/actions'
 
 const app = express()
 const version = getEnv('npm_package_version')
@@ -126,6 +127,7 @@ export const initHandler =
         server.on('close', () => {
           storeSlice('cacheWarmer').dispatch(warmupShutdown())
           storeSlice('errorBackoff').dispatch(shutdown())
+          storeSlice('ws').dispatch(WSReset())
           context.cache?.instance?.close()
         })
 

--- a/packages/sources/cfbenchmarks/test/integration/adapter.test.ts
+++ b/packages/sources/cfbenchmarks/test/integration/adapter.test.ts
@@ -79,7 +79,7 @@ describe('websocket', () => {
 
     oldEnv = JSON.parse(JSON.stringify(process.env))
     process.env.WS_ENABLED = 'true'
-    process.env.WS_SUBSCRIPTION_TTL = '300'
+    process.env.WS_SUBSCRIPTION_TTL = '1000'
 
     server = await startServer()
     req = request(`localhost:${(server.address() as AddressInfo).port}`)
@@ -128,7 +128,7 @@ describe('websocket', () => {
 
       // This final request should disable the cache warmer, sleep is used to make sure that the data is  pulled from the websocket
       // populated cache entries.
-      await util.sleep(10)
+      await util.sleep(500)
       const response = await makeRequest()
 
       expect(response.body).toEqual({

--- a/packages/sources/coinmetrics/test/integration/adapter.test.ts
+++ b/packages/sources/coinmetrics/test/integration/adapter.test.ts
@@ -83,7 +83,7 @@ describe('websocket', () => {
 
     oldEnv = JSON.parse(JSON.stringify(process.env))
     process.env.WS_ENABLED = 'true'
-    process.env.WS_SUBSCRIPTION_TTL = '100'
+    process.env.WS_SUBSCRIPTION_TTL = '1000'
 
     server = await startServer()
     req = request(`localhost:${(server.address() as AddressInfo).port}`)
@@ -134,7 +134,7 @@ describe('websocket', () => {
 
       // This final request should disable the cache warmer, sleep is used to make sure that the data is  pulled from the websocket
       // populated cache entries.
-      await util.sleep(10)
+      await util.sleep(500)
       const response = await makeRequest()
 
       expect(response.body).toEqual({

--- a/packages/sources/cryptocompare/test/integration/adapter.test.ts
+++ b/packages/sources/cryptocompare/test/integration/adapter.test.ts
@@ -181,7 +181,7 @@ describe('websocket', () => {
 
     oldEnv = JSON.parse(JSON.stringify(process.env))
     process.env.WS_ENABLED = 'true'
-    process.env.WS_SUBSCRIPTION_TTL = '300'
+    process.env.WS_SUBSCRIPTION_TTL = '1000'
 
     server = await startServer()
     req = request(`localhost:${(server.address() as AddressInfo).port}`)
@@ -233,7 +233,7 @@ describe('websocket', () => {
 
       // This final request should disable the cache warmer, sleep is used to make sure that the data is  pulled from the websocket
       // populated cache entries.
-      await util.sleep(10)
+      await util.sleep(500)
       const response = await makeRequest()
 
       expect(response.body).toEqual({

--- a/packages/sources/tiingo/test/integration/adapter.test.ts
+++ b/packages/sources/tiingo/test/integration/adapter.test.ts
@@ -254,7 +254,7 @@ describe('websocket', () => {
 
     oldEnv = JSON.parse(JSON.stringify(process.env))
     process.env.WS_ENABLED = 'true'
-    process.env.WS_SUBSCRIPTION_TTL = '300'
+    process.env.WS_SUBSCRIPTION_TTL = '1000'
 
     server = await startServer()
     req = request(`localhost:${(server.address() as AddressInfo).port}`)
@@ -306,7 +306,7 @@ describe('websocket', () => {
 
       // This final request should disable the cache warmer, sleep is used to make sure that the data is  pulled from the websocket
       // populated cache entries.
-      await util.sleep(10)
+      await util.sleep(500)
       const response = await makeRequest()
 
       expect(response.body).toEqual({


### PR DESCRIPTION


## Closes #1790


## Changes

- Added redux action and reducer to reset websocket state on server close
- Modified some WS integration tests to not fail due to timing issues.

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

`yarn test:ci:integration`

## Quality Assurance

- [ ] Ran `yarn changeset` if adapter source code was changed
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
