### PR TITLE
Fix v3 cfbenchmarks rest transport logic

### DIFF
--- a/.changeset/three-penguins-laugh.md
+++ b/.changeset/three-penguins-laugh.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/cfbenchmarks-test-adapter': patch
+---
+
+Fixed rest transports

--- a/packages/sources/cfbenchmarks-test/src/endpoint/rest/crypto.ts
+++ b/packages/sources/cfbenchmarks-test/src/endpoint/rest/crypto.ts
@@ -22,11 +22,10 @@ export const makeRestTransport = (
 ): HttpTransport<RestEndpointTypes> => {
   return new HttpTransport<RestEndpointTypes>({
     prepareRequests: (params, config) => {
-      const [{ index }] = params
       const { API_USERNAME, API_PASSWORD, API_ENDPOINT, SECONDARY_API_ENDPOINT } = config
       const encodedCreds = Buffer.from(`${API_USERNAME}:${API_PASSWORD}`).toString('base64')
-      return {
-        params,
+      return params.map((param) => ({
+        params: [param],
         request: {
           baseURL: type === 'primary' ? API_ENDPOINT : SECONDARY_API_ENDPOINT,
           url: '/v1/values',
@@ -34,28 +33,26 @@ export const makeRestTransport = (
             Authorization: `Basic ${encodedCreds}`,
           },
           params: {
-            id: index,
+            id: param.index,
           },
         },
-      }
+      }))
     },
-    parseResponse: ([{ index }], res) => {
+    parseResponse: (params, res) => {
       const values = res.data.payload.sort((a, b) => b.time - a.time) // Descending
       const value = Number(values[0].value)
-      return [
-        {
-          params: { index },
-          response: {
+      return params.map((param) => ({
+        params: param,
+        response: {
+          result: value,
+          data: {
             result: value,
-            data: {
-              result: value,
-            },
-            timestamps: {
-              providerIndicatedTimeUnixMs: values[0].time,
-            },
+          },
+          timestamps: {
+            providerIndicatedTimeUnixMs: values[0].time,
           },
         },
-      ]
+      }))
     },
   })
 }


### PR DESCRIPTION
## Closes [PDI-1954](https://smartcontract-it.atlassian.net/browse/PDI-1954)

## Description

Fixed rest transport logic only handling the first request in subscription set

## Changes

- Fixed logic to handle all params in http transport `prepareRequest` and `parseResponse`

## Steps to Test

1. yarn test packages/sources/cfbenchmarks-test/test

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[PDI-1954]: https://smartcontract-it.atlassian.net/browse/PDI-1954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ