### PR TITLE
[PDI-146] Avalanche Platform Chain adapter for PoR

### DIFF
--- a/.changeset/pink-oranges-relax.md
+++ b/.changeset/pink-oranges-relax.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/avalanche-platform-adapter': major
+---
+
+Initial version of the adapter

--- a/.changeset/warm-olives-eat.md
+++ b/.changeset/warm-olives-eat.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/proof-of-reserves-adapter': minor
+---
+
+Added support for the avalanche-platform balance adapter

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -7030,6 +7030,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@chainlink/proof-of-reserves-adapter", "workspace:packages/composites/proof-of-reserves"],\
             ["@chainlink/ada-balance-adapter", "workspace:packages/sources/ada-balance"],\
             ["@chainlink/amberdata-adapter", "workspace:packages/sources/amberdata"],\
+            ["@chainlink/avalanche-platform-adapter", "workspace:packages/sources/avalanche-platform"],\
             ["@chainlink/bitcoin-json-rpc-adapter", "workspace:packages/composites/bitcoin-json-rpc"],\
             ["@chainlink/blockchain.com-adapter", "workspace:packages/sources/blockchain.com"],\
             ["@chainlink/blockchair-adapter", "workspace:packages/sources/blockchair"],\

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -237,6 +237,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         "reference": "workspace:packages/sources/armanino"\
       },\
       {\
+        "name": "@chainlink/avalanche-platform-adapter",\
+        "reference": "workspace:packages/sources/avalanche-platform"\
+      },\
+      {\
         "name": "@chainlink/bank-frick-adapter",\
         "reference": "workspace:packages/sources/bank-frick"\
       },\
@@ -818,6 +822,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
       ["@chainlink/apy-finance-adapter", ["workspace:packages/composites/apy-finance"]],\
       ["@chainlink/armanino-adapter", ["workspace:packages/sources/armanino"]],\
       ["@chainlink/augur-adapter", ["workspace:packages/composites/augur"]],\
+      ["@chainlink/avalanche-platform-adapter", ["workspace:packages/sources/avalanche-platform"]],\
       ["@chainlink/bank-frick-adapter", ["workspace:packages/sources/bank-frick"]],\
       ["@chainlink/bea-adapter", ["workspace:packages/sources/bea"]],\
       ["@chainlink/binance-adapter", ["workspace:packages/sources/binance"]],\
@@ -4170,6 +4175,24 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "linkType": "SOFT"\
         }]\
       ]],\
+      ["@chainlink/avalanche-platform-adapter", [\
+        ["workspace:packages/sources/avalanche-platform", {\
+          "packageLocation": "./packages/sources/avalanche-platform/",\
+          "packageDependencies": [\
+            ["@chainlink/avalanche-platform-adapter", "workspace:packages/sources/avalanche-platform"],\
+            ["@chainlink/ea-bootstrap", "workspace:packages/core/bootstrap"],\
+            ["@chainlink/ea-test-helpers", "workspace:packages/core/test-helpers"],\
+            ["@types/jest", "npm:27.5.2"],\
+            ["@types/node", "npm:16.11.51"],\
+            ["@types/supertest", "npm:2.0.12"],\
+            ["nock", "npm:13.2.9"],\
+            ["supertest", "npm:6.2.4"],\
+            ["tslib", "npm:2.4.0"],\
+            ["typescript", "patch:typescript@npm%3A4.7.4#~builtin<compat/typescript>::version=4.7.4&hash=a1c5e5"]\
+          ],\
+          "linkType": "SOFT"\
+        }]\
+      ]],\
       ["@chainlink/bank-frick-adapter", [\
         ["workspace:packages/sources/bank-frick", {\
           "packageLocation": "./packages/sources/bank-frick/",\
@@ -5303,6 +5326,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@chainlink/anyblock-adapter", "workspace:packages/sources/anyblock"],\
             ["@chainlink/ap-election-adapter", "workspace:packages/sources/ap-election"],\
             ["@chainlink/armanino-adapter", "workspace:packages/sources/armanino"],\
+            ["@chainlink/avalanche-platform-adapter", "workspace:packages/sources/avalanche-platform"],\
             ["@chainlink/bank-frick-adapter", "workspace:packages/sources/bank-frick"],\
             ["@chainlink/bea-adapter", "workspace:packages/sources/bea"],\
             ["@chainlink/binance-adapter", "workspace:packages/sources/binance"],\

--- a/packages/composites/proof-of-reserves/package.json
+++ b/packages/composites/proof-of-reserves/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@chainlink/ada-balance-adapter": "workspace:*",
     "@chainlink/amberdata-adapter": "workspace:*",
+    "@chainlink/avalanche-platform-adapter": "workspace:*",
     "@chainlink/bitcoin-json-rpc-adapter": "workspace:*",
     "@chainlink/blockchain.com-adapter": "workspace:*",
     "@chainlink/blockchair-adapter": "workspace:*",

--- a/packages/composites/proof-of-reserves/src/utils/balance.ts
+++ b/packages/composites/proof-of-reserves/src/utils/balance.ts
@@ -21,6 +21,7 @@ import * as lotus from '@chainlink/lotus-adapter'
 import * as ethBalance from '@chainlink/eth-balance-adapter'
 import * as adaBalance from '@chainlink/ada-balance-adapter'
 import * as ethBeacon from '@chainlink/eth-beacon-adapter'
+import * as avalanchePlatform from '@chainlink/avalanche-platform-adapter'
 
 // TODO: type
 export const adapters: AdapterImplementation[] = [
@@ -37,6 +38,7 @@ export const adapters: AdapterImplementation[] = [
   ethBalance as unknown as AdapterImplementation,
   adaBalance as unknown as AdapterImplementation,
   ethBeacon as unknown as AdapterImplementation,
+  avalanchePlatform as unknown as AdapterImplementation,
 ]
 
 export type Indexer = typeof adapters[number]['NAME']

--- a/packages/composites/proof-of-reserves/tsconfig.json
+++ b/packages/composites/proof-of-reserves/tsconfig.json
@@ -12,6 +12,7 @@
     { "path": "../../core/test-helpers" },
     { "path": "../../sources/ada-balance" },
     { "path": "../../sources/amberdata" },
+    { "path": "../../sources/avalanche-platform" },
     { "path": "../../sources/blockchain.com" },
     { "path": "../../sources/blockchair" },
     { "path": "../../sources/blockcypher" },

--- a/packages/core/legos/package.json
+++ b/packages/core/legos/package.json
@@ -39,6 +39,7 @@
     "@chainlink/anyblock-adapter": "workspace:*",
     "@chainlink/ap-election-adapter": "workspace:*",
     "@chainlink/armanino-adapter": "workspace:*",
+    "@chainlink/avalanche-platform-adapter": "workspace:*",
     "@chainlink/bank-frick-adapter": "workspace:*",
     "@chainlink/bea-adapter": "workspace:*",
     "@chainlink/binance-adapter": "workspace:*",

--- a/packages/core/legos/src/sources.ts
+++ b/packages/core/legos/src/sources.ts
@@ -8,6 +8,7 @@ import * as amberdata from '@chainlink/amberdata-adapter'
 import * as anyblock from '@chainlink/anyblock-adapter'
 import * as ap_election from '@chainlink/ap-election-adapter'
 import * as armanino from '@chainlink/armanino-adapter'
+import * as avalanche_platform from '@chainlink/avalanche-platform-adapter'
 import * as bank_frick from '@chainlink/bank-frick-adapter'
 import * as bea from '@chainlink/bea-adapter'
 import * as binance from '@chainlink/binance-adapter'
@@ -157,6 +158,7 @@ export default {
   anyblock,
   ap_election,
   armanino,
+  avalanche_platform,
   bank_frick,
   bea,
   binance,

--- a/packages/core/legos/tsconfig.json
+++ b/packages/core/legos/tsconfig.json
@@ -41,6 +41,9 @@
       "path": "../../sources/armanino"
     },
     {
+      "path": "../../sources/avalanche-platform"
+    },
+    {
       "path": "../../sources/bank-frick"
     },
     {

--- a/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts
+++ b/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts
@@ -8,6 +8,7 @@ export const SoakTestBlacklist: string[] = [
   'ap-election',
   'apy-finance', // Missing: Needs registry address, source adapters
   'augur',
+  'avalanche-platform',
   'bea',
   'bitcoin-json-rpc', // Missing: RPC URL
   'blockcypher',

--- a/packages/sources/avalanche-platform/CHANGELOG.md
+++ b/packages/sources/avalanche-platform/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @chainlink/avalanche-platform-adapter

--- a/packages/sources/avalanche-platform/README.md
+++ b/packages/sources/avalanche-platform/README.md
@@ -1,0 +1,3 @@
+# Chainlink External Adapter for Avalanche-platform
+
+This README will be generated automatically when code is merged to `develop`. If you would like to generate a preview of the README, please run `yarn generate:readme <ADAPTER_NAME>`.

--- a/packages/sources/avalanche-platform/package.json
+++ b/packages/sources/avalanche-platform/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@chainlink/avalanche-platform-adapter",
+  "version": "0.0.0",
+  "description": "Chainlink Avalanche Platform adapter.",
+  "keywords": [
+    "Chainlink",
+    "LINK",
+    "blockchain",
+    "oracle",
+    "avalanche-platform"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "url": "https://github.com/smartcontractkit/external-adapters-js",
+    "type": "git"
+  },
+  "license": "MIT",
+  "scripts": {
+    "clean": "rm -rf dist && rm -f tsconfig.tsbuildinfo",
+    "prepack": "yarn build",
+    "build": "tsc -b",
+    "server": "node -e 'require(\"./index.js\").server()'",
+    "server:dist": "node -e 'require(\"./dist/index.js\").server()'",
+    "start": "yarn server:dist"
+  },
+  "dependencies": {
+    "@chainlink/ea-bootstrap": "workspace:*",
+    "@chainlink/ea-test-helpers": "workspace:*",
+    "tslib": "^2.3.1"
+  },
+  "devDependencies": {
+    "@types/jest": "27.5.2",
+    "@types/node": "16.11.51",
+    "@types/supertest": "2.0.12",
+    "nock": "13.2.9",
+    "supertest": "6.2.4",
+    "typescript": "4.7.4"
+  }
+}

--- a/packages/sources/avalanche-platform/schemas/env.json
+++ b/packages/sources/avalanche-platform/schemas/env.json
@@ -2,12 +2,12 @@
   "$id": "https://external-adapters.chainlinklabs.com/schemas/example-source-adapter.json",
   "title": "Example Source Adapter",
   "description": "Example Source Adapter (this title and description were pulled from source/schemas/env.json)",
-  "required": ["RPC_URL"],
+  "required": ["P_CHAIN_RPC_URL"],
   "type": "object",
   "properties": {
-    "RPC_URL": {
+    "P_CHAIN_RPC_URL": {
       "type": "string",
-      "description": "RPC URL for the avalanche platform chain",
+      "description": "Full RPC URL for the avalanche platform chain",
       "required": true
     }
   },

--- a/packages/sources/avalanche-platform/schemas/env.json
+++ b/packages/sources/avalanche-platform/schemas/env.json
@@ -7,7 +7,7 @@
   "properties": {
     "P_CHAIN_RPC_URL": {
       "type": "string",
-      "description": "Full RPC URL for the avalanche platform chain (e.g. http://localhost:5000/ext/bc/p)",
+      "description": "Full RPC URL for the avalanche platform chain (e.g. https://api.avax.network/ext/bc/P)",
       "required": true
     }
   },

--- a/packages/sources/avalanche-platform/schemas/env.json
+++ b/packages/sources/avalanche-platform/schemas/env.json
@@ -1,13 +1,13 @@
 {
-  "$id": "https://external-adapters.chainlinklabs.com/schemas/example-source-adapter.json",
-  "title": "Example Source Adapter",
-  "description": "Example Source Adapter (this title and description were pulled from source/schemas/env.json)",
+  "$id": "https://external-adapters.chainlinklabs.com/schemas/avalanche-platform-adapter.json",
+  "title": "Avalanche Platform Adapter",
+  "description": "Chainlink External adapter for reading from the Avalanche Platform chain's API",
   "required": ["P_CHAIN_RPC_URL"],
   "type": "object",
   "properties": {
     "P_CHAIN_RPC_URL": {
       "type": "string",
-      "description": "Full RPC URL for the avalanche platform chain",
+      "description": "Full RPC URL for the avalanche platform chain (e.g. http://localhost:5000/ext/bc/p)",
       "required": true
     }
   },

--- a/packages/sources/avalanche-platform/schemas/env.json
+++ b/packages/sources/avalanche-platform/schemas/env.json
@@ -1,0 +1,19 @@
+{
+  "$id": "https://external-adapters.chainlinklabs.com/schemas/example-source-adapter.json",
+  "title": "Example Source Adapter",
+  "description": "Example Source Adapter (this title and description were pulled from source/schemas/env.json)",
+  "required": ["RPC_URL"],
+  "type": "object",
+  "properties": {
+    "RPC_URL": {
+      "type": "string",
+      "description": "RPC URL for the avalanche platform chain",
+      "required": true
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://external-adapters.chainlinklabs.com/schemas/ea-bootstrap.json"
+    }
+  ]
+}

--- a/packages/sources/avalanche-platform/src/adapter.ts
+++ b/packages/sources/avalanche-platform/src/adapter.ts
@@ -1,0 +1,32 @@
+import { Builder } from '@chainlink/ea-bootstrap'
+import {
+  Config,
+  ExecuteWithConfig,
+  ExecuteFactory,
+  AdapterRequest,
+  APIEndpoint,
+} from '@chainlink/ea-bootstrap'
+import { makeConfig } from './config'
+import * as endpoints from './endpoint' // The endpoints must be exported as shown in endpoint/index.ts for README generation.
+
+export const execute: ExecuteWithConfig<Config, endpoints.TInputParameters> = async (
+  request,
+  context,
+  config,
+) => {
+  return Builder.buildSelector<Config, endpoints.TInputParameters>(
+    request,
+    context,
+    config,
+    endpoints,
+  )
+}
+
+export const endpointSelector = (
+  request: AdapterRequest,
+): APIEndpoint<Config, endpoints.TInputParameters> =>
+  Builder.selectEndpoint<Config, endpoints.TInputParameters>(request, makeConfig(), endpoints)
+
+export const makeExecute: ExecuteFactory<Config, endpoints.TInputParameters> = (config) => {
+  return async (request, context) => execute(request, context, config || makeConfig())
+}

--- a/packages/sources/avalanche-platform/src/adapter.ts
+++ b/packages/sources/avalanche-platform/src/adapter.ts
@@ -7,7 +7,7 @@ import {
   APIEndpoint,
 } from '@chainlink/ea-bootstrap'
 import { makeConfig } from './config'
-import * as endpoints from './endpoint' // The endpoints must be exported as shown in endpoint/index.ts for README generation.
+import * as endpoints from './endpoint'
 
 export const execute: ExecuteWithConfig<Config, endpoints.TInputParameters> = async (
   request,

--- a/packages/sources/avalanche-platform/src/config/index.ts
+++ b/packages/sources/avalanche-platform/src/config/index.ts
@@ -4,10 +4,10 @@ import { Config } from '@chainlink/ea-bootstrap'
 export const NAME = 'AVALANCHE_PLATFORM'
 
 export const DEFAULT_ENDPOINT = 'balance'
-export const ENV_RPC_URL = 'RPC_URL'
+export const ENV_P_CHAIN_RPC_URL = 'P_CHAIN_RPC_URL'
 
 export const makeConfig = (prefix?: string): Config => {
-  const rpcURL = util.getRequiredEnv(ENV_RPC_URL, prefix)
+  const rpcURL = util.getRequiredEnv(ENV_P_CHAIN_RPC_URL, prefix)
   const defaultConfig = Requester.getDefaultConfig(prefix)
   return {
     ...defaultConfig,

--- a/packages/sources/avalanche-platform/src/config/index.ts
+++ b/packages/sources/avalanche-platform/src/config/index.ts
@@ -1,0 +1,20 @@
+import { Requester, util } from '@chainlink/ea-bootstrap'
+import { Config } from '@chainlink/ea-bootstrap'
+
+export const NAME = 'AVALANCHE_PLATFORM'
+
+export const DEFAULT_ENDPOINT = 'balance'
+export const ENV_RPC_URL = 'RPC_URL'
+
+export const makeConfig = (prefix?: string): Config => {
+  const rpcURL = util.getRequiredEnv(ENV_RPC_URL, prefix)
+  const defaultConfig = Requester.getDefaultConfig(prefix)
+  return {
+    ...defaultConfig,
+    api: {
+      ...defaultConfig.api,
+      baseURL: rpcURL,
+    },
+    defaultEndpoint: DEFAULT_ENDPOINT,
+  }
+}

--- a/packages/sources/avalanche-platform/src/endpoint/balance.ts
+++ b/packages/sources/avalanche-platform/src/endpoint/balance.ts
@@ -115,10 +115,8 @@ const queryPlatformChain = async (
   addresses: Address[],
   field: string,
 ) => {
-  const url = '/ext/bc/P'
   const options: AxiosRequestConfig = {
     ...config.api,
-    url,
     method: 'POST',
     data: {
       jsonrpc: '2.0',

--- a/packages/sources/avalanche-platform/src/endpoint/balance.ts
+++ b/packages/sources/avalanche-platform/src/endpoint/balance.ts
@@ -1,0 +1,156 @@
+import {
+  Config,
+  Validator,
+  Requester,
+  AdapterInputError,
+  AxiosRequestConfig,
+} from '@chainlink/ea-bootstrap'
+import type { ExecuteWithConfig, InputParameters } from '@chainlink/ea-bootstrap'
+
+export const supportedEndpoints = ['balance']
+
+export const description =
+  'The balance endpoint will fetch the validator balance of each address in the query. Adapts the response for the Proof of Reserves adapter.'
+
+enum Field {
+  STAKE_AMOUNT = 'stakeAmount',
+  POTENTIAL_REWARD = 'potentialReward',
+}
+
+export type TInputParameters = { addresses: Address[]; field: string }
+export const inputParameters: InputParameters<TInputParameters> = {
+  addresses: {
+    aliases: ['result'],
+    required: true,
+    type: 'array',
+    description:
+      'An array of addresses to get the balances of (as an object with string `address` as an attribute)',
+  },
+  field: {
+    required: true,
+    type: 'string',
+    description: 'The field that should be returned in the results',
+    options: Object.values(Field),
+  },
+}
+
+type Address = {
+  address: string
+}
+
+export const execute: ExecuteWithConfig<Config> = async (request, _, config) => {
+  const validator = new Validator(request, inputParameters)
+
+  const jobRunID = validator.validated.id
+  const addresses = validator.validated.data.addresses as Address[]
+  const field = validator.validated.data.field
+
+  if (!Array.isArray(addresses) || addresses.length === 0) {
+    throw new AdapterInputError({
+      jobRunID,
+      message: `Input, at 'addresses' or 'result' path, must be a non-empty array.`,
+      statusCode: 400,
+    })
+  }
+
+  return await queryPlatformChain(jobRunID, config, addresses, field)
+}
+
+interface ResponseSchema {
+  result: {
+    validators: ValidatorState[]
+  }
+}
+
+interface ValidatorState {
+  txID: string
+  startTime: string
+  endTime: string
+  stakeAmount: string
+  nodeID: string
+  weight: string
+  validationRewardOwner: {
+    locktime: string
+    threshold: string
+    addresses: string[]
+  }
+  delegationRewardOwner: {
+    locktime: string
+    threshold: string
+    addresses: string[]
+  }
+  potentialReward: string
+  delegationFee: string
+  uptime: string
+  connected: boolean
+  signer: {
+    publicKey: string
+    proofOfPosession: string
+  }
+  delegators: Delegator[]
+}
+
+interface Delegator {
+  txID: string
+  startTime: string
+  endTime: string
+  stakeAmount: string
+  nodeID: string
+  rewardOwner: {
+    locktime: string
+    threshold: string
+    addresses: string[]
+  }
+  potentialReward: string
+}
+
+interface BalanceResponse {
+  address: string
+  balance: string
+}
+
+const queryPlatformChain = async (
+  jobRunID: string,
+  config: Config,
+  addresses: Address[],
+  field: string,
+) => {
+  const url = '/ext/bc/P'
+  const options: AxiosRequestConfig = {
+    ...config.api,
+    url,
+    method: 'POST',
+    data: {
+      jsonrpc: '2.0',
+      method: 'platform.getCurrentValidators',
+      params: { nodeIDs: addresses.map(({ address }) => address) },
+      id: jobRunID,
+    },
+  }
+
+  const response = await Requester.request<ResponseSchema>(options)
+  const balances: BalanceResponse[] = []
+
+  if (field === Field.STAKE_AMOUNT) {
+    response.data.result.validators.forEach((validator) => {
+      balances.push({ address: validator.nodeID, balance: validator.stakeAmount })
+    })
+  } else if (field === Field.POTENTIAL_REWARD) {
+    const today = new Date().setHours(0, 0, 0, 0)
+    response.data.result.validators.forEach((validator) => {
+      // Filter result by endTime > today as per requirements
+      // endTime is returned in seconds, convert to miliseconds before comparison
+      if (new Date(Number(validator.endTime) * 1000).getTime() > today) {
+        balances.push({ address: validator.nodeID, balance: validator.potentialReward })
+      }
+    })
+  }
+
+  const result = {
+    data: {
+      validators: response.data.result.validators,
+      result: balances,
+    },
+  }
+  return Requester.success(jobRunID, result, config.verbose)
+}

--- a/packages/sources/avalanche-platform/src/endpoint/index.ts
+++ b/packages/sources/avalanche-platform/src/endpoint/index.ts
@@ -1,0 +1,5 @@
+import type { TInputParameters as ExampleInputParameters } from './balance'
+
+export type TInputParameters = ExampleInputParameters
+
+export * as balance from './balance'

--- a/packages/sources/avalanche-platform/src/endpoint/index.ts
+++ b/packages/sources/avalanche-platform/src/endpoint/index.ts
@@ -1,5 +1,5 @@
-import type { TInputParameters as ExampleInputParameters } from './balance'
+import type { TInputParameters as BalanceInputParameters } from './balance'
 
-export type TInputParameters = ExampleInputParameters
+export type TInputParameters = BalanceInputParameters
 
 export * as balance from './balance'

--- a/packages/sources/avalanche-platform/src/index.ts
+++ b/packages/sources/avalanche-platform/src/index.ts
@@ -1,0 +1,9 @@
+import { expose } from '@chainlink/ea-bootstrap'
+import { makeExecute, endpointSelector } from './adapter'
+import * as endpoints from './endpoint'
+import { makeConfig, NAME } from './config'
+
+const adapterContext = { name: NAME }
+
+const { server } = expose(adapterContext, makeExecute(), undefined, endpointSelector)
+export { NAME, makeExecute, makeConfig, server, endpoints }

--- a/packages/sources/avalanche-platform/test-payload.json
+++ b/packages/sources/avalanche-platform/test-payload.json
@@ -1,0 +1,10 @@
+{
+ "requests": [{
+    "result": [
+      {
+        "address": "NodeID-4gPY8c21HFsLjRm3nCUS3KA8WZsEsqEKC"
+      }
+    ],
+    "field": "stakeAmount"
+  }]
+}

--- a/packages/sources/avalanche-platform/test/e2e/balance.test.ts
+++ b/packages/sources/avalanche-platform/test/e2e/balance.test.ts
@@ -17,10 +17,9 @@ describe('execute', () => {
           data: {
             addresses: [
               {
-                address: 'NodeID-4gPY8c21HFsLjRm3nCUS3KA8WZsEsqEKC',
+                address: 'P-fuji1vd9sddlllrlk9fvj9lhntpw8t00lmvtnqkl2jt',
               },
             ],
-            field: 'stakeAmount',
           },
         },
       },
@@ -31,10 +30,9 @@ describe('execute', () => {
           data: {
             addresses: [
               {
-                address: 'NodeID-4gPY8c21HFsLjRm3nCUS3KA8WZsEsqEKC',
+                address: 'P-fuji1vd9sddlllrlk9fvj9lhntpw8t00lmvtnqkl2jt',
               },
             ],
-            field: 'stakeAmount',
           },
         },
       },
@@ -45,13 +43,12 @@ describe('execute', () => {
           data: {
             result: [
               {
-                address: 'NodeID-4gPY8c21HFsLjRm3nCUS3KA8WZsEsqEKC',
+                address: 'P-fuji1vd9sddlllrlk9fvj9lhntpw8t00lmvtnqkl2jt',
               },
               {
-                address: 'NodeID-F823qVX3w3sVb6EWKnTFvfhnmTCCX91gX',
+                address: 'P-fuji1wycv8n7d2fg9aq6unp23pnj4q0arv03ysya8jw',
               },
             ],
-            field: 'stakeAmount',
           },
         },
       },

--- a/packages/sources/avalanche-platform/test/e2e/balance.test.ts
+++ b/packages/sources/avalanche-platform/test/e2e/balance.test.ts
@@ -1,0 +1,88 @@
+import { assertSuccess, validationErrors } from '@chainlink/ea-test-helpers'
+import { AdapterRequest, Execute } from '@chainlink/ea-bootstrap'
+import { makeExecute } from '../../src'
+import { TInputParameters } from '../../src/endpoint'
+
+jest.setTimeout(30000)
+
+describe('execute', () => {
+  const jobID = '1'
+  const execute = makeExecute()
+
+  describe('successful calls', () => {
+    const requests = [
+      {
+        name: 'id not supplied',
+        testData: {
+          data: {
+            addresses: [
+              {
+                address: 'NodeID-4gPY8c21HFsLjRm3nCUS3KA8WZsEsqEKC',
+              },
+            ],
+            field: 'stakeAmount',
+          },
+        },
+      },
+      {
+        name: 'single address supplied',
+        testData: {
+          id: jobID,
+          data: {
+            addresses: [
+              {
+                address: 'NodeID-4gPY8c21HFsLjRm3nCUS3KA8WZsEsqEKC',
+              },
+            ],
+            field: 'stakeAmount',
+          },
+        },
+      },
+      {
+        name: 'multiple addresses supplied',
+        testData: {
+          id: jobID,
+          data: {
+            result: [
+              {
+                address: 'NodeID-4gPY8c21HFsLjRm3nCUS3KA8WZsEsqEKC',
+              },
+              {
+                address: 'NodeID-F823qVX3w3sVb6EWKnTFvfhnmTCCX91gX',
+              },
+            ],
+            field: 'stakeAmount',
+          },
+        },
+      },
+    ]
+
+    requests.forEach((req) => {
+      it(`${req.name}`, async () => {
+        const data = await execute(req.testData as AdapterRequest<TInputParameters>, {})
+        assertSuccess({ expected: 200, actual: data.statusCode }, data, jobID)
+        expect(data.result?.toString().length).toBeGreaterThan(0)
+        expect(data.result?.toString().length).toBeGreaterThan(0)
+      })
+    })
+  })
+
+  describe('error calls', () => {
+    validationErrors(
+      [
+        { name: 'empty body', testData: {} },
+        {
+          name: 'empty addresses',
+          testData: {
+            id: jobID,
+            data: {
+              endpoint: 'balance',
+              result: [],
+            },
+          },
+        },
+      ],
+      execute as Execute,
+    )
+  })
+})

--- a/packages/sources/avalanche-platform/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/avalanche-platform/test/integration/__snapshots__/adapter.test.ts.snap
@@ -35,7 +35,7 @@ Object {
     "result": Array [
       Object {
         "address": "NodeID-4gPY8c21HFsLjRm3nCUS3KA8WZsEsqEKC",
-        "balance": "2000000000",
+        "balance": "182188941",
       }
     ],
   },
@@ -43,7 +43,7 @@ Object {
   "result": Array [
     Object {
       "address": "NodeID-4gPY8c21HFsLjRm3nCUS3KA8WZsEsqEKC",
-      "balance": "2000000000",
+      "balance": "182188941",
     }
   ],
   "statusCode": 200,

--- a/packages/sources/avalanche-platform/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/avalanche-platform/test/integration/__snapshots__/adapter.test.ts.snap
@@ -5,45 +5,20 @@ Object {
   "data": Object {
     "result": Array [
       Object {
-        "address": "NodeID-4gPY8c21HFsLjRm3nCUS3KA8WZsEsqEKC",
-        "balance": "2000000000",
-      },
-      Object {
-        "address": "NodeID-F823qVX3w3sVb6EWKnTFvfhnmTCCX91gX",
-        "balance": "1009000000",
+        "addresses": Array [
+          "P-fuji1vd9sddlllrlk9fvj9lhntpw8t00lmvtnqkl2jt",
+        ],
+        "balance": "1606136960057",
       },
     ],
   },
   "jobRunID": "1",
   "result": Array [
     Object {
-      "address": "NodeID-4gPY8c21HFsLjRm3nCUS3KA8WZsEsqEKC",
-      "balance": "2000000000",
-    },
-    Object {
-      "address": "NodeID-F823qVX3w3sVb6EWKnTFvfhnmTCCX91gX",
-      "balance": "1009000000",
-    },
-  ],
-  "statusCode": 200,
-}
-`;
-
-exports[`execute balance api (potentialReward) should return success 1`] = `
-Object {
-  "data": Object {
-    "result": Array [
-      Object {
-        "address": "NodeID-4gPY8c21HFsLjRm3nCUS3KA8WZsEsqEKC",
-        "balance": "182188941",
-      },
-    ],
-  },
-  "jobRunID": "1",
-  "result": Array [
-    Object {
-      "address": "NodeID-4gPY8c21HFsLjRm3nCUS3KA8WZsEsqEKC",
-      "balance": "182188941",
+      "addresses": Array [
+        "P-fuji1vd9sddlllrlk9fvj9lhntpw8t00lmvtnqkl2jt",
+      ],
+      "balance": "1606136960057",
     },
   ],
   "statusCode": 200,

--- a/packages/sources/avalanche-platform/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/avalanche-platform/test/integration/__snapshots__/adapter.test.ts.snap
@@ -1,0 +1,51 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`execute balance api (stakeAmount) should return success 1`] = `
+Object {
+  "data": Object {
+    "result": Array [
+      Object {
+        "address": "NodeID-4gPY8c21HFsLjRm3nCUS3KA8WZsEsqEKC",
+        "balance": "2000000000",
+      },
+      Object {
+        "address": "NodeID-F823qVX3w3sVb6EWKnTFvfhnmTCCX91gX",
+        "balance": "1009000000",
+      },
+    ],
+  },
+  "jobRunID": "1",
+  "result": Array [
+    Object {
+      "address": "NodeID-4gPY8c21HFsLjRm3nCUS3KA8WZsEsqEKC",
+      "balance": "2000000000",
+    },
+    Object {
+      "address": "NodeID-F823qVX3w3sVb6EWKnTFvfhnmTCCX91gX",
+      "balance": "1009000000",
+    },
+  ],
+  "statusCode": 200,
+}
+`;
+
+exports[`execute balance api (potentialReward) should return success 1`] = `
+Object {
+  "data": Object {
+    "result": Array [
+      Object {
+        "address": "NodeID-4gPY8c21HFsLjRm3nCUS3KA8WZsEsqEKC",
+        "balance": "2000000000",
+      }
+    ],
+  },
+  "jobRunID": "1",
+  "result": Array [
+    Object {
+      "address": "NodeID-4gPY8c21HFsLjRm3nCUS3KA8WZsEsqEKC",
+      "balance": "2000000000",
+    }
+  ],
+  "statusCode": 200,
+}
+`;

--- a/packages/sources/avalanche-platform/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/avalanche-platform/test/integration/__snapshots__/adapter.test.ts.snap
@@ -36,7 +36,7 @@ Object {
       Object {
         "address": "NodeID-4gPY8c21HFsLjRm3nCUS3KA8WZsEsqEKC",
         "balance": "182188941",
-      }
+      },
     ],
   },
   "jobRunID": "1",
@@ -44,7 +44,7 @@ Object {
     Object {
       "address": "NodeID-4gPY8c21HFsLjRm3nCUS3KA8WZsEsqEKC",
       "balance": "182188941",
-    }
+    },
   ],
   "statusCode": 200,
 }

--- a/packages/sources/avalanche-platform/test/integration/adapter.test.ts
+++ b/packages/sources/avalanche-platform/test/integration/adapter.test.ts
@@ -1,0 +1,79 @@
+import { AdapterRequest } from '@chainlink/ea-bootstrap'
+import { SuperTest, Test } from 'supertest'
+import { server as startServer } from '../../src'
+import { mockBalanceSuccess } from './fixtures'
+import { setupExternalAdapterTest, SuiteContext } from '@chainlink/ea-test-helpers'
+import process from 'process'
+
+describe('execute', () => {
+  const id = '1'
+  const context: SuiteContext = {
+    req: null,
+    server: startServer,
+  }
+
+  const envVariables = {
+    CACHE_ENABLED: 'false',
+    ETHEREUM_RPC_URL: process.env.ETHEREUM_RPC_URL || 'http://localhost:3500',
+  }
+
+  setupExternalAdapterTest(envVariables, context)
+
+  describe('balance api', () => {
+    it('(stakeAmount) should return success', async () => {
+      const data: AdapterRequest = {
+        id,
+        data: {
+          result: [
+            {
+              address: 'NodeID-4gPY8c21HFsLjRm3nCUS3KA8WZsEsqEKC',
+            },
+            {
+              address: 'NodeID-F823qVX3w3sVb6EWKnTFvfhnmTCCX91gX',
+            },
+          ],
+          field: 'stakeAmount',
+        },
+      }
+
+      mockBalanceSuccess()
+
+      const response = await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+      expect(response.body).toMatchSnapshot()
+    })
+
+    it('(potentialReward) should return success', async () => {
+      const data: AdapterRequest = {
+        id,
+        data: {
+          result: [
+            {
+              address: 'NodeID-4gPY8c21HFsLjRm3nCUS3KA8WZsEsqEKC',
+            },
+            {
+              address: 'NodeID-F823qVX3w3sVb6EWKnTFvfhnmTCCX91gX',
+            },
+          ],
+          field: 'potentialReward',
+        },
+      }
+
+      mockBalanceSuccess()
+
+      const response = await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+      expect(response.body).toMatchSnapshot()
+    })
+  })
+})

--- a/packages/sources/avalanche-platform/test/integration/adapter.test.ts
+++ b/packages/sources/avalanche-platform/test/integration/adapter.test.ts
@@ -1,9 +1,8 @@
 import { AdapterRequest } from '@chainlink/ea-bootstrap'
 import { SuperTest, Test } from 'supertest'
 import { server as startServer } from '../../src'
-import { mockBalanceSuccess } from './fixtures'
+import { mockPotentialRewardSuccess, mockStakeAmountSuccess } from './fixtures'
 import { setupExternalAdapterTest, SuiteContext } from '@chainlink/ea-test-helpers'
-import process from 'process'
 
 describe('execute', () => {
   const id = '1'
@@ -15,7 +14,7 @@ describe('execute', () => {
   const envVariables = {
     METRICS_ENABLED: 'false',
     CACHE_ENABLED: 'false',
-    RPC_URL: process.env.RPC_URL || 'http://localhost:3500',
+    P_CHAIN_RPC_URL: 'http://localhost:3500/ext/bc/P',
   }
 
   setupExternalAdapterTest(envVariables, context)
@@ -37,7 +36,7 @@ describe('execute', () => {
         },
       }
 
-      mockBalanceSuccess()
+      mockStakeAmountSuccess()
 
       const response = await (context.req as SuperTest<Test>)
         .post('/')
@@ -65,7 +64,7 @@ describe('execute', () => {
         },
       }
 
-      mockBalanceSuccess()
+      mockPotentialRewardSuccess()
 
       const response = await (context.req as SuperTest<Test>)
         .post('/')

--- a/packages/sources/avalanche-platform/test/integration/adapter.test.ts
+++ b/packages/sources/avalanche-platform/test/integration/adapter.test.ts
@@ -13,8 +13,9 @@ describe('execute', () => {
   }
 
   const envVariables = {
+    METRICS_ENABLED: 'false',
     CACHE_ENABLED: 'false',
-    ETHEREUM_RPC_URL: process.env.ETHEREUM_RPC_URL || 'http://localhost:3500',
+    RPC_URL: process.env.RPC_URL || 'http://localhost:3500',
   }
 
   setupExternalAdapterTest(envVariables, context)

--- a/packages/sources/avalanche-platform/test/integration/adapter.test.ts
+++ b/packages/sources/avalanche-platform/test/integration/adapter.test.ts
@@ -26,41 +26,9 @@ describe('execute', () => {
         data: {
           result: [
             {
-              address: 'NodeID-4gPY8c21HFsLjRm3nCUS3KA8WZsEsqEKC',
-            },
-            {
-              address: 'NodeID-F823qVX3w3sVb6EWKnTFvfhnmTCCX91gX',
+              address: 'P-fuji1vd9sddlllrlk9fvj9lhntpw8t00lmvtnqkl2jt',
             },
           ],
-          field: 'stakeAmount',
-        },
-      }
-
-      mockBalanceSuccess()
-
-      const response = await (context.req as SuperTest<Test>)
-        .post('/')
-        .send(data)
-        .set('Accept', '*/*')
-        .set('Content-Type', 'application/json')
-        .expect('Content-Type', /json/)
-        .expect(200)
-      expect(response.body).toMatchSnapshot()
-    })
-
-    it('(potentialReward) should return success', async () => {
-      const data: AdapterRequest = {
-        id,
-        data: {
-          result: [
-            {
-              address: 'NodeID-4gPY8c21HFsLjRm3nCUS3KA8WZsEsqEKC',
-            },
-            {
-              address: 'NodeID-F823qVX3w3sVb6EWKnTFvfhnmTCCX91gX',
-            },
-          ],
-          field: 'potentialReward',
         },
       }
 

--- a/packages/sources/avalanche-platform/test/integration/adapter.test.ts
+++ b/packages/sources/avalanche-platform/test/integration/adapter.test.ts
@@ -1,7 +1,7 @@
 import { AdapterRequest } from '@chainlink/ea-bootstrap'
 import { SuperTest, Test } from 'supertest'
 import { server as startServer } from '../../src'
-import { mockPotentialRewardSuccess, mockStakeAmountSuccess } from './fixtures'
+import { mockBalanceSuccess } from './fixtures'
 import { setupExternalAdapterTest, SuiteContext } from '@chainlink/ea-test-helpers'
 
 describe('execute', () => {
@@ -36,7 +36,7 @@ describe('execute', () => {
         },
       }
 
-      mockStakeAmountSuccess()
+      mockBalanceSuccess()
 
       const response = await (context.req as SuperTest<Test>)
         .post('/')
@@ -64,7 +64,7 @@ describe('execute', () => {
         },
       }
 
-      mockPotentialRewardSuccess()
+      mockBalanceSuccess()
 
       const response = await (context.req as SuperTest<Test>)
         .post('/')

--- a/packages/sources/avalanche-platform/test/integration/fixtures.ts
+++ b/packages/sources/avalanche-platform/test/integration/fixtures.ts
@@ -1,6 +1,6 @@
 import nock from 'nock'
 
-export const mockStakeAmountSuccess = (): nock.Scope =>
+export const mockBalanceSuccess = (): nock.Scope =>
   nock('http://localhost:3500')
     .post('/ext/bc/P', {
       jsonrpc: '2.0',
@@ -22,96 +22,7 @@ export const mockStakeAmountSuccess = (): nock.Scope =>
             {
               txID: 'taPBfrrqdXnGNde21ckvd5Rr5zFkfnGs5t5MSii9jVpd2EN5P',
               startTime: '1645162810',
-              endTime: '1671082776',
-              stakeAmount: '2000000000',
-              nodeID: 'NodeID-4gPY8c21HFsLjRm3nCUS3KA8WZsEsqEKC',
-              rewardOwner: {
-                locktime: '0',
-                threshold: '1',
-                addresses: ['P-fuji16mluftw2xl8vusmuup9mgp24ghkjc6u85523zw'],
-              },
-              validationRewardOwner: {
-                locktime: '0',
-                threshold: '1',
-                addresses: ['P-fuji16mluftw2xl8vusmuup9mgp24ghkjc6u85523zw'],
-              },
-              delegationRewardOwner: {
-                locktime: '0',
-                threshold: '1',
-                addresses: ['P-fuji16mluftw2xl8vusmuup9mgp24ghkjc6u85523zw'],
-              },
-              potentialReward: '182188941',
-              delegationFee: '2.0000',
-              uptime: '0.0012',
-              connected: false,
-              delegators: null,
-            },
-            {
-              txID: 'vB3taDDmFdS1qxLasZvCpqTfUja7jZNfPzTARYLShpSwtJcnq',
-              startTime: '1',
-              endTime: '1',
-              stakeAmount: '1009000000',
-              nodeID: 'NodeID-F823qVX3w3sVb6EWKnTFvfhnmTCCX91gX',
-              rewardOwner: {
-                locktime: '0',
-                threshold: '1',
-                addresses: ['P-fuji100vvz8u2jf6g62twwxpd0qguqtaeyt2yru2aes'],
-              },
-              validationRewardOwner: {
-                locktime: '0',
-                threshold: '1',
-                addresses: ['P-fuji100vvz8u2jf6g62twwxpd0qguqtaeyt2yru2aes'],
-              },
-              delegationRewardOwner: {
-                locktime: '0',
-                threshold: '1',
-                addresses: ['P-fuji100vvz8u2jf6g62twwxpd0qguqtaeyt2yru2aes'],
-              },
-              potentialReward: '7526406',
-              delegationFee: '100.0000',
-              uptime: '0.0001',
-              connected: false,
-              delegators: null,
-            },
-          ],
-        },
-        id: '1',
-      },
-      [
-        'content-type',
-        'application/json',
-        'server',
-        'Lighthouse/v3.1.0-aa022f4/x86_64-linux',
-        'content-length',
-        '124',
-        'date',
-        'Wed, 21 Sep 2022 10:58:34 GMT',
-      ],
-    )
-
-export const mockPotentialRewardSuccess = (): nock.Scope =>
-  nock('http://localhost:3500')
-    .post('/ext/bc/P', {
-      jsonrpc: '2.0',
-      method: 'platform.getCurrentValidators',
-      params: {
-        nodeIDs: [
-          'NodeID-4gPY8c21HFsLjRm3nCUS3KA8WZsEsqEKC',
-          'NodeID-F823qVX3w3sVb6EWKnTFvfhnmTCCX91gX',
-        ],
-      },
-      id: '1',
-    })
-    .reply(
-      200,
-      {
-        jsonrpc: '2.0',
-        result: {
-          validators: [
-            {
-              txID: 'taPBfrrqdXnGNde21ckvd5Rr5zFkfnGs5t5MSii9jVpd2EN5P',
-              startTime: '1645162810',
-              endTime: '1671082776',
+              endTime: '167108277600',
               stakeAmount: '2000000000',
               nodeID: 'NodeID-4gPY8c21HFsLjRm3nCUS3KA8WZsEsqEKC',
               rewardOwner: {

--- a/packages/sources/avalanche-platform/test/integration/fixtures.ts
+++ b/packages/sources/avalanche-platform/test/integration/fixtures.ts
@@ -1,0 +1,80 @@
+import nock from 'nock'
+
+export const mockBalanceSuccess = (): nock.Scope =>
+  nock('http://localhost:3500', { encodedQueryParams: true })
+    .get('/ext/bc/P')
+    .reply(
+      200,
+      {
+        jsonrpc: '2.0',
+        result: {
+          validators: [
+            {
+              txID: 'taPBfrrqdXnGNde21ckvd5Rr5zFkfnGs5t5MSii9jVpd2EN5P',
+              startTime: '1645162810',
+              endTime: '1671082776',
+              stakeAmount: '2000000000',
+              nodeID: 'NodeID-4gPY8c21HFsLjRm3nCUS3KA8WZsEsqEKC',
+              rewardOwner: {
+                locktime: '0',
+                threshold: '1',
+                addresses: ['P-fuji16mluftw2xl8vusmuup9mgp24ghkjc6u85523zw'],
+              },
+              validationRewardOwner: {
+                locktime: '0',
+                threshold: '1',
+                addresses: ['P-fuji16mluftw2xl8vusmuup9mgp24ghkjc6u85523zw'],
+              },
+              delegationRewardOwner: {
+                locktime: '0',
+                threshold: '1',
+                addresses: ['P-fuji16mluftw2xl8vusmuup9mgp24ghkjc6u85523zw'],
+              },
+              potentialReward: '182188941',
+              delegationFee: '2.0000',
+              uptime: '0.0012',
+              connected: false,
+              delegators: null,
+            },
+            {
+              txID: 'vB3taDDmFdS1qxLasZvCpqTfUja7jZNfPzTARYLShpSwtJcnq',
+              startTime: '1',
+              endTime: '1',
+              stakeAmount: '1009000000',
+              nodeID: 'NodeID-F823qVX3w3sVb6EWKnTFvfhnmTCCX91gX',
+              rewardOwner: {
+                locktime: '0',
+                threshold: '1',
+                addresses: ['P-fuji100vvz8u2jf6g62twwxpd0qguqtaeyt2yru2aes'],
+              },
+              validationRewardOwner: {
+                locktime: '0',
+                threshold: '1',
+                addresses: ['P-fuji100vvz8u2jf6g62twwxpd0qguqtaeyt2yru2aes'],
+              },
+              delegationRewardOwner: {
+                locktime: '0',
+                threshold: '1',
+                addresses: ['P-fuji100vvz8u2jf6g62twwxpd0qguqtaeyt2yru2aes'],
+              },
+              potentialReward: '7526406',
+              delegationFee: '100.0000',
+              uptime: '0.0001',
+              connected: false,
+              delegators: null,
+            },
+          ],
+        },
+        id: '1',
+      },
+      [
+        'content-type',
+        'application/json',
+        'server',
+        'Lighthouse/v3.1.0-aa022f4/x86_64-linux',
+        'content-length',
+        '124',
+        'date',
+        'Wed, 21 Sep 2022 10:58:34 GMT',
+      ],
+    )

--- a/packages/sources/avalanche-platform/test/integration/fixtures.ts
+++ b/packages/sources/avalanche-platform/test/integration/fixtures.ts
@@ -1,8 +1,107 @@
 import nock from 'nock'
 
-export const mockBalanceSuccess = (): nock.Scope =>
-  nock('http://localhost:3500', { encodedQueryParams: true })
-    .get('/ext/bc/P')
+export const mockStakeAmountSuccess = (): nock.Scope =>
+  nock('http://localhost:3500')
+    .post('/ext/bc/P', {
+      jsonrpc: '2.0',
+      method: 'platform.getCurrentValidators',
+      params: {
+        nodeIDs: [
+          'NodeID-4gPY8c21HFsLjRm3nCUS3KA8WZsEsqEKC',
+          'NodeID-F823qVX3w3sVb6EWKnTFvfhnmTCCX91gX',
+        ],
+      },
+      id: '1',
+    })
+    .reply(
+      200,
+      {
+        jsonrpc: '2.0',
+        result: {
+          validators: [
+            {
+              txID: 'taPBfrrqdXnGNde21ckvd5Rr5zFkfnGs5t5MSii9jVpd2EN5P',
+              startTime: '1645162810',
+              endTime: '1671082776',
+              stakeAmount: '2000000000',
+              nodeID: 'NodeID-4gPY8c21HFsLjRm3nCUS3KA8WZsEsqEKC',
+              rewardOwner: {
+                locktime: '0',
+                threshold: '1',
+                addresses: ['P-fuji16mluftw2xl8vusmuup9mgp24ghkjc6u85523zw'],
+              },
+              validationRewardOwner: {
+                locktime: '0',
+                threshold: '1',
+                addresses: ['P-fuji16mluftw2xl8vusmuup9mgp24ghkjc6u85523zw'],
+              },
+              delegationRewardOwner: {
+                locktime: '0',
+                threshold: '1',
+                addresses: ['P-fuji16mluftw2xl8vusmuup9mgp24ghkjc6u85523zw'],
+              },
+              potentialReward: '182188941',
+              delegationFee: '2.0000',
+              uptime: '0.0012',
+              connected: false,
+              delegators: null,
+            },
+            {
+              txID: 'vB3taDDmFdS1qxLasZvCpqTfUja7jZNfPzTARYLShpSwtJcnq',
+              startTime: '1',
+              endTime: '1',
+              stakeAmount: '1009000000',
+              nodeID: 'NodeID-F823qVX3w3sVb6EWKnTFvfhnmTCCX91gX',
+              rewardOwner: {
+                locktime: '0',
+                threshold: '1',
+                addresses: ['P-fuji100vvz8u2jf6g62twwxpd0qguqtaeyt2yru2aes'],
+              },
+              validationRewardOwner: {
+                locktime: '0',
+                threshold: '1',
+                addresses: ['P-fuji100vvz8u2jf6g62twwxpd0qguqtaeyt2yru2aes'],
+              },
+              delegationRewardOwner: {
+                locktime: '0',
+                threshold: '1',
+                addresses: ['P-fuji100vvz8u2jf6g62twwxpd0qguqtaeyt2yru2aes'],
+              },
+              potentialReward: '7526406',
+              delegationFee: '100.0000',
+              uptime: '0.0001',
+              connected: false,
+              delegators: null,
+            },
+          ],
+        },
+        id: '1',
+      },
+      [
+        'content-type',
+        'application/json',
+        'server',
+        'Lighthouse/v3.1.0-aa022f4/x86_64-linux',
+        'content-length',
+        '124',
+        'date',
+        'Wed, 21 Sep 2022 10:58:34 GMT',
+      ],
+    )
+
+export const mockPotentialRewardSuccess = (): nock.Scope =>
+  nock('http://localhost:3500')
+    .post('/ext/bc/P', {
+      jsonrpc: '2.0',
+      method: 'platform.getCurrentValidators',
+      params: {
+        nodeIDs: [
+          'NodeID-4gPY8c21HFsLjRm3nCUS3KA8WZsEsqEKC',
+          'NodeID-F823qVX3w3sVb6EWKnTFvfhnmTCCX91gX',
+        ],
+      },
+      id: '1',
+    })
     .reply(
       200,
       {

--- a/packages/sources/avalanche-platform/test/integration/fixtures.ts
+++ b/packages/sources/avalanche-platform/test/integration/fixtures.ts
@@ -4,12 +4,9 @@ export const mockBalanceSuccess = (): nock.Scope =>
   nock('http://localhost:3500')
     .post('/ext/bc/P', {
       jsonrpc: '2.0',
-      method: 'platform.getCurrentValidators',
+      method: 'platform.getBalance',
       params: {
-        nodeIDs: [
-          'NodeID-4gPY8c21HFsLjRm3nCUS3KA8WZsEsqEKC',
-          'NodeID-F823qVX3w3sVb6EWKnTFvfhnmTCCX91gX',
-        ],
+        addresses: ['P-fuji1vd9sddlllrlk9fvj9lhntpw8t00lmvtnqkl2jt'],
       },
       id: '1',
     })
@@ -18,60 +15,26 @@ export const mockBalanceSuccess = (): nock.Scope =>
       {
         jsonrpc: '2.0',
         result: {
-          validators: [
+          balance: '1606136960057',
+          unlocked: '1606136960057',
+          lockedStakeable: '0',
+          lockedNotStakeable: '0',
+          balances: {
+            U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK: '1606136960057',
+          },
+          unlockeds: {
+            U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK: '1606136960057',
+          },
+          lockedStakeables: {},
+          lockedNotStakeables: {},
+          utxoIDs: [
             {
-              txID: 'taPBfrrqdXnGNde21ckvd5Rr5zFkfnGs5t5MSii9jVpd2EN5P',
-              startTime: '1645162810',
-              endTime: '167108277600',
-              stakeAmount: '2000000000',
-              nodeID: 'NodeID-4gPY8c21HFsLjRm3nCUS3KA8WZsEsqEKC',
-              rewardOwner: {
-                locktime: '0',
-                threshold: '1',
-                addresses: ['P-fuji16mluftw2xl8vusmuup9mgp24ghkjc6u85523zw'],
-              },
-              validationRewardOwner: {
-                locktime: '0',
-                threshold: '1',
-                addresses: ['P-fuji16mluftw2xl8vusmuup9mgp24ghkjc6u85523zw'],
-              },
-              delegationRewardOwner: {
-                locktime: '0',
-                threshold: '1',
-                addresses: ['P-fuji16mluftw2xl8vusmuup9mgp24ghkjc6u85523zw'],
-              },
-              potentialReward: '182188941',
-              delegationFee: '2.0000',
-              uptime: '0.0012',
-              connected: false,
-              delegators: null,
+              txID: '2E9jBifwAKMajtgrwmJxwuW4UtYmTauAggCgRQv2wWF7PiXwgD',
+              outputIndex: 1,
             },
             {
-              txID: 'vB3taDDmFdS1qxLasZvCpqTfUja7jZNfPzTARYLShpSwtJcnq',
-              startTime: '1',
-              endTime: '1',
-              stakeAmount: '1009000000',
-              nodeID: 'NodeID-F823qVX3w3sVb6EWKnTFvfhnmTCCX91gX',
-              rewardOwner: {
-                locktime: '0',
-                threshold: '1',
-                addresses: ['P-fuji100vvz8u2jf6g62twwxpd0qguqtaeyt2yru2aes'],
-              },
-              validationRewardOwner: {
-                locktime: '0',
-                threshold: '1',
-                addresses: ['P-fuji100vvz8u2jf6g62twwxpd0qguqtaeyt2yru2aes'],
-              },
-              delegationRewardOwner: {
-                locktime: '0',
-                threshold: '1',
-                addresses: ['P-fuji100vvz8u2jf6g62twwxpd0qguqtaeyt2yru2aes'],
-              },
-              potentialReward: '7526406',
-              delegationFee: '100.0000',
-              uptime: '0.0001',
-              connected: false,
-              delegators: null,
+              txID: '2E9jBifwAKMajtgrwmJxwuW4UtYmTauAggCgRQv2wWF7PiXwgD',
+              outputIndex: 0,
             },
           ],
         },

--- a/packages/sources/avalanche-platform/test/unit/adapter.test.ts
+++ b/packages/sources/avalanche-platform/test/unit/adapter.test.ts
@@ -1,0 +1,16 @@
+import * as adapter from '../../src'
+
+describe('adapter', () => {
+  it('has expected root exports', () => {
+    expect(adapter).toHaveProperty('NAME')
+    expect(typeof adapter.NAME).toBe('string')
+    expect(adapter).toHaveProperty('makeExecute')
+    expect(typeof adapter.makeExecute).toBe('function')
+    expect(adapter).toHaveProperty('makeConfig')
+    expect(typeof adapter.makeConfig).toBe('function')
+    expect(adapter).toHaveProperty('server')
+    expect(typeof adapter.server).toBe('function')
+    expect(adapter).toHaveProperty('endpoints')
+    expect(typeof adapter.endpoints).toBe('object')
+  })
+})

--- a/packages/sources/avalanche-platform/test/unit/balance.test.ts
+++ b/packages/sources/avalanche-platform/test/unit/balance.test.ts
@@ -1,0 +1,36 @@
+import { AdapterError, Requester } from '@chainlink/ea-bootstrap'
+import { assertError } from '@chainlink/ea-test-helpers'
+import { makeExecute } from '../../src'
+
+describe('execute', () => {
+  const jobID = '1'
+  const execute = makeExecute()
+
+  process.env.RPC_URL = process.env.RPC_URL || 'fake_rpc_url'
+
+  describe('validation error', () => {
+    const requests = [
+      { name: 'empty body', testData: {} },
+      { name: 'empty data', testData: { data: {} } },
+      {
+        name: 'empty addresses',
+        testData: { id: jobID, data: { addresses: [] } },
+      },
+      {
+        name: 'empty result',
+        testData: { id: jobID, data: { result: [] } },
+      },
+    ]
+
+    requests.forEach((req) => {
+      it(`${req.name}`, async () => {
+        try {
+          await execute(req.testData as never, {})
+        } catch (error) {
+          const errorResp = Requester.errored(jobID, error as AdapterError)
+          assertError({ expected: 400, actual: errorResp.statusCode }, errorResp, jobID)
+        }
+      })
+    })
+  })
+})

--- a/packages/sources/avalanche-platform/test/unit/balance.test.ts
+++ b/packages/sources/avalanche-platform/test/unit/balance.test.ts
@@ -6,7 +6,7 @@ describe('execute', () => {
   const jobID = '1'
   const execute = makeExecute()
 
-  process.env.RPC_URL = process.env.RPC_URL || 'fake_rpc_url'
+  process.env.P_CHAIN_RPC_URL = process.env.P_CHAIN_RPC_URL || 'fake_rpc_url'
 
   describe('validation error', () => {
     const requests = [

--- a/packages/sources/avalanche-platform/tsconfig.json
+++ b/packages/sources/avalanche-platform/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*", "src/**/*.json"],
+  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
+  "references": [{ "path": "../../core/test-helpers" }, { "path": "../../core/bootstrap" }]
+}

--- a/packages/sources/avalanche-platform/tsconfig.test.json
+++ b/packages/sources/avalanche-platform/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*", "**/test", "src/**/*.json"],
+  "compilerOptions": {
+    "noEmit": true
+  }
+}

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -153,6 +153,9 @@
       "path": "./sources/armanino"
     },
     {
+      "path": "./sources/avalanche-platform"
+    },
+    {
       "path": "./sources/bank-frick"
     },
     {

--- a/packages/tsconfig.test.json
+++ b/packages/tsconfig.test.json
@@ -153,6 +153,9 @@
       "path": "./sources/armanino/tsconfig.test.json"
     },
     {
+      "path": "./sources/avalanche-platform/tsconfig.test.json"
+    },
+    {
       "path": "./sources/bank-frick/tsconfig.test.json"
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1775,6 +1775,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@chainlink/avalanche-platform-adapter@workspace:*, @chainlink/avalanche-platform-adapter@workspace:packages/sources/avalanche-platform":
+  version: 0.0.0-use.local
+  resolution: "@chainlink/avalanche-platform-adapter@workspace:packages/sources/avalanche-platform"
+  dependencies:
+    "@chainlink/ea-bootstrap": "workspace:*"
+    "@chainlink/ea-test-helpers": "workspace:*"
+    "@types/jest": 27.5.2
+    "@types/node": 16.11.51
+    "@types/supertest": 2.0.12
+    nock: 13.2.9
+    supertest: 6.2.4
+    tslib: ^2.3.1
+    typescript: 4.7.4
+  languageName: unknown
+  linkType: soft
+
 "@chainlink/bank-frick-adapter@workspace:*, @chainlink/bank-frick-adapter@workspace:packages/sources/bank-frick":
   version: 0.0.0-use.local
   resolution: "@chainlink/bank-frick-adapter@workspace:packages/sources/bank-frick"
@@ -2921,6 +2937,7 @@ __metadata:
     "@chainlink/anyblock-adapter": "workspace:*"
     "@chainlink/ap-election-adapter": "workspace:*"
     "@chainlink/armanino-adapter": "workspace:*"
+    "@chainlink/avalanche-platform-adapter": "workspace:*"
     "@chainlink/bank-frick-adapter": "workspace:*"
     "@chainlink/bea-adapter": "workspace:*"
     "@chainlink/binance-adapter": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4355,6 +4355,7 @@ __metadata:
   dependencies:
     "@chainlink/ada-balance-adapter": "workspace:*"
     "@chainlink/amberdata-adapter": "workspace:*"
+    "@chainlink/avalanche-platform-adapter": "workspace:*"
     "@chainlink/bitcoin-json-rpc-adapter": "workspace:*"
     "@chainlink/blockchain.com-adapter": "workspace:*"
     "@chainlink/blockchair-adapter": "workspace:*"


### PR DESCRIPTION
## Closes [PDI-146](https://smartcontract-it.atlassian.net/browse/PDI-146)

## Description

Created an adapter to read node balances on the Avalanche platform chain for PoR.

## Changes

- Created new adapter to retrieve balances from the Avalanche platform chain
- Support 2 different fields `stakeAmount` and `potentialReward` for 2 different feeds

## Steps to Test

1. yarn test packages/sources/avalanche-platform/test 

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[PDI-146]: https://smartcontract-it.atlassian.net/browse/PDI-146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ