### PR TITLE
Add port to default WS_API_ENDPOINT

### DIFF
--- a/.changeset/ten-trains-judge.md
+++ b/.changeset/ten-trains-judge.md
@@ -1,0 +1,6 @@
+---
+'@chainlink/icap-adapter': minor
+'@chainlink/tp-adapter': minor
+---
+
+Update WS_API_ENDPOINT for TP and ICAP EAs

--- a/packages/sources/tp/src/config/index.ts
+++ b/packages/sources/tp/src/config/index.ts
@@ -16,6 +16,6 @@ export const config = new AdapterConfig({
   WS_API_ENDPOINT: {
     description: 'Endpoint for WS prices',
     type: 'string',
-    default: 'ws://json.mktdata.portal.apac.parametasolutions.com',
+    default: 'ws://json.mktdata.portal.apac.parametasolutions.com:12000',
   },
 })


### PR DESCRIPTION
## Description
Add port to WS_API_ENDPOINT default to ensure the EAs work without needing to configure this env var

## Changes
- Add port to WS_API_ENDPOINT for TP (and ICAP) config
- 
## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [x] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
