### PR TITLE
Release v1.47.0 [develop]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/external-adapters-js",
-  "version": "1.46.0",
+  "version": "1.47.0",
   "license": "MIT",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Changelog

### Breaking Changes
- ea-framework/all adapters: Deprecated the METRICS_NAME env var so the app_name label will always use the adapter name. Current users of this env var would notice metric name changes from their unique one.

### Features
- elwood-test: Added error caching for failed subscribe/unsubscribe messages
- gsr-test: Add "crypto" endpoint alias
- eth-beacon: Added smarter batching to improve performance
- ea-framework:
  - Made max payload size configurable with min/max limits
  - Added a warning log when METRICS_ENABLED is set to false.
  - Added a log to show the full metrics endpoint on startup rather than just the port number.

### Bug Fixes
- proof-of-reserves: Updated env vars list in schema
- ncfx-test: Bumped framework version and fixed breaking changes

### Notable Adapter Updates

This release has changes to the framework that changes all adapter versions:

### Composite External Adapters

|                 Package Name                 |  Version  |
| ----------- | :-----: |
|          anchor-adapter           |   4.0.9   |
|        apy-finance-adapter        |  2.0.11   |
|           augur-adapter           |   2.0.9   |
|     bitcoin-json-rpc-adapter      |  1.3.25   |
|        bsol-price-adapter         |  2.2.30   |
|      circuit-breaker-adapter      |  1.2.24   |
|  crypto-volatility-index-adapter  |  1.3.30   |
|        curve-3pool-adapter        |  3.0.11   |
|        defi-dozen-adapter         |  1.2.30   |
|        defi-pulse-adapter         |  1.2.30   |
|     dns-record-check-adapter      |  1.3.25   |
|           dxdao-adapter           |  2.0.11   |
|       dydx-rewards-adapter        |   2.0.9   |
|      google-weather-adapter       |  1.3.17   |
|    historical-average-adapter     |  1.2.27   |
|       implied-price-adapter       |  1.1.17   |
|      linear-finance-adapter       |  2.3.19   |
|      market-closure-adapter       |  1.2.25   |
|        medianizer-adapter         |  1.2.24   |
|           nftx-adapter            |   3.0.9   |
|     outlier-detection-adapter     |  1.2.48   |
|        por-indexer-adapter        |  1.2.33   |
|     proof-of-reserves-adapter     |  1.14.13  |
|    reference-transform-adapter    |  1.2.48   |
|        rocket-pool-adapter        |   1.0.2   |
|        savax-price-adapter        |  3.0.12   |
|      set-token-index-adapter      |  2.0.11   |
|        synth-index-adapter        |  1.2.30   |
|         the-graph-adapter         |  1.2.25   |
|          vesper-adapter           |  2.0.11   |
|       xsushi-price-adapter        |  2.0.11   |


### Source and Target External Adapters
|                 Package Name                 |  Version  |
| ----------- | :-----: |
|          1forge-adapter           |  1.6.26   |
|        accuweather-adapter        |  1.3.25   |
|        ada-balance-adapter        |  2.5.25   |
|          agoric-adapter           |  2.1.25   |
|        alphachain-adapter         |  1.3.25   |
|       alphavantage-adapter        |  1.3.25   |
|          alpine-adapter           |   2.0.0   |
|         amberdata-adapter         |  1.8.18   |
|         anyblock-adapter          |  1.4.25   |
|        ap-election-adapter        |  1.3.25   |
|         armanino-adapter          |  1.0.40   |
|        bank-frick-adapter         |   0.1.1   |
|      bank-frick-test-adapter      |   1.0.1   |
|            bea-adapter            |  1.3.25   |
|          binance-adapter          |  1.4.25   |
|        binance-dex-adapter        |  1.6.17   |
|           bitex-adapter           |  1.5.25   |
|           bitso-adapter           |  1.4.25   |
|      blockchain.com-adapter       |  1.3.25   |
|        blockchair-adapter         |  1.3.25   |
|        blockcypher-adapter        |  1.4.25   |
|     blocksize-capital-adapter     |  1.0.36   |
|        blockstream-adapter        |  1.4.25   |
|            bob-adapter            |   2.0.7   |
|       bravenewcoin-adapter        |  1.3.25   |
|          btc.com-adapter          |  1.3.25   |
|        cache.gold-adapter         |  1.3.25   |
|         ccip-read-adapter         |   3.0.0   |
|   celsius-address-list-adapter    |   2.0.9   |
|       cfbenchmarks-adapter        |  1.5.25   |
|     cfbenchmarks-test-adapter     |   1.0.3   |
|   chain-reserve-wallet-adapter    |   3.0.9   |
|          coinapi-adapter          |  1.3.15   |
|         coinbase-adapter          |   2.0.9   |
|         coincodex-adapter         |  1.3.25   |
|         coingecko-adapter         |  1.9.17   |
|      coingecko-test-adapter       |   1.2.2   |
|         coinlore-adapter          |  1.3.25   |
|       coinmarketcap-adapter       |  1.5.27   |
|        coinmetrics-adapter        |  1.3.25   |
|     coinmetrics-test-adapter      |   1.0.3   |
|        coinpaprika-adapter        |  1.10.17  |
|        coinranking-adapter        |  1.3.17   |
|          conflux-adapter          |  1.1.25   |
|       covid-tracker-adapter       |  1.4.17   |
|          cryptex-adapter          |   2.0.9   |
|        cryptoapis-adapter         |  1.2.25   |
|       cryptoapis-v2-adapter       |  1.2.25   |
|       cryptocompare-adapter       |  1.4.25   |
|    cryptocompare-test-adapter     |   1.0.0   |
|         cryptoid-adapter          |  1.3.25   |
|         cryptomkt-adapter         |  1.3.25   |
|       currencylayer-adapter       |  2.0.17   |
|           curve-adapter           |   2.0.9   |
|          deribit-adapter          |  1.2.25   |
|         dns-query-adapter         |  1.6.17   |
|          dwolla-adapter           |  1.2.25   |
|          dxfeed-adapter           |  1.3.25   |
|     dxfeed-secondary-adapter      |  1.2.25   |
|        dydx-stark-adapter         |  1.1.25   |
|          elwood-adapter           |  1.0.11   |
|        elwood-test-adapter        |   1.1.0   |
|            ens-adapter            |   2.0.9   |
|          enzyme-adapter           |   2.0.9   |
|     eodhistoricaldata-adapter     |  1.3.25   |
|        eth-balance-adapter        |   2.0.9   |
|        eth-beacon-adapter         |   1.3.0   |
|        etherchain-adapter         |  1.4.25   |
|         etherscan-adapter         |  1.3.25   |
|       ethgasstation-adapter       |  1.4.25   |
|        ethgaswatch-adapter        |  1.3.25   |
|         ethwrite-adapter          |   2.0.9   |
|     expert-car-broker-adapter     |  1.3.25   |
|          fcsapi-adapter           |  1.2.25   |
|          finage-adapter           |  1.6.10   |
|          finnhub-adapter          |  1.2.25   |
|           fixer-adapter           |  2.0.17   |
|        flightaware-adapter        |  1.2.25   |
|      fluent-finance-adapter       |   1.1.1   |
|         fmpcloud-adapter          |  1.3.25   |
|          galaxis-adapter          |   4.0.2   |
|          galaxy-adapter           |   1.2.8   |
|        galaxy-test-adapter        |   1.0.2   |
|          gemini-adapter           |  2.2.25   |
|    genesis-volatility-adapter     |  1.3.25   |
|           geodb-adapter           |  1.2.25   |
|      google-bigquery-adapter      |  1.2.25   |
|         gramchain-adapter         |  1.1.25   |
|          graphql-adapter          |  1.2.25   |
|            gsr-adapter            |  1.0.30   |
|         gsr-test-adapter          |   1.0.4   |
|          harmony-adapter          |  1.1.25   |
|         iex-cloud-adapter         |  1.2.25   |
|         intrinio-adapter          |  1.3.25   |
|           ipfs-adapter            |  1.3.25   |
|           jpegd-adapter           |  2.1.25   |
|         json-rpc-adapter          |  1.3.25   |
|           kaiko-adapter           |  1.5.19   |
|  layer2-sequencer-health-adapter  |   2.3.5   |
|            lcx-adapter            |  1.3.25   |
|           lido-adapter            |   2.0.9   |
|         linkpool-adapter          |  1.2.25   |
|          lition-adapter           |  1.2.25   |
|           lotus-adapter           |  2.2.25   |
|        marketstack-adapter        |  1.3.25   |
|          messari-adapter          |  1.2.25   |
|         metalsapi-adapter         |  1.7.25   |
|          mock-ea-adapter          |  2.1.25   |
|        mycryptoapi-adapter        |  1.3.25   |
|           ncfx-adapter            |  2.1.14   |
|         ncfx-test-adapter         |   1.0.2   |
|          nikkei-adapter           |  1.2.25   |
|          nomics-adapter           |  1.3.25   |
|        oilpriceapi-adapter        |  2.1.25   |
|        onchain-gas-adapter        |  1.3.25   |
|     openexchangerates-adapter     |  1.5.19   |
|     orchid-bandwidth-adapter      |  1.2.25   |
|           paxos-adapter           |  1.4.17   |
|          paypal-adapter           |  1.2.25   |
|            poa-adapter            |  1.3.25   |
|          polygon-adapter          |  1.7.12   |
|     por-address-list-adapter      |   4.0.8   |
|     renvm-address-set-adapter     |  1.5.24   |
|       satoshitango-adapter        |  1.3.25   |
|         snowflake-adapter         |  1.2.25   |
|          sochain-adapter          |  1.3.25   |
|   solana-view-function-adapter    |  2.2.25   |
|   spectral-macro-score-adapter    |   2.0.9   |
|       sportsdataio-adapter        |  1.3.17   |
|    stader-address-list-adapter    |   1.2.1   |
|        stader-labs-adapter        |   3.0.2   |
|          stasis-adapter           |  1.2.25   |
|    swell-address-list-adapter     |   1.0.8   |
|    synthetix-debt-pool-adapter    |   4.0.9   |
|           taapi-adapter           |  1.2.25   |
|    terra-view-function-adapter    |  1.3.25   |
|        therundown-adapter         |  1.3.25   |
|          tiingo-adapter           |  1.12.15  |
|        tradermade-adapter         |   1.9.8   |
|     tradingeconomics-adapter      |  2.2.11   |
|          trueusd-adapter          |  1.6.14   |
|        twelvedata-adapter         |  1.2.25   |
|          unibit-adapter           |  1.4.25   |
|        uniswap-v2-adapter         |   2.0.9   |
|        uniswap-v3-adapter         |   2.0.9   |
|          upvest-adapter           |  1.3.25   |
|         uscpi-one-adapter         |  1.3.25   |
|       view-function-adapter       |   2.0.9   |
|     wbtc-address-set-adapter      |  1.4.33   |
|         wootrade-adapter          |  1.2.25   |
|          wrapped-adapter          |  2.2.25   |
|           xbto-adapter            |  1.3.25   |
