### PR TITLE
[SC-49568] Batch Warmer TTL Warning

### DIFF
--- a/packages/core/bootstrap/src/lib/middleware/cache/utils/ttl.ts
+++ b/packages/core/bootstrap/src/lib/middleware/cache/utils/ttl.ts
@@ -2,6 +2,7 @@ import { logger } from '../../../modules/logger'
 import type { AdapterRequestWithRateLimit } from '../../../../types'
 import { defaultOptions } from '..'
 import type { CacheOptions } from '../types'
+import { WARMUP_BATCH_REQUEST_ID } from '../../cache-warmer/config'
 
 export const WARNING_MAX_AGE = 1000 * 60 * 2 // 2 minutes
 
@@ -21,14 +22,17 @@ export const getRateLimitMaxAge = (
       adapterRequest,
     )
   if (maxAge > options.cacheImplOptions.maxAge) {
-    logger.warn(
-      `${
-        feedId && feedId[0] !== '{' ? `[${feedId}]` : ''
-      } Cache: Incoming requests exceed the configured data provider rate limit capacity. Defaulting to the max cache age value of ${
-        options.cacheImplOptions.maxAge / 1000 / 60
-      } minutes. WARNING: This may cause you to exceed your Data Provider rate limits and report stale data!`,
-      adapterRequest,
-    )
+    // Avoid displaying rate limit warnings for batch warmer requests
+    if (adapterRequest.id !== WARMUP_BATCH_REQUEST_ID) {
+      logger.warn(
+        `${
+          feedId && feedId[0] !== '{' ? `[${feedId}]` : ''
+        } Cache: Incoming requests exceed the configured data provider rate limit capacity. Defaulting to the max cache age value of ${
+          options.cacheImplOptions.maxAge / 1000 / 60
+        } minutes. WARNING: This may cause you to exceed your Data Provider rate limits and report stale data!`,
+        adapterRequest,
+      )
+    }
     return options.cacheImplOptions.maxAge
   }
   return maxAge


### PR DESCRIPTION
## Closes SC-49568

## Description

Skipping the rate limit capacity warning for batch warmer requests. This warning occurs when the max age of a request exceeds the default max age. This scenario occurs for batch warmer parent requests since the max age calculation weighs its polling throughput to its children's throughputs. In the case of batch warming, parent requests are not sharing API capacity with children so this warning on max age is irrelevant.

## Changes

- Wrapped rate limit capacity warning with a check to only log when it is not a batch warmer request

## Steps to Test

1. Run an EA that supports batching such as CoinAPI
2. Send a minimum of 2 different requests that can be batched
3. Wait for the batch warmer request to poll
4. Check logs for mention of rate limit capacity warning

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
