### PR TITLE
Fixed tradingeconomics error when specifying legacy endpoints

### DIFF
--- a/packages/sources/tradingeconomics/CHANGELOG.md
+++ b/packages/sources/tradingeconomics/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chainlink/tradingeconomics-adapter
 
+## 2.1.0
+
+### Minor Changes
+
+- Exported `price-ws` endpoint
+
 ## 2.0.3
 
 ### Patch Changes

--- a/packages/sources/tradingeconomics/CHANGELOG.md
+++ b/packages/sources/tradingeconomics/CHANGELOG.md
@@ -1,10 +1,11 @@
 # @chainlink/tradingeconomics-adapter
 
-## 2.1.0
+## 2.0.4
 
-### Minor Changes
+### Patch Changes
 
-- Exported `price-ws` endpoint
+- Updated dependencies [a54b4216b]
+  - @chainlink/ea-test-helpers@1.4.1
 
 ## 2.0.3
 

--- a/packages/sources/tradingeconomics/README.md
+++ b/packages/sources/tradingeconomics/README.md
@@ -1,6 +1,6 @@
 # Chainlink External Adapter for Tradingeconomics
 
-![1.1.41](https://img.shields.io/github/package-json/v/smartcontractkit/external-adapters-js?filename=packages/sources/tradingeconomics/package.json)
+![2.0.4](https://img.shields.io/github/package-json/v/smartcontractkit/external-adapters-js?filename=packages/sources/tradingeconomics/package.json)
 
 This adapter uses the Tradingeconomics WS stream
 
@@ -22,9 +22,9 @@ This document was generated automatically. Please see [README Generator](../../s
 
 Every EA supports base input parameters from [this list](../../core/bootstrap#base-input-parameters)
 
-| Required? |   Name   |     Description     |  Type  |         Options          | Default |
-| :-------: | :------: | :-----------------: | :----: | :----------------------: | :-----: |
-|           | endpoint | The endpoint to use | string | [price](#price-endpoint) | `price` |
+| Required? |   Name   |     Description     |  Type  |                         Options                          |  Default   |
+| :-------: | :------: | :-----------------: | :----: | :------------------------------------------------------: | :--------: |
+|           | endpoint | The endpoint to use | string | [price-ws](#price_ws-endpoint), [price](#price-endpoint) | `price-ws` |
 
 ## Price Endpoint
 
@@ -44,8 +44,8 @@ Request:
 {
   "id": "1",
   "data": {
-    "endpoint": "price",
-    "base": "EURUSD:CUR"
+    "base": "EURUSD:CUR",
+    "endpoint": "price"
   },
   "debug": {
     "cacheKey": "1CbLEKoATl+/z1X7pi4LVsQRqBs="
@@ -67,6 +67,22 @@ Response:
   "providerStatusCode": 200
 }
 ```
+
+---
+
+## Price_ws Endpoint
+
+`price-ws` is the only supported name for this endpoint.
+
+### Input Params
+
+| Required? | Name |     Aliases     |           Description            |  Type  | Options | Default | Depends On | Not Valid With |
+| :-------: | :--: | :-------------: | :------------------------------: | :----: | :-----: | :-----: | :--------: | :------------: |
+|    ✅     | base | `asset`, `from` | The symbol of the asset to query | string |         |         |            |                |
+
+### Example
+
+There are no examples for this endpoint.
 
 ---
 

--- a/packages/sources/tradingeconomics/README.md
+++ b/packages/sources/tradingeconomics/README.md
@@ -1,6 +1,6 @@
 # Chainlink External Adapter for Tradingeconomics
 
-![2.0.4](https://img.shields.io/github/package-json/v/smartcontractkit/external-adapters-js?filename=packages/sources/tradingeconomics/package.json)
+![2.0.5](https://img.shields.io/github/package-json/v/smartcontractkit/external-adapters-js?filename=packages/sources/tradingeconomics/package.json)
 
 This adapter uses the Tradingeconomics WS stream
 

--- a/packages/sources/tradingeconomics/package.json
+++ b/packages/sources/tradingeconomics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/tradingeconomics-adapter",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "Chainlink TradingEconomics adapter.",
   "keywords": [
     "Chainlink",

--- a/packages/sources/tradingeconomics/package.json
+++ b/packages/sources/tradingeconomics/package.json
@@ -35,10 +35,10 @@
   },
   "devDependencies": {
     "@types/jest": "27.5.2",
-    "@types/node": "16.11.45",
+    "@types/node": "16.11.41",
     "@types/supertest": "2.0.12",
-    "nock": "13.2.9",
-    "supertest": "6.2.4",
+    "nock": "13.2.7",
+    "supertest": "6.2.3",
     "typescript": "4.7.4"
   }
 }

--- a/packages/sources/tradingeconomics/package.json
+++ b/packages/sources/tradingeconomics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/tradingeconomics-adapter",
-  "version": "2.1.0",
+  "version": "2.0.4",
   "description": "Chainlink TradingEconomics adapter.",
   "keywords": [
     "Chainlink",
@@ -35,10 +35,10 @@
   },
   "devDependencies": {
     "@types/jest": "27.5.2",
-    "@types/node": "16.11.41",
+    "@types/node": "16.11.45",
     "@types/supertest": "2.0.12",
-    "nock": "13.2.7",
-    "supertest": "6.2.3",
+    "nock": "13.2.9",
+    "supertest": "6.2.4",
     "typescript": "4.7.4"
   }
 }

--- a/packages/sources/tradingeconomics/package.json
+++ b/packages/sources/tradingeconomics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/tradingeconomics-adapter",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Chainlink TradingEconomics adapter.",
   "keywords": [
     "Chainlink",

--- a/packages/sources/tradingeconomics/src/endpoint/index.ts
+++ b/packages/sources/tradingeconomics/src/endpoint/index.ts
@@ -3,3 +3,4 @@ import type { TInputParameters as PriceInputParameters } from './price'
 export type TInputParameters = PriceInputParameters
 
 export * as price from './price'
+export * as price_ws from './price-ws'


### PR DESCRIPTION
## Changelog

### Breaking Changes
- None

### New Adapters
- None

### Features
- None

### Bug Fixes
- Fixed error in `tradingeconomics` adapter where requests are not properly routed if a legacy endpoint is specified

### Documentation
- None

### Notable Adapter Updates
|    Adapter    | Version | Description |
| :-----------: | :-----: | :---------: |
| tradingeconomics | v2.1.0  | Fixed error of incorrect routing to default endpoint when legacy endpoint is specified |