### PR TITLE
Remove BASE_URL from accounts endpoint in Bank Frick

### DIFF
--- a/.changeset/small-toes-clap.md
+++ b/.changeset/small-toes-clap.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/bank-frick-test-adapter': patch
+---
+
+accounts and authorize now use the same URL (\$API_ENDPOINT)

--- a/packages/sources/bank-frick-test/src/endpoint/accounts.ts
+++ b/packages/sources/bank-frick-test/src/endpoint/accounts.ts
@@ -93,10 +93,10 @@ export class BankFrickAccountsTransport implements Transport<AccountsEndpointTyp
     _: AdapterInputParameters,
     config: AdapterConfig<typeof customSettings>,
   ): AxiosRequestConfig<BankFrickAccountsRequestSchema> {
-    const { API_ENDPOINT, BASE_URL, PAGE_SIZE } = config
+    const { API_ENDPOINT, PAGE_SIZE } = config
 
     return {
-      baseURL: API_ENDPOINT + BASE_URL,
+      baseURL: API_ENDPOINT,
       url: 'accounts',
       method: 'GET',
       params: {


### PR DESCRIPTION
authorize uses API_ENDPOINT, accounts uses API_ENDPOINT+BASE_URL. They should use the same URL. The v2 adapter uses API_ENDPOINT for both (but the config variable is unfortunately named "BASE_URL" in v2). This restores the v2 behavior.

A NOP using a base url of /bank-frick hit this issue.