### PR TITLE
Bug/TradingEconomics crypto pair overrides

### DIFF
--- a/.changeset/unlucky-worms-perform.md
+++ b/.changeset/unlucky-worms-perform.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/tradingeconomics-adapter': patch
+---
+
+Added crypto pair overrides

--- a/packages/sources/tradingeconomics/src/config/includes.json
+++ b/packages/sources/tradingeconomics/src/config/includes.json
@@ -119,5 +119,55 @@
         "inverse": true
       }
     ]
+  },
+  {
+    "from": "BTC",
+    "to": "USD",
+    "includes": [
+      {
+        "from": "BTCUSD:CUR",
+        "to": ""
+      }
+    ]
+  },
+  {
+    "from": "ETH",
+    "to": "USD",
+    "includes": [
+      {
+        "from": "ETHUSD:CUR",
+        "to": ""
+      }
+    ]
+  },
+  {
+    "from": "LTC",
+    "to": "USD",
+    "includes": [
+      {
+        "from": "LTCUSD:CUR",
+        "to": ""
+      }
+    ]
+  },
+  {
+    "from": "BNB",
+    "to": "USD",
+    "includes": [
+      {
+        "from": "BNBUSD:CUR",
+        "to": ""
+      }
+    ]
+  },
+  {
+    "from": "XMR",
+    "to": "USD",
+    "includes": [
+      {
+        "from": "XMRUSD:CUR",
+        "to": ""
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## Closes [PDI-95](https://smartcontract-it.atlassian.net/browse/PDI-95)

## Description

Added missing crypto pair overrides. Fixed issue where the `tradingeconomics` adapter was not returning data for crypto.

## Changes

- Added overrides for `BTC`,`ETH`,`LTC`,`BNB`, and `XMR`

## Steps to Test

1. yarn test packages/sources/tradingeconomics/test/unit
2. yarn test packages/sources/tradingeconomics/test/integration

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
