### PR TITLE
[Feat] TrueUSD adapter 'chain' filtering

### DIFF
--- a/.changeset/neat-teachers-kiss.md
+++ b/.changeset/neat-teachers-kiss.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/trueusd-adapter': minor
+---
+
+Add 'chain' input parameter to filter data by blockchain

--- a/packages/sources/trueusd/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/trueusd/test/integration/__snapshots__/adapter.test.ts.snap
@@ -3,11 +3,11 @@
 exports[`execute should return success for token 1`] = `
 Object {
   "data": Object {
-    "result": 1373465520.7227664,
+    "result": 137.87276643,
   },
   "jobRunID": "1",
   "providerStatusCode": 200,
-  "result": 1373465520.7227664,
+  "result": 137.87276643,
   "statusCode": 200,
 }
 `;
@@ -15,11 +15,35 @@ Object {
 exports[`execute should return success for trust 1`] = `
 Object {
   "data": Object {
-    "result": 1385192938.49,
+    "result": 140,
   },
   "jobRunID": "1",
   "providerStatusCode": 200,
-  "result": 1385192938.49,
+  "result": 140,
+  "statusCode": 200,
+}
+`;
+
+exports[`execute should return success when given a chain 1`] = `
+Object {
+  "data": Object {
+    "result": 21,
+  },
+  "jobRunID": "1",
+  "providerStatusCode": 200,
+  "result": 21,
+  "statusCode": 200,
+}
+`;
+
+exports[`execute should return success when given a chain and resultPath 1`] = `
+Object {
+  "data": Object {
+    "result": 20.72,
+  },
+  "jobRunID": "1",
+  "providerStatusCode": 200,
+  "result": 20.72,
   "statusCode": 200,
 }
 `;

--- a/packages/sources/trueusd/test/integration/adapter.test.ts
+++ b/packages/sources/trueusd/test/integration/adapter.test.ts
@@ -55,4 +55,45 @@ describe('execute', () => {
       .expect(200)
     expect(response.body).toMatchSnapshot()
   })
+
+  it('should return success when given a chain', async () => {
+    const data: AdapterRequest = {
+      id,
+      data: {
+        chain: 'AVA',
+      },
+    }
+
+    mockResponseSuccess()
+
+    const response = await context.req
+      .post('/')
+      .send(data)
+      .set('Accept', '*/*')
+      .set('Content-Type', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200)
+    expect(response.body).toMatchSnapshot()
+  })
+
+  it('should return success when given a chain and resultPath', async () => {
+    const data: AdapterRequest = {
+      id,
+      data: {
+        chain: 'AVA',
+        resultPath: 'totalTokenbyChain',
+      },
+    }
+
+    mockResponseSuccess()
+
+    const response = await context.req
+      .post('/')
+      .send(data)
+      .set('Accept', '*/*')
+      .set('Content-Type', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200)
+    expect(response.body).toMatchSnapshot()
+  })
 })

--- a/packages/sources/trueusd/test/integration/fixtures.ts
+++ b/packages/sources/trueusd/test/integration/fixtures.ts
@@ -1,6 +1,6 @@
 import nock from 'nock'
 
-export const mockResponseSuccess = (): nock =>
+export const mockResponseSuccess = (): nock.Scope =>
   nock('https://api.real-time-attest.trustexplorer.io', {
     encodedQueryParams: true,
   })
@@ -9,14 +9,71 @@ export const mockResponseSuccess = (): nock =>
       200,
       (_, request) => ({
         accountName: 'TrueUSD',
-        totalTrust: 1385192938.49,
-        totalToken: 1373465520.7227664,
-        updatedAt: '2022-04-05T16:45:04.973Z',
+        totalTrust: 140,
+        totalToken: 137.87276643,
+        updatedAt: '2022-04-08T14:39:13.724Z',
+        updatedTms: 1649428753724,
         token: [
-          { principle: 5316985.88276643, tokenName: 'TUSDB (BNB)' },
-          { principle: 254336540.22, tokenName: 'TUSD (TRON)' },
-          { principle: 1109418823.8999999, tokenName: 'TUSD (ETH)' },
-          { principle: 4393170.72, tokenName: 'TUSD (AVA)' },
+          {
+            tokenName: 'TUSDB (BNB)',
+            totalTokenbyChain: 76.39276643,
+            totalTrustbyChain: 77,
+            bankBalances: [
+              {
+                'Prime Trust': 1,
+                Silvergate: 2,
+                'Signature Bank': 3,
+                'First Digital Trust': 4,
+                'Customers Bank': 5,
+                Other: 6,
+              },
+            ],
+          },
+          {
+            tokenName: 'TUSD (TRON)',
+            totalTokenbyChain: 20.22,
+            totalTrustbyChain: 21,
+            bankBalances: [
+              {
+                'Prime Trust': 1,
+                Silvergate: 2,
+                'Signature Bank': 3,
+                'First Digital Trust': 4,
+                'Customers Bank': 5,
+                Other: 6,
+              },
+            ],
+          },
+          {
+            tokenName: 'TUSD (ETH)',
+            totalTokenbyChain: 20.54,
+            totalTrustbyChain: 21,
+            bankBalances: [
+              {
+                'Prime Trust': 1,
+                Silvergate: 2,
+                'Signature Bank': 3,
+                'First Digital Trust': 4,
+                'Customers Bank': 5,
+                Other: 6,
+              },
+            ],
+          },
+          {
+            tokenName: 'TUSD (AVA)',
+            totalTokenbyChain: 20.72,
+            totalTrustbyChain: 21,
+            bankBalances: [
+              {
+                'Prime Trust': 1,
+                Silvergate: 2,
+                'Signature Bank': 3,
+                'First Digital Trust': 4,
+                'Customers Bank': 5,
+                Other: 6,
+              },
+            ],
+          },
         ],
       }),
       [

--- a/packages/sources/trueusd/test/unit/trueusd.test.ts
+++ b/packages/sources/trueusd/test/unit/trueusd.test.ts
@@ -12,12 +12,8 @@ describe('execute', () => {
       { name: 'empty body', testData: {} },
       { name: 'empty data', testData: { data: {} } },
       {
-        name: 'empty field',
-        testData: { id: jobID, data: { field: '' } },
-      },
-      {
-        name: 'bad field',
-        testData: { id: jobID, data: { field: 'asd' } },
+        name: 'empty result path',
+        testData: { id: jobID, data: { resultPath: '' } },
       },
     ]
 
@@ -28,6 +24,26 @@ describe('execute', () => {
         } catch (error) {
           const errorResp = Requester.errored(jobID, error)
           assertError({ expected: 400, actual: errorResp.statusCode }, errorResp, jobID)
+        }
+      })
+    })
+  })
+
+  describe('interal error', () => {
+    const requests = [
+      {
+        name: 'bad result path',
+        testData: { id: jobID, data: { resultPath: 'asd' } },
+      },
+    ]
+
+    requests.forEach((req) => {
+      it(`${req.name}`, async () => {
+        try {
+          await execute(req.testData as AdapterRequest, {})
+        } catch (error) {
+          const errorResp = Requester.errored(jobID, error)
+          assertError({ expected: 502, actual: errorResp.statusCode }, errorResp, jobID)
         }
       })
     })


### PR DESCRIPTION
## Closes sc-46121

## Description
TrustToken is now breaking out their reserves for TUSD by blockchain. To allow easier accessing of this data a new input parameter was added to filter by chain.

## Changes

- Updated `ResponseSchema` for new API response structure
- Added `chain` input parameter
- When a `chain` is given, the default resultPath changes to `totalTrustbyChain`
- Tests updated

- (unrelated) Added missing `endpointResultPaths` and marked `field` as deprecated.

## Steps to Test

```
yarn test packages/sources/trueusd
```

See test file diff

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
