### PR TITLE
Added resultPath to tiingo v3 endpoint

### DIFF
--- a/.changeset/rare-ways-hug.md
+++ b/.changeset/rare-ways-hug.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/tiingo-test-adapter': patch
+---
+
+Added resultPath to request parameter to specify which result should be returned

--- a/packages/sources/tiingo-test/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/tiingo-test/test/integration/__snapshots__/adapter.test.ts.snap
@@ -113,7 +113,7 @@ Object {
     "realVol30Day": 0.851625908515737,
     "realVol7Day": 0.6687492814959118,
   },
-  "result": null,
+  "result": 0.851625908515737,
   "statusCode": 200,
   "timestamps": Object {
     "providerDataReceivedUnixMs": 1641035471111,


### PR DESCRIPTION
## Closes #DF-18799

## Description

Added resultPath to Tiingo V3 endpoint. The field will allow flexibility of which data field is returned within the result.

## Changes

Request param now contains resultPath field

## Steps to Test

1. yarn test
2. add 'resultPath: <realVol30Day | realVol7Day | realVol1Day>' to select which result should be returned. An empty result path will return the 30 day by default.

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
