### PR TITLE
[Release] v1.30.1

### DIFF
--- a/.changeset/cold-dolls-tap.md
+++ b/.changeset/cold-dolls-tap.md
@@ -1,5 +1,0 @@
----
-'@chainlink/tradingeconomics-adapter': major
----
-
-Turn off default HTTP failover behavior

--- a/.changeset/cold-dolls-tap.md
+++ b/.changeset/cold-dolls-tap.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/tradingeconomics-adapter': major
+---
+
+Turn off default HTTP failover behavior

--- a/.changeset/five-houses-begin.md
+++ b/.changeset/five-houses-begin.md
@@ -1,0 +1,6 @@
+---
+'@chainlink/1forge-adapter': patch
+'@chainlink/currencylayer-adapter': patch
+---
+
+Fix validation of batchable property path

--- a/.changeset/five-houses-begin.md
+++ b/.changeset/five-houses-begin.md
@@ -1,6 +1,0 @@
----
-'@chainlink/1forge-adapter': patch
-'@chainlink/currencylayer-adapter': patch
----
-
-Fix validation of batchable property path

--- a/.github/actions/release/publish-artifacts/action.yml
+++ b/.github/actions/release/publish-artifacts/action.yml
@@ -103,3 +103,14 @@ runs:
       if: inputs.latest || steps.check-image-exists.outputs.image-exists == 'false'
       shell: bash
       run: docker push ${{ steps.generate-image-name.outputs.image_name }}
+    - name: Write Shasum File
+      if: inputs.latest || steps.check-image-exists.outputs.image-exists == 'false'
+      shell: bash
+      run: docker inspect --format='{{.Id}}' ${{ steps.generate-image-name.outputs.image_name }} > ${{ steps.generate-image-name.outputs.image_name }}.shasum
+    - name: Upload Shasum Artifact
+      if: inputs.latest || steps.check-image-exists.outputs.image-exists == 'false'
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ steps.generate-image-name.outputs.image_name }}
+        path: ${{ steps.generate-image-name.outputs.image_name }}.shasum
+        retention: 1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/external-adapters-js",
-  "version": "1.30.0",
+  "version": "1.30.1",
   "license": "MIT",
   "private": true,
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/external-adapters-js",
-  "version": "1.29.1",
+  "version": "1.30.0",
   "license": "MIT",
   "private": true,
   "workspaces": [

--- a/packages/composites/outlier-detection/CHANGELOG.md
+++ b/packages/composites/outlier-detection/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chainlink/outlier-detection-adapter
 
+## 1.2.8
+
+### Patch Changes
+
+- @chainlink/ea@1.3.7
+
 ## 1.2.7
 
 ### Patch Changes

--- a/packages/composites/outlier-detection/package.json
+++ b/packages/composites/outlier-detection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/outlier-detection-adapter",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Chainlink Outlier Detection adapter.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/composites/reference-transform/CHANGELOG.md
+++ b/packages/composites/reference-transform/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chainlink/reference-transform-adapter
 
+## 1.2.8
+
+### Patch Changes
+
+- @chainlink/ea@1.3.7
+
 ## 1.2.7
 
 ### Patch Changes

--- a/packages/composites/reference-transform/package.json
+++ b/packages/composites/reference-transform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/reference-transform-adapter",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Transform external adapter results from an on-chain reference.",
   "keywords": [
     "Chainlink",

--- a/packages/core/legos/CHANGELOG.md
+++ b/packages/core/legos/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @chainlink/ea
 
+## 1.3.7
+
+### Patch Changes
+
+- Updated dependencies [698e5670f]
+- Updated dependencies [99a5aad35]
+  - @chainlink/tradingeconomics-adapter@2.0.0
+  - @chainlink/1forge-adapter@1.6.7
+  - @chainlink/currencylayer-adapter@1.4.7
+
 ## 1.3.6
 
 ### Patch Changes

--- a/packages/core/legos/package.json
+++ b/packages/core/legos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/ea",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "Build with composable Chainlink External Adapters",
   "keywords": [
     "Chainlink",

--- a/packages/sources/1forge/CHANGELOG.md
+++ b/packages/sources/1forge/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chainlink/1forge-adapter
 
+## 1.6.7
+
+### Patch Changes
+
+- 99a5aad35: Fix validation of batchable property path
+
 ## 1.6.6
 
 ### Patch Changes

--- a/packages/sources/1forge/package.json
+++ b/packages/sources/1forge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/1forge-adapter",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sources/1forge/src/adapter.ts
+++ b/packages/sources/1forge/src/adapter.ts
@@ -1,4 +1,4 @@
-import { Builder, Requester, Validator } from '@chainlink/ea-bootstrap'
+import { Builder, Logger, Requester, Validator } from '@chainlink/ea-bootstrap'
 import {
   DefaultConfig,
   ExecuteWithConfig,
@@ -49,6 +49,18 @@ export const makeWSHandler = (config?: DefaultConfig): MakeWSHandler => {
       { shouldThrowError: false },
     )
     if (validator.error) return
+    if (Array.isArray(validator.validated.data.quote)) {
+      Logger.debug(
+        `[WS]: ${validator.validated.data.quote} supplied as quote. Only non-array tickers can be used for WS`,
+      )
+      return
+    }
+    if (Array.isArray(validator.validated.data.base)) {
+      Logger.debug(
+        `[WS]: ${validator.validated.data.base} supplied as base. Only non-array tickers can be used for WS`,
+      )
+      return
+    }
     const symbol = validator.validated.data.base.toUpperCase()
     const convert = validator.validated.data.quote.toUpperCase()
     return `${symbol}/${convert}`

--- a/packages/sources/1forge/src/endpoint/quotes.ts
+++ b/packages/sources/1forge/src/endpoint/quotes.ts
@@ -18,20 +18,18 @@ export const description = `Returns a batched price comparison from a list curre
 
 **NOTE: the \`price\` endpoint is temporarily still supported, however, is being deprecated. Please use the \`quotes\` endpoint instead.**`
 
-export type TInputParameters = { base: string; quote: string }
+export type TInputParameters = { base: string | string[]; quote: string | string[] }
 
 export const inputParameters: InputParameters<TInputParameters> = {
   base: {
     aliases: ['from'],
     description: 'The symbol of the currency to query',
     required: true,
-    type: 'string',
   },
   quote: {
     aliases: ['to'],
     description: ' The symbol of the currency to convert to',
     required: true,
-    type: 'string',
   },
 }
 

--- a/packages/sources/coinapi/src/endpoint/assets.ts
+++ b/packages/sources/coinapi/src/endpoint/assets.ts
@@ -42,7 +42,7 @@ export interface ResponseSchema {
 }
 
 export type TInputParameters = {
-  base: string
+  base: string | string[]
 }
 
 export const inputParameters: InputParameters<TInputParameters> = {

--- a/packages/sources/coinmarketcap/src/endpoint/crypto.ts
+++ b/packages/sources/coinmarketcap/src/endpoint/crypto.ts
@@ -100,7 +100,12 @@ export const description = `https://pro-api.coinmarketcap.com/v1/cryptocurrency/
 
 **NOTE: the \`price\` endpoint is temporarily still supported, however, is being deprecated. Please use the \`crypto\` endpoint instead.**`
 
-export type TInputParameters = { base: string; convert: string; cid: string; slug: string }
+export type TInputParameters = {
+  base: string | string[]
+  convert: string | string[]
+  cid: string
+  slug: string
+}
 export const inputParameters: InputParameters<TInputParameters> = {
   base: {
     aliases: ['from', 'coin', 'sym', 'symbol'],

--- a/packages/sources/cryptocompare/src/adapter.ts
+++ b/packages/sources/cryptocompare/src/adapter.ts
@@ -1,4 +1,4 @@
-import { Builder, Requester, Validator } from '@chainlink/ea-bootstrap'
+import { Builder, Logger, Requester, Validator } from '@chainlink/ea-bootstrap'
 import {
   AdapterRequest,
   Config,
@@ -76,6 +76,12 @@ export const makeWSHandler = (config?: Config): MakeWSHandler<Message | any> =>
       const endpoint = validator.validated.data.endpoint?.toLowerCase()
       if (endpoint == 'marketcap') return false
       const base = validator.overrideSymbol(NAME, validator.validated.data.base)
+      if (Array.isArray(validator.validated.data.quote)) {
+        Logger.debug(
+          `[WS]: ${validator.validated.data.quote} supplied as quote. Only non-array tickers can be used for WS`,
+        )
+        return false
+      }
       const quote = validator.validated.data.quote.toUpperCase()
       return `${base}~${quote}`
     }

--- a/packages/sources/cryptocompare/src/endpoint/crypto.ts
+++ b/packages/sources/cryptocompare/src/endpoint/crypto.ts
@@ -130,7 +130,7 @@ export interface ResponseSchema {
 export const description =
   '**NOTE: the `price` endpoint is temporarily still supported, however, is being deprecated. Please use the `crypto` endpoint instead.**'
 
-export type TInputParameters = { base: string; quote: string }
+export type TInputParameters = { base: string | string[]; quote: string | string[] }
 export const inputParameters: InputParameters<TInputParameters> = {
   base: {
     aliases: ['from', 'coin', 'fsym'],

--- a/packages/sources/currencylayer/CHANGELOG.md
+++ b/packages/sources/currencylayer/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chainlink/currencylayer-adapter
 
+## 1.4.7
+
+### Patch Changes
+
+- 99a5aad35: Fix validation of batchable property path
+
 ## 1.4.6
 
 ### Patch Changes

--- a/packages/sources/currencylayer/package.json
+++ b/packages/sources/currencylayer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/currencylayer-adapter",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "description": "Chainlink currencylayer adapter.",
   "keywords": [
     "Chainlink",

--- a/packages/sources/currencylayer/src/endpoint/live.ts
+++ b/packages/sources/currencylayer/src/endpoint/live.ts
@@ -17,7 +17,7 @@ const customError = (data: ResponseSchema) => !data.success
 export const description =
   'Returns a batched price comparison from one currency to a list of other currencies.'
 
-export type TInputParameters = { base: string; quote: string; amount: number }
+export type TInputParameters = { base: string; quote: string | string[]; amount: number }
 export const inputParameters: InputParameters<TInputParameters> = {
   base: {
     aliases: ['from', 'coin'],
@@ -29,7 +29,6 @@ export const inputParameters: InputParameters<TInputParameters> = {
     aliases: ['to', 'market'],
     description: 'The symbol of the currency to convert to',
     required: true,
-    type: 'string',
   },
   amount: {
     description: 'An amount of the currency',

--- a/packages/sources/finage/src/adapter.ts
+++ b/packages/sources/finage/src/adapter.ts
@@ -3,6 +3,7 @@ import {
   APIEndpoint,
   ExecuteFactory,
   ExecuteWithConfig,
+  Logger,
   MakeWSHandler,
 } from '@chainlink/ea-bootstrap'
 import { Builder, Requester, Validator } from '@chainlink/ea-bootstrap'
@@ -57,6 +58,12 @@ export const makeWSHandler = (config?: Config): MakeWSHandler<Message | any> =>
         { shouldThrowError: false, overrides },
       )
       if (validator.error) return
+      if (Array.isArray(validator.validated.data.base)) {
+        Logger.debug(
+          `[WS]: ${validator.validated.data.base} supplied as base. Only non-array tickers can be used for WS`,
+        )
+        return
+      }
       return validator.validated.data.base.toUpperCase()
     }
     const isStock = (input: AdapterRequest): boolean =>

--- a/packages/sources/finage/src/endpoint/stock.ts
+++ b/packages/sources/finage/src/endpoint/stock.ts
@@ -16,7 +16,7 @@ export const batchablePropertyPath = [{ name: 'base' }]
 export const description = `https://finage.co.uk/docs/api/stock-last-quote
 The result will be calculated as the midpoint between the ask and the bid.`
 
-export type TInputParameters = { base: string }
+export type TInputParameters = { base: string | string[] }
 export const inputParameters: InputParameters<TInputParameters> = {
   base: {
     required: true,
@@ -41,7 +41,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
   const base = validator.validated.data.base
   const symbol = Array.isArray(base)
     ? base.map((symbol) => symbol.toUpperCase()).join(',')
-    : validator.overrideSymbol(NAME, validator.validated.data.base).toUpperCase()
+    : validator.overrideSymbol(NAME, base).toUpperCase()
 
   const url = getStockURL(base, symbol)
   const params = {

--- a/packages/sources/fixer/src/endpoint/latest.ts
+++ b/packages/sources/fixer/src/endpoint/latest.ts
@@ -27,7 +27,7 @@ const customError = (data: ResponseSchema) => !data.success
 export const description =
   'Returns a batched price comparison from one currency to a list of other currencies.'
 
-export type TInputParameters = { base: string; quote: string }
+export type TInputParameters = { base: string; quote: string | string[] }
 export const inputParameters: InputParameters<TInputParameters> = {
   base: {
     required: true,
@@ -39,7 +39,6 @@ export const inputParameters: InputParameters<TInputParameters> = {
     required: true,
     aliases: ['to', 'market'],
     description: 'The symbol of the currency to convert to',
-    type: 'string',
   },
 }
 

--- a/packages/sources/metalsapi/src/endpoint/latest.ts
+++ b/packages/sources/metalsapi/src/endpoint/latest.ts
@@ -15,7 +15,7 @@ export const batchablePropertyPath = [{ name: 'quote' }]
 export const description =
   'Returns a batched price comparison from one currency to a list of other currencies.'
 
-export type TInputParameters = { base: string; quote: string }
+export type TInputParameters = { base: string; quote: string | string[] }
 export const inputParameters: InputParameters<TInputParameters> = {
   base: {
     required: true,

--- a/packages/sources/nomics/src/endpoint/crypto.ts
+++ b/packages/sources/nomics/src/endpoint/crypto.ts
@@ -96,7 +96,7 @@ export const description = `The \`crypto\` endpoint fetches the price of a reque
 
 **NOTE: the \`price\` endpoint is temporarily still supported, however, is being deprecated. Please use the \`crypto\` endpoint instead.**`
 
-export type TInputParameters = { base: string; quote: string }
+export type TInputParameters = { base: string | string[]; quote: string }
 export const inputParameters: InputParameters<TInputParameters> = {
   base: {
     aliases: ['from', 'coin', 'ids'],

--- a/packages/sources/openexchangerates/src/endpoint/forex.ts
+++ b/packages/sources/openexchangerates/src/endpoint/forex.ts
@@ -15,7 +15,7 @@ export const batchablePropertyPath = [{ name: 'quote' }]
 export const description =
   '**NOTE: the `price` endpoint is temporarily still supported, however, is being deprecated. Please use the `forex` endpoint instead.**'
 
-export type TInputParameters = { base: string; quote: string }
+export type TInputParameters = { base: string; quote: string | string[] }
 export const inputParameters: InputParameters<TInputParameters> = {
   base: {
     aliases: ['from', 'coin'],

--- a/packages/sources/polygon/src/endpoint/tickers.ts
+++ b/packages/sources/polygon/src/endpoint/tickers.ts
@@ -16,7 +16,7 @@ export const description = `Convert a currency or currencies into another curren
 
 **NOTE: the \`price\` endpoint is temporarily still supported, however, is being deprecated. Please use the \`tickers\` endpoint instead.**`
 
-export type TInputParameters = { base: string | string[]; quote: string | string }
+export type TInputParameters = { base: string | string[]; quote: string | string[] }
 export const inputParameters: InputParameters<TInputParameters> = {
   base: {
     aliases: ['from'],

--- a/packages/sources/tradingeconomics/CHANGELOG.md
+++ b/packages/sources/tradingeconomics/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chainlink/tradingeconomics-adapter
 
+## 2.0.0
+
+### Major Changes
+
+- 698e5670f: Turn off default HTTP failover behavior
+
 ## 1.2.6
 
 ### Patch Changes

--- a/packages/sources/tradingeconomics/package.json
+++ b/packages/sources/tradingeconomics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/tradingeconomics-adapter",
-  "version": "1.2.6",
+  "version": "2.0.0",
   "description": "Chainlink TradingEconomics adapter.",
   "keywords": [
     "Chainlink",

--- a/packages/sources/tradingeconomics/src/adapter.ts
+++ b/packages/sources/tradingeconomics/src/adapter.ts
@@ -73,6 +73,7 @@ export const makeWSHandler = (
           defaultConfig.client.secret || '',
         ),
       },
+      noHttp: true, // Turned on due to negotiated plans having limited HTTP credits
       subscribe: (input) => {
         const validator = new Validator(
           input,

--- a/packages/sources/tradingeconomics/src/config/index.ts
+++ b/packages/sources/tradingeconomics/src/config/index.ts
@@ -9,7 +9,7 @@ export type Config = config & {
 }
 
 export const NAME = 'TRADINGECONOMICS'
-export const DEFAULT_ENDPOINT = 'price'
+export const DEFAULT_ENDPOINT = 'price-ws'
 
 export const DEFAULT_API_ENDPOINT = 'https://api.tradingeconomics.com/markets'
 export const DEFAULT_WS_API_ENDPOINT = 'wss://stream.tradingeconomics.com/'

--- a/packages/sources/tradingeconomics/src/endpoint/price-ws.ts
+++ b/packages/sources/tradingeconomics/src/endpoint/price-ws.ts
@@ -1,0 +1,22 @@
+import { AdapterConfigError, Validator } from '@chainlink/ea-bootstrap'
+import { ExecuteWithConfig, InputParameters } from '@chainlink/ea-bootstrap'
+import { Config } from '../config'
+
+export const supportedEndpoints = ['price-ws']
+
+export type TInputParameters = { base: string }
+export const inputParameters: InputParameters<TInputParameters> = {
+  base: {
+    aliases: ['from', 'asset'],
+    required: true,
+    description: 'The symbol of the asset to query',
+    type: 'string',
+  },
+}
+export const execute: ExecuteWithConfig<Config> = async (request) => {
+  new Validator(request, inputParameters)
+  throw new AdapterConfigError({
+    message:
+      'The default configuration for the TradingEconomics adapter does not support making HTTP requests. Make sure WS is enabled in the adapter configuration. To use HTTP requests switch to using "endpoint: price"',
+  })
+}

--- a/packages/sources/tradingeconomics/test/integration/adapter.test.ts
+++ b/packages/sources/tradingeconomics/test/integration/adapter.test.ts
@@ -33,6 +33,7 @@ describe('execute', () => {
     const data: AdapterRequest = {
       id,
       data: {
+        endpoint: 'price',
         base: 'EURUSD:CUR',
       },
     }
@@ -89,6 +90,7 @@ describe('websocket', () => {
       const data: AdapterRequest = {
         id: jobID,
         data: {
+          endpoint: 'price',
           base: 'EURUSD:CUR',
         },
       }


### PR DESCRIPTION
## Changelog

### Breaking Changes
- The default endpoint for `tradingeconomics-adapter` has changed to not allow HTTP requests. If you wish to continue this functionality use `endpoint: 'price'` in your job spec's external adapter parameters.

### Bug Fixes
- Fix for batch warming enabled adapters that were erroneously type validating batch requests

### Notable Adapter Updates
|    Adapter    | Version | Description |
| :-----------: | :-----: | :---------: |
| tradingeconomics-adapter | v2.0.0  | Turn off default HTTP failover |
| 1forge-adapter | v1.6.7 | Fix type validation for batch request |
| currencylayer-adapter | v1.4.7  | Fix type validation for batch request |