### PR TITLE
Release/v1.26.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/external-adapters-js",
-  "version": "1.25.0",
+  "version": "1.26.0",
   "license": "MIT",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Changelog

### Breaking Changes
- None

### New Adapters
- None

### Features
- Validation and duplicate of addresses for the proof-of-reserves adapter
- Improved logging of data provider issues for finnhub, fixer, kaiko and tradermade
- Added warnings to the polygon adapter about data that may not be available over the weekend when trading is closed
- Added price alias to the tiingo adapter
- Improved logging for the layer2-sequencer-health adapter
- Added new error types to adapters
- Updated dydx-rewards adapter with new formula and linked addresses

### Bug Fixes
- Fixed issue with data provider status codes not being set to 200 upon a successful request
- Fixed Vesper EA when used with Coingecko

### Documentation
- Improved instructions for building and running adapters with Docker

### Notable Adapter Updates
|    Adapter    | Version | Description |
| :-----------: | :-----: | :---------: |
| proof-of-reserves | v1.7.0 | Duplicate address filtering and validation |
| finnhub | v1.1.26 | Improved logging of data provider issues |
| fixer | v1.3.36 | Improved logging of data provider issues |
| kaiko | v1.3.10  | Improved logging of data provider issues |
| tradermade | v1.6.35 | Improved logging of data provider issues |
| polygon | v1.5.0 | Added warnings to data points that are not supported outside trading times |
| tiingo | v1.10.9 | Added 'price' alias |
| layer2-sequencer-health | v1.3.0 | Improved logging |
| vesper | v1.2.38 | Fixed to support Coingecko |
| dydx-rewards | v1.2.0 | New formula and linked addresses |