### PR TITLE
Add WS_ENABLED back to cryptocompare v3

### DIFF
--- a/.changeset/funny-pumas-glow.md
+++ b/.changeset/funny-pumas-glow.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/cryptocompare-test-adapter': minor
+---
+
+Added custom routing using WS_ENABLED env var

--- a/packages/sources/cryptocompare-test/src/config/index.ts
+++ b/packages/sources/cryptocompare-test/src/config/index.ts
@@ -22,4 +22,9 @@ export const config = new AdapterConfig({
     type: 'string',
     sensitive: true,
   },
+  WS_ENABLED: {
+    description: 'Whether data should be returned from websocket or not',
+    type: 'boolean',
+    default: false,
+  },
 })

--- a/packages/sources/cryptocompare-test/src/endpoint/crypto-router.ts
+++ b/packages/sources/cryptocompare-test/src/endpoint/crypto-router.ts
@@ -11,6 +11,9 @@ export const endpoint = new CryptoPriceEndpoint<CryptoEndpointTypes>({
     .register('ws', wsTransport)
     .register('rest', httpTransport),
   defaultTransport: 'rest',
+  customRouter: (_req, adapterConfig) => {
+    return adapterConfig.WS_ENABLED ? 'ws' : 'rest'
+  },
   inputParameters: cryptoInputParams,
   overrides: overrides.cryptocompare,
 })

--- a/packages/sources/cryptocompare-test/test/integration/crypto-ws.test.ts
+++ b/packages/sources/cryptocompare-test/test/integration/crypto-ws.test.ts
@@ -49,6 +49,7 @@ describe('execute', () => {
       process.env['METRICS_ENABLED'] = 'false'
       process.env['WS_API_ENDPOINT'] = wsEndpoint
       process.env['API_KEY'] = 'fake-api-key'
+      process.env['WS_ENABLED'] = 'true'
       const mockDate = new Date('2022-11-11T11:11:11.111Z')
       spy = jest.spyOn(Date, 'now').mockReturnValue(mockDate.getTime())
 


### PR DESCRIPTION
## Description

While EngOps is still working to add the `"transport": "ws"` param to all of the required feeds, the `WS_ENABLED` env var will be needed for `cryptocompare` to maintain backwards compatibility in the meantime. This is a temporary workaround that will be reverted once feeds are properly set. 

## Changes

- Added `WS_ENABLED` custom config
- Used env var in custom router to direct requests solely on this flag

## Steps to Test

1. yarn test packages/sources/cryptocompare-test/test

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
