### PR TITLE
Support Quote symbol overrides in Finage WS

### DIFF
--- a/.changeset/silver-llamas-remember.md
+++ b/.changeset/silver-llamas-remember.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/finage-adapter': patch
+---
+
+Add quote override support for Finage WS

--- a/packages/sources/finage/src/adapter.ts
+++ b/packages/sources/finage/src/adapter.ts
@@ -81,7 +81,7 @@ export const makeWSHandler = (config?: Config): MakeWSHandler<Message | any> =>
       )
       if (validator.error) return
       const from = validator.overrideSymbol(NAME, validator.validated.data.base).toUpperCase()
-      const to = validator.validated.data.quote.toUpperCase()
+      const to = validator.overrideSymbol(NAME, validator.validated.data.quote).toUpperCase()
       return `${from}${to}`
     }
 
@@ -94,7 +94,7 @@ export const makeWSHandler = (config?: Config): MakeWSHandler<Message | any> =>
       )
       if (validator.error) return
       const from = validator.overrideSymbol(NAME, validator.validated.data.base).toUpperCase()
-      const to = validator.validated.data.quote.toUpperCase()
+      const to = validator.overrideSymbol(NAME, validator.validated.data.quote).toUpperCase()
       return `${from}/${to}` // Note that this adds the "/", whereas the REST endpoint doesn't use this
     }
     const isForex = (input: AdapterRequest): boolean =>


### PR DESCRIPTION
## Closes [DF-17373](https://smartcontract-it.atlassian.net/browse/DF-17373?atlOrigin=eyJpIjoiMjU2NmFjYzBjYjhjNGMyYTgzY2YxMDI1ZWI0NmQ5MjYiLCJwIjoiaiJ9)

## Description
Add overrides for quote symbols for the Finage EA WS transport.

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [x] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
