### PR TITLE
[Fix] Batchable property path type validation

### DIFF
--- a/.changeset/five-houses-begin.md
+++ b/.changeset/five-houses-begin.md
@@ -1,0 +1,6 @@
+---
+'@chainlink/1forge-adapter': patch
+'@chainlink/currencylayer-adapter': patch
+---
+
+Fix validation of batchable property path

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/external-adapters-js",
-  "version": "1.29.1",
+  "version": "1.30.0",
   "license": "MIT",
   "private": true,
   "workspaces": [

--- a/packages/sources/1forge/src/adapter.ts
+++ b/packages/sources/1forge/src/adapter.ts
@@ -1,4 +1,4 @@
-import { Builder, Requester, Validator } from '@chainlink/ea-bootstrap'
+import { Builder, Logger, Requester, Validator } from '@chainlink/ea-bootstrap'
 import {
   DefaultConfig,
   ExecuteWithConfig,
@@ -49,6 +49,18 @@ export const makeWSHandler = (config?: DefaultConfig): MakeWSHandler => {
       { shouldThrowError: false },
     )
     if (validator.error) return
+    if (Array.isArray(validator.validated.data.quote)) {
+      Logger.debug(
+        `[WS]: ${validator.validated.data.quote} supplied as quote. Only non-array tickers can be used for WS`,
+      )
+      return
+    }
+    if (Array.isArray(validator.validated.data.base)) {
+      Logger.debug(
+        `[WS]: ${validator.validated.data.base} supplied as base. Only non-array tickers can be used for WS`,
+      )
+      return
+    }
     const symbol = validator.validated.data.base.toUpperCase()
     const convert = validator.validated.data.quote.toUpperCase()
     return `${symbol}/${convert}`

--- a/packages/sources/1forge/src/endpoint/quotes.ts
+++ b/packages/sources/1forge/src/endpoint/quotes.ts
@@ -18,20 +18,18 @@ export const description = `Returns a batched price comparison from a list curre
 
 **NOTE: the \`price\` endpoint is temporarily still supported, however, is being deprecated. Please use the \`quotes\` endpoint instead.**`
 
-export type TInputParameters = { base: string; quote: string }
+export type TInputParameters = { base: string | string[]; quote: string | string[] }
 
 export const inputParameters: InputParameters<TInputParameters> = {
   base: {
     aliases: ['from'],
     description: 'The symbol of the currency to query',
     required: true,
-    type: 'string',
   },
   quote: {
     aliases: ['to'],
     description: ' The symbol of the currency to convert to',
     required: true,
-    type: 'string',
   },
 }
 

--- a/packages/sources/coinapi/src/endpoint/assets.ts
+++ b/packages/sources/coinapi/src/endpoint/assets.ts
@@ -42,7 +42,7 @@ export interface ResponseSchema {
 }
 
 export type TInputParameters = {
-  base: string
+  base: string | string[]
 }
 
 export const inputParameters: InputParameters<TInputParameters> = {

--- a/packages/sources/coinmarketcap/src/endpoint/crypto.ts
+++ b/packages/sources/coinmarketcap/src/endpoint/crypto.ts
@@ -100,7 +100,12 @@ export const description = `https://pro-api.coinmarketcap.com/v1/cryptocurrency/
 
 **NOTE: the \`price\` endpoint is temporarily still supported, however, is being deprecated. Please use the \`crypto\` endpoint instead.**`
 
-export type TInputParameters = { base: string; convert: string; cid: string; slug: string }
+export type TInputParameters = {
+  base: string | string[]
+  convert: string | string[]
+  cid: string
+  slug: string
+}
 export const inputParameters: InputParameters<TInputParameters> = {
   base: {
     aliases: ['from', 'coin', 'sym', 'symbol'],

--- a/packages/sources/cryptocompare/src/adapter.ts
+++ b/packages/sources/cryptocompare/src/adapter.ts
@@ -1,4 +1,4 @@
-import { Builder, Requester, Validator } from '@chainlink/ea-bootstrap'
+import { Builder, Logger, Requester, Validator } from '@chainlink/ea-bootstrap'
 import {
   AdapterRequest,
   Config,
@@ -76,6 +76,12 @@ export const makeWSHandler = (config?: Config): MakeWSHandler<Message | any> =>
       const endpoint = validator.validated.data.endpoint?.toLowerCase()
       if (endpoint == 'marketcap') return false
       const base = validator.overrideSymbol(NAME, validator.validated.data.base)
+      if (Array.isArray(validator.validated.data.quote)) {
+        Logger.debug(
+          `[WS]: ${validator.validated.data.quote} supplied as quote. Only non-array tickers can be used for WS`,
+        )
+        return false
+      }
       const quote = validator.validated.data.quote.toUpperCase()
       return `${base}~${quote}`
     }

--- a/packages/sources/cryptocompare/src/endpoint/crypto.ts
+++ b/packages/sources/cryptocompare/src/endpoint/crypto.ts
@@ -130,7 +130,7 @@ export interface ResponseSchema {
 export const description =
   '**NOTE: the `price` endpoint is temporarily still supported, however, is being deprecated. Please use the `crypto` endpoint instead.**'
 
-export type TInputParameters = { base: string; quote: string }
+export type TInputParameters = { base: string | string[]; quote: string | string[] }
 export const inputParameters: InputParameters<TInputParameters> = {
   base: {
     aliases: ['from', 'coin', 'fsym'],

--- a/packages/sources/currencylayer/src/endpoint/live.ts
+++ b/packages/sources/currencylayer/src/endpoint/live.ts
@@ -17,7 +17,7 @@ const customError = (data: ResponseSchema) => !data.success
 export const description =
   'Returns a batched price comparison from one currency to a list of other currencies.'
 
-export type TInputParameters = { base: string; quote: string; amount: number }
+export type TInputParameters = { base: string; quote: string | string[]; amount: number }
 export const inputParameters: InputParameters<TInputParameters> = {
   base: {
     aliases: ['from', 'coin'],
@@ -29,7 +29,6 @@ export const inputParameters: InputParameters<TInputParameters> = {
     aliases: ['to', 'market'],
     description: 'The symbol of the currency to convert to',
     required: true,
-    type: 'string',
   },
   amount: {
     description: 'An amount of the currency',

--- a/packages/sources/finage/src/adapter.ts
+++ b/packages/sources/finage/src/adapter.ts
@@ -3,6 +3,7 @@ import {
   APIEndpoint,
   ExecuteFactory,
   ExecuteWithConfig,
+  Logger,
   MakeWSHandler,
 } from '@chainlink/ea-bootstrap'
 import { Builder, Requester, Validator } from '@chainlink/ea-bootstrap'
@@ -57,6 +58,12 @@ export const makeWSHandler = (config?: Config): MakeWSHandler<Message | any> =>
         { shouldThrowError: false, overrides },
       )
       if (validator.error) return
+      if (Array.isArray(validator.validated.data.base)) {
+        Logger.debug(
+          `[WS]: ${validator.validated.data.base} supplied as base. Only non-array tickers can be used for WS`,
+        )
+        return
+      }
       return validator.validated.data.base.toUpperCase()
     }
     const isStock = (input: AdapterRequest): boolean =>

--- a/packages/sources/finage/src/endpoint/stock.ts
+++ b/packages/sources/finage/src/endpoint/stock.ts
@@ -16,7 +16,7 @@ export const batchablePropertyPath = [{ name: 'base' }]
 export const description = `https://finage.co.uk/docs/api/stock-last-quote
 The result will be calculated as the midpoint between the ask and the bid.`
 
-export type TInputParameters = { base: string }
+export type TInputParameters = { base: string | string[] }
 export const inputParameters: InputParameters<TInputParameters> = {
   base: {
     required: true,

--- a/packages/sources/finage/src/endpoint/stock.ts
+++ b/packages/sources/finage/src/endpoint/stock.ts
@@ -41,7 +41,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
   const base = validator.validated.data.base
   const symbol = Array.isArray(base)
     ? base.map((symbol) => symbol.toUpperCase()).join(',')
-    : validator.overrideSymbol(NAME, validator.validated.data.base).toUpperCase()
+    : validator.overrideSymbol(NAME, base).toUpperCase()
 
   const url = getStockURL(base, symbol)
   const params = {

--- a/packages/sources/fixer/src/endpoint/latest.ts
+++ b/packages/sources/fixer/src/endpoint/latest.ts
@@ -27,7 +27,7 @@ const customError = (data: ResponseSchema) => !data.success
 export const description =
   'Returns a batched price comparison from one currency to a list of other currencies.'
 
-export type TInputParameters = { base: string; quote: string }
+export type TInputParameters = { base: string; quote: string | string[] }
 export const inputParameters: InputParameters<TInputParameters> = {
   base: {
     required: true,
@@ -39,7 +39,6 @@ export const inputParameters: InputParameters<TInputParameters> = {
     required: true,
     aliases: ['to', 'market'],
     description: 'The symbol of the currency to convert to',
-    type: 'string',
   },
 }
 

--- a/packages/sources/metalsapi/src/endpoint/latest.ts
+++ b/packages/sources/metalsapi/src/endpoint/latest.ts
@@ -15,7 +15,7 @@ export const batchablePropertyPath = [{ name: 'quote' }]
 export const description =
   'Returns a batched price comparison from one currency to a list of other currencies.'
 
-export type TInputParameters = { base: string; quote: string }
+export type TInputParameters = { base: string; quote: string | string[] }
 export const inputParameters: InputParameters<TInputParameters> = {
   base: {
     required: true,

--- a/packages/sources/nomics/src/endpoint/crypto.ts
+++ b/packages/sources/nomics/src/endpoint/crypto.ts
@@ -96,7 +96,7 @@ export const description = `The \`crypto\` endpoint fetches the price of a reque
 
 **NOTE: the \`price\` endpoint is temporarily still supported, however, is being deprecated. Please use the \`crypto\` endpoint instead.**`
 
-export type TInputParameters = { base: string; quote: string }
+export type TInputParameters = { base: string | string[]; quote: string }
 export const inputParameters: InputParameters<TInputParameters> = {
   base: {
     aliases: ['from', 'coin', 'ids'],

--- a/packages/sources/openexchangerates/src/endpoint/forex.ts
+++ b/packages/sources/openexchangerates/src/endpoint/forex.ts
@@ -15,7 +15,7 @@ export const batchablePropertyPath = [{ name: 'quote' }]
 export const description =
   '**NOTE: the `price` endpoint is temporarily still supported, however, is being deprecated. Please use the `forex` endpoint instead.**'
 
-export type TInputParameters = { base: string; quote: string }
+export type TInputParameters = { base: string; quote: string | string[] }
 export const inputParameters: InputParameters<TInputParameters> = {
   base: {
     aliases: ['from', 'coin'],

--- a/packages/sources/polygon/src/endpoint/tickers.ts
+++ b/packages/sources/polygon/src/endpoint/tickers.ts
@@ -16,7 +16,7 @@ export const description = `Convert a currency or currencies into another curren
 
 **NOTE: the \`price\` endpoint is temporarily still supported, however, is being deprecated. Please use the \`tickers\` endpoint instead.**`
 
-export type TInputParameters = { base: string | string[]; quote: string | string }
+export type TInputParameters = { base: string | string[]; quote: string | string[] }
 export const inputParameters: InputParameters<TInputParameters> = {
   base: {
     aliases: ['from'],


### PR DESCRIPTION
## Description
Input parameters that are batchable should have an array typed input parameter

## Changes

- Adds correct types for batchable property paths
- Fixes validation of batchable property paths away from non-arrayed type

## Steps to Test

1. Start 1forge adapter
2. Request with base and quote as arrayed data
3. The request should succeed

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
