### PR TITLE
Eth Beacon - Swallow 404s

### DIFF
--- a/.changeset/chatty-tips-heal.md
+++ b/.changeset/chatty-tips-heal.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/eth-beacon-adapter': minor
+---
+
+When queried with status, invalid validators return a 0 balance instead of erroring

--- a/packages/sources/eth-beacon/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/eth-beacon/test/integration/__snapshots__/adapter.test.ts.snap
@@ -29,3 +29,32 @@ Object {
   "statusCode": 200,
 }
 `;
+
+exports[`execute balance api should return success with validator that is not on the beacon chain 1`] = `
+Object {
+  "data": Object {
+    "result": Array [
+      Object {
+        "address": "0x8bdb63ea991f42129d6defa8d3cc5926108232c89824ad50d57f49a0310de73e81e491eae6587bd1465fa5fd8e4dee21",
+        "balance": "32081209325",
+      },
+      Object {
+        "address": "0xb672b5976879c6423ad484ba4fa0e76069684eed8e2a8081f6730907f3618d43828d1b399d2fd22d7961824594f73462",
+        "balance": "32067790944",
+      },
+    ],
+  },
+  "jobRunID": "1",
+  "result": Array [
+    Object {
+      "address": "0x8bdb63ea991f42129d6defa8d3cc5926108232c89824ad50d57f49a0310de73e81e491eae6587bd1465fa5fd8e4dee21",
+      "balance": "32081209325",
+    },
+    Object {
+      "address": "0xb672b5976879c6423ad484ba4fa0e76069684eed8e2a8081f6730907f3618d43828d1b399d2fd22d7961824594f73462",
+      "balance": "32067790944",
+    },
+  ],
+  "statusCode": 200,
+}
+`;

--- a/packages/sources/eth-beacon/test/integration/adapter.test.ts
+++ b/packages/sources/eth-beacon/test/integration/adapter.test.ts
@@ -1,7 +1,7 @@
 import { AdapterRequest } from '@chainlink/ea-bootstrap'
 import { SuperTest, Test } from 'supertest'
 import { server as startServer } from '../../src'
-import { mockBalanceSuccess } from './fixtures'
+import { mockBalanceSuccess, mockBalanceWithStatusSuccess } from './fixtures'
 import { setupExternalAdapterTest, SuiteContext } from '@chainlink/ea-test-helpers/dist'
 import process from 'process'
 
@@ -20,24 +20,58 @@ describe('execute', () => {
   setupExternalAdapterTest(envVariables, context)
 
   describe('balance api', () => {
-    const data: AdapterRequest = {
-      id,
-      data: {
-        result: [
-          {
-            address:
-              '0x8bdb63ea991f42129d6defa8d3cc5926108232c89824ad50d57f49a0310de73e81e491eae6587bd1465fa5fd8e4dee21',
-          },
-          {
-            address:
-              '0xb672b5976879c6423ad484ba4fa0e76069684eed8e2a8081f6730907f3618d43828d1b399d2fd22d7961824594f73462',
-          },
-        ],
-      },
-    }
-
     it('should return success', async () => {
+      const data: AdapterRequest = {
+        id,
+        data: {
+          result: [
+            {
+              address:
+                '0x8bdb63ea991f42129d6defa8d3cc5926108232c89824ad50d57f49a0310de73e81e491eae6587bd1465fa5fd8e4dee21',
+            },
+            {
+              address:
+                '0xb672b5976879c6423ad484ba4fa0e76069684eed8e2a8081f6730907f3618d43828d1b399d2fd22d7961824594f73462',
+            },
+          ],
+        },
+      }
+
       mockBalanceSuccess()
+
+      const response = await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+      expect(response.body).toMatchSnapshot()
+    })
+
+    it('should return success with validator that is not on the beacon chain', async () => {
+      const data: AdapterRequest = {
+        id,
+        data: {
+          result: [
+            {
+              address:
+                '0x8bdb63ea991f42129d6defa8d3cc5926108232c89824ad50d57f49a0310de73e81e491eae6587bd1465fa5fd8e4dee21',
+            },
+            {
+              address:
+                '0xb672b5976879c6423ad484ba4fa0e76069684eed8e2a8081f6730907f3618d43828d1b399d2fd22d7961824594f73462',
+            },
+            {
+              address:
+                '0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+            },
+          ],
+          validatorStatus: ['active'],
+        },
+      }
+
+      mockBalanceWithStatusSuccess()
 
       const response = await (context.req as SuperTest<Test>)
         .post('/')

--- a/packages/sources/eth-beacon/test/integration/fixtures.ts
+++ b/packages/sources/eth-beacon/test/integration/fixtures.ts
@@ -25,3 +25,92 @@ export const mockBalanceSuccess = (): nock.Scope =>
         'Wed, 21 Sep 2022 10:58:34 GMT',
       ],
     )
+
+export const mockBalanceWithStatusSuccess = (): void => {
+  nock('http://localhost:3500', { encodedQueryParams: true })
+    .get(
+      '/eth/v1/beacon/states/finalized/validators/0x8bdb63ea991f42129d6defa8d3cc5926108232c89824ad50d57f49a0310de73e81e491eae6587bd1465fa5fd8e4dee21',
+    )
+    .reply(
+      200,
+      {
+        execution_optimistic: true,
+        data: {
+          index: '416512',
+          balance: '32081209325',
+          status: 'active',
+          validator: {
+            pubkey:
+              '0x8bdb63ea991f42129d6defa8d3cc5926108232c89824ad50d57f49a0310de73e81e491eae6587bd1465fa5fd8e4dee21',
+            withdrawal_credentials: '',
+            effective_balance: '32081209325',
+            slashed: false,
+            activation_eligibility_epoch: '',
+            activation_epoch: '',
+            exit_epoch: '',
+            withdrawable_epoch: '',
+          },
+        },
+      },
+      [
+        'content-type',
+        'application/json',
+        'server',
+        'Lighthouse/v3.1.0-aa022f4/x86_64-linux',
+        'content-length',
+        '124',
+        'date',
+        'Wed, 21 Sep 2022 10:58:34 GMT',
+      ],
+    )
+  nock('http://localhost:3500', { encodedQueryParams: true })
+    .get(
+      '/eth/v1/beacon/states/finalized/validators/0xb672b5976879c6423ad484ba4fa0e76069684eed8e2a8081f6730907f3618d43828d1b399d2fd22d7961824594f73462',
+    )
+    .reply(
+      200,
+      {
+        execution_optimistic: true,
+        data: {
+          index: '416580',
+          balance: '32067790944',
+          status: 'active',
+          validator: {
+            pubkey:
+              '0xb672b5976879c6423ad484ba4fa0e76069684eed8e2a8081f6730907f3618d43828d1b399d2fd22d7961824594f73462',
+            withdrawal_credentials: '',
+            effective_balance: '32067790944',
+            slashed: false,
+            activation_eligibility_epoch: '',
+            activation_epoch: '',
+            exit_epoch: '',
+            withdrawable_epoch: '',
+          },
+        },
+      },
+      [
+        'content-type',
+        'application/json',
+        'server',
+        'Lighthouse/v3.1.0-aa022f4/x86_64-linux',
+        'content-length',
+        '124',
+        'date',
+        'Wed, 21 Sep 2022 10:58:34 GMT',
+      ],
+    )
+  nock('http://localhost:3500', { encodedQueryParams: true })
+    .get(
+      '/eth/v1/beacon/states/finalized/validators/0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+    )
+    .reply(404, {}, [
+      'content-type',
+      'application/json',
+      'server',
+      'Lighthouse/v3.1.0-aa022f4/x86_64-linux',
+      'content-length',
+      '124',
+      'date',
+      'Wed, 21 Sep 2022 10:58:34 GMT',
+    ])
+}


### PR DESCRIPTION
## Description
Changes behavior of `eth-beacon` to swallow errors when a validator address cannot be found.

## Steps to Test
`yarn test packages/sources/eth-beacon/test/integration/adapter.test.ts`

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
