### PR TITLE
Add pre-commit hook to test for staged npm tokens

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,8 @@
 . "$(dirname "$0")/_/husky.sh"
 
 yarn lint-staged
+
+
+# Check for npm tokens and block commits if found
+! git diff --cached --name-only \
+| xargs -r -I {} sh -c 'echo "Checking {}" && grep -q -E "npm_[A-Za-z0-9]{36}" {} && echo "NPM token found in file {} staged for commit, remove it!"'


### PR DESCRIPTION
Script to reproduce and test behavior:
```bash
# Write a file with an npm token in it
echo 'npm_123456789012345678901234567890123456' > bad_file.txt
git add bad_file.txt

# Attempt to commit
git commit -m 'Super safe commit, surely!' # Will fail because the hook will find the token

# Remove the leaked content
echo 'actually safe content' > bad_file.txt

# Now the commit actually goes through
git commit -m 'Thank you preemptive measures'
```

Screenshot of this in action:
![image](https://user-images.githubusercontent.com/5432103/198446755-5e2ba233-fa34-457d-abf1-41660c3e34f7.png)
