### PR TITLE
Fix/CFBenchmarks overrides and caching bugs

### DIFF
--- a/.changeset/nine-parents-give.md
+++ b/.changeset/nine-parents-give.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/cfbenchmarks-test-adapter': patch
+---
+
+Fixed overrides and caching issues

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -4563,7 +4563,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./packages/sources/cfbenchmarks-test/",\
           "packageDependencies": [\
             ["@chainlink/cfbenchmarks-test-adapter", "workspace:packages/sources/cfbenchmarks-test"],\
-            ["@chainlink/external-adapter-framework", "npm:0.11.0"],\
+            ["@chainlink/external-adapter-framework", "npm:0.11.1"],\
             ["@types/jest", "npm:27.5.2"],\
             ["@types/node", "npm:16.11.51"],\
             ["@types/supertest", "npm:2.0.12"],\

--- a/packages/sources/cfbenchmarks-test/package.json
+++ b/packages/sources/cfbenchmarks-test/package.json
@@ -28,7 +28,7 @@
     "start": "yarn server:dist"
   },
   "dependencies": {
-    "@chainlink/external-adapter-framework": "0.11.0",
+    "@chainlink/external-adapter-framework": "0.11.1",
     "tslib": "2.4.1"
   },
   "devDependencies": {

--- a/packages/sources/cfbenchmarks-test/src/endpoint/common/crypto.ts
+++ b/packages/sources/cfbenchmarks-test/src/endpoint/common/crypto.ts
@@ -57,15 +57,11 @@ export const additionalInputValidation = ({ index, base, quote }: Params): void 
 export const cryptoRequestTransform = (req: AdapterRequest<RequestParams>): void => {
   // TODO: Move additional input validations to proper location after framework supports it
   additionalInputValidation(req.requestContext.data)
-  if (req.requestContext.data.index) {
-    // If an id was given, clear base quote to ensure an exact match in the cache
-    delete req.requestContext.data.base
-    delete req.requestContext.data.quote
-  } else {
+  if (!req.requestContext.data.index) {
     const isSecondary = process.env.API_SECONDARY
     const type = isSecondary ? 'secondary' : 'primary'
     // If there is no index set
-    // we know that base and quote exist from the extra validation in the routing handler
+    // we know that base and quote exist from the extra input validation above
     // coerce to strings
     req.requestContext.data.index = getIdFromBaseQuote(
       req.requestContext.data.base as string,
@@ -73,6 +69,9 @@ export const cryptoRequestTransform = (req: AdapterRequest<RequestParams>): void
       type,
     )
   }
+  // Clear base quote to ensure an exact match in the cache with index
+  delete req.requestContext.data.base
+  delete req.requestContext.data.quote
 }
 
 export const routingTransport = new RoutingTransport(

--- a/packages/sources/cfbenchmarks-test/src/endpoint/websocket/crypto.ts
+++ b/packages/sources/cfbenchmarks-test/src/endpoint/websocket/crypto.ts
@@ -27,10 +27,7 @@ export const makeWsTransport = (
   type: 'primary' | 'secondary',
 ): WebSocketTransport<WsEndpointTypes> => {
   return new WebSocketTransport<WsEndpointTypes>({
-    url: ({
-      adapterConfig: { WS_API_ENDPOINT, DEFAULT_WS_API_ENDPOINT, SECONDARY_WS_API_ENDPOINT },
-    }) => {
-      if (WS_API_ENDPOINT) return WS_API_ENDPOINT
+    url: ({ adapterConfig: { DEFAULT_WS_API_ENDPOINT, SECONDARY_WS_API_ENDPOINT } }) => {
       return type === 'primary' ? DEFAULT_WS_API_ENDPOINT : SECONDARY_WS_API_ENDPOINT
     },
 

--- a/packages/sources/cfbenchmarks-test/src/utils.ts
+++ b/packages/sources/cfbenchmarks-test/src/utils.ts
@@ -27,11 +27,17 @@ const buildIdOverrideFromBaseQuote = (
 const idOverrideFromBaseQuote: IdToBaseQuoteLookup =
   buildIdOverrideFromBaseQuote(overridenBaseQuoteFromId)
 
-export const overrideId = (base: string, quote: string): string | undefined =>
-  idOverrideFromBaseQuote[base][quote]
+export const overrideId = (base: string, quote: string): string | undefined => {
+  const baseOverride = idOverrideFromBaseQuote[base]
+  if (baseOverride) {
+    return baseOverride[quote]
+  } else {
+    return undefined
+  }
+}
 
-export const getPrimaryId = (base: string, quote: string): string => `${base}/${quote}_RTI`
-export const getSecondaryId = (base: string, quote: string): string => `U_${base}/${quote}_RTI`
+export const getPrimaryId = (base: string, quote: string): string => `${base}${quote}_RTI`
+export const getSecondaryId = (base: string, quote: string): string => `U_${base}${quote}_RTI`
 
 export const getIdFromBaseQuote = (
   base: string,

--- a/packages/sources/cfbenchmarks-test/test/integration/adapter.test.ts
+++ b/packages/sources/cfbenchmarks-test/test/integration/adapter.test.ts
@@ -79,7 +79,7 @@ describe('websocket', () => {
     process.env['CACHE_POLLING_MAX_RETRIES'] = '0'
     process.env['METRICS_ENABLED'] = 'false'
     process.env['WS_ENABLED'] = 'true'
-    process.env['WS_API_ENDPOINT'] = wsEndpoint
+    process.env['DEFAULT_WS_API_ENDPOINT'] = wsEndpoint
     process.env['API_USERNAME'] = 'fake-api-username'
     process.env['API_PASSWORD'] = 'fake-api-password'
 

--- a/packages/sources/cfbenchmarks-test/test/unit/adapter.test.ts
+++ b/packages/sources/cfbenchmarks-test/test/unit/adapter.test.ts
@@ -1,0 +1,50 @@
+import { getIdFromBaseQuote } from '../../src/utils'
+
+describe('getIdFromBaseQuote', () => {
+  const tests: {
+    name: string
+    input: { data: { base: string; quote: string } }
+    output: string
+    useSecondary: boolean
+  }[] = [
+    {
+      name: 'uses base/quote if present',
+      input: { data: { base: 'ETH', quote: 'USD' } },
+      output: 'ETHUSD_RTI',
+      useSecondary: false,
+    },
+    {
+      name: 'uses aliases base/quote if present',
+      input: { data: { base: 'USDT', quote: 'USD' } },
+      output: 'USDTUSD_RTI',
+      useSecondary: false,
+    },
+    {
+      name: 'maps BTC/USD quote BRTI',
+      input: { data: { base: 'BTC', quote: 'USD' } },
+      output: 'BRTI',
+      useSecondary: false,
+    },
+    {
+      name: 'maps SOL/USD quote SOLUSD_RTI if not using secondary endpoint',
+      input: { data: { base: 'SOL', quote: 'USD' } },
+      output: 'SOLUSD_RTI',
+      useSecondary: false,
+    },
+    {
+      name: 'maps SOL/USD quote U_SOLUSD_RTI if using secondary endpoint',
+      input: { data: { base: 'SOL', quote: 'USD' } },
+      output: 'U_SOLUSD_RTI',
+      useSecondary: true,
+    },
+  ]
+
+  tests.forEach((test) => {
+    it(`${test.name}`, async () => {
+      const type = test.useSecondary ? 'secondary' : 'primary'
+      expect(getIdFromBaseQuote(test.input.data.base, test.input.data.quote, type)).toEqual(
+        test.output,
+      )
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2130,7 +2130,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@chainlink/cfbenchmarks-test-adapter@workspace:packages/sources/cfbenchmarks-test"
   dependencies:
-    "@chainlink/external-adapter-framework": 0.11.0
+    "@chainlink/external-adapter-framework": 0.11.1
     "@types/jest": 27.5.2
     "@types/node": 16.11.51
     "@types/supertest": 2.0.12


### PR DESCRIPTION
## Closes [PDI-90](https://smartcontract-it.atlassian.net/browse/PDI-90)

## Description

Fixed issue with overrides erroring out when base did not exist in map. Fixed issue where requests with base/quote couldn't find answers in the cache due to the extra fields in the cache key.

## Changes

- Added null check when pulling overrides for a base prior to querying for quote
- Delete base and quote from request context when setting
- Bumped framework version and made required fixes

## Steps to Test

1. yarn test packages/sources/cfbenchmarks-test/test/unit/adapter.test.ts
2. yarn test packages/sources/cfbenchmarks-test/test/integration/adapter.test.ts

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
