### PR TITLE
Add totalMarketCap endpoint to coinranking adapter

### DIFF
--- a/.changeset/neat-balloons-heal.md
+++ b/.changeset/neat-balloons-heal.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/coinranking-adapter': major
+---
+
+Added totalMarketCap endpoint to coinranking

--- a/packages/sources/coinranking/README.md
+++ b/packages/sources/coinranking/README.md
@@ -16,9 +16,9 @@ This document was generated automatically. Please see [README Generator](../../s
 
 Every EA supports base input parameters from [this list](../../core/bootstrap#base-input-parameters)
 
-| Required? |   Name   |     Description     |  Type  |                                       Options                                        | Default  |
-| :-------: | :------: | :-----------------: | :----: | :----------------------------------------------------------------------------------: | :------: |
-|           | endpoint | The endpoint to use | string | [crypto](#crypto-endpoint), [marketcap](#crypto-endpoint), [price](#crypto-endpoint) | `crypto` |
+| Required? |   Name   |     Description     |  Type  |                                                                                 Options                                                                                 | Default  |
+| :-------: | :------: | :-----------------: | :----: | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :------: |
+|           | endpoint | The endpoint to use | string | [crypto](#crypto-endpoint), [marketcap](#crypto-endpoint), [price](#crypto-endpoint), [totalMarketCap](#totalmarketcap-endpoint), [totalmcap](#totalmarketcap-endpoint) | `crypto` |
 
 ## Crypto Endpoint
 
@@ -315,6 +315,104 @@ Response:
 ```
 
 </details>
+
+---
+
+## TotalMarketCap Endpoint
+
+Returns the totalMarketCap value provided by coinranking's 'stats' endpoint
+
+Supported names for this endpoint are: `totalMarketCap`, `totalmcap`.
+
+### Input Params
+
+There are no input parameters for this endpoint.
+
+### Example
+
+Request:
+
+```json
+{
+  "id": "1",
+  "data": {
+    "endpoint": "totalMarketCap"
+  },
+  "debug": {
+    "cacheKey": "ow1rfzVUhrabsezQrFXAy1jncWo="
+  }
+}
+```
+
+Response:
+
+```json
+{
+  "jobRunID": "1",
+  "data": {
+    "status": "success",
+    "data": {
+      "referenceCurrencyRate": 1,
+      "totalCoins": 23349,
+      "totalMarkets": 37921,
+      "totalExchanges": 179,
+      "totalMarketCap": "1139638848309",
+      "total24hVolume": "85309476474",
+      "btcDominance": 41.393155263964395,
+      "bestCoins": [
+        {
+          "uuid": "fmHk13Rqw",
+          "symbol": "FLOKI*",
+          "name": "FLOKI",
+          "iconUrl": "https://cdn.coinranking.com/Yfn5I1O01/10804.png",
+          "coinrankingUrl": "https://coinranking.com/coin/fmHk13Rqw+floki-floki"
+        },
+        {
+          "uuid": "08CsQa-Ov",
+          "symbol": "WEMIX",
+          "name": "WEMIX TOKEN",
+          "iconUrl": "https://cdn.coinranking.com/1N84MQsoO/7548.png",
+          "coinrankingUrl": "https://coinranking.com/coin/08CsQa-Ov+wemixtoken-wemix"
+        },
+        {
+          "uuid": "jrP7Ptsct",
+          "symbol": "ACH**",
+          "name": "Alchemy Pay",
+          "iconUrl": "https://cdn.coinranking.com/tkKQoiNEr/alchemypay.svg",
+          "coinrankingUrl": "https://coinranking.com/coin/jrP7Ptsct+alchemypay-ach"
+        }
+      ],
+      "newestCoins": [
+        {
+          "uuid": "ZO8YGJCio",
+          "symbol": "HASHTAG",
+          "name": "Hashtag United F.C Fan Token",
+          "iconUrl": "https://cdn.coinranking.com/FYBQpoUyV/HASH.PNG",
+          "coinrankingUrl": "https://coinranking.com/coin/ZO8YGJCio+hashtagunitedfcfantoken-hashtag"
+        },
+        {
+          "uuid": "BYg5FxSE-",
+          "symbol": "FLAME",
+          "name": "Flame Chain",
+          "iconUrl": "https://cdn.coinranking.com/mv2256upC/FLAME_LOGO.png",
+          "coinrankingUrl": "https://coinranking.com/coin/BYg5FxSE-+flamechain-flame"
+        },
+        {
+          "uuid": "EK1DC7MeO",
+          "symbol": "SFIL",
+          "name": "Super File Coin",
+          "iconUrl": "https://cdn.coinranking.com/n15BzWVX7/SFIL_LOGO.png",
+          "coinrankingUrl": "https://coinranking.com/coin/EK1DC7MeO+superfilecoin-sfil"
+        }
+      ]
+    },
+    "result": 1139638848309
+  },
+  "result": 1139638848309,
+  "statusCode": 200,
+  "providerStatusCode": 200
+}
+```
 
 ---
 

--- a/packages/sources/coinranking/src/endpoint/index.ts
+++ b/packages/sources/coinranking/src/endpoint/index.ts
@@ -1,5 +1,7 @@
 import type { TInputParameters as CryptoInputParameters } from './crypto'
+import type { TInputParameters as TotalMarketCapInputParameters } from './totalMarketCap'
 
-export type TInputParameters = CryptoInputParameters
+export type TInputParameters = CryptoInputParameters | TotalMarketCapInputParameters
 
 export * as crypto from './crypto'
+export * as totalMarketCap from './totalMarketCap'

--- a/packages/sources/coinranking/src/endpoint/totalMarketCap.ts
+++ b/packages/sources/coinranking/src/endpoint/totalMarketCap.ts
@@ -1,0 +1,49 @@
+import { ExecuteWithConfig, Config, Validator, InputParameters } from '@chainlink/ea-bootstrap'
+import { Requester } from '@chainlink/ea-bootstrap'
+
+export const supportedEndpoints = ['totalMarketCap', 'totalmcap']
+
+export type TInputParameters = Record<string, never>
+export const inputParameters: InputParameters<TInputParameters> = {}
+
+export const description =
+  "Returns the totalMarketCap value provided by coinranking's 'stats' endpoint"
+
+export interface ResponseSchema {
+  status: string
+  data: {
+    referenceCurrencyRate: number
+    totalCoins: number
+    totalMarkets: number
+    totalExchanges: number
+    totalMarketCap: string
+    total24hVolume: string
+    btcDominance: number
+    bestCoins: {
+      uuid: string
+      symbol: string
+      name: string
+      iconUrl: string
+      coinrankingUrl: string
+    }[]
+    newestCoins: {
+      uuid: string
+      symbol: string
+      name: string
+      iconUrl: string
+      coinrankingUrl: string
+    }[]
+  }
+}
+
+export const execute: ExecuteWithConfig<Config> = async (input, _, config) => {
+  const validator = new Validator(input, inputParameters)
+  const jobRunID = validator.validated.id
+
+  const response = await Requester.request<ResponseSchema>({
+    ...config.api,
+    url: 'stats',
+  })
+  const result = Requester.validateResultNumber(response.data, ['data', 'totalMarketCap'])
+  return Requester.success(jobRunID, Requester.withResult(response, result), config.verbose)
+}

--- a/packages/sources/coinranking/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/coinranking/test/integration/__snapshots__/adapter.test.ts.snap
@@ -36,3 +36,15 @@ Object {
   "statusCode": 200,
 }
 `;
+
+exports[`execute totalMarketCap api should return success 1`] = `
+Object {
+  "data": Object {
+    "result": 1139638848309,
+  },
+  "jobRunID": "1",
+  "providerStatusCode": 200,
+  "result": 1139638848309,
+  "statusCode": 200,
+}
+`;

--- a/packages/sources/coinranking/test/integration/adapter.test.ts
+++ b/packages/sources/coinranking/test/integration/adapter.test.ts
@@ -5,6 +5,7 @@ import {
   mockCryptoResponseFailure,
   mockCryptoResponseSuccess,
   mockReferenceCurrenciesSuccess,
+  mockTotalMarketCapSuccess,
 } from './fixtures'
 import { setupExternalAdapterTest } from '@chainlink/ea-test-helpers'
 import type { SuiteContext } from '@chainlink/ea-test-helpers'
@@ -93,6 +94,28 @@ describe('execute', () => {
         .set('Content-Type', 'application/json')
         .expect('Content-Type', /json/)
         .expect(500)
+      expect(response.body).toMatchSnapshot()
+    })
+  })
+
+  describe('totalMarketCap api', () => {
+    const data: AdapterRequest = {
+      id,
+      data: {
+        endpoint: 'totalMarketCap',
+      },
+    }
+
+    it('should return success', async () => {
+      mockTotalMarketCapSuccess()
+
+      const response = await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
       expect(response.body).toMatchSnapshot()
     })
   })

--- a/packages/sources/coinranking/test/integration/fixtures.ts
+++ b/packages/sources/coinranking/test/integration/fixtures.ts
@@ -356,3 +356,84 @@ export const mockCryptoResponseFailure = (): nock.Scope =>
         'Origin',
       ],
     )
+
+export const mockTotalMarketCapSuccess = (): nock.Scope =>
+  nock('https://api.coinranking.com/v2', {
+    encodedQueryParams: true,
+    reqheaders: {
+      'x-access-token': 'fake-api-key',
+    },
+  })
+    .get('/stats')
+    .reply(
+      200,
+      {
+        status: 'success',
+        data: {
+          referenceCurrencyRate: 1,
+          totalCoins: 23349,
+          totalMarkets: 37921,
+          totalExchanges: 179,
+          totalMarketCap: '1139638848309',
+          total24hVolume: '85309476474',
+          btcDominance: 41.393155263964395,
+          bestCoins: [
+            {
+              uuid: 'fmHk13Rqw',
+              symbol: 'FLOKI*',
+              name: 'FLOKI',
+              iconUrl: 'https://cdn.coinranking.com/Yfn5I1O01/10804.png',
+              coinrankingUrl: 'https://coinranking.com/coin/fmHk13Rqw+floki-floki',
+            },
+            {
+              uuid: '08CsQa-Ov',
+              symbol: 'WEMIX',
+              name: 'WEMIX TOKEN',
+              iconUrl: 'https://cdn.coinranking.com/1N84MQsoO/7548.png',
+              coinrankingUrl: 'https://coinranking.com/coin/08CsQa-Ov+wemixtoken-wemix',
+            },
+            {
+              uuid: 'jrP7Ptsct',
+              symbol: 'ACH**',
+              name: 'Alchemy Pay',
+              iconUrl: 'https://cdn.coinranking.com/tkKQoiNEr/alchemypay.svg',
+              coinrankingUrl: 'https://coinranking.com/coin/jrP7Ptsct+alchemypay-ach',
+            },
+          ],
+          newestCoins: [
+            {
+              uuid: 'ZO8YGJCio',
+              symbol: 'HASHTAG',
+              name: 'Hashtag United F.C Fan Token',
+              iconUrl: 'https://cdn.coinranking.com/FYBQpoUyV/HASH.PNG',
+              coinrankingUrl:
+                'https://coinranking.com/coin/ZO8YGJCio+hashtagunitedfcfantoken-hashtag',
+            },
+            {
+              uuid: 'BYg5FxSE-',
+              symbol: 'FLAME',
+              name: 'Flame Chain',
+              iconUrl: 'https://cdn.coinranking.com/mv2256upC/FLAME_LOGO.png',
+              coinrankingUrl: 'https://coinranking.com/coin/BYg5FxSE-+flamechain-flame',
+            },
+            {
+              uuid: 'EK1DC7MeO',
+              symbol: 'SFIL',
+              name: 'Super File Coin',
+              iconUrl: 'https://cdn.coinranking.com/n15BzWVX7/SFIL_LOGO.png',
+              coinrankingUrl: 'https://coinranking.com/coin/EK1DC7MeO+superfilecoin-sfil',
+            },
+          ],
+        },
+      },
+      [
+        'Content-Type',
+        'application/json',
+        'Connection',
+        'close',
+        'Vary',
+        'Accept-Encoding',
+        'Vary',
+        'Origin',
+      ],
+    )


### PR DESCRIPTION
## Closes #DF-390

## Description
- Added totalMarketCap endpoint to coinranking adapter
- Added tests for new endpoint
......

## Steps to Test

`yarn test packages/sources/coinranking/test/integration`

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [x] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
