### PR TITLE
Correctly label DP errors as "dataProviderError" instead of "connecti…

### DIFF
--- a/.changeset/fluffy-insects-brush.md
+++ b/.changeset/fluffy-insects-brush.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/ea-bootstrap': patch
+---
+
+Make data provider errors be correctly labeled as "dataProviderError" instead of "connectionError"

--- a/packages/core/bootstrap/src/lib/modules/requester.ts
+++ b/packages/core/bootstrap/src/lib/modules/requester.ts
@@ -89,14 +89,19 @@ export class Requester {
         if (n === 1) {
           const providerStatusCode: number | undefined = error?.response?.status ?? 0 // 0 -> connection error
           record(config.method, providerStatusCode)
-          throw new AdapterConnectionError({
+          const errorInput = {
             statusCode: 200,
             providerStatusCode,
             message: error?.message,
             cause: error,
             errorResponse: error?.response?.data?.error,
             url,
-          })
+          }
+          if (providerStatusCode === 0) {
+            throw new AdapterConnectionError(errorInput)
+          } else {
+            throw new AdapterDataProviderError(errorInput)
+          }
         }
 
         return await _delayRetry(

--- a/packages/core/bootstrap/src/lib/modules/requester.ts
+++ b/packages/core/bootstrap/src/lib/modules/requester.ts
@@ -87,7 +87,7 @@ export class Requester {
         }
 
         if (n === 1) {
-          const providerStatusCode: number | undefined = error?.response?.status ?? 0 // 0 -> connection error
+          const providerStatusCode = error?.response?.status ?? 0 // 0 -> connection error
           record(config.method, providerStatusCode)
           const errorInput = {
             statusCode: 200,


### PR DESCRIPTION
## Changes

- Made Requester throw DP error unless status code is 0 (connection error)

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. Run EA
2. Send request that will fail on DP side
3. Verify in logs/metrics that the error type is "dataProviderError"

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
