### PR TITLE
Release/v1.28.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/external-adapters-js",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "license": "MIT",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Changelog

### Breaking Changes
- None

### New Adapters
- None

### Features
- None

### Bug Fixes
- Removed request_origin label from metrics & tests. Added 'result' to excluded properties in cache key & feed ID generation
- Updated etherchain gasprice endpoint to use /api/gasnow api. Updated tests to match new endpoint
- Clean all redux state after server shutdown

### Documentation
- None

### Notable Adapter Updates
|    Adapter    | Version | Description |
| :-----------: | :-----: | :---------: |
| etherchain-adapter  | v1.3.0  | Updated etherchain gasprice endpoint to use /api/gasnow api. Updated speed options & tests to match new endpoint. |