### PR TITLE
Override Kaiko v3 max requester queue size

### DIFF
--- a/.changeset/many-goats-bake.md
+++ b/.changeset/many-goats-bake.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/kaiko-test-adapter': patch
+---
+
+Set default override for MAX_HTTP_REQUEST_QUEUE_LENGTH to 300

--- a/packages/sources/kaiko-test/src/config/index.ts
+++ b/packages/sources/kaiko-test/src/config/index.ts
@@ -16,7 +16,7 @@ export const config = new AdapterConfig(
   },
   {
     envDefaultOverrides: {
-      API_TIMEOUT: 30000,
+      MAX_HTTP_REQUEST_QUEUE_LENGTH: 300,
     },
   },
 )


### PR DESCRIPTION
## Closes [PDI-80](https://smartcontract-it.atlassian.net/browse/PDI-80)

## Description

Override `kaiko-test` max requester queue size to 300. Adapter does not have batching so the requester queue is at risk of overflowing if subscription set gets large.

## Changes

- Set env default override for `MAX_HTTP_REQUEST_QUEUE_LENGTH` to 300

## Steps to Test

1. yarn test packages/sources/kaiko-test/test

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[PDI-80]: https://smartcontract-it.atlassian.net/browse/PDI-80?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ