### PR TITLE
schedule renovate bot to run on weekends

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,8 @@
     "preview:dockerCompose",
     "preview:dockerVersions",
     ":automergePr",
-    ":automergeRequireAllStatusChecks"
+    ":automergeRequireAllStatusChecks",
+    "schedule:weekends"
   ],
   "ignorePaths": [".yarn/sdks"],
   "prConcurrentLimit": 5


### PR DESCRIPTION


## Description

Currently renovate bot is not configured to run at specific days or hours which means dependency update PRs are opened randomly , most of the times during working hours. In order to save pipeline resources during working hours this PR adds new preset in renovate.json so that the bot will run only on weekends  when nobody is using pipeline resources. 

......

## Changes

- Added `schedule:weekends` in renovate.json



## Quality Assurance

- [ ] Ran `yarn changeset` if adapter source code was changed
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [ ] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
