### PR TITLE
Update Kaiko default params

### DIFF
--- a/.changeset/eighty-kangaroos-draw.md
+++ b/.changeset/eighty-kangaroos-draw.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/kaiko-adapter': patch
+---
+
+Update config defaults to enable more reliable prices

--- a/packages/sources/kaiko/src/endpoint/trades.ts
+++ b/packages/sources/kaiko/src/endpoint/trades.ts
@@ -47,7 +47,7 @@ export const inputParameters: InputParameters<TInputParameters> = {
     required: false,
     description:
       'Number of milliseconds from the current time that will determine start_time to use in the query',
-    default: 86400000,// 24 hours
+    default: 86_400_000, // 24 hours
   },
   sort: {
     required: false,

--- a/packages/sources/kaiko/src/endpoint/trades.ts
+++ b/packages/sources/kaiko/src/endpoint/trades.ts
@@ -41,13 +41,13 @@ export const inputParameters: InputParameters<TInputParameters> = {
     required: false,
     description:
       'The time interval to use in the query. NOTE: Changing this will likely require changing `millisecondsAgo` accordingly',
-    default: '1m',
+    default: '2m',
   },
   millisecondsAgo: {
     required: false,
     description:
       'Number of milliseconds from the current time that will determine start_time to use in the query',
-    default: 1800000,
+    default: 86400000,// 24 hours
   },
   sort: {
     required: false,


### PR DESCRIPTION
## Closes #[28637](https://app.shortcut.com/chainlinklabs/story/28637/unsupported-pairs-on-kaiko-ea)

## Description
Update Kaiko defaults to avoid situation where there are not enough trades to fetch a recent price.

## Changes
- Update default interval to be `2m`
- Update default time window to be `24 hours` instead of `30 minutes`

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test
1. Run adapter with usual config
2. Query for problematic pairs, such as `MIM/USD` and `ETH/CRO`

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
