### PR TITLE
fixed incorrect path when generating readme

### DIFF
--- a/packages/scripts/src/generate-readme/generator.ts
+++ b/packages/scripts/src/generate-readme/generator.ts
@@ -1,10 +1,11 @@
+import path from 'path'
+import process from 'process'
 import { cat, exec, test } from 'shelljs'
 import { buildTable, TableText } from '../shared/tableUtils'
 import {
   capitalize,
   codeList,
   getJsonFile,
-  localPathToRoot,
   saveText,
   wrapCode,
   wrapJson,
@@ -93,14 +94,14 @@ export class ReadmeGenerator {
       this.adapterPath + 'src/config.ts',
       this.adapterPath + 'src/config/index.ts',
     ])
-    const configFile = await require(localPathToRoot + configPath)
+    const configFile = await require(path.join(process.cwd(), configPath))
     this.defaultEndpoint = configFile.DEFAULT_ENDPOINT
     this.defaultBaseUrl = configFile.DEFAULT_BASE_URL || configFile.DEFAULT_WS_API_ENDPOINT
 
     if (this.verbose) console.log(`${this.adapterPath}: Importing src/endpoint/index.ts`)
 
     const endpointPath = checkFilePaths([this.adapterPath + 'src/endpoint/index.ts'])
-    this.endpointDetails = await require(localPathToRoot + endpointPath)
+    this.endpointDetails = await require(path.join(process.cwd(), endpointPath))
   }
 
   buildReadme(): void {


### PR DESCRIPTION
Fixed README generation by using the current working directory instead of a relative path.