### PR TITLE
Feature/50371 Tradermade inverse

### DIFF
--- a/.changeset/slow-fireants-compete.md
+++ b/.changeset/slow-fireants-compete.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/tradermade-adapter': minor
+---
+
+Added inverse pair functionality to tradermade live & WS endpoints

--- a/packages/sources/tradermade/src/adapter.ts
+++ b/packages/sources/tradermade/src/adapter.ts
@@ -5,11 +5,14 @@ import {
   AdapterRequest,
   ExecuteFactory,
   APIEndpoint,
+  util,
+  IncludePair,
 } from '@chainlink/ea-bootstrap'
 import { Requester, Validator, Builder } from '@chainlink/ea-bootstrap'
-import { makeConfig, DEFAULT_WS_API_ENDPOINT } from './config'
+import { makeConfig, DEFAULT_WS_API_ENDPOINT, NAME } from './config'
 import * as endpoints from './endpoint'
 import overrides from './config/symbols.json'
+import includes from './config/includes.json'
 
 export const execute: ExecuteWithConfig<Config, endpoints.TInputParameters> = async (
   request,
@@ -60,12 +63,21 @@ export const makeWSHandler = (
       input,
       endpoints.forex.inputParameters,
       {},
-      { shouldThrowError: false, overrides },
+      { shouldThrowError: false, includes, overrides },
     )
-    if (validator.error) return
-    const base = validator.validated.data.base.toUpperCase()
-    const quote = validator.validated.data.quote.toUpperCase()
-    return `${base}${quote}`
+    if (validator.error) return { pair: '', inverse: false }
+
+    const { from, to, inverse } = util.getPairOptions<IncludePair, endpoints.TInputParameters>(
+      NAME,
+      validator,
+      (_, i: IncludePair) => i,
+      (from: string, to: string) => ({ from, to }),
+    )
+
+    return {
+      pair: `${from.toUpperCase()}${to.toUpperCase()}`,
+      inverse,
+    }
   }
   return () => {
     const defaultConfig = config || makeConfig()
@@ -77,7 +89,7 @@ export const makeWSHandler = (
         if (!input.data.endpoint) return true
         return endpoints.forex.supportedEndpoints.indexOf(input.data.endpoint) === -1
       },
-      subscribe: (input: AdapterRequest) => getSubscription(getPair(input)),
+      subscribe: (input: AdapterRequest) => getSubscription(getPair(input).pair),
       unsubscribe: () => undefined, // Tradermade does not support unsubscribing.
       subsFromMessage: (message: Message) => {
         if (!message.symbol) return ''
@@ -85,8 +97,9 @@ export const makeWSHandler = (
       },
       isError: () => false, // No error
       filter: (message: Message) => !!message.mid,
-      toResponse: (message: Message) => {
-        const result = Requester.validateResultNumber(message, ['mid'])
+      toResponse: (message: Message, input: AdapterRequest) => {
+        const { inverse } = getPair(input)
+        const result = Requester.validateResultNumber(message, ['mid'], { inverse })
         return Requester.success('1', { data: { result } })
       },
     }

--- a/packages/sources/tradermade/src/config/includes.json
+++ b/packages/sources/tradermade/src/config/includes.json
@@ -1,0 +1,13 @@
+[
+  {
+    "from": "USD",
+    "to": "IDR",
+    "includes": [
+      {
+        "from": "IDR",
+        "to": "USD",
+        "inverse": true
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Closes #50371

## Description

Added inverse pair functionality to tradermade live & WS endpoints

## Steps to Test

1. `yarn test packages/sources/tradermade/test/integration`
2. `yarn test packages/sources/tradermade/test/unit`
3. Test manually using USD/IDR pair

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
