### PR TITLE
Release v1.60.0 [develop]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/external-adapters-js",
-  "version": "1.59.0",
+  "version": "1.60.0",
   "license": "MIT",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Changelog

### Breaking Changes
- Removed `WS_ENABLED` env var on cfbenchmarks-test, dxfeed-test, finage-test, intrinio-test, tiingo-test

### Features
- ea-bootstrap: Updated Requester.validateResultNumber to take acceptZeroValue option
- Updated Typescript to v4.9.5
- cfbenchmarks & cfbenchmarks-test: Added BIRC endpoint
- Bumped v3 framework version on various v3 EAs

### Bug Fixes
- NCFX: remove previous typo fix from NCFX

### Documentation
- fluent-finance: Updated endpoint description

### Notable Adapter Updates

### Composite External Adapters

|                 Adapter Name                 | Version  |
|-----------------------------------|-----------|
|          anchor-adapter           |  4.0.12  |
|        apy-finance-adapter        |  2.0.18  |
|           augur-adapter           |  2.0.12  |
|     bitcoin-json-rpc-adapter      |  1.3.28  |
|        bsol-price-adapter         |  2.2.37  |
|      circuit-breaker-adapter      |  1.2.27  |
|  crypto-volatility-index-adapter  |  1.3.37  |
|        curve-3pool-adapter        |  3.0.18  |
|        defi-dozen-adapter         |  1.2.37  |
|        defi-pulse-adapter         |  1.2.37  |
|     dns-record-check-adapter      |  1.3.28  |
|           dxdao-adapter           |  2.0.18  |
|       dydx-rewards-adapter        |  2.0.12  |
|      google-weather-adapter       |  1.3.20  |
|    historical-average-adapter     |  1.2.31  |
|       implied-price-adapter       |  1.1.20  |
|      linear-finance-adapter       |  2.3.26  |
|      market-closure-adapter       |  1.2.28  |
|        medianizer-adapter         |  1.2.27  |
|           nftx-adapter            |  3.0.12  |
|     outlier-detection-adapter     |  1.2.69  |
|        por-indexer-adapter        |  1.2.39  |
|     proof-of-reserves-adapter     |  1.16.1  |
|    reference-transform-adapter    |  1.2.69  |
|        rocket-pool-adapter        |  1.1.3   |
|        savax-price-adapter        |  3.0.19  |
|      set-token-index-adapter      |  2.0.18  |
|        synth-index-adapter        |  1.2.37  |
|         the-graph-adapter         |  1.2.28  |
|          vesper-adapter           |  2.0.18  |
|       xsushi-price-adapter        |  2.0.18  |


### Source and Target External Adapters

|                 Adapter Name                 |  Version  |
|-----------------------------------|-----------|
|          1forge-adapter           |  1.6.29   |
|        accuweather-adapter        |  1.3.28   |
|        ada-balance-adapter        |  2.5.28   |
|          agoric-adapter           |  2.1.28   |
|         alongside-adapter         |   1.1.1   |
|        alphachain-adapter         |  1.3.28   |
|       alphavantage-adapter        |  1.3.28   |
|          alpine-adapter           |   2.0.1   |
|         amberdata-adapter         |  1.8.21   |
|         anyblock-adapter          |   2.0.1   |
|        ap-election-adapter        |  1.3.28   |
|         armanino-adapter          |  1.0.43   |
|    avalanche-platform-adapter     |   1.0.1   |
|        bank-frick-adapter         |   1.0.2   |
|            bea-adapter            |  1.3.28   |
|          binance-adapter          |  1.4.28   |
|        binance-dex-adapter        |  1.6.20   |
|           bitex-adapter           |  1.5.28   |
|           bitso-adapter           |  1.4.28   |
|      blockchain.com-adapter       |  1.3.28   |
|        blockchair-adapter         |  1.3.28   |
|        blockcypher-adapter        |  1.4.28   |
|     blocksize-capital-adapter     |  1.0.39   |
|  blocksize-capital-test-adapter   |   1.0.1   |
|        blockstream-adapter        |  1.4.28   |
|            bob-adapter            |  2.0.10   |
|       bravenewcoin-adapter        |  1.3.28   |
|          btc.com-adapter          |  1.3.28   |
|        cache.gold-adapter         |  1.3.28   |
|         ccip-read-adapter         |   3.0.1   |
|   celsius-address-list-adapter    |  2.0.12   |
|       cfbenchmarks-adapter        |   1.6.0   |
|     cfbenchmarks-test-adapter     |   1.2.0   |
|   chain-reserve-wallet-adapter    |  3.0.12   |
|          coinapi-adapter          |  1.3.18   |
|       coinapi-test-adapter        |   1.0.1   |
|         coinbase-adapter          |  2.0.12   |
|         coincodex-adapter         |  1.3.28   |
|         coingecko-adapter         |  1.9.20   |
|      coingecko-test-adapter       |   1.5.4   |
|         coinlore-adapter          |  1.3.28   |
|       coinmarketcap-adapter       |  1.5.31   |
|    coinmarketcap-test-adapter     |   1.0.2   |
|        coinmetrics-adapter        |  1.3.28   |
|     coinmetrics-test-adapter      |   1.0.8   |
|        coinpaprika-adapter        |  1.10.20  |
|     coinpaprika-test-adapter      |   1.0.2   |
|        coinranking-adapter        |   2.0.1   |
|          conflux-adapter          |  1.1.28   |
|       covid-tracker-adapter       |  1.4.20   |
|          cryptex-adapter          |  2.0.12   |
|        cryptoapis-adapter         |  1.2.28   |
|       cryptoapis-v2-adapter       |  1.2.28   |
|       cryptocompare-adapter       |  1.4.28   |
|    cryptocompare-test-adapter     |   1.1.1   |
|         cryptoid-adapter          |  1.3.28   |
|         cryptomkt-adapter         |  1.3.28   |
|       currencylayer-adapter       |  2.0.20   |
|           curve-adapter           |  2.0.12   |
|            dar-adapter            |   1.0.6   |
|          deribit-adapter          |  1.2.28   |
|         dns-query-adapter         |  1.6.20   |
|          dwolla-adapter           |  1.2.28   |
|          dxfeed-adapter           |  1.3.28   |
|     dxfeed-secondary-adapter      |  1.2.28   |
|        dxfeed-test-adapter        |   1.0.2   |
|        dydx-stark-adapter         |  1.1.28   |
|          elwood-adapter           |   2.0.2   |
|            ens-adapter            |  2.0.12   |
|          enzyme-adapter           |  2.0.12   |
|     eodhistoricaldata-adapter     |  1.3.28   |
|        eth-balance-adapter        |  2.0.12   |
|        eth-beacon-adapter         |   1.3.4   |
|        etherchain-adapter         |  1.4.28   |
|         etherscan-adapter         |  1.3.28   |
|       ethgasstation-adapter       |  1.4.28   |
|        ethgaswatch-adapter        |  1.3.28   |
|         ethwrite-adapter          |  2.0.12   |
|     expert-car-broker-adapter     |  1.3.28   |
|          fcsapi-adapter           |  1.2.28   |
|          finage-adapter           |  1.6.14   |
|        finage-test-adapter        |   1.0.2   |
|          finnhub-adapter          |  1.2.28   |
|           fixer-adapter           |  2.0.20   |
|        flightaware-adapter        |  1.2.28   |
|      fluent-finance-adapter       |   2.0.2   |
|         fmpcloud-adapter          |  1.3.28   |
|          galaxis-adapter          |   4.0.5   |
|          galaxy-adapter           |   2.0.2   |
|          gemini-adapter           |  2.2.28   |
|    genesis-volatility-adapter     |  1.3.28   |
|           geodb-adapter           |  1.2.28   |
|      google-bigquery-adapter      |  1.2.28   |
|         gramchain-adapter         |  1.1.28   |
|          graphql-adapter          |  1.2.28   |
|            gsr-adapter            |   2.0.4   |
|          harmony-adapter          |  1.1.28   |
|         iex-cloud-adapter         |  1.2.28   |
|         intrinio-adapter          |  1.3.28   |
|       intrinio-test-adapter       |   1.0.2   |
|           ipfs-adapter            |  1.3.28   |
|           jpegd-adapter           |  2.1.28   |
|         json-rpc-adapter          |  1.3.28   |
|           kaiko-adapter           |  1.5.22   |
|        kaiko-test-adapter         |   1.0.3   |
|  layer2-sequencer-health-adapter  |   2.3.8   |
|            lcx-adapter            |  1.3.28   |
|           lido-adapter            |  2.0.12   |
|         linkpool-adapter          |  1.2.28   |
|          lition-adapter           |  1.2.28   |
|           lotus-adapter           |  2.2.28   |
|        marketstack-adapter        |  1.3.28   |
|          messari-adapter          |  1.2.28   |
|         metalsapi-adapter         |  1.7.28   |
|          mock-ea-adapter          |  2.1.28   |
|   moonbeam-address-list-adapter   |   1.0.1   |
|        mycryptoapi-adapter        |  1.3.28   |
|           ncfx-adapter            |   3.0.3   |
|       nft-blue-chip-adapter       |   1.0.1   |
|          nikkei-adapter           |  1.2.28   |
|          nomics-adapter           |  1.3.28   |
|        nomics-test-adapter        |   1.0.1   |
|           oanda-adapter           |   1.0.1   |
|        oilpriceapi-adapter        |  2.1.28   |
|        onchain-gas-adapter        |  1.3.28   |
|     openexchangerates-adapter     |  1.5.22   |
|     orchid-bandwidth-adapter      |  1.2.28   |
|           paxos-adapter           |  1.4.20   |
|          paypal-adapter           |  1.2.28   |
|            poa-adapter            |  1.3.28   |
|     polkadot-balance-adapter      |   1.0.1   |
|          polygon-adapter          |  1.7.15   |
|     por-address-list-adapter      |  4.0.11   |
|     renvm-address-set-adapter     |  1.5.30   |
|       satoshitango-adapter        |  1.3.28   |
|         snowflake-adapter         |  1.2.28   |
|          sochain-adapter          |  1.3.28   |
|   solana-view-function-adapter    |  2.2.28   |
|   spectral-macro-score-adapter    |  2.0.12   |
|       sportsdataio-adapter        |  1.3.20   |
|    stader-address-list-adapter    |   1.2.4   |
|        stader-labs-adapter        |   3.0.5   |
|          stasis-adapter           |  1.2.28   |
|    swell-address-list-adapter     |  1.0.11   |
|    synthetix-debt-pool-adapter    |  4.0.12   |
|           taapi-adapter           |  1.2.28   |
|    terra-view-function-adapter    |  1.3.28   |
|        therundown-adapter         |  1.3.28   |
|          tiingo-adapter           |  1.12.18  |
|        tiingo-test-adapter        |   1.0.1   |
|        tradermade-adapter         |  1.9.11   |
|      tradermade-test-adapter      |   1.0.1   |
|     tradingeconomics-adapter      |  2.2.14   |
|          trueusd-adapter          |  1.6.17   |
|        twelvedata-adapter         |  1.2.28   |
|         twosigma-adapter          |   1.0.1   |
|          unibit-adapter           |  1.4.28   |
|        uniswap-v2-adapter         |  2.0.12   |
|        uniswap-v3-adapter         |  2.0.12   |
|          upvest-adapter           |  1.3.28   |
|         uscpi-one-adapter         |  1.3.28   |
|       view-function-adapter       |  2.0.12   |
|     wbtc-address-set-adapter      |  1.4.39   |
|         wootrade-adapter          |  1.2.28   |
|          wrapped-adapter          |  2.2.28   |
|           xbto-adapter            |  1.3.28   |
