### PR TITLE
Fix/pre commit exit first failure

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,9 +1,13 @@
-#!/bin/sh
+#!/bin/bash
 . "$(dirname "$0")/_/husky.sh"
 
 yarn lint-staged
 
-
-# Check for npm tokens and block commits if found
-! git diff --cached --name-only \
-| xargs -n 1 -r -I {} sh -c 'echo "Checking {}" && grep -q -E "npm_[A-Za-z0-9]{36}" {} && echo "NPM token found in file {} staged for commit, remove it!" || exit 255'
+for line in $(git diff --cached --name-only)
+do
+  # Check for npm tokens and block commits if found
+  if grep -qiE "npm_[A-Za-z0-9]{36}" "$line"; then
+    echo "NPM token found in file \"$line\" staged for commit, remove it!"
+    exit 1
+  fi
+done


### PR DESCRIPTION
Fixes [PDI-151](https://smartcontract-it.atlassian.net/browse/PDI-151).

Original implementation with xargs would continue on error. If the last of the staged files **didn't** trigger the npm token check, then the script would exit with 0. The fix is to get xargs to abort with exit 255, but this approach isn't foolproof since the exit command succeeds so xargs will still exit with 0.

Rather than tweak xargs, esp since the command is long and you don't get syntax checking in a string, I made the script instead run a for loop, which should have comparable performance while reliably exiting when an npm token is detected.

No changeset because this is internal

To test this script:
```bash
touch a.txt && c.txt
echo "npm_0123456789...012345" > b.txt #Can't put the full string here or it'll get flagged
git add a.txt b.txt c.txt
./.husky/pre-commit
```