### PR TITLE
Add ETH to coinmetrics WS valid quote params

### DIFF
--- a/.changeset/ninety-meals-confess.md
+++ b/.changeset/ninety-meals-confess.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/coinmetrics-adapter': patch
+---
+
+Add ETH to valid quotes for WS endpoint

--- a/.changeset/ninety-meals-confess.md
+++ b/.changeset/ninety-meals-confess.md
@@ -2,4 +2,4 @@
 '@chainlink/coinmetrics-adapter': patch
 ---
 
-Add ETH to valid quotes for WS endpoint
+Add ETH and BTC to valid quotes for WS endpoint

--- a/packages/sources/coinmetrics/src/adapter.ts
+++ b/packages/sources/coinmetrics/src/adapter.ts
@@ -29,15 +29,17 @@ export interface WebsocketResponseSchema {
   cm_sequence_id: string
 }
 
+const VALID_REFERENCE_RATE_QUOTES = ['USD', 'EUR', 'ETH', 'BTC']
+
 const getSubKeyInfo = (input: AdapterRequest) => {
   const validator = new Validator(input, endpoints.price.inputParameters)
   const asset = validator.validated.data.base.toLowerCase()
   const quote = validator.validated.data.quote.toUpperCase()
-  if (quote !== 'USD' && quote !== 'EUR')
+  if (!VALID_REFERENCE_RATE_QUOTES.includes(quote))
     throw new AdapterError({
       jobRunID: input.id,
       statusCode: 400,
-      message: 'Quote must be of type USD or EUR',
+      message: `Quote must be one of ${VALID_REFERENCE_RATE_QUOTES}`,
     })
   const metrics = `ReferenceRate${quote}`
   return { asset, metrics }


### PR DESCRIPTION
## Description

Needed for SUSD/ETH feed, coinmetrics ws api now supports `ReferenceRateETH` (and for BTC as well). This is a simple PR to add that.