### PR TITLE
Increase CACHE REDIS MAX QUEUED ITEMS default [sc-38955]

### DIFF
--- a/.changeset/eighty-ravens-bathe.md
+++ b/.changeset/eighty-ravens-bathe.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/ea-bootstrap': minor
+---
+
+Increased the default max Redis cache from 100 to 500

--- a/packages/core/bootstrap/README.md
+++ b/packages/core/bootstrap/README.md
@@ -51,18 +51,27 @@ Detailed here is optional configuration that can be provided to any EA through e
 ### Table of Contents
 
 - [Chainlink External Adapter Bootstrap](#chainlink-external-adapter-bootstrap)
-  - [Table of Contents](#table-of-contents)
+  - [Middlewares](#middlewares)
+    - [Caching](#caching)
+    - [Cache Warming](#cache-warming)
+    - [Batching](#batching)
+    - [Rate limiting](#rate-limiting)
+    - [Error Backoff](#error-backoff)
+  - [Architecture](#architecture)
+  - [Configuration](#configuration)
+    - [Table of Contents](#table-of-contents)
   - [Server configuration](#server-configuration)
+    - [Base input parameters](#base-input-parameters)
   - [Performance](#performance)
     - [Error back offs](#error-back-offs)
-    - [Caching](#caching)
+    - [Caching](#caching-1)
     - [Cache key](#cache-key)
       - [Ignoring keys](#ignoring-keys)
     - [Local cache](#local-cache)
     - [Redis](#redis)
-    - [Rate Limiting](#rate-limiting)
+    - [Rate Limiting](#rate-limiting-1)
       - [Provider Limits](#provider-limits)
-    - [Cache Warming](#cache-warming)
+    - [Cache Warming](#cache-warming-1)
     - [Request Coalescing](#request-coalescing)
   - [Metrics](#metrics)
   - [Websockets](#websockets)
@@ -156,7 +165,7 @@ For example, if the `CACHE_KEY_IGNORED_PROPS=timestamp` is set, these requests w
 | :-------: | :----------------------------------: | :---------------------------------------------------------------------------------------------------------------------------------------------: | :-----: | :---------: |
 |           |   `CACHE_REDIS_CONNECTION_TIMEOUT`   |                                             Timeout to end socket connection due to inactivity (ms)                                             |         |   `15000`   |
 |           |          `CACHE_REDIS_HOST`          |                                                         IP address of the Redis server.                                                         |         | `127.0.0.1` |
-|           |    `CACHE_REDIS_MAX_QUEUED_ITEMS`    |                                              Maximum length of the client's internal command queue                                              |         |     100     |
+|           |    `CACHE_REDIS_MAX_QUEUED_ITEMS`    |                                              Maximum length of the client's internal command queue                                              |         |     500     |
 |           | `CACHE_REDIS_MAX_RECONNECT_COOLDOWN` |                                              Max cooldown time before attempting to reconnect (ms)                                              |         |   `3000`    |
 |           |          `CACHE_REDIS_PORT`          |                                                            Port of the Redis server.                                                            |         |   `6379`    |
 |           |          `CACHE_REDIS_PATH`          |                                                   The UNIX socket string of the Redis server.                                                   |         |  undefined  |

--- a/packages/core/bootstrap/src/lib/util.ts
+++ b/packages/core/bootstrap/src/lib/util.ts
@@ -23,7 +23,7 @@ export const baseEnvDefaults: EnvDefaults = {
   CACHE_UPDATE_AGE_ON_GET: 'false',
   CACHE_REDIS_CONNECTION_TIMEOUT: '15000', // Timeout per long lived connection (ms)
   CACHE_REDIS_HOST: '127.0.0.1', // IP address of the Redis server
-  CACHE_REDIS_MAX_QUEUED_ITEMS: '100', // Maximum length of the client's internal command queue
+  CACHE_REDIS_MAX_QUEUED_ITEMS: '500', // Maximum length of the client's internal command queue
   CACHE_REDIS_MAX_RECONNECT_COOLDOWN: '3000', // Max cooldown time before attempting to reconnect (ms)
   CACHE_REDIS_PORT: '6379', // Port of the Redis server
   CACHE_REDIS_TIMEOUT: '500', // Timeout per request (ms)


### PR DESCRIPTION
## Changes

- Increased the default value for CACHE_REDIS_MAX_QUEUED_ITEMS from 100 to 500

## Steps to Test

yarn test

## Quality Assurance

- [x] Ran `yarn changeset` if adapter source code was changed
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
