### PR TITLE
Add COP/USD to inverse includes on openexchangerates

### DIFF
--- a/.changeset/spotty-vans-ring.md
+++ b/.changeset/spotty-vans-ring.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/openexchangerates-adapter': patch
+---
+
+Add COP/USD to inverse includes list

--- a/packages/sources/openexchangerates/src/config/includes.json
+++ b/packages/sources/openexchangerates/src/config/includes.json
@@ -9,5 +9,16 @@
         "inverse": true
       }
     ]
+  },
+  {
+    "from": "COP",
+    "to": "USD",
+    "includes": [
+      {
+        "from": "USD",
+        "to": "COP",
+        "inverse": true
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## Changes
- Add COP/USD to inverse includes list on openeexchangerates

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
