### PR TITLE
Elwood v3 subscription error caching

### DIFF
--- a/.changeset/curly-ligers-protect.md
+++ b/.changeset/curly-ligers-protect.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/elwood-test-adapter': minor
+---
+
+Added error caching for failed subscribe/unsubscribe messages

--- a/packages/sources/elwood-test/src/config/index.ts
+++ b/packages/sources/elwood-test/src/config/index.ts
@@ -3,6 +3,7 @@ export const customSettings = {
     description: 'API key',
     type: 'string',
     required: true,
+    sensitive: true,
   },
   WS_API_ENDPOINT: {
     description: 'The websocket url for coinmetrics',

--- a/packages/sources/elwood-test/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/elwood-test/test/integration/__snapshots__/adapter.test.ts.snap
@@ -14,3 +14,14 @@ Object {
   },
 }
 `;
+
+exports[`websocket price endpoint should return cached subscribe error 1`] = `
+Object {
+  "errorMessage": "Symbol is not supported",
+  "statusCode": 400,
+  "timestamps": Object {
+    "providerDataReceived": 1652198967193,
+    "providerDataStreamEstablished": 1652198967193,
+  },
+}
+`;

--- a/packages/sources/elwood-test/test/integration/fixtures.ts
+++ b/packages/sources/elwood-test/test/integration/fixtures.ts
@@ -23,3 +23,25 @@ export const mockUnsubscribeResponse = (apiKey: string) => {
     })
     .reply(200, {}, [])
 }
+
+export const mockSubscribeError = (apiKey: string) => {
+  nock(`https://api.chk.elwood.systems`, { encodedQueryParams: true })
+    .persist()
+    .post(`/v1/stream?apiKey=${apiKey}`, {
+      action: 'subscribe',
+      stream: 'index',
+      symbol: 'XXX-USD',
+      index_freq: 1000,
+    })
+    .reply(400, {
+      error: {
+        code: 400,
+        message: 'Symbol is not supported',
+        errors: [
+          {
+            domain: 'stream',
+          },
+        ],
+      },
+    })
+}


### PR DESCRIPTION
## Closes [PDI-168](https://smartcontract-it.atlassian.net/browse/PDI-168)

## Description

Cache errors when subscribe/unsubscribe messages fail to return more immediate responses rather than polling for every request

## Changes

- Handle subscribe/unsubscribe post request errors and store them in cache

## Steps to Test

1. Start the Elwood v3 adapter
2. Send request for an unsupported pair such as `XXX/USD`
3. After timeout, send the same request again
4. Notice that a response is immediately returned with the error

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
