### PR TITLE
fix/PDI-121 

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -12,22 +12,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Check NPM_AUTH_TOKEN is defined # .yarnrc.yml requires NPM_AUTH_TOKEN to be set as an env var specifically
-      if: ${{ env.NPM_AUTH_TOKEN  == '' }}
-      run: exit 1
-      shell: bash
     - uses: actions/setup-node@v3
       with:
         node-version: 16
     - name: Install yarn
       run: npm i -g yarn
-      shell: bash
-    - run: |
-        yarn config set npmRegistryServer https://registry.npmjs.org/
-        yarn config set npmAlwaysAuth true
-        yarn config set npmAuthToken ${{ env.NPM_AUTH_TOKEN}}
-      shell: bash
-    - run: yarn prettier --write .yarnrc.yml #`yarn config set` strips the newline from .yarnrc.yml, so restore it
       shell: bash
     - name: yarn install
       run: |

--- a/.github/workflows/airtable.yml
+++ b/.github/workflows/airtable.yml
@@ -5,8 +5,7 @@ on:
   push:
     branches:
       - master
-env:
-  NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+
 jobs:
   airtable-generation:
     name: Airtable Master List Generation

--- a/.github/workflows/cleanupAdaptersOnClose.yml
+++ b/.github/workflows/cleanupAdaptersOnClose.yml
@@ -3,8 +3,7 @@ name: Clean up on PR close
 on:
   pull_request:
     types: [closed]
-env:
-  NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+
 jobs:
   cleanup-ephemeral-adapters-on-pr-close:
     name: Cleanup Ephemeral Adapters used for testing

--- a/.github/workflows/consume-changesets.yml
+++ b/.github/workflows/consume-changesets.yml
@@ -4,8 +4,7 @@ on:
   push:
     branches:
       - develop
-env:
-  NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+
 jobs:
   consume-changesets:
     name: Consume changesets

--- a/.github/workflows/generate-readmes.yml
+++ b/.github/workflows/generate-readmes.yml
@@ -4,8 +4,7 @@ on:
   push:
     branches:
       - changeset-release/develop
-env:
-  NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+
 jobs:
   generate-readmes:
     name: Generate READMEs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,8 +11,6 @@ concurrency:
   group: main-${{ github.ref }}
   cancel-in-progress: true
 
-env: # NPM_AUTH_TOKEN is needed for any yarn command. Having it at the top is not precise, but it's convenient
-  NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 jobs:
   packages:
     name: Verify dependency package archives

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,6 @@ on:
 
 env:
   publicecr-name: chainlink
-  NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 jobs:
   matrix-adapters:
     runs-on: ubuntu-latest

--- a/.github/workflows/soakTest.yml
+++ b/.github/workflows/soakTest.yml
@@ -4,9 +4,6 @@ on:
   pull_request: ~
   workflow_dispatch:
 
-env:
-  NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-
 jobs:
   run-soak-tests:
     name: Run Soak Tests Against Changed Adapters

--- a/README.md
+++ b/README.md
@@ -18,15 +18,6 @@ This repository contains the source code for Chainlink external adapters. If you
 - Node.js v16
 - Yarn
 
-### Configure
-
-```sh
-  export NPM_AUTH_TOKEN= #npm token w/ read access to @chainlink scope
-  yarn config set npmRegistryServer https://registry.npmjs.org/
-  yarn config set npmAlwaysAuth true
-  yarn config set npmAuthToken $NPM_AUTH_TOKEN
-```
-
 ### Install
 
 ```sh

--- a/packages/scripts/src/framework/version-bump.sh
+++ b/packages/scripts/src/framework/version-bump.sh
@@ -18,14 +18,6 @@ function bump() (
 
 cd packages
 
-if [[ -z "${NPM_AUTH_TOKEN}" ]]; then
-  echo "The NPM_AUTH_TOKEN variable needs to be set"
-  exit 1
-fi
-
-# This will cause changes to .yarnrc.yml, so we'll need to remove them later
-yarn config set npmAuthToken $NPM_AUTH_TOKEN
-
 if [[ -n "$1" ]]; then
   # Run bump only for one package
   if jq -e 'if (.dependencies."@chainlink/external-adapter-framework" != null) then true else false end' "sources/${1}/package.json" > /dev/null ; then


### PR DESCRIPTION
Fixes [PDI-121](https://smartcontract-it.atlassian.net/browse/PDI-121). The cached dependencies in .yarn contain the EA framework. Although the framework is private, the cached dependency means we don't have to fetch it from NPM, meaning we don't need credentials in CI.

No changeset because this is a CI change