### PR TITLE
Update stader-address-list 

### DIFF
--- a/.changeset/smart-cherries-sin.md
+++ b/.changeset/smart-cherries-sin.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/stader-address-list-adapter': minor
+---
+
+Update Görli contract address & change to 0 indexed lookup of validators

--- a/packages/sources/stader-address-list/src/endpoint/address.ts
+++ b/packages/sources/stader-address-list/src/endpoint/address.ts
@@ -12,7 +12,7 @@ type NetworkChainMap = { [network: string]: { [chain: string]: string } }
 const staderNetworkChainMap: NetworkChainMap = {
   ethereum: {
     mainnet: '',
-    goerli: '0x50FD3384783EE49011E7b57d7A3430a762b3f3F2',
+    goerli: '0x00eA010E050Ba28976059241B2cF558b96D1d2B7',
   },
 }
 

--- a/packages/sources/stader-address-list/src/utils.ts
+++ b/packages/sources/stader-address-list/src/utils.ts
@@ -25,7 +25,7 @@ export const fetchAddressList = async (
     const fetchAddresses = async (index: number) =>
       addressManager.validatorsRegistry(index, { blockTag })
     const response = await Promise.all<validatorsRegistryResponse>(
-      new Array(numAddresses.toNumber()).fill(0).map((_, i) => fetchAddresses(i + 1)),
+      new Array(numAddresses.toNumber()).fill(0).map((_, i) => fetchAddresses(i)),
     )
     return response.map(([pubKey, registrationStatus]) => ({
       address: pubKey,

--- a/packages/sources/stader-address-list/test/integration/adapter.test.ts
+++ b/packages/sources/stader-address-list/test/integration/adapter.test.ts
@@ -36,9 +36,7 @@ jest.mock('ethers', () => {
       Contract: function () {
         return {
           validatorCount: jest.fn().mockReturnValue(mockAddressListLength),
-          validatorsRegistry: jest
-            .fn()
-            .mockImplementation((index) => mockExpectedAddresses[index - 1]), // 1 indexed instead of 0 indexed
+          validatorsRegistry: jest.fn().mockImplementation((index) => mockExpectedAddresses[index]),
         }
       },
     },


### PR DESCRIPTION
## Closes sc-56420

## Description
Update Stader Address List adapter

## Changes
- update Görli contract address (to proxy address, yay!)
- change to 0 indexed lookup of validators

## Steps to Test

1. `yarn test packages/sources/stader-address-list/test/integration/adapter.test.ts`
2. Notice, snapshots unchanged.

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
