### PR TITLE
Remove extra unnecessary build step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,6 @@
-# bcrypto requires python >=3.6
-FROM python:buster as builder
+FROM node:16 as builder
 ARG location
 ARG package
-
-# Install node prereqs, nodejs and yarn
-# Ref: https://deb.nodesource.com/setup_16.x
-# Ref: https://yarnpkg.com/en/docs/install
-RUN \
-  echo "deb https://deb.nodesource.com/node_16.x buster main" > /etc/apt/sources.list.d/nodesource.list && \
-  wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-  echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list && \
-  wget -qO- https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-  apt-get update && \
-  apt-get install -yqq nodejs yarn && \
-  npm i -g npm@^6 && \
-  curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python && ln -s /root/.poetry/bin/poetry /usr/local/bin && \
-  rm -rf /var/lib/apt/lists/*
 
 WORKDIR /home/node/app
 


### PR DESCRIPTION
## Changes

- Remove extra Python-related build step in Dockerfile

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. Build EA with Docker
2. Run EA with Docker

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [ ] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
