### PR TITLE
Fix/42679 - Reduce metrics cardinality

### DIFF
--- a/.changeset/twelve-queens-sell.md
+++ b/.changeset/twelve-queens-sell.md
@@ -2,4 +2,4 @@
 '@chainlink/ea-bootstrap': minor
 ---
 
-Removed request_origin label from metrics
+Removed request_origin label from metrics & tests. Added 'result' to excluded properties in cache key & feed ID generation.

--- a/.changeset/twelve-queens-sell.md
+++ b/.changeset/twelve-queens-sell.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/ea-bootstrap': minor
+---
+
+Removed request_origin label from metrics

--- a/packages/core/bootstrap/src/lib/metrics/index.ts
+++ b/packages/core/bootstrap/src/lib/metrics/index.ts
@@ -16,8 +16,6 @@ export const setupMetrics = (name: string): void => {
 }
 const DEFAULT_SUCCESSFUL_PROVIDER_STATUS_CODE = 200
 export const getMetricsMeta = (input: AdapterRequest): AdapterMetricsMeta => ({
-  // If no requestOrigin comes through, then this is a cache warmer request
-  requestOrigin: input.data.metricsMeta?.requestOrigin || util.WARMER_FEED_ID,
   feedId: util.getFeedId(input),
 })
 
@@ -44,7 +42,6 @@ export const withMetrics: Middleware =
         is_cache_warming: String(input.id === WARMUP_REQUEST_ID),
         method: 'POST',
         feed_id: metricsMeta.feedId,
-        request_origin: metricsMeta.requestOrigin,
       }
       const end = httpRequestDurationSeconds.startTimer()
 
@@ -95,7 +92,6 @@ export const httpRequestsTotal = new client.Counter({
     'is_cache_warming',
     'feed_id',
     'provider_status_code',
-    'request_origin',
   ] as const,
 })
 

--- a/packages/core/bootstrap/src/lib/middleware/cache-key/util.ts
+++ b/packages/core/bootstrap/src/lib/middleware/cache-key/util.ts
@@ -10,6 +10,7 @@ export const excludableAdapterRequestProperties: Record<string, true> = [
   'debug',
   'rateLimitMaxAge',
   'metricsMeta',
+  'result',
 ]
   .concat((process.env.CACHE_KEY_IGNORED_PROPS || '').split(',').filter((k) => k))
   .reduce((prev, next) => {

--- a/packages/core/bootstrap/src/lib/middleware/cache/index.ts
+++ b/packages/core/bootstrap/src/lib/middleware/cache/index.ts
@@ -173,7 +173,6 @@ export class AdapterCache {
       isFromWs: !!adapterRequest.debug?.ws,
       participantId: key,
       feedId: adapterRequest.metricsMeta?.feedId || 'N/A',
-      requestOrigin: adapterRequest.metricsMeta?.requestOrigin || 'N/A',
     })
 
     const cachedAdapterResponse = this.options.requestCoalescing.enabled
@@ -276,7 +275,6 @@ export const withCache =
         isFromWs: !!adapterRequest.debug?.ws,
         participantId: key,
         feedId: adapterRequest.metricsMeta?.feedId || 'N/A',
-        requestOrigin: adapterRequest.metricsMeta?.requestOrigin || 'N/A',
       })
 
       const tryDoDistributedCacheAction = async (

--- a/packages/core/bootstrap/src/lib/middleware/cache/metrics.ts
+++ b/packages/core/bootstrap/src/lib/middleware/cache/metrics.ts
@@ -4,19 +4,16 @@ import { getEnv } from '../../util'
 interface CacheExecutionDurationParams {
   participantId: string
   feedId?: string
-  requestOrigin?: string
   isFromWs: boolean
 }
 export const beginObserveCacheMetrics = ({
   participantId,
   feedId,
-  requestOrigin,
   isFromWs,
 }: CacheExecutionDurationParams) => {
   const cacheType = getEnv('CACHE_TYPE') === 'redis' ? CacheTypes.Redis : CacheTypes.Local
   const base = {
     feed_id: feedId,
-    request_origin: requestOrigin,
     participant_id: participantId,
     experimental: 'true',
     cache_type: cacheType,
@@ -58,7 +55,6 @@ const baseLabels = [
   'cache_type',
   'is_from_ws',
   'experimental',
-  'request_origin',
 ] as const
 
 const cache_execution_duration_seconds = new client.Histogram({

--- a/packages/core/bootstrap/src/lib/middleware/rate-limit/index.ts
+++ b/packages/core/bootstrap/src/lib/middleware/rate-limit/index.ts
@@ -84,7 +84,6 @@ export const withRateLimit =
 
     const defaultLabels = {
       feed_id: input.metricsMeta?.feedId ?? 'N/A',
-      request_origin: input.metricsMeta?.requestOrigin ?? 'N/A',
       participant_id: requestTypeId,
       experimental: 'true',
     }

--- a/packages/core/bootstrap/src/lib/middleware/rate-limit/metrics.ts
+++ b/packages/core/bootstrap/src/lib/middleware/rate-limit/metrics.ts
@@ -3,5 +3,5 @@ import * as client from 'prom-client'
 export const rateLimitCreditsSpentTotal = new client.Counter({
   name: 'rate_limit_credits_spent_total',
   help: 'The number of data provider credits the adapter is consuming',
-  labelNames: ['participant_id', 'feed_id', 'request_origin', 'experimental'] as const,
+  labelNames: ['participant_id', 'feed_id', 'experimental'] as const,
 })

--- a/packages/core/bootstrap/src/lib/middleware/ws/epics.ts
+++ b/packages/core/bootstrap/src/lib/middleware/ws/epics.ts
@@ -18,7 +18,7 @@ import {
 import { webSocket } from 'rxjs/webSocket'
 import { withCache } from '../cache'
 import { censor, logger } from '../../modules'
-import { getFeedId, WARMER_FEED_ID } from '../../metrics/util'
+import { getFeedId } from '../../metrics/util'
 import {
   connectFailed,
   connectFulfilled,
@@ -785,7 +785,7 @@ export const writeMessageToCacheEpic: Epic<AnyAction, AnyAction, { ws: RootState
           ...input,
           data: { maxAge: wsConfig.subscriptionTTL, ...input.data },
           debug: { ws: true, ...input.debug },
-          metricsMeta: { feedId: getFeedId(input), requestOrigin: WARMER_FEED_ID },
+          metricsMeta: { feedId: getFeedId(input) },
         }
         await cache(wsResponse, context)
         logger.trace('WS: Saved result', { input, result: response.result })

--- a/packages/core/bootstrap/src/lib/server.ts
+++ b/packages/core/bootstrap/src/lib/server.ts
@@ -63,18 +63,14 @@ export const initHandler =
     app.post<{
       Body: AdapterRequest
     }>(baseUrl, async (req, res) => {
-      const clientIp = getClientIp(req)
-      const metricsMeta = METRICS_ENABLED ? { metricsMeta: { requestOrigin: clientIp } } : {}
-
       req.body.data = {
         ...(req.body.data || {}),
         ...toObjectWithNumbers(req.query),
-        ...metricsMeta,
       }
 
       context = {
         ...context,
-        ip: clientIp,
+        ip: getClientIp(req),
         hostname: req.hostname,
       }
 

--- a/packages/core/bootstrap/test/unit/metrics/metrics.test.ts
+++ b/packages/core/bootstrap/test/unit/metrics/metrics.test.ts
@@ -39,13 +39,11 @@ describe('withMetrics middleware', () => {
       ...mockResponse,
       metricsMeta: {
         feedId: '{"data":{"endpoint":"testDownstreamEndpoint","source":"SOMESOURCEADAPTER"}}',
-        requestOrigin: 'CACHE_WARMER',
       },
     }
 
     const expectedLabels = {
       feed_id: '{"data":{"endpoint":"testDownstreamEndpoint","source":"SOMESOURCEADAPTER"}}',
-      request_origin: 'CACHE_WARMER',
       is_cache_warming: 'false',
       method: 'POST',
       provider_status_code: 200,
@@ -81,13 +79,11 @@ describe('withMetrics middleware', () => {
       ...mockResponse,
       metricsMeta: {
         feedId: '{"data":{"endpoint":"testDownstreamEndpoint","source":"SOMESOURCEADAPTER"}}',
-        requestOrigin: 'CACHE_WARMER',
       },
     }
 
     const expectedLabels = {
       feed_id: '{"data":{"endpoint":"testDownstreamEndpoint","source":"SOMESOURCEADAPTER"}}',
-      request_origin: 'CACHE_WARMER',
       is_cache_warming: 'false',
       method: 'POST',
       provider_status_code: 200,
@@ -116,7 +112,6 @@ describe('withMetrics middleware', () => {
 
     const expectedLabels = {
       feed_id: '{"data":{"endpoint":"testDownstreamEndpoint","source":"SOMESOURCEADAPTER"}}',
-      request_origin: 'CACHE_WARMER',
       is_cache_warming: 'false',
       method: 'POST',
       provider_status_code: undefined,

--- a/packages/core/bootstrap/test/unit/metrics/util.test.ts
+++ b/packages/core/bootstrap/test/unit/metrics/util.test.ts
@@ -76,6 +76,16 @@ describe('Bootstrap/Metrics Utils', () => {
       expect(feedName).toMatchInlineSnapshot(`"{\\"data\\":{}}"`)
     })
 
+    it(`Removes 'result' from stringified JSON`, () => {
+      const input = {
+        id: '',
+        data: { base: 'LINK' },
+        result: 123,
+      }
+      const feedName = util.getFeedId(input)
+      expect(feedName).toMatchInlineSnapshot(`"{\\"data\\":{\\"base\\":\\"LINK\\"}}"`)
+    })
+
     it(`Does not throw error if pricefeed parameters are missing`, () => {
       const input: AdapterRequest = {
         id: '',

--- a/packages/core/types/@chainlink/index.d.ts
+++ b/packages/core/types/@chainlink/index.d.ts
@@ -42,7 +42,6 @@ declare module '@chainlink/types' {
    */
   export interface AdapterMetricsMeta {
     feedId: string
-    requestOrigin: string
   }
 
   import { BigNumberish } from 'ethers'


### PR DESCRIPTION
## Closes #42679

## Description

- Removed request_origin label from metrics to reduce metrics cardinality. The IP & hostname are being logged for each request so it's not worth it to keep it as a metrics label if it increases the size of metrics data too much.
- Added 'result' to excluded properties in cache key & feed ID generation

## Changes

- Removed request_origin label from metrics & tests
- Added 'result' to excluded properties in cache key & feed ID generation

## Steps to Test

1. `yarn test:unit`
2. `yarn test:integration`
3. Run an EA locally with metric enabled & check that request_origin label is no longer present in metrics

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
