### PR TITLE
Add default endpoint for twosigma

### DIFF
--- a/.changeset/fifty-birds-draw.md
+++ b/.changeset/fifty-birds-draw.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/twosigma-adapter': patch
+---
+
+Added default websocket endpoint URL

--- a/packages/sources/twosigma/src/config/index.ts
+++ b/packages/sources/twosigma/src/config/index.ts
@@ -2,9 +2,11 @@ import { AdapterConfig } from '@chainlink/external-adapter-framework/config'
 
 export const config = new AdapterConfig({
   WS_API_ENDPOINT: {
-    description: 'The WebSocket API URL',
+    description:
+      'The WebSocket API URL. Either "wss://chainlinkcloud1.twosigma.com:8765" or "wss://chainlinkcloud1.twosigma.com:8766"',
     type: 'string',
     required: true,
+    default: 'wss://chainlinkcloud1.twosigma.com:8765',
   },
   WS_API_KEY: {
     description: 'The API key used to authenticate requests',


### PR DESCRIPTION
Add a default endpoint for Twosigma EA that should work for all NOPs. I've also updated the comment to include a secondary URL.