### PR TITLE
Change ws map keys to lowercase for finage-test

### DIFF
--- a/.changeset/violet-taxis-destroy.md
+++ b/.changeset/violet-taxis-destroy.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/finage-test-adapter': patch
+---
+
+Fixed issue with websocket reverse map keys

--- a/packages/sources/finage-test/src/endpoint/ws/crypto-ws.ts
+++ b/packages/sources/finage-test/src/endpoint/ws/crypto-ws.ts
@@ -28,7 +28,7 @@ export const wsTransport: WebsocketReverseMappingTransport<EndpointTypes, string
     },
     handlers: {
       message(message) {
-        const pair = wsTransport.getReverseMapping(message.s)
+        const pair = wsTransport.getReverseMapping(message.s.toLowerCase())
         if (!message.p || !pair) {
           return []
         }
@@ -53,7 +53,7 @@ export const wsTransport: WebsocketReverseMappingTransport<EndpointTypes, string
 
     builders: {
       subscribeMessage: (params) => {
-        wsTransport.setReverseMapping(`${params.base}${params.quote}`, params)
+        wsTransport.setReverseMapping(`${params.base}${params.quote}`.toLowerCase(), params)
         return { action: 'subscribe', symbols: `${params.base}${params.quote}`.toUpperCase() }
       },
       unsubscribeMessage: (params) => {


### PR DESCRIPTION
`setReverseMapping` and `getReverseMapping` methods of `WebsocketReverseMappingTransport` are case sensitive . This PR fixes the issue with Finage-test ea so that we change keys to lowercase when storing and same when getting so that we always will get a right value  for different input params like ETH/usd , eth/USD, eth/usd, ETH/USD