### PR TITLE
Fix/image dispatcher artifacts

### DIFF
--- a/.github/workflows/consume-release.yml
+++ b/.github/workflows/consume-release.yml
@@ -28,13 +28,24 @@ jobs:
         with:
           result-encoding: string
           script: |
-            const allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+            let artifactsPage
+            const allArtifacts = []
+            let page = 1 // First page
+
+            do {
+              artifactsPage = await github.rest.actions.listWorkflowRunArtifacts({
               ...context.repo,
               run_id: process.env.WORKFLOW_RUN_ID,
+              page,
+              per_page: 100, // Max results per page
             });
+              allArtifacts.push(...artifactsPage.data.artifacts)
+              page += 1
+            } while (artifactsPage.data.artifacts.length > 0);
+
             // Create whitespace separated URLs for downloading ECR adapter images based on uploaded workflow artifacts 
             const pathPrefix = process.env.AWS_PRIVATE_ECR_PATH
-            return allArtifacts.data.artifacts
+            return allArtifacts
               .map(({name}) => `${pathPrefix}/adapters/${name.replace('-shasum', '')}`)
               .join(' ')
       - name: 'Trigger Image Dispatcher'


### PR DESCRIPTION
## Closes [#52221](https://app.shortcut.com/chainlinklabs/story/52221/fetch-all-paginated-ea-images-for-deployment)

## Description
The `listWorkflowRunArtifacts` method only returns the first 30 results by default ([docs here](https://docs.github.com/en/rest/actions/artifacts#list-workflow-run-artifacts)), and the results are paginated, so the consume-release workflow is updated to fetch the list of artifacts in pages of 100.

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
