### PR TITLE
Feature/redis autopipeline

### DIFF
--- a/.changeset/old-spies-stare.md
+++ b/.changeset/old-spies-stare.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/ea-bootstrap': patch
+---
+
+Improved redis cache performance with auto-pipelining

--- a/packages/core/bootstrap/src/lib/middleware/cache/index.ts
+++ b/packages/core/bootstrap/src/lib/middleware/cache/index.ts
@@ -331,9 +331,7 @@ export const withCache =
 
             //Cache batch requests
             if (data?.results?.length) {
-              const pipelineQue: Promise<string | null | boolean>[] = []
-
-              data.results.forEach((batchParticipant) => {
+              const batchEntries = data.results.map((batchParticipant) => {
                 const [key, , result] = batchParticipant
                 const childKey = adapterCacheToUse.getKey(key)
                 const debugBatchablePropertyPath = debug
@@ -346,14 +344,10 @@ export const withCache =
                   maxAge,
                   debug: debugBatchablePropertyPath,
                 }
-                const cacheResponsePromise = cacheToUse.setResponse(
-                  childKey,
-                  entryBatchParticipant,
-                  maxAge,
-                )
-                pipelineQue.push(cacheResponsePromise)
+                return { key: childKey, entry: entryBatchParticipant, maxAge }
               })
-              await Promise.all(pipelineQue)
+
+              await cache.setBatchResponse(batchEntries)
             }
           }
           // Notify pending requests by removing the in-flight mark

--- a/packages/core/bootstrap/src/lib/middleware/cache/local/index.ts
+++ b/packages/core/bootstrap/src/lib/middleware/cache/local/index.ts
@@ -43,7 +43,13 @@ export class LocalLRUCache implements ICache {
   }
 
   setResponse(key: string, value: any, maxAge: number) {
-    return Promise.resolve(this.client.set(key, value, maxAge))
+    this.client.set(key, value, maxAge)
+  }
+
+  setBatchResponse(batchEntries: { key: string; entry: CacheEntry; maxAge: number }[]) {
+    batchEntries.forEach((batchParticipant) => {
+      this.client.set(batchParticipant.key, batchParticipant.entry, batchParticipant.maxAge)
+    })
   }
 
   setFlightMarker(key: string, maxAge: number) {

--- a/packages/core/bootstrap/src/lib/middleware/cache/local/index.ts
+++ b/packages/core/bootstrap/src/lib/middleware/cache/local/index.ts
@@ -43,7 +43,7 @@ export class LocalLRUCache implements ICache {
   }
 
   setResponse(key: string, value: any, maxAge: number) {
-    this.client.set(key, value, maxAge)
+    return this.client.set(key, value, maxAge)
   }
 
   setBatchResponse(batchEntries: { key: string; entry: CacheEntry; maxAge: number }[]) {

--- a/packages/core/bootstrap/src/lib/middleware/cache/local/index.ts
+++ b/packages/core/bootstrap/src/lib/middleware/cache/local/index.ts
@@ -43,7 +43,7 @@ export class LocalLRUCache implements ICache {
   }
 
   setResponse(key: string, value: any, maxAge: number) {
-    return this.client.set(key, value, maxAge)
+    return Promise.resolve(this.client.set(key, value, maxAge))
   }
 
   setFlightMarker(key: string, maxAge: number) {

--- a/packages/core/bootstrap/src/lib/middleware/cache/redis/redis.ts
+++ b/packages/core/bootstrap/src/lib/middleware/cache/redis/redis.ts
@@ -75,17 +75,9 @@ export class RedisCache implements ICache {
     return cache
   }
 
-  async setResponse(key: string, value: CacheEntry, maxAge: number): Promise<string | null> {
+  setResponse(key: string, value: CacheEntry, maxAge: number): Promise<string | null> {
     const entry = JSON.stringify(value)
-    return await this.contextualTimeout(
-      this.client.set(key, entry, { PX: maxAge }),
-      'setResponse',
-      {
-        key,
-        value,
-        maxAge,
-      },
-    )
+    return this.client.set(key, entry, { PX: maxAge })
   }
 
   async setFlightMarker(key: string, maxAge: number): Promise<string | null> {

--- a/packages/core/bootstrap/src/lib/middleware/cache/redis/redis.ts
+++ b/packages/core/bootstrap/src/lib/middleware/cache/redis/redis.ts
@@ -75,9 +75,41 @@ export class RedisCache implements ICache {
     return cache
   }
 
-  setResponse(key: string, value: CacheEntry, maxAge: number): Promise<string | null> {
+  async setResponse(key: string, value: CacheEntry, maxAge: number): Promise<string | null> {
     const entry = JSON.stringify(value)
-    return this.client.set(key, entry, { PX: maxAge })
+    return await this.contextualTimeout(
+      this.client.set(key, entry, { PX: maxAge }),
+      'setResponse',
+      {
+        key,
+        value,
+        maxAge,
+      },
+    )
+  }
+
+  async setBatchResponse(batchEntries: { key: string; entry: CacheEntry; maxAge: number }[]) {
+    const pipelineQue: Promise<string | null>[] = []
+
+    batchEntries.forEach((batchParticipant) => {
+      const entry = JSON.stringify(batchParticipant.entry)
+      const cacheResponse = this.client.set(batchParticipant.key, entry, {
+        PX: batchParticipant.maxAge,
+      })
+      pipelineQue.push(cacheResponse)
+    })
+
+    try {
+      await Promise.all(pipelineQue)
+      metrics.redis_commands_sent_count
+        .labels({ status: metrics.CMD_SENT_STATUS.SUCCESS, function_name: 'setBatchResponse' })
+        .inc()
+    } catch (e) {
+      metrics.redis_commands_sent_count
+        .labels({ status: metrics.CMD_SENT_STATUS.FAIL, function_name: 'setBatchResponse' })
+        .inc()
+      throw e
+    }
   }
 
   async setFlightMarker(key: string, maxAge: number): Promise<string | null> {


### PR DESCRIPTION
## Description

Apparently the way current Redis implementation works isn't very performant. For batch requests to be cached each request to redis takes one round trip (RTT). The PR enables auto-pipelining feature so that all  batch requests entries will be sent to redis with one round trip. This is mainly to test and understand what is the impact as the implementation is not full, for example `redis_commands_sent_count` metric is totally ignored. 

## Changes

-  changed `setResponse` function in redis implementation to return Promise without `contextualTimeout`
-  changed `setResponse` function in LocalLRUCache implementation to return `Promise` instead of boolean
- changed `withCache` middleware to SET cache values  concurrently 


## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
