### PR TITLE
remove rate limit config from kaiko-test

### DIFF
--- a/.changeset/silver-points-remain.md
+++ b/.changeset/silver-points-remain.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/kaiko-test-adapter': patch
+---
+
+Removed rate limit config

--- a/packages/sources/kaiko-test/src/endpoint/trades.ts
+++ b/packages/sources/kaiko-test/src/endpoint/trades.ts
@@ -43,12 +43,6 @@ export interface RequestParams {
   sort: string
 }
 
-export interface RequestBody {
-  interval: string
-  sort: string
-  start_time: string
-}
-
 export interface ResponseSchema {
   query: {
     page_size: number

--- a/packages/sources/kaiko-test/src/endpoint/trades.ts
+++ b/packages/sources/kaiko-test/src/endpoint/trades.ts
@@ -84,7 +84,7 @@ type EndpointTypes = {
   Response: SingleNumberResultResponse
   CustomSettings: typeof customSettings
   Provider: {
-    RequestBody: RequestBody
+    RequestBody: never
     ResponseBody: ResponseSchema
   }
 }

--- a/packages/sources/kaiko-test/src/index.ts
+++ b/packages/sources/kaiko-test/src/index.ts
@@ -10,14 +10,6 @@ export const adapter = new PriceAdapter({
   name: 'KAIKO',
   endpoints: [trades],
   customSettings,
-  rateLimiting: {
-    tiers: {
-      default: {
-        rateLimit1h: -1,
-        note: 'claims no rate limits',
-      },
-    },
-  },
   envDefaultOverrides: {
     API_TIMEOUT: 30000,
   },


### PR DESCRIPTION
removed rate limit config from EA. Negative rate limits values are not supported by the EA framework