### PR TITLE
Remove UNI mapping from Kaiko

### DIFF
--- a/.changeset/empty-hounds-look.md
+++ b/.changeset/empty-hounds-look.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/kaiko-adapter': patch
+---
+
+Remove symbol mapping for UNI

--- a/packages/sources/kaiko/src/config/symbols.json
+++ b/packages/sources/kaiko/src/config/symbols.json
@@ -1,6 +1,5 @@
 {
   "kaiko": {
-    "RAI": "RAIR",
-    "uni": "uniswap"
+    "RAI": "RAIR"
   }
 }


### PR DESCRIPTION
## Closes [#52651](https://app.shortcut.com/chainlinklabs/story/52651/remove-uni-mapping-for-kaiko-ea)

## Description
Kaiko's asset code for `UNI` changed from `uniswap` to `uni` months ago, so we should remove this mapping.
## Changes

## Steps to Test

1. Run Kaiko EA
2. Query UNI/USD price and expect a result

## Quality Assurance
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
