### PR TITLE
Fix/Readme generator issue

### DIFF
--- a/.github/workflows/generate-readmes.yml
+++ b/.github/workflows/generate-readmes.yml
@@ -22,8 +22,8 @@ jobs:
           yarn lint-staged
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git commit --amend --no-edit
-          git push --force
+          git commit -m "Generated README(s)"
+          git push
           echo "README(s) generated successfully."
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Closes SC-54826

## Description

Removed commit amend and force push during the readme generator. It was causing issues with the branch history but also wanted to use safer commands for the automated process.

## Changes

- Changed the generated readme commit to be a separate one in consume changeset
- Removed force push since it was no longer needed 

## Steps to Test

1. Trigger github actions on the consume changeset PR to run the readme generator action
2. Validate results

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
