### PR TITLE
Chore/Spammy layer2 sequencer health log

### DIFF
--- a/.changeset/many-seahorses-smile.md
+++ b/.changeset/many-seahorses-smile.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/layer2-sequencer-health-adapter': patch
+---
+
+Changed spammy missing endpoint log to debug

--- a/packages/sources/layer2-sequencer-health/src/adapter.ts
+++ b/packages/sources/layer2-sequencer-health/src/adapter.ts
@@ -1,11 +1,11 @@
-import { Builder } from '@chainlink/ea-bootstrap'
+import { Builder, Logger } from '@chainlink/ea-bootstrap'
 import {
   ExecuteWithConfig,
   ExecuteFactory,
   AdapterRequest,
   APIEndpoint,
 } from '@chainlink/ea-bootstrap'
-import { ExtendedConfig, makeConfig } from './config'
+import { ExtendedConfig, HEALTH_ENDPOINTS, makeConfig, Networks } from './config'
 import * as endpoints from './endpoint'
 
 export const execute: ExecuteWithConfig<ExtendedConfig, endpoints.TInputParameters> = async (
@@ -31,5 +31,10 @@ export const endpointSelector = (
   )
 
 export const makeExecute: ExecuteFactory<ExtendedConfig, endpoints.TInputParameters> = (config) => {
+  // Disclaimer on startup
+  Object.keys(HEALTH_ENDPOINTS).forEach((network) => {
+    if (!HEALTH_ENDPOINTS[network as Networks]?.endpoint)
+      Logger.info(`Health endpoint not available for network: ${network}`)
+  })
   return async (request, context) => execute(request, context, config || makeConfig())
 }

--- a/packages/sources/layer2-sequencer-health/src/network.ts
+++ b/packages/sources/layer2-sequencer-health/src/network.ts
@@ -41,7 +41,6 @@ export const checkSequencerHealth: NetworkHealthCheck = async (
   network: Networks,
 ): Promise<undefined | boolean> => {
   if (!HEALTH_ENDPOINTS[network]?.endpoint) {
-    Logger.debug(`Health endpoint not available for network: ${network}`)
     return
   }
   const response = await Requester.request({

--- a/packages/sources/layer2-sequencer-health/src/network.ts
+++ b/packages/sources/layer2-sequencer-health/src/network.ts
@@ -41,7 +41,7 @@ export const checkSequencerHealth: NetworkHealthCheck = async (
   network: Networks,
 ): Promise<undefined | boolean> => {
   if (!HEALTH_ENDPOINTS[network]?.endpoint) {
-    Logger.info(`Health endpoint not available for network: ${network}`)
+    Logger.debug(`Health endpoint not available for network: ${network}`)
     return
   }
   const response = await Requester.request({


### PR DESCRIPTION
## Closes [PDI-103](https://smartcontract-it.atlassian.net/browse/PDI-103)

## Description

`layer2-sequencer-health` logs when a health endpoint is missing for the network. For Arbitrum, this is expected behavior causing NOPs to get spammed in the logs for every call for this network. The log statement was moved to on-startup to alleviate the spam.

## Changes

- Moved unavailable endpoint log to startup

## Steps to Test

1. Start the `layer2-sequencer-health` adapter
2. Notice ```Health endpoint not available for network:``` log for `arbitrum` and `starkware` 
3. Send a request for the `arbitrum` or `starkware` network
4. Check to make sure the log is not printing on request

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
