### PR TITLE
Fix/coinranking marketcap alias

### DIFF
--- a/.changeset/chatty-crews-crash.md
+++ b/.changeset/chatty-crews-crash.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/coinranking-adapter': patch
+---
+
+Add globalmarketcap endpoint alias

--- a/packages/sources/coinranking/src/endpoint/totalMarketCap.ts
+++ b/packages/sources/coinranking/src/endpoint/totalMarketCap.ts
@@ -1,7 +1,7 @@
 import { ExecuteWithConfig, Config, Validator, InputParameters } from '@chainlink/ea-bootstrap'
 import { Requester } from '@chainlink/ea-bootstrap'
 
-export const supportedEndpoints = ['totalMarketCap', 'totalmcap']
+export const supportedEndpoints = ['totalMarketCap', 'totalmcap', 'globalmarketcap']
 
 export type TInputParameters = Record<string, never>
 export const inputParameters: InputParameters<TInputParameters> = {}

--- a/packages/sources/coinranking/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/coinranking/test/integration/__snapshots__/adapter.test.ts.snap
@@ -25,6 +25,18 @@ Object {
 }
 `;
 
+exports[`execute globalmarketcap endpoint alias should return success 1`] = `
+Object {
+  "data": Object {
+    "result": 1139638848309,
+  },
+  "jobRunID": "1",
+  "providerStatusCode": 200,
+  "result": 1139638848309,
+  "statusCode": 200,
+}
+`;
+
 exports[`execute marketcap api should return success 1`] = `
 Object {
   "data": Object {

--- a/packages/sources/coinranking/test/integration/adapter.test.ts
+++ b/packages/sources/coinranking/test/integration/adapter.test.ts
@@ -119,4 +119,26 @@ describe('execute', () => {
       expect(response.body).toMatchSnapshot()
     })
   })
+
+  describe('globalmarketcap endpoint alias', () => {
+    const data: AdapterRequest = {
+      id,
+      data: {
+        endpoint: 'globalmarketcap',
+      },
+    }
+
+    it('should return success', async () => {
+      mockTotalMarketCapSuccess()
+
+      const response = await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+      expect(response.body).toMatchSnapshot()
+    })
+  })
 })


### PR DESCRIPTION
<!-- Employees: Please use Clubhouse/Shortcuts's "Open PR" button from the relevant story or include links to relevant Clubhouse/Shortcut stories in your branch name, commit messages, or pull request comments. Do not add links to your pull request description, they will be ignored. https://help.clubhouse.io/hc/en-us/articles/207540323-Using-The-Clubhouse-GitHub-Integration -->

<!-- Employees: Delete this section. -->

## Closes #[DF-18699](https://smartcontract-it.atlassian.net/browse/DF-18699)

## Description
Add `globalmarketcap` alias for coinranking EA's `totalMarketCap` endpoint

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test
`yarn && yarn changeset && yarn test packages/coinranking/test/integration/*`

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [x] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[DF-18699]: https://smartcontract-it.atlassian.net/browse/DF-18699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ