### PR TITLE
Chore/Metrics env var risk mitigations

### DIFF
--- a/.changeset/strong-toes-taste.md
+++ b/.changeset/strong-toes-taste.md
@@ -1,5 +1,7 @@
 ---
-'@chainlink/ea-bootstrap': patch
+'@chainlink/ea-bootstrap': minor
 ---
 
-Applied metrics env var risk mitigations
+Deprecated the METRICS_NAME env var so the app_name label will always use the adapter name. Current users of this env var would notice metric name changes from their unique one.
+Added a warning log when METRICS_ENABLED is set to false.
+Added a log to show the full metrics endpoint on startup rather than just the port number.

--- a/.changeset/strong-toes-taste.md
+++ b/.changeset/strong-toes-taste.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/ea-bootstrap': patch
+---
+
+Applied metrics env var risk mitigations

--- a/packages/core/bootstrap/README.md
+++ b/packages/core/bootstrap/README.md
@@ -280,7 +280,6 @@ When enabled, a metrics endpoint is opened on `/metrics`, which can be prepended
 |           |   `METRICS_ENABLED`    |                          Enables metrics collection.                           |         |   `true`    |
 |           | `METRICS_USE_BASE_URL` | Set to "true" to have the internal metrics endpoint use the supplied base url. |         |   `false`   |
 |           |     `METRICS_PORT`     |                   The port the metrics endpoint is served on                   |         |   `9080`    |
-|           |     `METRICS_NAME`     |                    set to apply a label of to each metric.                     |         |  undefined  |
 
 To run Prometheus and Grafana with development setup:
 

--- a/packages/core/bootstrap/schemas/env.json
+++ b/packages/core/bootstrap/schemas/env.json
@@ -36,9 +36,6 @@
     "METRICS_PORT": {
       "type": "number"
     },
-    "METRICS_NAME": {
-      "type": "string"
-    },
 
     "RATE_LIMIT_ENABLED": {
       "type": "boolean"

--- a/packages/core/bootstrap/src/lib/metrics/index.ts
+++ b/packages/core/bootstrap/src/lib/metrics/index.ts
@@ -13,7 +13,7 @@ export const METRICS_ENABLED = parseBool(
 export const setupMetrics = (name: string): void => {
   client.collectDefaultMetrics()
   client.register.setDefaultLabels({
-    app_name: getEnv('METRICS_NAME') || name || 'N/A',
+    app_name: name || 'N/A',
     app_version: getEnv('npm_package_version'),
   })
 }

--- a/packages/core/bootstrap/src/lib/server.ts
+++ b/packages/core/bootstrap/src/lib/server.ts
@@ -20,6 +20,7 @@ import {
   getClientIp,
   getEnv,
   logEnvVarWarnings,
+  parseBool,
   toObjectWithNumbers,
 } from './util'
 import { Limits } from './config/provider-limits'
@@ -157,7 +158,7 @@ export const initHandler =
 
     return new Promise((resolve) => {
       app.listen(port, eaHost, (_, address) => {
-        logger.info(`Server listening on ${address}!`)
+        logger.info(`Server listening on ${address}`)
         resolve(app)
       })
     })
@@ -168,7 +169,8 @@ function setupMetricsServer(name: string) {
     logger: false,
   })
   const metricsPort = parseInt(getEnv('METRICS_PORT') as string)
-  const endpoint = getEnv('METRICS_USE_BASE_URL') ? join(baseUrl, 'metrics') : '/metrics'
+  const endpoint = parseBool(getEnv('METRICS_USE_BASE_URL')) ? join(baseUrl, 'metrics') : '/metrics'
+  logger.info(`Metrics endpoint: http://${eaHost}:${metricsPort}${endpoint}`)
 
   setupMetrics(name)
 
@@ -177,7 +179,5 @@ function setupMetricsServer(name: string) {
     res.send(await client.register.metrics())
   })
 
-  metricsApp.listen(metricsPort, eaHost, () =>
-    logger.info(`Monitoring listening on port ${metricsPort}!`),
-  )
+  metricsApp.listen(metricsPort, eaHost)
 }

--- a/packages/core/bootstrap/src/lib/util.ts
+++ b/packages/core/bootstrap/src/lib/util.ts
@@ -707,21 +707,28 @@ export const buildCensorList = (): void => {
 // Logs warnings based on env vars to properly inform of risks involved with using particular settings
 export const logEnvVarWarnings = (): void => {
   if (
-    process.env['LOG_LEVEL']?.toUpperCase() === 'DEBUG' ||
-    process.env['LOG_LEVEL']?.toUpperCase() === 'TRACE'
+    getEnv('LOG_LEVEL')?.toUpperCase() === 'DEBUG' ||
+    getEnv('LOG_LEVEL')?.toUpperCase() === 'TRACE'
   ) {
     logger.warn(
-      `LOG_LEVEL has been set to ${process.env[
-        'LOG_LEVEL'
-      ].toUpperCase()}. Setting higher log levels results in increased memory usage and potentially slower performance.`,
+      `LOG_LEVEL has been set to ${getEnv(
+        'LOG_LEVEL',
+      )?.toUpperCase()}. Setting higher log levels results in increased memory usage and potentially slower performance.`,
     )
   }
-  if (process.env['DEBUG'] === 'true') {
+  if (parseBool(getEnv('DEBUG')) === true) {
     logger.warn(`The adapter is running with DEBUG mode on.`)
   }
-  if (process.env['NODE_ENV'] === 'development') {
+  if (getEnv('NODE_ENV') === 'development') {
     logger.warn(
       `The adapter is running with NODE_ENV set to development. YOU SHOULD NOT BE RUNNING THIS IN PRODUCTION!`,
+    )
+  }
+  if (parseBool(getEnv('METRICS_ENABLED')) === false) {
+    logger.warn(
+      `METRICS_ENABLED has been set to ${getEnv(
+        'METRICS_ENABLED',
+      )}. Metrics should not be disabled in a production environment.`,
     )
   }
 }


### PR DESCRIPTION
## Closes [PDI-84](https://smartcontract-it.atlassian.net/browse/PDI-84)

## Description

Applied proposed risk mitigations for metrics env vars

## Changes

- Added warning for `METRICS_ENABLED=false`
- Removed `METRICS_NAME` env var to always set as adapter name
- Added log for full metrics endpoint
- Updated env var warnings logs to use `getEnv` util methods

## Steps to Test

1. Set `METRICS_ENABLED` to `false`
2. Start up any adapter
3. Check that `METRICS_ENABLED` warning shows up

1. Set `METRICS_ENABLED` to `true`
2. Set `METRICS_NAME` to anything other than adapter name
3. Start any adapter
5. Notice log with full metrics endpoint URL
6. Perform a GET call on the URL
7. Notice `app_name` is still the adapter name and not what was set in `METRICS_NAME`
8. Shut down adapter
9. Set `METRICS_USE_BASE_URL` to `true`
10. Set `BASE_URL` to `/test`
11. Start up any adapter
12. Notice full metric endpoint prepends the `BASE_URL` to `/metrics`

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
