### PR TITLE
Set correct default Chain ID for Avalanche

### DIFF
--- a/.changeset/shy-snails-train.md
+++ b/.changeset/shy-snails-train.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/savax-price-adapter': patch
+---
+
+Set correct default chain ID

--- a/packages/composites/savax-price/src/config/index.ts
+++ b/packages/composites/savax-price/src/config/index.ts
@@ -10,7 +10,7 @@ export const FLOATING_POINT_DECIMALS = 18
 
 export const ENV_AVALANCHE_RPC_URL = 'AVALANCHE_RPC_URL'
 export const ENV_AVALANCHE_CHAIN_ID = 'AVALANCHE_CHAIN_ID'
-export const DEFAULT_CHAIN_ID = '1'
+export const DEFAULT_CHAIN_ID = '43114'
 
 export interface Config extends DefaultConfig {
   sAvaxAddress: string


### PR DESCRIPTION
## Changes

- Fixed default chain ID for Avalanche

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. Run the savax-price EA against an Avalanche RPC

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
