### PR TITLE
[Bug] Turn off TradingEconomics HTTP failover

### DIFF
--- a/.changeset/cold-dolls-tap.md
+++ b/.changeset/cold-dolls-tap.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/tradingeconomics-adapter': major
+---
+
+Turn off default HTTP failover behavior

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/external-adapters-js",
-  "version": "1.29.1",
+  "version": "1.30.0",
   "license": "MIT",
   "private": true,
   "workspaces": [

--- a/packages/sources/tradingeconomics/src/adapter.ts
+++ b/packages/sources/tradingeconomics/src/adapter.ts
@@ -73,6 +73,7 @@ export const makeWSHandler = (
           defaultConfig.client.secret || '',
         ),
       },
+      noHttp: true, // Turned on due to negotiated plans having limited HTTP credits
       subscribe: (input) => {
         const validator = new Validator(
           input,

--- a/packages/sources/tradingeconomics/src/config/index.ts
+++ b/packages/sources/tradingeconomics/src/config/index.ts
@@ -9,7 +9,7 @@ export type Config = config & {
 }
 
 export const NAME = 'TRADINGECONOMICS'
-export const DEFAULT_ENDPOINT = 'price'
+export const DEFAULT_ENDPOINT = 'price-ws'
 
 export const DEFAULT_API_ENDPOINT = 'https://api.tradingeconomics.com/markets'
 export const DEFAULT_WS_API_ENDPOINT = 'wss://stream.tradingeconomics.com/'

--- a/packages/sources/tradingeconomics/src/endpoint/price-ws.ts
+++ b/packages/sources/tradingeconomics/src/endpoint/price-ws.ts
@@ -1,0 +1,22 @@
+import { AdapterConfigError, Validator } from '@chainlink/ea-bootstrap'
+import { ExecuteWithConfig, InputParameters } from '@chainlink/ea-bootstrap'
+import { Config } from '../config'
+
+export const supportedEndpoints = ['price-ws']
+
+export type TInputParameters = { base: string }
+export const inputParameters: InputParameters<TInputParameters> = {
+  base: {
+    aliases: ['from', 'asset'],
+    required: true,
+    description: 'The symbol of the asset to query',
+    type: 'string',
+  },
+}
+export const execute: ExecuteWithConfig<Config> = async (request) => {
+  new Validator(request, inputParameters)
+  throw new AdapterConfigError({
+    message:
+      'The default configuration for the TradingEconomics adapter does not support making HTTP requests. Make sure WS is enabled in the adapter configuration. To use HTTP requests switch to using "endpoint: price"',
+  })
+}


### PR DESCRIPTION
## Closes sc-46729

## Description
The Chainlink Labs TradingEconomics API plans do not contain allowances for HTTP requests.
This means that the default behavior should be to not ever attempt any HTTP requests.
Currently they happen as failover to WS.

## Changes

- Turn on noHttp for TradingEconomics WS
- Create dummy `price-ws` endpoint
- Set dummy endpoint to default endpoint

## Steps to Test

1. Run `tradingeconomics` with WS_ENABLED
2. Send any request
3. No HTTP requests should be sent, instead it should await WS data

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
