### PR TITLE
Bump xsushi-price-adapter version to realign latest

### DIFF
--- a/packages/composites/xsushi-price/package.json
+++ b/packages/composites/xsushi-price/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/xsushi-price-adapter",
-  "version": "1.0.24",
+  "version": "1.0.42",
   "description": "Chainlink xsushi-price adapter.",
   "keywords": [
     "Chainlink",


### PR DESCRIPTION
## Description
When [syncing a previous release](https://github.com/smartcontractkit/external-adapters-js/commit/6dd84cbe29b658e524f05fb48562d37c34082a50) to develop, the `xsushi-price-adapter` version was reset to `1.0.1`, misaligning the latest version #. This PR realigns the latest package version #.

## Changes
- Bump xsushi version from 1.0.24 to 1.0.42

## Quality Assurance

- [x] Ran `yarn changeset` if adapter source code was changed
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
