### PR TITLE
Fetch a new GSR auth token on every new WS connection

### DIFF
--- a/.changeset/nice-deers-wink.md
+++ b/.changeset/nice-deers-wink.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/gsr-adapter': patch
+---
+
+Fetch a new auth token on every new WS connection


### PR DESCRIPTION
## Changes

- Fetch a new GSR auth token on every new WS connection

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. Run EA
2. Send a request

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [x] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
