### PR TITLE
Blacklisted cvi from soak test

### DIFF
--- a/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts
+++ b/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts
@@ -17,6 +17,7 @@ export const SoakTestBlacklist: string[] = [
   'coinapi',
   'conflux',
   'covid-tracker',
+  'crypto-volatility-index',
   'cryptoapis',
   'defi-pulse',
   'dns-query', // Missing: env vars


### PR DESCRIPTION
## Description

Found soak tests are failing for release PR's due `crypto-volatility-index`. A test payload cannot be generated as shown in the logs below

```
[UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "No test payloads found for crypto-volatility-index adapter".] {
  code: 'ERR_UNHANDLED_REJECTION'
}
Error: Process completed with exit code 1.
```

## Changes

- Added `crypto-volatility-index` to the soak test black list

## Steps to Test

1. Run soak test CI that includes `cvi`
2. Notice soak testing does not fail out anymore

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
