### PR TITLE
Fix blocksize-capital-test ws response parsing

### DIFF
--- a/.changeset/beige-moose-flow.md
+++ b/.changeset/beige-moose-flow.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/blocksize-capital-test-adapter': patch
+---
+
+Fixed ws response parsing

--- a/packages/sources/blocksize-capital-test/test/integration/fixtures.ts
+++ b/packages/sources/blocksize-capital-test/test/integration/fixtures.ts
@@ -4,6 +4,12 @@ export const mockSubscribeResponse = {
   params: {
     updates: [
       {
+        ticker: 'LINKETH',
+        price: 0.003893549745197962,
+        size: 76.53,
+        volume: 0.297973362,
+      },
+      {
         ticker: 'ETHEUR',
         price: 2400.209999999564,
         size: 0.06804130000001375,


### PR DESCRIPTION
## Description

Fixed websocket response parsing not handling multiple updates in single message. Previous behavior would only retrieve the first update and ignore the rest.

## Steps to Test

1. yarn test packages/sources/blocksize-capital/test

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
