### PR TITLE
bugfix for polling blocks in l2 sequencer health ea

### DIFF
--- a/packages/sources/layer2-sequencer-health/src/evm.ts
+++ b/packages/sources/layer2-sequencer-health/src/evm.ts
@@ -14,7 +14,7 @@ import {
   Networks,
   RPC_ENDPOINTS,
 } from './config'
-import { race, ResponseSchema, retry } from './network'
+import { race, ResponseSchema, retry } from './utils'
 
 export const sendEVMDummyTransaction = async (
   network: EVMNetworks,
@@ -86,12 +86,12 @@ export const checkOptimisticRollupBlockHeight = (
         message: `Block found #${block} is previous to last seen #${lastSeenBlock.block} with more than ${deltaBlocks} difference`,
       })
     if (!_isStaleBlock(block, delta)) {
-      if (!_isPastBlock(block)) _updateLastSeenBlock(block)
       Logger.info(
         `Block #${block} is not considered stale at ${Date.now()}. Last seen block #${
           lastSeenBlock.block
         } was at ${lastSeenBlock.timestamp}`,
       )
+      if (!_isPastBlock(block)) _updateLastSeenBlock(block)
       return true
     }
     Logger.warn(

--- a/packages/sources/layer2-sequencer-health/src/starkware.ts
+++ b/packages/sources/layer2-sequencer-health/src/starkware.ts
@@ -1,7 +1,7 @@
 import { Logger } from '@chainlink/ea-bootstrap'
 import { DEFAULT_PRIVATE_KEY, ExtendedConfig } from './config'
 import { ec, Account, InvokeFunctionResponse, GetBlockResponse } from 'starknet'
-import { race, retry } from './network'
+import { race, retry } from './utils'
 
 interface StarkwareState {
   lastBlockResponse: GetBlockResponse | null

--- a/packages/sources/layer2-sequencer-health/src/utils.ts
+++ b/packages/sources/layer2-sequencer-health/src/utils.ts
@@ -1,0 +1,49 @@
+import { util } from '@chainlink/ea-bootstrap'
+import { ExtendedConfig } from './config'
+
+export interface ResponseSchema {
+  result: number
+}
+
+export async function retry<T>({
+  promise,
+  retryConfig,
+}: {
+  promise: () => Promise<T>
+  retryConfig: ExtendedConfig['retryConfig']
+}): Promise<T> {
+  let numTries = 0
+  let error
+  while (numTries < retryConfig.numRetries) {
+    try {
+      return await promise()
+    } catch (e) {
+      error = e
+      numTries++
+      await util.sleep(retryConfig.retryInterval)
+    }
+  }
+  throw error
+}
+
+export function race<T>({
+  promise,
+  timeout,
+  error,
+}: {
+  promise: Promise<T>
+  timeout: number
+  error: string
+}): Promise<T> {
+  let timer: NodeJS.Timeout
+
+  return Promise.race([
+    new Promise((_, reject) => {
+      timer = setTimeout(reject, timeout, error)
+    }) as Promise<T>,
+    promise.then((value) => {
+      clearTimeout(timer)
+      return value
+    }),
+  ])
+}

--- a/packages/sources/layer2-sequencer-health/test/unit/network.test.ts
+++ b/packages/sources/layer2-sequencer-health/test/unit/network.test.ts
@@ -1,12 +1,41 @@
 import { ExtendedConfig, makeConfig, Networks } from '../../src/config'
 import * as network from '../../src/network'
+import * as evm from '../../src/evm'
 import * as starkware from '../../src/starkware'
+import { useFakeTimers } from 'sinon'
+
+jest.mock('../../src/evm', () => {
+  const mockNetworkHandler = jest.fn().mockReturnValue(1)
+  return {
+    ...jest.requireActual('../../src/evm'),
+    requestBlockHeight: mockNetworkHandler,
+    checkOptimisticRollupBlockHeight: jest.fn().mockImplementation((network) => () => {
+      mockNetworkHandler(network)
+      return true
+    }),
+  }
+})
+
+jest.mock('../../src/starkware', () => {
+  return {
+    ...jest.requireActual('../../src/starkware'),
+    checkStarkwareSequencerPendingTransactions: jest
+      .fn()
+      .mockReturnValue(jest.fn().mockReturnValue(true)),
+  }
+})
 
 describe('network', () => {
   let config: ExtendedConfig
+  let clock: any
 
   beforeEach(async () => {
     config = makeConfig()
+    clock = useFakeTimers()
+  })
+
+  afterEach(() => {
+    clock.restore()
   })
 
   describe('#getStatusByTransaction', () => {
@@ -43,5 +72,27 @@ describe('network', () => {
      * TO_BE_IMPLEMENTED
      *  describe('when fetching EVM Sequencer status', () => {})
      *  */
+  })
+
+  describe('#checkNetworkProgressFn', () => {
+    it('checks for the Arbitrum block height correctly', async () => {
+      await network.checkNetworkProgress(Networks.Arbitrum, config)
+      expect(evm.requestBlockHeight).toHaveBeenCalledWith(Networks.Arbitrum)
+    })
+
+    it('checks for the Starkware block height correctly', async () => {
+      await network.checkNetworkProgress(Networks.Starkware, config)
+      expect(starkware.checkStarkwareSequencerPendingTransactions).toHaveBeenCalled()
+    })
+
+    it('checks for the Optimism block height correctly', async () => {
+      await network.checkNetworkProgress(Networks.Optimism, config)
+      expect(evm.requestBlockHeight).toHaveBeenCalledWith(Networks.Optimism)
+    })
+
+    it('checks for the Metis block height correctly', async () => {
+      await network.checkNetworkProgress(Networks.Metis, config)
+      expect(evm.requestBlockHeight).toHaveBeenCalledWith(Networks.Metis)
+    })
   })
 })


### PR DESCRIPTION
## Description

There is a bug in the L2 Sequencer health EA where the EA does not correctly correctly check that the L2 network's block height is growing. The issue was the current block number was not correctly stored in the EA's state as it was reset whenever `checkOptimisticRollupBlockHeight` is called.  The fix for this was to assign an instance of `checkOptimisticRollupBlockHeight` to Metis, Optimism and Arbitrum so that the current block number is saved and can be compared to the next block number when the next request comes in.

## Changes

- Add unit tests to make sure that the blocks are correctly polled.
- Assign an instance of `checkOptimisticRollupBlockHeight` to each EVM chain being checked (Metis, Arbitrum and Optimism).

## Steps to Test

1. Write unit tests to make sure that stale blocks are correctly identified over time.

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [x] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
