### PR TITLE
Reduce coinmarketcap-test rate limit tiers 

### DIFF
--- a/.changeset/little-peas-draw.md
+++ b/.changeset/little-peas-draw.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/coinmarketcap-test-adapter': patch
+---
+
+Reduced rate limit tiers to account for multiple credits used per request

--- a/packages/sources/coinmarketcap-test/src/index.ts
+++ b/packages/sources/coinmarketcap-test/src/index.ts
@@ -10,25 +10,25 @@ export const adapter = new PriceAdapter({
   rateLimiting: {
     tiers: {
       free: {
-        rateLimit1m: 30,
-        rateLimit1h: 13.698630137,
-        note: "10k credits/month, 730h in a month, ignoring daily limits since they're soft caps",
+        rateLimit1m: 7.5,
+        rateLimit1h: 3,
+        note: "10k credits/month, 730h in a month, ignoring daily limits since they're soft caps. Divided by 4 to account for multiple credits per request",
       },
       hobbyist: {
-        rateLimit1m: 30,
-        rateLimit1h: 54.794520548,
+        rateLimit1m: 7.5,
+        rateLimit1h: 13,
       },
       startup: {
-        rateLimit1m: 30,
-        rateLimit1h: 164.383561644,
+        rateLimit1m: 7.5,
+        rateLimit1h: 41,
       },
       standard: {
-        rateLimit1m: 60,
-        rateLimit1h: 684.931506849,
+        rateLimit1m: 15,
+        rateLimit1h: 171,
       },
       professional: {
-        rateLimit1m: 90,
-        rateLimit1h: 4109.589041096,
+        rateLimit1m: 22.5,
+        rateLimit1h: 1027,
       },
     },
   },


### PR DESCRIPTION
## Closes [PDI-76](https://smartcontract-it.atlassian.net/browse/PDI-76)

## Description

Reduced rate limit tiers for the v3 coinmarketcap adapter to account for multiple credits used per request. The current v3 rate limiters can only account for outgoing requests without any concept of credits.

## Changes

- Divided all v3 coinmarketcap rate limits by 4 to represent the highest number of credits used by NOPs per request

## Steps to Test

1. yarn test packages/sources/coinmarketcap-test/test

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[PDI-76]: https://smartcontract-it.atlassian.net/browse/PDI-76?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ