### PR TITLE
Add WS_ENABLED back to specific v3 adapters with transport routing

### DIFF
--- a/.changeset/swift-zoos-dress.md
+++ b/.changeset/swift-zoos-dress.md
@@ -1,0 +1,9 @@
+---
+'@chainlink/dxfeed-secondary-test-adapter': minor
+'@chainlink/dxfeed-test-adapter': minor
+'@chainlink/finage-test-adapter': minor
+'@chainlink/intrinio-test-adapter': minor
+'@chainlink/tradermade-test-adapter': minor
+---
+
+Added custom routing using WS_ENABLED env var

--- a/packages/sources/dxfeed-secondary-test/src/endpoint/price-router.ts
+++ b/packages/sources/dxfeed-secondary-test/src/endpoint/price-router.ts
@@ -15,6 +15,9 @@ export const endpoint = new AdapterEndpoint({
     .register('ws', buildDxFeedWsTransport())
     .register('rest', buildDxFeedHttpTransport()),
   defaultTransport: 'rest',
+  customRouter: (_req, adapterConfig) => {
+    return adapterConfig.WS_ENABLED ? 'ws' : 'rest'
+  },
   inputParameters,
   customInputValidation,
 })

--- a/packages/sources/dxfeed-secondary-test/test/integration/adapter.test.ts
+++ b/packages/sources/dxfeed-secondary-test/test/integration/adapter.test.ts
@@ -93,6 +93,7 @@ describe('execute', () => {
       process.env['CACHE_POLLING_MAX_RETRIES'] = '0'
       process.env['METRICS_ENABLED'] = 'false'
       process.env['WS_API_ENDPOINT'] = wsEndpoint
+      process.env['WS_ENABLED'] = 'true'
       const mockDate = new Date('2022-11-11T11:11:11.111Z')
       spy = jest.spyOn(Date, 'now').mockReturnValue(mockDate.getTime())
 

--- a/packages/sources/dxfeed-test/src/config/index.ts
+++ b/packages/sources/dxfeed-test/src/config/index.ts
@@ -30,4 +30,9 @@ export const config = new AdapterConfig({
       return ''
     },
   },
+  WS_ENABLED: {
+    description: 'Whether data should be returned from websocket or not',
+    type: 'boolean',
+    default: false,
+  },
 })

--- a/packages/sources/dxfeed-test/src/endpoint/price-router.ts
+++ b/packages/sources/dxfeed-test/src/endpoint/price-router.ts
@@ -41,6 +41,9 @@ export const endpoint = new AdapterEndpoint({
     .register('ws', buildDxFeedWsTransport())
     .register('rest', buildDxFeedHttpTransport()),
   defaultTransport: 'rest',
+  customRouter: (_req, adapterConfig) => {
+    return adapterConfig.WS_ENABLED ? 'ws' : 'rest'
+  },
   inputParameters: inputParameters,
   overrides: overrides.dxfeed,
   customInputValidation,

--- a/packages/sources/dxfeed-test/test/integration/adapter.test.ts
+++ b/packages/sources/dxfeed-test/test/integration/adapter.test.ts
@@ -93,6 +93,7 @@ describe('execute', () => {
       process.env['CACHE_POLLING_MAX_RETRIES'] = '0'
       process.env['METRICS_ENABLED'] = 'false'
       process.env['WS_API_ENDPOINT'] = wsEndpoint
+      process.env['WS_ENABLED'] = 'true'
       const mockDate = new Date('2022-11-11T11:11:11.111Z')
       spy = jest.spyOn(Date, 'now').mockReturnValue(mockDate.getTime())
 

--- a/packages/sources/finage-test/src/config/index.ts
+++ b/packages/sources/finage-test/src/config/index.ts
@@ -33,4 +33,9 @@ export const config = new AdapterConfig({
     default: 'wss://72x8wsyx7t.finage.ws:6008',
     description: 'The Websocket endpoint to connect to for crypto data',
   },
+  WS_ENABLED: {
+    description: 'Whether data should be returned from websocket or not',
+    type: 'boolean',
+    default: false,
+  },
 })

--- a/packages/sources/finage-test/src/endpoint/crypto-router.ts
+++ b/packages/sources/finage-test/src/endpoint/crypto-router.ts
@@ -42,6 +42,9 @@ export const endpoint = new CryptoPriceEndpoint({
     .register('ws', wsTransport)
     .register('rest', httpTransport),
   defaultTransport: 'rest',
+  customRouter: (_req, adapterConfig) => {
+    return adapterConfig.WS_ENABLED ? 'ws' : 'rest'
+  },
   inputParameters: inputParameters,
   overrides: overrides.finage,
 })

--- a/packages/sources/finage-test/src/endpoint/forex-router.ts
+++ b/packages/sources/finage-test/src/endpoint/forex-router.ts
@@ -37,6 +37,9 @@ export const endpoint = new PriceEndpoint<EndpointTypes>({
     .register('ws', wsTransport)
     .register('rest', httpTransport),
   defaultTransport: 'rest',
+  customRouter: (_req, adapterConfig) => {
+    return adapterConfig.WS_ENABLED ? 'ws' : 'rest'
+  },
   inputParameters: inputParameters,
   overrides: overrides.finage,
 })

--- a/packages/sources/finage-test/src/endpoint/stock-router.ts
+++ b/packages/sources/finage-test/src/endpoint/stock-router.ts
@@ -34,6 +34,9 @@ export const endpoint = new AdapterEndpoint<EndpointTypes>({
     .register('ws', wsTransport)
     .register('rest', httpTransport),
   defaultTransport: 'rest',
+  customRouter: (_req, adapterConfig) => {
+    return adapterConfig.WS_ENABLED ? 'ws' : 'rest'
+  },
   inputParameters: inputParameters,
   overrides: overrides.finage,
 })

--- a/packages/sources/intrinio-test/src/config/index.ts
+++ b/packages/sources/intrinio-test/src/config/index.ts
@@ -12,4 +12,9 @@ export const config = new AdapterConfig({
     require: true,
     sensitive: true,
   },
+  WS_ENABLED: {
+    description: 'Whether data should be returned from websocket or not',
+    type: 'boolean',
+    default: false,
+  },
 })

--- a/packages/sources/intrinio-test/src/endpoint/price-router.ts
+++ b/packages/sources/intrinio-test/src/endpoint/price-router.ts
@@ -34,5 +34,8 @@ export const endpoint = new AdapterEndpoint<EndpointTypes>({
     .register('ws', wsTransport)
     .register('rest', httpTransport),
   defaultTransport: 'rest',
+  customRouter: (_req, adapterConfig) => {
+    return adapterConfig.WS_ENABLED ? 'ws' : 'rest'
+  },
   inputParameters: inputParameters,
 })

--- a/packages/sources/intrinio-test/test/integration/adapter.test.ts
+++ b/packages/sources/intrinio-test/test/integration/adapter.test.ts
@@ -87,6 +87,7 @@ describe('execute', () => {
       process.env['CACHE_POLLING_MAX_RETRIES'] = '0'
       process.env['METRICS_ENABLED'] = 'false'
       process.env['API_KEY'] = 'fake-api-key'
+      process.env['WS_ENABLED'] = 'true'
 
       const mockDate = new Date('2022-11-11T11:11:11.111Z')
       spy = jest.spyOn(Date, 'now').mockReturnValue(mockDate.getTime())

--- a/packages/sources/tradermade-test/src/config/index.ts
+++ b/packages/sources/tradermade-test/src/config/index.ts
@@ -24,4 +24,9 @@ export const config = new AdapterConfig({
     default: 'wss://marketdata.tradermade.com/feedadv',
     description: 'The Websocket endpoint to connect to for forex data',
   },
+  WS_ENABLED: {
+    description: 'Whether data should be returned from websocket or not',
+    type: 'boolean',
+    default: false,
+  },
 })

--- a/packages/sources/tradermade-test/src/endpoint/forex-router.ts
+++ b/packages/sources/tradermade-test/src/endpoint/forex-router.ts
@@ -31,6 +31,9 @@ export const endpoint = new PriceEndpoint({
     .register('ws', wsTransport)
     .register('rest', httpTransport),
   defaultTransport: 'rest',
+  customRouter: (_req, adapterConfig) => {
+    return adapterConfig.WS_ENABLED ? 'ws' : 'rest'
+  },
   inputParameters: inputParameters,
   customInputValidation,
   overrides: overrides.tradermade,

--- a/packages/sources/tradermade-test/test/integration/adapter.test.ts
+++ b/packages/sources/tradermade-test/test/integration/adapter.test.ts
@@ -124,6 +124,7 @@ describe('execute', () => {
         process.env['WS_API_KEY'] = 'fake-api-key'
         process.env['API_KEY'] = 'fake-api-key'
         process.env['WS_API_ENDPOINT'] = wsEndpoint
+        process.env['WS_ENABLED'] = 'true'
         const mockDate = new Date('2022-11-11T11:11:11.111Z')
         spy = jest.spyOn(Date, 'now').mockReturnValue(mockDate.getTime())
 


### PR DESCRIPTION
## Description

While EngOps is still working to add the `"transport": "ws"` param to all of the required feeds, the `WS_ENABLED` env var will be needed to maintain backwards compatibility for some v3 adapters in the meantime. This is a temporary workaround that will be reverted once feeds are properly set. 

## Changes

- Added `WS_ENABLED` to config and used env var in custom router to direct requests solely on this flag for
  - `dxfeed-test`
  - `dxfeed-secondary-test`
  - `finage-test`
  - `intrinio-test`
  - `tradermade-test`

## Steps to Test

1. yarn test packages/sources/dxfeed-test/test
2. yarn test packages/sources/dxfeed-secondary-test/test
3. yarn test packages/sources/finage-test/test
4. yarn test packages/sources/intrinio-test/test
5. yarn test packages/sources/tradermade-test/test

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
