### PR TITLE
Add cid for stETH on CMC

### DIFF
--- a/.changeset/neat-camels-walk.md
+++ b/.changeset/neat-camels-walk.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/coinmarketcap-adapter': patch
+---
+
+Add CID for stETH on coinmarketcap

--- a/packages/sources/coinmarketcap/src/endpoint/crypto.ts
+++ b/packages/sources/coinmarketcap/src/endpoint/crypto.ts
@@ -91,6 +91,7 @@ const presetIds: { [symbol: string]: number } = {
   SUSHI: 6758,
   YFI: 5864,
   BAL: 5728,
+  STETH: 8085,
   '1INCH': 8104,
 }
 


### PR DESCRIPTION
## Closes #[38795](https://app.shortcut.com/chainlinklabs/story/38795/cmc-errors-on-steth-usd-crypto-request)

## Description
Add CID for STETH on coinmarketcap

## Steps to Test
1. send request to the adapter with the following body:
```
{"jobRunId": 1, "data": {"endpoint":"crypto","base": "stETH", "quote": "USD"}}
```
Expect a successful price in the `result` response

## Quality Assurance
- [x] Ran `yarn changeset` if adapter source code was changed
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
