### PR TITLE
Release/v1.39.1

### DIFF
--- a/.changeset/sharp-flowers-press.md
+++ b/.changeset/sharp-flowers-press.md
@@ -1,5 +1,0 @@
----
-'@chainlink/por-address-list-adapter': major
----
-
-Added new required network and chainId params

--- a/.changeset/sharp-flowers-press.md
+++ b/.changeset/sharp-flowers-press.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/por-address-list-adapter': major
+---
+
+Added new required network and chainId params

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/external-adapters-js",
-  "version": "1.39.0",
+  "version": "1.39.1",
   "license": "MIT",
   "private": true,
   "workspaces": [

--- a/packages/composites/outlier-detection/CHANGELOG.md
+++ b/packages/composites/outlier-detection/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chainlink/outlier-detection-adapter
 
+## 1.2.30
+
+### Patch Changes
+
+- @chainlink/ea@1.3.29
+
 ## 1.2.29
 
 ### Patch Changes

--- a/packages/composites/outlier-detection/CHANGELOG.md
+++ b/packages/composites/outlier-detection/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chainlink/outlier-detection-adapter
 
+## 1.2.31
+
+### Patch Changes
+
+- @chainlink/ea@1.3.30
+
 ## 1.2.30
 
 ### Patch Changes

--- a/packages/composites/outlier-detection/package.json
+++ b/packages/composites/outlier-detection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/outlier-detection-adapter",
-  "version": "1.2.29",
+  "version": "1.2.30",
   "description": "Chainlink Outlier Detection adapter.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/composites/outlier-detection/package.json
+++ b/packages/composites/outlier-detection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/outlier-detection-adapter",
-  "version": "1.2.30",
+  "version": "1.2.31",
   "description": "Chainlink Outlier Detection adapter.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/composites/por-indexer/CHANGELOG.md
+++ b/packages/composites/por-indexer/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chainlink/por-indexer-adapter
 
+## 1.2.22
+
+### Patch Changes
+
+- @chainlink/proof-of-reserves-adapter@1.14.2
+
 ## 1.2.21
 
 ### Patch Changes

--- a/packages/composites/por-indexer/CHANGELOG.md
+++ b/packages/composites/por-indexer/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chainlink/por-indexer-adapter
 
+## 1.2.21
+
+### Patch Changes
+
+- @chainlink/proof-of-reserves-adapter@1.14.1
+
 ## 1.2.20
 
 ### Patch Changes

--- a/packages/composites/por-indexer/package.json
+++ b/packages/composites/por-indexer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/por-indexer-adapter",
-  "version": "1.2.20",
+  "version": "1.2.21",
   "description": "Adapter to query a PoR Indexer Service.",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/composites/por-indexer/package.json
+++ b/packages/composites/por-indexer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/por-indexer-adapter",
-  "version": "1.2.21",
+  "version": "1.2.22",
   "description": "Adapter to query a PoR Indexer Service.",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/composites/proof-of-reserves/CHANGELOG.md
+++ b/packages/composites/proof-of-reserves/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @chainlink/proof-of-reserves-adapter
 
+## 1.14.1
+
+### Patch Changes
+
+- Updated dependencies [25218e0bb]
+  - @chainlink/por-address-list-adapter@4.0.0
+  - @chainlink/por-indexer-adapter@1.2.21
+  - @chainlink/renvm-address-set-adapter@1.5.12
+  - @chainlink/wbtc-address-set-adapter@1.4.21
+
 ## 1.14.0
 
 ### Minor Changes

--- a/packages/composites/proof-of-reserves/CHANGELOG.md
+++ b/packages/composites/proof-of-reserves/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @chainlink/proof-of-reserves-adapter
 
+## 1.14.2
+
+### Patch Changes
+
+- Updated dependencies [0c98ad38b]
+  - @chainlink/eth-beacon-adapter@1.1.1
+  - @chainlink/por-indexer-adapter@1.2.22
+  - @chainlink/renvm-address-set-adapter@1.5.13
+  - @chainlink/wbtc-address-set-adapter@1.4.22
+
 ## 1.14.1
 
 ### Patch Changes

--- a/packages/composites/proof-of-reserves/package.json
+++ b/packages/composites/proof-of-reserves/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/proof-of-reserves-adapter",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "description": "Chainlink BTC Proof of Reserves composite adapter. Combines multiple adapters to find total balance in custody for wBTC or renBTC.",
   "keywords": [
     "Chainlink",

--- a/packages/composites/proof-of-reserves/package.json
+++ b/packages/composites/proof-of-reserves/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/proof-of-reserves-adapter",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "description": "Chainlink BTC Proof of Reserves composite adapter. Combines multiple adapters to find total balance in custody for wBTC or renBTC.",
   "keywords": [
     "Chainlink",

--- a/packages/composites/reference-transform/CHANGELOG.md
+++ b/packages/composites/reference-transform/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chainlink/reference-transform-adapter
 
+## 1.2.30
+
+### Patch Changes
+
+- @chainlink/ea@1.3.29
+
 ## 1.2.29
 
 ### Patch Changes

--- a/packages/composites/reference-transform/CHANGELOG.md
+++ b/packages/composites/reference-transform/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chainlink/reference-transform-adapter
 
+## 1.2.31
+
+### Patch Changes
+
+- @chainlink/ea@1.3.30
+
 ## 1.2.30
 
 ### Patch Changes

--- a/packages/composites/reference-transform/package.json
+++ b/packages/composites/reference-transform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/reference-transform-adapter",
-  "version": "1.2.30",
+  "version": "1.2.31",
   "description": "Transform external adapter results from an on-chain reference.",
   "keywords": [
     "Chainlink",

--- a/packages/composites/reference-transform/package.json
+++ b/packages/composites/reference-transform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/reference-transform-adapter",
-  "version": "1.2.29",
+  "version": "1.2.30",
   "description": "Transform external adapter results from an on-chain reference.",
   "keywords": [
     "Chainlink",

--- a/packages/core/legos/CHANGELOG.md
+++ b/packages/core/legos/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @chainlink/ea
 
+## 1.3.29
+
+### Patch Changes
+
+- Updated dependencies [25218e0bb]
+  - @chainlink/por-address-list-adapter@4.0.0
+  - @chainlink/renvm-address-set-adapter@1.5.12
+  - @chainlink/wbtc-address-set-adapter@1.4.21
+
 ## 1.3.28
 
 ### Patch Changes

--- a/packages/core/legos/CHANGELOG.md
+++ b/packages/core/legos/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @chainlink/ea
 
+## 1.3.30
+
+### Patch Changes
+
+- Updated dependencies [0c98ad38b]
+  - @chainlink/eth-beacon-adapter@1.1.1
+  - @chainlink/renvm-address-set-adapter@1.5.13
+  - @chainlink/wbtc-address-set-adapter@1.4.22
+
 ## 1.3.29
 
 ### Patch Changes

--- a/packages/core/legos/package.json
+++ b/packages/core/legos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/ea",
-  "version": "1.3.29",
+  "version": "1.3.30",
   "description": "Build with composable Chainlink External Adapters",
   "keywords": [
     "Chainlink",

--- a/packages/core/legos/package.json
+++ b/packages/core/legos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/ea",
-  "version": "1.3.28",
+  "version": "1.3.29",
   "description": "Build with composable Chainlink External Adapters",
   "keywords": [
     "Chainlink",

--- a/packages/sources/eth-beacon/CHANGELOG.md
+++ b/packages/sources/eth-beacon/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chainlink/eth-beacon-adapter
 
+## 1.1.1
+
+### Patch Changes
+
+- 0c98ad38b: Remove input vs. output length check
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/sources/eth-beacon/package.json
+++ b/packages/sources/eth-beacon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/eth-beacon-adapter",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Chainlink eth-beacon adapter.",
   "keywords": [
     "Chainlink",

--- a/packages/sources/eth-beacon/src/endpoint/balance.ts
+++ b/packages/sources/eth-beacon/src/endpoint/balance.ts
@@ -1,10 +1,4 @@
-import {
-  Config,
-  Validator,
-  Requester,
-  AdapterInputError,
-  AdapterDataProviderError,
-} from '@chainlink/ea-bootstrap'
+import { Config, Validator, Requester, AdapterInputError } from '@chainlink/ea-bootstrap'
 import type { ExecuteWithConfig, InputParameters } from '@chainlink/ea-bootstrap'
 
 export const supportedEndpoints = ['balance']
@@ -80,12 +74,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
     address: validator.index,
     balance: validator.balance,
   }))
-  if (balances.length != addresses.length) {
-    throw new AdapterDataProviderError({
-      jobRunID,
-      message: `Beacon node did not return the right amount of balances.`,
-    })
-  }
+
   const result = {
     ...response,
     data: {

--- a/packages/sources/por-address-list/CHANGELOG.md
+++ b/packages/sources/por-address-list/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chainlink/por-address-list-source-adapter
 
+## 4.0.0
+
+### Major Changes
+
+- 25218e0bb: Added new required network and chainId params
+
 ## 3.0.0
 
 ### Major Changes

--- a/packages/sources/por-address-list/README.md
+++ b/packages/sources/por-address-list/README.md
@@ -36,6 +36,8 @@ This EA fetches the list of custodial addresses that hold the funds for a PoR fe
 |           |  confirmations  |         |        The number of confirmations to query data from        |      |         |         |            |                |
 |    ✅     | contractAddress |         |     The contract address holding the custodial addresses     |      |         |         |            |                |
 |           |    batchSize    |         | The number of addresses to fetch from the contract at a time |      |         |  `10`   |            |                |
+|    ✅     |     network     |         |       The network name to associate with the addresses       |      |         |         |            |                |
+|    ✅     |     chainId     |         |         The chain ID to associate with the addresses         |      |         |         |            |                |
 
 ### Example
 

--- a/packages/sources/por-address-list/package.json
+++ b/packages/sources/por-address-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/por-address-list-adapter",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Chainlink por-address-list adapter.",
   "keywords": [
     "Chainlink",

--- a/packages/sources/por-address-list/test/e2e/adapter.test.ts
+++ b/packages/sources/por-address-list/test/e2e/adapter.test.ts
@@ -18,6 +18,8 @@ describe('execute', () => {
             contractAddress: '0x203E97cF02dB2aE52c598b2e5e6c6A778EB1987B',
             batchSize: 3,
             confirmations: 0,
+            network: 'ethereum',
+            chainId: 'mainnet',
           },
         },
       },
@@ -27,6 +29,8 @@ describe('execute', () => {
           id: '1',
           data: {
             contractAddress: '0x203E97cF02dB2aE52c598b2e5e6c6A778EB1987B',
+            network: 'ethereum',
+            chainId: 'mainnet',
           },
         },
       },
@@ -37,6 +41,8 @@ describe('execute', () => {
           data: {
             contractAddress: '0x203E97cF02dB2aE52c598b2e5e6c6A778EB1987B',
             confirmations: 1,
+            network: 'ethereum',
+            chainId: 'mainnet',
           },
         },
       },
@@ -47,6 +53,8 @@ describe('execute', () => {
           data: {
             contractAddress: '0x203E97cF02dB2aE52c598b2e5e6c6A778EB1987B',
             batchSize: 10,
+            network: 'ethereum',
+            chainId: 'mainnet',
           },
         },
       },

--- a/packages/sources/por-address-list/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/por-address-list/test/integration/__snapshots__/adapter.test.ts.snap
@@ -6,33 +6,53 @@ Object {
     "result": Array [
       Object {
         "address": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+        "chainId": "mainnet",
+        "network": "ethereum",
       },
       Object {
         "address": "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+        "chainId": "mainnet",
+        "network": "ethereum",
       },
       Object {
         "address": "0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc",
+        "chainId": "mainnet",
+        "network": "ethereum",
       },
       Object {
         "address": "0x90f79bf6eb2c4f870365e785982e1f101e93b906",
+        "chainId": "mainnet",
+        "network": "ethereum",
       },
       Object {
         "address": "0x15d34aaf54267db7d7c367839aaf71a00a2c6a65",
+        "chainId": "mainnet",
+        "network": "ethereum",
       },
       Object {
         "address": "0x9965507d1a55bcc2695c58ba16fb37d819b0a4dc",
+        "chainId": "mainnet",
+        "network": "ethereum",
       },
       Object {
         "address": "0x976ea74026e726554db657fa54763abd0c3a0aa9",
+        "chainId": "mainnet",
+        "network": "ethereum",
       },
       Object {
         "address": "0x14dc79964da2c08b23698b3d3cc7ca32193d9955",
+        "chainId": "mainnet",
+        "network": "ethereum",
       },
       Object {
         "address": "0x23618e81e3f5cdf7f54c3d65f7fbc0abf5b21e8f",
+        "chainId": "mainnet",
+        "network": "ethereum",
       },
       Object {
         "address": "0xa0ee7a142d267c1f36714e4a8f75612f20a79720",
+        "chainId": "mainnet",
+        "network": "ethereum",
       },
     ],
   },
@@ -40,33 +60,53 @@ Object {
   "result": Array [
     Object {
       "address": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+      "chainId": "mainnet",
+      "network": "ethereum",
     },
     Object {
       "address": "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+      "chainId": "mainnet",
+      "network": "ethereum",
     },
     Object {
       "address": "0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc",
+      "chainId": "mainnet",
+      "network": "ethereum",
     },
     Object {
       "address": "0x90f79bf6eb2c4f870365e785982e1f101e93b906",
+      "chainId": "mainnet",
+      "network": "ethereum",
     },
     Object {
       "address": "0x15d34aaf54267db7d7c367839aaf71a00a2c6a65",
+      "chainId": "mainnet",
+      "network": "ethereum",
     },
     Object {
       "address": "0x9965507d1a55bcc2695c58ba16fb37d819b0a4dc",
+      "chainId": "mainnet",
+      "network": "ethereum",
     },
     Object {
       "address": "0x976ea74026e726554db657fa54763abd0c3a0aa9",
+      "chainId": "mainnet",
+      "network": "ethereum",
     },
     Object {
       "address": "0x14dc79964da2c08b23698b3d3cc7ca32193d9955",
+      "chainId": "mainnet",
+      "network": "ethereum",
     },
     Object {
       "address": "0x23618e81e3f5cdf7f54c3d65f7fbc0abf5b21e8f",
+      "chainId": "mainnet",
+      "network": "ethereum",
     },
     Object {
       "address": "0xa0ee7a142d267c1f36714e4a8f75612f20a79720",
+      "chainId": "mainnet",
+      "network": "ethereum",
     },
   ],
   "statusCode": 200,

--- a/packages/sources/por-address-list/test/integration/adapter.test.ts
+++ b/packages/sources/por-address-list/test/integration/adapter.test.ts
@@ -61,6 +61,8 @@ describe('execute', () => {
       id,
       data: {
         contractAddress: '0x203E97cF02dB2aE52c598b2e5e6c6A778EB1987B',
+        network: 'ethereum',
+        chainId: 'mainnet',
       },
     }
 

--- a/packages/sources/renvm-address-set/CHANGELOG.md
+++ b/packages/sources/renvm-address-set/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chainlink/renvm-address-set-adapter
 
+## 1.5.13
+
+### Patch Changes
+
+- @chainlink/proof-of-reserves-adapter@1.14.2
+
 ## 1.5.12
 
 ### Patch Changes

--- a/packages/sources/renvm-address-set/CHANGELOG.md
+++ b/packages/sources/renvm-address-set/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chainlink/renvm-address-set-adapter
 
+## 1.5.12
+
+### Patch Changes
+
+- @chainlink/proof-of-reserves-adapter@1.14.1
+
 ## 1.5.11
 
 ### Patch Changes

--- a/packages/sources/renvm-address-set/package.json
+++ b/packages/sources/renvm-address-set/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/renvm-address-set-adapter",
-  "version": "1.5.12",
+  "version": "1.5.13",
   "description": "Chainlink adapter to query RenVM address set.",
   "keywords": [
     "Chainlink",

--- a/packages/sources/renvm-address-set/package.json
+++ b/packages/sources/renvm-address-set/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/renvm-address-set-adapter",
-  "version": "1.5.11",
+  "version": "1.5.12",
   "description": "Chainlink adapter to query RenVM address set.",
   "keywords": [
     "Chainlink",

--- a/packages/sources/wbtc-address-set/CHANGELOG.md
+++ b/packages/sources/wbtc-address-set/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chainlink/wbtc-address-set-adapter
 
+## 1.4.21
+
+### Patch Changes
+
+- @chainlink/proof-of-reserves-adapter@1.14.1
+
 ## 1.4.20
 
 ### Patch Changes

--- a/packages/sources/wbtc-address-set/CHANGELOG.md
+++ b/packages/sources/wbtc-address-set/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chainlink/wbtc-address-set-adapter
 
+## 1.4.22
+
+### Patch Changes
+
+- @chainlink/proof-of-reserves-adapter@1.14.2
+
 ## 1.4.21
 
 ### Patch Changes

--- a/packages/sources/wbtc-address-set/package.json
+++ b/packages/sources/wbtc-address-set/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/wbtc-address-set-adapter",
-  "version": "1.4.20",
+  "version": "1.4.21",
   "description": "Chainlink adapter to query wBTC address set.",
   "keywords": [
     "Chainlink",

--- a/packages/sources/wbtc-address-set/package.json
+++ b/packages/sources/wbtc-address-set/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/wbtc-address-set-adapter",
-  "version": "1.4.21",
+  "version": "1.4.22",
   "description": "Chainlink adapter to query wBTC address set.",
   "keywords": [
     "Chainlink",


### PR DESCRIPTION
## Changelog

### Breaking Changes
- Updated input parameters of the `por-address-list` adapters to include required chainId and network

### Bug Fixes & Minor Changes
- Fixed errors experienced in the `proof-of-reserves` adapter when using `por-address-list` as protocol due to missing chainId and network
- Removed input vs. output length check from the `eth-beacon` adapter

### Notable Adapter Updates
|    Adapter    | Version | Description |
| :-----------: | :-----: | :---------: |
| eth-beacon | v1.1.1 | Removed input vs. output length check |
| por-address-list  | v4.0.0  | Added new required network and chainId params |