### PR TITLE
Fix Includes string[] param behavior

### DIFF
--- a/.changeset/wicked-eggs-work.md
+++ b/.changeset/wicked-eggs-work.md
@@ -1,0 +1,6 @@
+---
+'@chainlink/ea-bootstrap': patch
+'@chainlink/amberdata-adapter': patch
+---
+
+Support includes param in request as string[]

--- a/packages/core/bootstrap/src/lib/middleware/cache-warmer/reducer.ts
+++ b/packages/core/bootstrap/src/lib/middleware/cache-warmer/reducer.ts
@@ -4,6 +4,7 @@ import type {
   AdapterRequestData,
   BatchableProperty,
   Execute,
+  Includes,
 } from '../../../types'
 import { combineReducers, createReducer } from '@reduxjs/toolkit'
 import { logger } from '../../modules/logger'
@@ -141,7 +142,7 @@ export const subscriptionsReducer = createReducer<SubscriptionState>({}, (builde
           batchWarmer.origin.includes = uniq([
             ...(batchWarmer.origin.includes || []),
             ...(childRequestData.includes || []),
-          ])
+          ]) as Includes[] | string[]
       }
     }
   })
@@ -186,7 +187,9 @@ export const subscriptionsReducer = createReducer<SubscriptionState>({}, (builde
       if (childOriginData.tokenOverrides)
         acc.tokenOverrides = merge(acc.tokenOverrides || {}, childOriginData.tokenOverrides)
       if (childOriginData.includes)
-        acc.includes = uniq([...(acc.includes || []), ...childOriginData.includes])
+        acc.includes = uniq([...(acc.includes || []), ...childOriginData.includes]) as
+          | Includes[]
+          | string[]
       return acc
     }, {})
 

--- a/packages/core/bootstrap/src/lib/modules/validator.ts
+++ b/packages/core/bootstrap/src/lib/modules/validator.ts
@@ -167,7 +167,7 @@ export class Validator<
         ...this.validatorOptions.includes,
       ]
       if (!includesArray.every((val) => isObject(val) || typeof val === 'string')) {
-        this.throwInvalid(`'includes' array is not of type Includes[]`)
+        this.throwInvalid(`'includes' array is not of type Includes[] | string[]`)
       }
 
       this.validated.includes = includesArray

--- a/packages/core/bootstrap/src/lib/modules/validator.ts
+++ b/packages/core/bootstrap/src/lib/modules/validator.ts
@@ -13,7 +13,7 @@ import type {
   NestableValue,
 } from '../../types'
 import { cloneDeep } from 'lodash'
-import { isArray, isObject } from '../util'
+import { isObject } from '../util'
 import { AdapterError, AdapterInputError } from './error'
 import presetTokens from '../config/overrides/presetTokens.json'
 import { Requester } from './requester'
@@ -29,7 +29,7 @@ export type OverrideType = 'overrides' | 'tokenOverrides' | 'includes'
 export interface ValidatedData {
   overrides?: OverrideMap
   tokenOverrides?: OverrideMap
-  includes?: Includes[]
+  includes?: (Includes | string)[]
 }
 export interface ValidatorOptions {
   shouldThrowError: boolean
@@ -162,10 +162,15 @@ export class Validator<
 
   validateIncludeOverrides(): void {
     try {
-      this.validated.includes = this.formatIncludeOverrides([
-        ...(Array.isArray(this.input.data?.includes) ? this.input.data.includes : []),
-        ...(this.validatorOptions.includes || []),
-      ])
+      const includesArray = [
+        ...(this.input.data?.includes ?? []),
+        ...this.validatorOptions.includes,
+      ]
+      if (!includesArray.every((val) => isObject(val) || typeof val === 'string')) {
+        this.throwInvalid(`'includes' array is not of type Includes[]`)
+      }
+
+      this.validated.includes = includesArray
     } catch (e: any) {
       const error = e as Error
       this.parseError(error)
@@ -220,7 +225,11 @@ export class Validator<
 
   overrideIncludes = (from: string, to: string): IncludePair | undefined => {
     // Search through `presetIncludes` to find matching override for adapter and to/from pairing.
-    const pairs = (this.validated.includes as Includes[]).filter(
+    const pairs = (
+      this.validated.includes?.filter(
+        (val: Includes | string) => typeof val !== 'string',
+      ) as Includes[]
+    ).filter(
       (pair) =>
         pair.from.toLowerCase() === from.toLowerCase() &&
         pair.to.toLowerCase() === to.toLowerCase(),
@@ -245,17 +254,6 @@ export class Validator<
       if (overridden.toLowerCase() === symbol.toLowerCase()) originalSymbol = original
     })
     return originalSymbol || symbol
-  }
-
-  formatIncludeOverrides = (param: Includes[]): Includes[] => {
-    const _throwInvalid = () =>
-      this.throwInvalid(`Parameter supplied with wrong format: "includes"`)
-    if (!isArray(param)) _throwInvalid()
-
-    const _isValid = Object.values(param).every((val) => isObject(val) || typeof val === 'string')
-    if (!_isValid) _throwInvalid()
-
-    return param
   }
 
   throwInvalid = (message: string): void => {

--- a/packages/core/bootstrap/src/lib/util.ts
+++ b/packages/core/bootstrap/src/lib/util.ts
@@ -624,7 +624,6 @@ export const getPairOptions = <TOptions, TInputParameters extends BasePairInputP
         const defaultOverrideIncludes = (base: string, _: string, includes: string[]) => ({
           from: base,
           to: includes[0],
-          inverse: false,
         })
         const getOverrideIncludes = customOverrideIncludes ?? defaultOverrideIncludes
         baseIncludes = getOverrideIncludes(base, quote, includes as string[])

--- a/packages/core/bootstrap/src/types/index.ts
+++ b/packages/core/bootstrap/src/types/index.ts
@@ -118,7 +118,7 @@ export type TBaseInputParameters = {
   resultPath?: ResultPath
   overrides?: OverrideRecord
   tokenOverrides?: { [network: string]: { [token: string]: string } }
-  includes?: Includes[]
+  includes?: Includes[] | string[]
   maxAge?: number
   cost?: number
   error?: { code: number }

--- a/packages/core/bootstrap/test/unit/utils.test.ts
+++ b/packages/core/bootstrap/test/unit/utils.test.ts
@@ -5,7 +5,6 @@ import {
   Includes,
   InputParameters,
   OverrideRecord,
-  TBaseInputParameters,
 } from '@chainlink/ea-bootstrap'
 import { FastifyRequest } from 'fastify'
 import { RequiredEnvError } from '../../src/lib/modules/error'

--- a/packages/core/bootstrap/test/unit/utils.test.ts
+++ b/packages/core/bootstrap/test/unit/utils.test.ts
@@ -5,6 +5,7 @@ import {
   Includes,
   InputParameters,
   OverrideRecord,
+  TBaseInputParameters,
 } from '@chainlink/ea-bootstrap'
 import { FastifyRequest } from 'fastify'
 import { RequiredEnvError } from '../../src/lib/modules/error'
@@ -559,6 +560,50 @@ describe('utils', () => {
           },
         },
       })
+    })
+
+    it('returns the includesOptions for a single base/quote pair with includes string[] param', () => {
+      const request: AdapterRequest = {
+        id: '1',
+        data: {
+          base: 'LINK',
+          quote: 'USD',
+          includes: ['USDT'],
+        },
+      }
+
+      const validator = new Validator<TInputParameters>(request, inputParameters)
+
+      const pairOptions = getPairOptions<TOptions, TInputParameters>(
+        'TEST_ADAPTER_NAME',
+        validator,
+        getIncludesOptions,
+        defaultGetOptions,
+      )
+
+      expect(pairOptions).toEqual({ base: 'LINK', quote: 'USDT' })
+    })
+
+    it('does not utilize includes string[] param when base/quote are in includesOptions', () => {
+      const request: AdapterRequest = {
+        id: '1',
+        data: {
+          base: 'LINK',
+          quote: 'USD',
+          includes: ['USDT'],
+        },
+      }
+
+      const validator = new Validator<TInputParameters>(request, inputParameters, {}, { includes })
+
+      const pairOptions = getPairOptions<TOptions, TInputParameters>(
+        'TEST_ADAPTER_NAME',
+        validator,
+        getIncludesOptions,
+        defaultGetOptions,
+      )
+
+      expect(pairOptions).toEqual({ base: 'USD', quote: 'LINK', inverse: true })
     })
   })
 })

--- a/packages/sources/amberdata/src/endpoint/crypto.ts
+++ b/packages/sources/amberdata/src/endpoint/crypto.ts
@@ -52,6 +52,13 @@ const getIncludesOptions = (
   }
 }
 
+const customOverrideIncludes = (base: string, _: string, includes: string[]) => ({
+  from: base,
+  to: includes[0],
+  inverse: false,
+  tokens: true,
+})
+
 export const description = `Gets the [latest spot VWAP price](https://docs.amberdata.io/reference#spot-price-pair-latest) from Amberdata.
 
 **NOTE: the \`price\` endpoint is temporarily still supported, however, is being deprecated. Please use the \`crypto\` endpoint instead.**`
@@ -100,6 +107,7 @@ export const execute: ExecuteWithConfig<Config> = async (input, _, config) => {
     validator,
     getIncludesOptions,
     symbolOptions,
+    customOverrideIncludes,
   ) as TOptions // If base and quote cannot be batched, getPairOptions will return TOptions
   const reqConfig = { ...config.api, params, url }
 

--- a/packages/sources/amberdata/src/endpoint/volume.ts
+++ b/packages/sources/amberdata/src/endpoint/volume.ts
@@ -63,6 +63,13 @@ const getIncludesOptions = (
   }
 }
 
+const customOverrideIncludes = (base: string, _: string, includes: string[]) => ({
+  from: base,
+  to: includes[0],
+  inverse: false,
+  tokens: true,
+})
+
 export const description =
   'Gets the [24h-volume for historical of a pair](https://docs.amberdata.io/reference#spot-price-pair-historical) from Amberdata.'
 
@@ -113,6 +120,7 @@ export const execute: ExecuteWithConfig<Config> = async (input, _, config) => {
     validator,
     getIncludesOptions,
     symbolOptions,
+    customOverrideIncludes,
   ) as TOptions // If base and quote cannot be batched, getPairOptions will return TOptions
   const reqConfig = { ...config.api, params, url }
 


### PR DESCRIPTION
## Closes #[46696](https://app.shortcut.com/chainlinklabs/story/46696/investigate-ea-decimal-truncating-issue-for-idr-usd-feed-on-mainnet)

## Description
Correct bugs introduced with https://github.com/smartcontractkit/external-adapters-js/pull/2028

## Changes
- Re-add support for string[] includes param in request options
- Add additional unit tests to confirm required behavior
- Improve typing to make the options more clear

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test
`yarn && yarn setup && yarn test packages/core/bootstrap/test/unit/utils.test.ts`

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
