### PR TITLE
Prevent IDE metadata to be committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ coverage
 cl-adapter-*
 packages/k6/src/config/ws.json
 packages/k6/src/config/http.json
+
+# IDE metadata
+.vscode
+.idea


### PR DESCRIPTION
Prevent adding IDE metadata with these entries in `.gitignore`