### PR TITLE
Add crypto yield and realized vol endpoints to Tiingo EAv2

### DIFF
--- a/.changeset/three-jokes-pay.md
+++ b/.changeset/three-jokes-pay.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/tiingo-adapter': minor
+---
+
+Add yield and realized vol endpoints to Tiingo EAv2

--- a/packages/sources/tiingo-test/src/result-path-adapter.ts
+++ b/packages/sources/tiingo-test/src/result-path-adapter.ts
@@ -1,0 +1,78 @@
+// import { SettingsDefinitionMap } from '@chainlink/external-adapter-framework/config'
+// import { AdapterRequest, AdapterRequestContext, AdapterResponse, RequestGenerics } from '@chainlink/external-adapter-framework/util'
+// import { PriceAdapter, AdapterParams, PriceEndpointParams, IncludesFile } from '@chainlink/external-adapter-framework/adapter'
+
+// export type PathPriceEndpointParams = PriceEndpointParams & { resultPath?: string }
+
+// type IncludeDetails = {
+//   from: string
+//   to: string
+//   inverse: boolean
+// }
+// type IncludesMap = Record<string, Record<string, IncludeDetails>>
+
+// type PriceAdapterRequest<T extends RequestGenerics> = AdapterRequest<T> & {
+//   requestContext: AdapterRequestContext<T> & {
+//     priceMeta: {
+//       inverse: boolean
+//     }
+//   }
+// }
+
+// /**
+//  * A PriceAdapter is a specific kind of Adapter that includes at least one PriceEnpoint.
+//  */
+//  export class PathPriceAdapter<
+//  CustomSettingsDefinition extends SettingsDefinitionMap,
+// > extends PriceAdapter<CustomSettingsDefinition> {
+//   includesMap?: IncludesMap
+
+//   constructor(
+//     params: AdapterParams<CustomSettingsDefinition> & {
+//       includes?: IncludesFile
+//     },
+//   ) {
+//     super(params)
+//   }
+
+//   override async handleRequest(
+//     req: PriceAdapterRequest<{
+//       Params: PathPriceEndpointParams
+//     }>,
+//     replySent: Promise<unknown>,
+//   ): Promise<AdapterResponse> {
+//     const { resultPath } = req.requestContext.data
+
+//     //TODO remove
+//     delete req.requestContext.data.resultPath
+//     // req.requestContext.data.resultPath = 'supplyRate'
+
+//     const transportName = endpoint.getTransportNameForRequest(req, adapter.config.settings)
+//       req.requestContext.cacheKey = calculateCacheKey({
+//         data: req.requestContext.data,
+//         adapterName: adapter.name,
+//         endpointName: endpoint.name,
+//         transportName,
+//         inputParameters: endpoint.inputParameters,
+//         adapterSettings: adapter.config.settings,
+//       })
+
+//     console.log({cacheKey: req.requestContext.cacheKey})
+// //
+//     const response = await super.handleRequest(req, replySent)
+
+//     //TODO remove
+//     const cachedResponse = await this.findResponseInCache(req)
+//     console.log({resultPath, data: req.requestContext.data, cachedResponse})
+
+//     if (resultPath) {
+//       const cloneResponse = { ...response }
+//       const data = cloneResponse.data as Record<string, any>
+//       console.log(data)
+//       cloneResponse.result = data[resultPath]
+//       return cloneResponse
+//     }
+
+//     return response
+//   }
+//   }

--- a/packages/sources/tiingo/src/endpoint/crypto/yield.ts
+++ b/packages/sources/tiingo/src/endpoint/crypto/yield.ts
@@ -1,0 +1,56 @@
+import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import { ExecuteWithConfig, Config, InputParameters } from '@chainlink/ea-bootstrap'
+
+export const supportedEndpoints = ['yield', 'cryptoyield', 'crypto-yield']
+
+export type TInputParameters = { poolCode: string }
+
+export const inputParameters: InputParameters<TInputParameters> = {
+  poolCode: {
+    default: 'ethnetwork_eth',
+    required: false,
+    type: 'string',
+    description: 'Tiingo staking pool code to return yield data for',
+  },
+}
+
+interface CryptoYieldResponse {
+  date: string
+  yieldPoolID: number
+  yieldPoolName: string
+  epoch: number
+  startSlot: number
+  endSlot: number
+  validatorReward: number
+  transactionReward: number
+  validatorSubtractions: number
+  deposits: number
+  totalReward: number
+  divisor: number
+  apr30Day: number
+  apr90Day: number
+}
+
+export const execute: ExecuteWithConfig<Config> = async (request, _, config) => {
+  const validator = new Validator(request, inputParameters, {})
+
+  const jobRunID = validator.validated.id
+  const poolCode = validator.validated.data.poolCode
+
+  const reqConfig = {
+    ...config.api,
+    params: {
+      poolCodes: poolCode,
+      token: config.apiKey,
+    },
+    url: 'tiingo/crypto-yield/ticks',
+  }
+
+  const response = await Requester.request<CryptoYieldResponse[]>(reqConfig)
+  let resultPath = validator.validated.data.resultPath?.toString()
+  if (!resultPath) {
+    resultPath = Object.keys(response.data[0]).includes('apr30Day') ? 'apr30Day' : 'supplyRate'
+  }
+  const result = Requester.validateResultNumber(response.data, [0, resultPath])
+  return Requester.success(jobRunID, Requester.withResult(response, result), config.verbose)
+}

--- a/packages/sources/tiingo/src/endpoint/index.ts
+++ b/packages/sources/tiingo/src/endpoint/index.ts
@@ -4,6 +4,8 @@ import type { TInputParameters as TopInputParameters } from './crypto/top'
 import type { TInputParameters as PricesInputParameters } from './crypto/prices'
 import type { TInputParameters as ForexInputParameters } from './forex'
 import type { TInputParameters as VwapInputParameters } from './crypto/vwap'
+import type { TInputParameters as YieldInputParameters } from './crypto/yield'
+import type { TInputParameters as RealizedVolInputParameters } from './realized-vol'
 
 export type TInputParameters =
   | EodInputParameters
@@ -12,6 +14,8 @@ export type TInputParameters =
   | PricesInputParameters
   | ForexInputParameters
   | VwapInputParameters
+  | YieldInputParameters
+  | RealizedVolInputParameters
 
 export * as eod from './eod'
 export * as iex from './iex'
@@ -19,3 +23,5 @@ export * as top from './crypto/top'
 export * as prices from './crypto/prices'
 export * as forex from './forex'
 export * as cryptoVwap from './crypto/vwap'
+export * as cyptoYield from './crypto/yield'
+export * as realizedVol from './realized-vol'

--- a/packages/sources/tiingo/src/endpoint/realized-vol.ts
+++ b/packages/sources/tiingo/src/endpoint/realized-vol.ts
@@ -1,0 +1,67 @@
+import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import { ExecuteWithConfig, Config, InputParameters } from '@chainlink/ea-bootstrap'
+
+export const supportedEndpoints = [
+  'realized-vol',
+  'realised-vol',
+  'realizedVol',
+  'realisedVol',
+  'rv',
+]
+
+const TIINGO_REALIZED_VOL_PREFIX = 'real_vol_'
+const TIINGO_REALIZED_VOL_URL = `tiingo/crypto/prices`
+const TIINGO_REALIZED_VOL_DEFAULT_QUOTE = 'USD'
+
+export type TInputParameters = { base: string; quote: string }
+
+export const inputParameters: InputParameters<TInputParameters> = {
+  base: {
+    aliases: ['from', 'coin'],
+    required: true,
+    type: 'string',
+    description: 'The base currency to query the realized volatility for',
+  },
+  quote: {
+    aliases: ['to', 'convert'],
+    required: false,
+    default: TIINGO_REALIZED_VOL_DEFAULT_QUOTE,
+    type: 'string',
+    description: 'The quote currency to convert the realized volatility to',
+  },
+}
+
+interface CryptoYieldResponse {
+  baseCurrency: string
+  quoteCurrency: string
+  realVolData: {
+    date: string
+    realVol1Day: number
+    realVol7Day: number
+    realVol30Day: number
+  }[]
+}
+
+export const execute: ExecuteWithConfig<Config> = async (request, _, config) => {
+  const validator = new Validator(request, inputParameters, {})
+
+  const jobRunID = validator.validated.id
+  const { base, quote } = validator.validated.data
+  const resultPath = (validator.validated.data.resultPath || 'realVol30Day').toString()
+
+  const reqConfig = {
+    ...config.api,
+    params: {
+      token: config.apiKey,
+      // prepend real_vol to baseCurrency
+      baseCurrency: `${TIINGO_REALIZED_VOL_PREFIX}${base}`,
+      convertCurrency: quote,
+      consolidateBaseCurrency: true,
+    },
+    url: TIINGO_REALIZED_VOL_URL,
+  }
+
+  const response = await Requester.request<CryptoYieldResponse[]>(reqConfig)
+  const result = Requester.validateResultNumber(response.data, [0, 'realVolData', 0, resultPath])
+  return Requester.success(jobRunID, Requester.withResult(response, result), config.verbose)
+}

--- a/packages/sources/tiingo/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/tiingo/test/integration/__snapshots__/adapter.test.ts.snap
@@ -24,6 +24,30 @@ Object {
 }
 `;
 
+exports[`execute cryptoyield endpoint with poolCode should return success 1`] = `
+Object {
+  "data": Object {
+    "result": 0.025501153223986828,
+  },
+  "jobRunID": "1",
+  "providerStatusCode": 200,
+  "result": 0.025501153223986828,
+  "statusCode": 200,
+}
+`;
+
+exports[`execute cryptoyield endpoint without poolCode should return success 1`] = `
+Object {
+  "data": Object {
+    "result": 0.05041705428139954,
+  },
+  "jobRunID": "1",
+  "providerStatusCode": 200,
+  "result": 0.05041705428139954,
+  "statusCode": 200,
+}
+`;
+
 exports[`execute eod api should return success 1`] = `
 Object {
   "data": Object {
@@ -68,6 +92,18 @@ Object {
   "jobRunID": "1",
   "providerStatusCode": 200,
   "result": 4462.5193860735335,
+  "statusCode": 200,
+}
+`;
+
+exports[`execute realized-vol endpoint should return success 1`] = `
+Object {
+  "data": Object {
+    "result": 0.851625908515737,
+  },
+  "jobRunID": "1",
+  "providerStatusCode": 200,
+  "result": 0.851625908515737,
   "statusCode": 200,
 }
 `;

--- a/packages/sources/tiingo/test/integration/adapter.test.ts
+++ b/packages/sources/tiingo/test/integration/adapter.test.ts
@@ -229,6 +229,75 @@ describe('execute', () => {
       expect(response.body).toMatchSnapshot()
     })
   })
+
+  describe('cryptoyield endpoint without poolCode', () => {
+    const data = {
+      id,
+      data: {
+        endpoint: 'cryptoyield',
+      },
+    }
+
+    it('should return success', async () => {
+      mockResponseSuccess()
+
+      const response = await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+      expect(response.body).toMatchSnapshot()
+    })
+  })
+
+  describe('cryptoyield endpoint with poolCode', () => {
+    const data = {
+      id,
+      data: {
+        endpoint: 'cryptoyield',
+        poolCode: 'compound_usdt',
+      },
+    }
+
+    it('should return success', async () => {
+      mockResponseSuccess()
+
+      const response = await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+      expect(response.body).toMatchSnapshot()
+    })
+  })
+
+  describe('realized-vol endpoint', () => {
+    const data = {
+      id,
+      data: {
+        base: 'ETH',
+        endpoint: 'realized-vol',
+      },
+    }
+
+    it('should return success', async () => {
+      mockResponseSuccess()
+
+      const response = await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+
+      expect(response.body).toMatchSnapshot()
+    })
+  })
 })
 
 describe('websocket', () => {

--- a/packages/sources/tiingo/test/integration/fixtures.ts
+++ b/packages/sources/tiingo/test/integration/fixtures.ts
@@ -277,6 +277,108 @@ export const mockResponseSuccess = (): nock.Scope =>
         'Origin',
       ],
     )
+    .get('/tiingo/crypto/prices')
+    .query({
+      token: 'fake-api-key',
+      baseCurrency: 'real_vol_ETH',
+      convertCurrency: 'USD',
+      consolidateBaseCurrency: true,
+    })
+    .reply(
+      200,
+      () => [
+        {
+          baseCurrency: 'eth',
+          quoteCurrency: 'usd',
+          realVolData: [
+            {
+              date: '2022-01-11T00:00:00+00:00',
+              realVol1Day: 0.3312392184952228,
+              realVol7Day: 0.6687492814959118,
+              realVol30Day: 0.851625908515737,
+            },
+          ],
+        },
+      ],
+      [
+        'Content-Type',
+        'application/json',
+        'Connection',
+        'close',
+        'Vary',
+        'Accept-Encoding',
+        'Vary',
+        'Origin',
+      ],
+    )
+    .get('/tiingo/crypto-yield/ticks')
+    .query({
+      token: 'fake-api-key',
+      poolCodes: 'ethnetwork_eth',
+    })
+    .reply(
+      200,
+      () => [
+        {
+          date: '2023-03-28T08:18:37.836912+00:00',
+          yieldPoolID: 42,
+          yieldPoolName: 'ethnetwork_eth',
+          epoch: 190538,
+          startSlot: 6097216,
+          endSlot: 6097247,
+          validatorReward: 8.387974508106709,
+          transactionReward: 0.9943422706363183,
+          validatorSubtractions: -0.03651446599984354,
+          deposits: 0,
+          totalReward: 9.345802312743183,
+          divisor: 17818985,
+          apr30Day: 0.05041705428139954,
+          apr90Day: 0.0509027044623858,
+        },
+      ],
+      [
+        'Content-Type',
+        'application/json',
+        'Connection',
+        'close',
+        'Vary',
+        'Accept-Encoding',
+        'Vary',
+        'Origin',
+      ],
+    )
+    .get('/tiingo/crypto-yield/ticks')
+    .query({
+      token: 'fake-api-key',
+      poolCodes: 'compound_usdt',
+    })
+    .reply(
+      200,
+      () => [
+        {
+          date: '2023-03-18T09:07:00+00:00',
+          poolCode: 'compound_usdt',
+          variableBorrowRate: 0.040187752938891874,
+          stableBorrowRate: null,
+          totalStableBorrowAmount: null,
+          totalVariableBorrowAmount: 109152599.889651,
+          totalBorrowAmount: 109152599.889651,
+          supplyRate: 0.025501153223986828,
+          totalSupplyAmount: 157984241.97059688,
+          availableLiquidityAmount: 48831642.08094588,
+        },
+      ],
+      [
+        'Content-Type',
+        'application/json',
+        'Connection',
+        'close',
+        'Vary',
+        'Accept-Encoding',
+        'Vary',
+        'Origin',
+      ],
+    )
 
 export const mockIexSubscribeResponse = {
   request: {


### PR DESCRIPTION
<!-- Employees: Please use Clubhouse/Shortcuts's "Open PR" button from the relevant story or include links to relevant Clubhouse/Shortcut stories in your branch name, commit messages, or pull request comments. Do not add links to your pull request description, they will be ignored. https://help.clubhouse.io/hc/en-us/articles/207540323-Using-The-Clubhouse-GitHub-Integration -->

<!-- Employees: Delete this section. -->

## Closes #[DF-18794](https://smartcontract-it.atlassian.net/browse/DF-18794)

## Description
Add crypto yield and realized vol endpoints to Tiingo EAv2 while Tiingo EAv3 is blocked due to testing.

## Changes
- Add crypto-yield endpoint with default `apr30Day` and `supplyRate` result paths
- Add realized vol endpoint with default `realVol30Day` result path

<!-- Acceptance testing steps, automated tests should _always_ be included -->
`yarn && yarn setup && yarn test packages/sources/tiingo/test/integration`

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [x] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
