### PR TITLE
Update cfbenchmarks custom router

### DIFF
--- a/.changeset/forty-grapes-wonder.md
+++ b/.changeset/forty-grapes-wonder.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/cfbenchmarks-test-adapter': patch
+---
+
+Updated custom router to default to websocket for secondary endpoints

--- a/.changeset/small-berries-eat.md
+++ b/.changeset/small-berries-eat.md
@@ -1,0 +1,6 @@
+---
+'@chainlink/coinmarketcap-test-adapter': patch
+'@chainlink/coinmetrics-test-adapter': patch
+---
+
+Empty change

--- a/packages/sources/cfbenchmarks-test/src/endpoint/common/crypto.ts
+++ b/packages/sources/cfbenchmarks-test/src/endpoint/common/crypto.ts
@@ -89,8 +89,8 @@ export const endpoint = new CryptoPriceEndpoint({
   defaultTransport: 'ws',
   customRouter: (req, adapterConfig) => {
     if (adapterConfig.API_SECONDARY) {
-      if (req.requestContext.transportName === 'ws') return 'wssecondary'
-      return 'restsecondary'
+      if (req.requestContext.transportName === 'rest') return 'restsecondary'
+      return 'wssecondary'
     } else {
       return req.requestContext.transportName
     }

--- a/packages/sources/coinmarketcap-test/src/endpoint/crypto.ts
+++ b/packages/sources/coinmarketcap-test/src/endpoint/crypto.ts
@@ -168,7 +168,6 @@ const httpTransport = new HttpTransport<CryptoEndpointTypes>({
   },
   parseResponse: (params, res) => {
     logger.debug(`CMC api call cost: ${res.data.cost}`)
-
     // Use the mapping to generate the responses
     return params.map((p) => {
       const data = res.data.data[p.cid || p.slug || p.base]

--- a/packages/sources/coinmetrics-test/src/endpoint/price-ws.ts
+++ b/packages/sources/coinmetrics-test/src/endpoint/price-ws.ts
@@ -69,6 +69,7 @@ export const calculateAssetMetricsUrl = (
   generated.searchParams.append('metrics', metrics)
   generated.searchParams.append('frequency', '1s')
   generated.searchParams.append('api_key', API_KEY)
+
   logger.debug(`Generated URL: ${generated.toString()}`)
   return generated.toString()
 }


### PR DESCRIPTION
## Closes [PDI-1954](https://smartcontract-it.atlassian.net/browse/PDI-1954)

## Description

Updated custom router logic to default to websocket for secondary endpoints.

## Steps to Test

1. yarn test packages/sources/cfbenchmarks-test/test

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[PDI-1954]: https://smartcontract-it.atlassian.net/browse/PDI-1954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ