### PR TITLE
Reduce Alongside lookback to 300,000 blocks

### DIFF
--- a/.changeset/swift-students-rush.md
+++ b/.changeset/swift-students-rush.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/alongside-adapter': patch
+---
+
+Reduced lookback period

--- a/packages/sources/alongside/src/endpoint/collateral/utils.ts
+++ b/packages/sources/alongside/src/endpoint/collateral/utils.ts
@@ -117,7 +117,7 @@ export class Collateral {
     const latestBlock = await this.provider.getBlock('latest')
     const logs = await this.provider.getLogs({
       ...indexToken.filters.MethodologySet(),
-      fromBlock: latestBlock.number - 1_000_000,
+      fromBlock: latestBlock.number - 300_000,
       toBlock: latestBlock.number,
     })
     // TODO replace me with an assert

--- a/packages/sources/alongside/test/integration/fixtures.ts
+++ b/packages/sources/alongside/test/integration/fixtures.ts
@@ -1016,7 +1016,7 @@ nock('https://mainnet.infura.io:443/v3/fake-infura-key')
     method: 'eth_getLogs',
     params: [
       {
-        fromBlock: '0xeed364',
+        fromBlock: '0xf981c4',
         toBlock: '0xfe15a4',
         address: '0xf17a3fe536f8f7847f1385ec1bc967b2ca9cae8d',
         topics: ['0xe6be68107100e39cb16d675c1086a4d5479fbd01108d721dabbccaa2249b995f'],


### PR DESCRIPTION
## Closes [PDI-2040](https://smartcontract-it.atlassian.net/browse/PDI-2040)

## Description

Reduced lookback period to 300,000 blocks from 1,000,000 blocks for the latest method info

## Changes

- Reduce lookback for eth_getLogs to 300,000 blocks

## Steps to Test

1. yarn test packages/sources/alongside/test

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[PDI-2040]: https://smartcontract-it.atlassian.net/browse/PDI-2040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ