### PR TITLE
Only test&build workflow on non-changeset changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,11 @@ on:
     branches:
       - master
       - develop
-  pull_request: ~
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - '**/package.json'
+      - '.changeset/**'
 
 jobs:
   packages:


### PR DESCRIPTION
### Description
`consume changesets` PRs are unable to run workflows, which results in them needing to be force merged (no workflows from a workflow)
This PR makes it so that the files that would be modified in those PRs do not trigger the `main.yml` workflow.