### PR TITLE
Update Alongside to allow generic rpc provider

### DIFF
--- a/.changeset/swift-pandas-bow.md
+++ b/.changeset/swift-pandas-bow.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/alongside-adapter': minor
+---
+
+Updated to allow generic rpc provider

--- a/packages/sources/alongside/src/config/index.ts
+++ b/packages/sources/alongside/src/config/index.ts
@@ -28,10 +28,9 @@ export const customSettings = {
     required: true,
     sensitive: true,
   },
-  INFURA_KEY: {
-    description: 'The infura key',
+  RPC_URL: {
+    description: 'The RPC URL to connect to the EVM chain the contract is deployed to',
     type: 'string',
     required: true,
-    sensitive: true,
   },
 } as const

--- a/packages/sources/alongside/src/endpoint/collateral/index.ts
+++ b/packages/sources/alongside/src/endpoint/collateral/index.ts
@@ -2,6 +2,7 @@ import { Transport, TransportDependencies } from '@chainlink/external-adapter-fr
 import {
   AdapterRequest,
   AdapterResponse,
+  makeLogger,
   SingleNumberResultResponse,
 } from '@chainlink/external-adapter-framework/util'
 import CryptoJS from 'crypto-js'
@@ -12,6 +13,8 @@ import { ResponseCache } from '@chainlink/external-adapter-framework/cache/respo
 import { AdapterEndpoint } from '@chainlink/external-adapter-framework/adapter'
 import { Collateral } from './utils'
 import { customSettings } from '../../config'
+
+const logger = makeLogger('AlongsideLogger')
 
 export type EndpointTypes = {
   Request: {
@@ -100,18 +103,21 @@ export class AlongsideCollateralTransport implements Transport<EndpointTypes> {
   ): Promise<AdapterResponse<EndpointTypes['Response']>> {
     const requestTradingBalance = this.prepareRequest('TRADING', config)
     const requestTradingVault = this.prepareRequest('VAULT', config)
-    const collateral = new Collateral(config.INFURA_KEY)
+    const collateral = new Collateral(config.RPC_URL)
     const providerDataRequestedUnixMs = Date.now()
+    logger.debug('Requesting trading balance')
     const tradingBalances = await this.requester.request<ProviderResponseBody>(
       req.id,
       requestTradingBalance,
     )
+    logger.debug('Requesting trading vault')
     const vaultBalances = await this.requester.request<ProviderResponseBody>(
       req.id,
       requestTradingVault,
     )
-
+    logger.debug('Getting asset weights')
     const units = await collateral.getAssetWeights()
+    logger.debug('Calculating minimum collateral')
     const result = collateral.calcMinCollateral(
       tradingBalances.response.data.balances,
       vaultBalances.response.data.balances,

--- a/packages/sources/alongside/src/endpoint/collateral/utils.ts
+++ b/packages/sources/alongside/src/endpoint/collateral/utils.ts
@@ -10,10 +10,8 @@ const logger = makeLogger('Alongside  collateral calculation logger')
 export class Collateral {
   provider: ethers.providers.JsonRpcProvider
   IndexToken: ethers.Contract
-  constructor(infuraKey: string) {
-    this.provider = new ethers.providers.JsonRpcProvider(
-      `https://mainnet.infura.io/v3/${infuraKey}`,
-    )
+  constructor(rpcUrl: string) {
+    this.provider = new ethers.providers.JsonRpcProvider(rpcUrl)
     this.IndexToken = new ethers.Contract(
       '0xF17A3fE536F8F7847F1385ec1bC967b2Ca9caE8D',
       abi,
@@ -33,6 +31,7 @@ export class Collateral {
   }
 
   getAssetWeightsInput = async () => {
+    logger.debug('Getting asset weights input')
     const indexToken = this.IndexToken
     const from = await this.getLatestMethodologySetInfo(indexToken)
     const latestBlock = await this.provider.getBlock('latest')
@@ -49,6 +48,7 @@ export class Collateral {
 
     // get all intervening fee changes
     const feeChanges = await this.getFeeChanges(indexToken, from.blockNumber, to.blockNumber)
+    logger.debug('Fetching methodology')
     const initialMethodology = await this.fetchMethodology()
     return {
       feeWhenMethodologySet,
@@ -66,6 +66,7 @@ export class Collateral {
     to: { timestamp: number; blockNumber?: number },
     initialMethodology: { [s: string]: unknown } | ArrayLike<unknown>,
   ) => {
+    logger.debug('Calculating asset weights')
     const intervals = [
       ...feeChanges,
       // and add the timestamp of the last mint/redeem
@@ -87,6 +88,7 @@ export class Collateral {
     startFee: number,
     intervals: Iterable<number[]>,
   ) => {
+    logger.debug('Calculating multi rate inflation')
     let inflation = 1
     let lastTimestamp = startTimestamp
     let lastFeeRate = startFee
@@ -99,6 +101,7 @@ export class Collateral {
   }
 
   calcInflation = (feeRate: number, fromTimestamp: number, toTimestamp: number) => {
+    logger.debug('Calculating inflation')
     const bigNumResult = bignumber(1)
       .div(bignumber(1).plus(feeRate))
       .pow(
@@ -110,6 +113,7 @@ export class Collateral {
   }
 
   getLatestMethodologySetInfo = async (indexToken: ethers.Contract) => {
+    logger.debug('Getting latest methodology info')
     const latestBlock = await this.provider.getBlock('latest')
     const logs = await this.provider.getLogs({
       ...indexToken.filters.MethodologySet(),
@@ -125,6 +129,7 @@ export class Collateral {
   }
 
   getFeeChanges = async (indexToken: ethers.Contract, fromBlock: number, toBlock: number) => {
+    logger.debug('Getting fee changes')
     return await Promise.all(
       (
         await this.provider.getLogs({
@@ -225,6 +230,7 @@ export class Collateral {
   }
 
   fetchIPFSFromPinata = async (path: string) => {
+    logger.debug('Fetching IPFS from Pinata')
     const newPath = path.replace('ipfs://', '')
     const baseURL = 'dxas'
     const ipfsUrl = `${baseURL}/${newPath}`
@@ -237,6 +243,7 @@ export class Collateral {
   }
 
   fetchIPFSFromInfura = async (path: string) => {
+    logger.debug('Fetching IPFS from Infura')
     const newPath = path.replace('ipfs://', '')
     const baseURL = 'https://amkt.infura-ipfs.io/ipfs'
     const ipfsUrl = `${baseURL}/${newPath}`

--- a/packages/sources/alongside/test/integration/adapter.test.ts
+++ b/packages/sources/alongside/test/integration/adapter.test.ts
@@ -34,7 +34,7 @@ describe('rest', () => {
     PASSPHRASE: process.env.PASSPHRASE || 'fake-passphrase',
     SIGNING_KEY: process.env.SIGNING_KEY || 'fake-signing-key',
     PORTFOLIO_ID: process.env.PORTFOLIO_ID || 'fake-portfolio',
-    INFURA_KEY: process.env.INFURA_KEY || 'fake-infura-key',
+    RPC_URL: process.env.RPC_URL || 'https://mainnet.infura.io:443/v3/fake-infura-key',
   }
   setupExternalAdapterTest(envVariables, context)
 


### PR DESCRIPTION
## Description

Updated Alongside to allow a generic rpc provider

## Changes

- Replaced `INFURA_KEY` env var with generic `RPC_URL`
- Updated adapter logic to use the new env var instead
- Added extra debug logging

## Steps to Test

1. yarn test packages/sources/alongside/test

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
