### PR TITLE
Nomics Adapter: Correct API plan link

### DIFF
--- a/packages/sources/nomics/README.md
+++ b/packages/sources/nomics/README.md
@@ -2,7 +2,7 @@
 
 ![1.3.15](https://img.shields.io/github/package-json/v/smartcontractkit/external-adapters-js?filename=packages/sources/nomics/package.json)
 
-An API key that can be obtained from [here](https://p.nomics.com/pricing#free-plan)
+An API key that can be obtained from [here](https://p.nomics.com/pricing#business-plan). A business plan is required to use Nomics data for commercial purposes.
 
 Base URL https://api.nomics.com/v1
 


### PR DESCRIPTION
## Description

Updates the Nomics API plan link to the current URL. Adds a note that commercial plans are required for commercial use and redistribution rights.
