### PR TITLE
Fix CMC request building for empty param list

### DIFF
--- a/.changeset/friendly-wasps-confess.md
+++ b/.changeset/friendly-wasps-confess.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/coinmarketcap-test-adapter': patch
+---
+
+Fixed request building for empty param lists

--- a/packages/sources/coinmarketcap-test/src/endpoint/crypto.ts
+++ b/packages/sources/coinmarketcap-test/src/endpoint/crypto.ts
@@ -141,26 +141,28 @@ const httpTransport = new HttpTransport<CryptoEndpointTypes>({
     }
 
     for (const [idType, fullList] of Object.entries(groupedParams)) {
-      // CMC does not support more than 120 unique quotes
-      const chunkedList = chunkArray(fullList, 120)
+      if (fullList && fullList.length > 0) {
+        // CMC does not support more than 120 unique quotes
+        const chunkedList = chunkArray(fullList, 120)
 
-      // This could be further optimized in cases with more than 120 entries, to make sure that
-      // chunkes are grouped optimally to avoid sending unnecessary converts
-      for (const list of chunkedList) {
-        requests.push({
-          params: list,
-          request: {
-            baseURL: settings.API_ENDPOINT,
-            url: '/cryptocurrency/quotes/latest',
-            headers: {
-              'X-CMC_PRO_API_KEY': settings.API_KEY,
+        // This could be further optimized in cases with more than 120 entries, to make sure that
+        // chunkes are grouped optimally to avoid sending unnecessary converts
+        for (const list of chunkedList) {
+          requests.push({
+            params: list,
+            request: {
+              baseURL: settings.API_ENDPOINT,
+              url: '/cryptocurrency/quotes/latest',
+              headers: {
+                'X-CMC_PRO_API_KEY': settings.API_KEY,
+              },
+              params: {
+                [idType]: [...new Set(list.map((p) => p.cid || p.slug || p.base))].join(','),
+                convert: [...new Set(list.map((p) => p.quote))].join(','),
+              },
             },
-            params: {
-              [idType]: [...new Set(list.map((p) => p.cid || p.slug || p.base))].join(','),
-              convert: [...new Set(list.map((p) => p.quote))].join(','),
-            },
-          },
-        })
+          })
+        }
       }
     }
 
@@ -168,6 +170,7 @@ const httpTransport = new HttpTransport<CryptoEndpointTypes>({
   },
   parseResponse: (params, res) => {
     logger.debug(`CMC api call cost: ${res.data.cost}`)
+
     // Use the mapping to generate the responses
     return params.map((p) => {
       const data = res.data.data[p.cid || p.slug || p.base]


### PR DESCRIPTION
## Closes [PDI-76](https://smartcontract-it.atlassian.net/browse/PDI-76)

## Description

Fixed request building for empty param list after filtering on cid, slug, and symbol

## Steps to Test

1. yarn test packages/sources/coinmarketcap-test/test

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[PDI-76]: https://smartcontract-it.atlassian.net/browse/PDI-76?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ