### PR TITLE
Fix/tradingeconomics endpoint

### DIFF
--- a/.changeset/purple-wasps-relate.md
+++ b/.changeset/purple-wasps-relate.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/tradingeconomics-adapter': patch
+---
+
+Export price_ws from tradingeconomics

--- a/packages/sources/tradingeconomics/README.md
+++ b/packages/sources/tradingeconomics/README.md
@@ -22,9 +22,9 @@ This document was generated automatically. Please see [README Generator](../../s
 
 Every EA supports base input parameters from [this list](../../core/bootstrap#base-input-parameters)
 
-| Required? |   Name   |     Description     |  Type  |         Options          |  Default   |
-| :-------: | :------: | :-----------------: | :----: | :----------------------: | :--------: |
-|           | endpoint | The endpoint to use | string | [price](#price-endpoint) | `price-ws` |
+| Required? |   Name   |     Description     |  Type  |                         Options                          |  Default   |
+| :-------: | :------: | :-----------------: | :----: | :------------------------------------------------------: | :--------: |
+|           | endpoint | The endpoint to use | string | [price-ws](#price_ws-endpoint), [price](#price-endpoint) | `price-ws` |
 
 ## Price Endpoint
 
@@ -67,6 +67,22 @@ Response:
   "providerStatusCode": 200
 }
 ```
+
+---
+
+## Price_ws Endpoint
+
+`price-ws` is the only supported name for this endpoint.
+
+### Input Params
+
+| Required? | Name |     Aliases     |           Description            |  Type  | Options | Default | Depends On | Not Valid With |
+| :-------: | :--: | :-------------: | :------------------------------: | :----: | :-----: | :-----: | :--------: | :------------: |
+|    ✅     | base | `asset`, `from` | The symbol of the asset to query | string |         |         |            |                |
+
+### Example
+
+There are no examples for this endpoint.
 
 ---
 

--- a/packages/sources/tradingeconomics/src/endpoint/index.ts
+++ b/packages/sources/tradingeconomics/src/endpoint/index.ts
@@ -3,3 +3,4 @@ import type { TInputParameters as PriceInputParameters } from './price'
 export type TInputParameters = PriceInputParameters
 
 export * as price from './price'
+export * as price_ws from './price-ws'


### PR DESCRIPTION
## Closes [#48659](https://app.shortcut.com/chainlinklabs/story/48659/tradingeconomics-ws-failure)

## Description
Fixes a bug introduced from #2021 

## Changes
- Add `price_ws` as an exported endpoint

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test
1. Run Tradingeconomics EA with `WS_ENABLED=true`
2. Query it with one of the following:
```
{
  "id": "1",
  "data": {
     "base": "BNB",
     "quote": "USD",
     "endpoint": "crypto"
  }
}
OR
{
  "id": "1",
  "data": {
     "base": "MYR",
     "quote": "USD",
     "endpoint": "forex"
  }
}
 ```

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
