### PR TITLE
Enable the burst limiter to recover if exceeding limits

### DIFF
--- a/.changeset/warm-bugs-study.md
+++ b/.changeset/warm-bugs-study.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/ea-bootstrap': patch
+---
+
+Fixed an issue where the burst limiter would never recover from exceeding the limit

--- a/packages/core/bootstrap/src/lib/middleware/burst-limit/actions.ts
+++ b/packages/core/bootstrap/src/lib/middleware/burst-limit/actions.ts
@@ -5,6 +5,8 @@ export interface RequestObservedPayload {
   input: AdapterRequest
 }
 
+export const initialRequestObserved = createAction('BL/INITIAL_REQUEST_OBSERVED')
+
 export const requestObserved = createAction<RequestObservedPayload>(
   'BL/SUCCESSFUL_REQUEST_OBSERVED',
 )

--- a/packages/core/bootstrap/src/lib/middleware/burst-limit/index.ts
+++ b/packages/core/bootstrap/src/lib/middleware/burst-limit/index.ts
@@ -52,6 +52,8 @@ export const withBurstLimit =
     if (!store || !config?.enabled || (!config.burstCapacity1m && !config.burstCapacity1s))
       return await execute(input, context)
 
+    store.dispatch(actions.initialRequestObserved())
+
     const state = store.getState()
     const { requests }: { requests: RequestsState } = state
 


### PR DESCRIPTION
## Changes

- Burst limiter now re-counts the second/limit numbers initially instead of waiting for a successful request

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. Run EA
2. Run mock-DP
3. Send a request to EA
4. Stop mock-DP
5. Wait for cache warmer to stop
6. Send more requests to EA, exceeding limits
7. Re-run mock-DP
8. Ensure new requests make it through burst limiting without getting stopped

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
