### PR TITLE
added overriding and uk_etf alias to twelve and eod historical

### DIFF
--- a/.changeset/pied-piper-picked.md
+++ b/.changeset/pied-piper-picked.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/ea-bootstrap': minor
+---
+
+Allowed overriding to eod historical data. Also added uk_etf to all endpoints of twelve data and eod historical data.

--- a/packages/sources/eodhistoricaldata/src/endpoint/stock.ts
+++ b/packages/sources/eodhistoricaldata/src/endpoint/stock.ts
@@ -1,5 +1,6 @@
 import { Requester, util, Validator } from '@chainlink/ea-bootstrap'
 import type { ExecuteWithConfig, Config, InputParameters } from '@chainlink/ea-bootstrap'
+import { NAME as AdapterName } from '../config'
 
 export const supportedEndpoints = ['price', 'stock']
 
@@ -10,7 +11,7 @@ export type TInputParameters = { base: string }
 export const inputParameters: InputParameters<TInputParameters> = {
   base: {
     required: true,
-    aliases: ['asset', 'from', 'symbol'],
+    aliases: ['asset', 'from', 'symbol', 'uk_etf'],
     type: 'string',
     description:
       'The symbol of the currency to query taken from [here](https://eodhistoricaldata.com/financial-apis/category/data-feeds/)',
@@ -41,7 +42,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
   const validator = new Validator(request, inputParameters)
 
   const jobRunID = validator.validated.id
-  let symbol = validator.validated.data.base.toUpperCase()
+  let symbol = validator.overrideSymbol(AdapterName, validator.validated.data.base).toUpperCase()
   if (commonKeys[symbol]) {
     symbol = commonKeys[symbol]
   }

--- a/packages/sources/eodhistoricaldata/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/eodhistoricaldata/test/integration/__snapshots__/adapter.test.ts.snap
@@ -1,5 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`execute stock api should fail without overriding 1`] = `
+Object {
+  "error": Object {
+    "feedID": "{\\"data\\":{\\"base\\":\\"IBTA\\"}}",
+    "message": "Nock: No match for request {
+  \\"method\\": \\"GET\\",
+  \\"url\\": \\"https://eodhistoricaldata.com/api/real-time/IBTA?api_token=fake-api-key&fmt=json\\",
+  \\"headers\\": {
+    \\"accept\\": \\"application/json\\",
+    \\"cache-control\\": \\"no-cache, no-store, must-revalidate\\",
+    \\"pragma\\": \\"no-cache\\",
+    \\"content-type\\": \\"application/json\\",
+    \\"user-agent\\": \\"axios/0.24.0\\"
+  }
+}",
+    "name": "AdapterError",
+    "url": "https:/eodhistoricaldata.com/api/real-time/IBTA",
+  },
+  "jobRunID": "1",
+  "providerStatusCode": 0,
+  "status": "errored",
+  "statusCode": 200,
+}
+`;
+
 exports[`execute stock api should return success 1`] = `
 Object {
   "data": Object {
@@ -8,6 +33,18 @@ Object {
   "jobRunID": "1",
   "providerStatusCode": 200,
   "result": 7310.3701,
+  "statusCode": 200,
+}
+`;
+
+exports[`execute stock api should return success with overriding 1`] = `
+Object {
+  "data": Object {
+    "result": 1310.3701,
+  },
+  "jobRunID": "1",
+  "providerStatusCode": 200,
+  "result": 1310.3701,
   "statusCode": 200,
 }
 `;

--- a/packages/sources/eodhistoricaldata/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/eodhistoricaldata/test/integration/__snapshots__/adapter.test.ts.snap
@@ -4,24 +4,12 @@ exports[`execute stock api should fail without overriding 1`] = `
 Object {
   "error": Object {
     "feedID": "{\\"data\\":{\\"base\\":\\"IBTA\\"}}",
-    "message": "Nock: No match for request {
-  \\"method\\": \\"GET\\",
-  \\"url\\": \\"https://eodhistoricaldata.com/api/real-time/IBTA?api_token=fake-api-key&fmt=json\\",
-  \\"headers\\": {
-    \\"accept\\": \\"application/json\\",
-    \\"cache-control\\": \\"no-cache, no-store, must-revalidate\\",
-    \\"pragma\\": \\"no-cache\\",
-    \\"content-type\\": \\"application/json\\",
-    \\"user-agent\\": \\"axios/0.24.0\\"
-  }
-}",
+    "message": "Invalid result received. This is likely an issue with the data provider or the input params/overrides.",
     "name": "AdapterError",
-    "url": "https:/eodhistoricaldata.com/api/real-time/IBTA",
   },
   "jobRunID": "1",
-  "providerStatusCode": 0,
   "status": "errored",
-  "statusCode": 200,
+  "statusCode": 400,
 }
 `;
 

--- a/packages/sources/eodhistoricaldata/test/integration/adapter.test.ts
+++ b/packages/sources/eodhistoricaldata/test/integration/adapter.test.ts
@@ -1,7 +1,7 @@
 import { AdapterRequest } from '@chainlink/ea-bootstrap'
 import * as process from 'process'
 import { server as startServer } from '../../src'
-import { mockResponseSuccess } from './fixtures'
+import { mockOverrideResponseSuccess, mockResponseSuccess } from './fixtures'
 import { setupExternalAdapterTest } from '@chainlink/ea-test-helpers'
 import type { SuiteContext } from '@chainlink/ea-test-helpers'
 import { SuperTest, Test } from 'supertest'
@@ -34,6 +34,51 @@ describe('execute', () => {
       const response = await (context.req as SuperTest<Test>)
         .post('/')
         .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+      expect(response.body).toMatchSnapshot()
+    })
+
+    const notFoundData: AdapterRequest = {
+      id,
+      data: {
+        base: 'IBTA',
+      },
+    }
+
+    it('should fail without overriding', async () => {
+      mockOverrideResponseSuccess()
+
+      const response = await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(notFoundData)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+      expect(response.body).toMatchSnapshot()
+    })
+
+    const overrideData: AdapterRequest = {
+      id,
+      data: {
+        base: 'IBTA',
+        overrides: {
+          eodhistoricaldata: {
+            IBTA: 'IBTA.LSE',
+          },
+        },
+      },
+    }
+
+    it('should return success with overriding', async () => {
+      mockOverrideResponseSuccess()
+
+      const response = await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(overrideData)
         .set('Accept', '*/*')
         .set('Content-Type', 'application/json')
         .expect('Content-Type', /json/)

--- a/packages/sources/eodhistoricaldata/test/integration/adapter.test.ts
+++ b/packages/sources/eodhistoricaldata/test/integration/adapter.test.ts
@@ -1,7 +1,7 @@
 import { AdapterRequest } from '@chainlink/ea-bootstrap'
 import * as process from 'process'
 import { server as startServer } from '../../src'
-import { mockOverrideResponseSuccess, mockResponseSuccess } from './fixtures'
+import { mockOverrideResponseSuccess, mockResponseFail, mockResponseSuccess } from './fixtures'
 import { setupExternalAdapterTest } from '@chainlink/ea-test-helpers'
 import type { SuiteContext } from '@chainlink/ea-test-helpers'
 import { SuperTest, Test } from 'supertest'
@@ -49,7 +49,7 @@ describe('execute', () => {
     }
 
     it('should fail without overriding', async () => {
-      mockOverrideResponseSuccess()
+      mockResponseFail()
 
       const response = await (context.req as SuperTest<Test>)
         .post('/')
@@ -57,7 +57,7 @@ describe('execute', () => {
         .set('Accept', '*/*')
         .set('Content-Type', 'application/json')
         .expect('Content-Type', /json/)
-        .expect(200)
+        .expect(400)
       expect(response.body).toMatchSnapshot()
     })
 

--- a/packages/sources/eodhistoricaldata/test/integration/fixtures.ts
+++ b/packages/sources/eodhistoricaldata/test/integration/fixtures.ts
@@ -32,3 +32,36 @@ export const mockResponseSuccess = (): nock.Scope =>
         'Origin',
       ],
     )
+
+export const mockOverrideResponseSuccess = (): nock.Scope =>
+  nock('https://eodhistoricaldata.com', {
+    encodedQueryParams: true,
+  })
+    .get('/api/real-time/IBTA.LSE')
+    .query({ fmt: 'json', api_token: 'fake-api-key' })
+    .reply(
+      200,
+      () => ({
+        code: 'IBTA.LSE',
+        timestamp: 1637858100,
+        gmtoffset: 1,
+        open: 1286.3198,
+        high: 1311.9399,
+        low: 1286.3198,
+        close: 1310.3701,
+        volume: 0,
+        previousClose: 1286.2998,
+        change: 14.0703,
+        change_p: 1.3304,
+      }),
+      [
+        'Content-Type',
+        'application/json',
+        'Connection',
+        'close',
+        'Vary',
+        'Accept-Encoding',
+        'Vary',
+        'Origin',
+      ],
+    )

--- a/packages/sources/eodhistoricaldata/test/integration/fixtures.ts
+++ b/packages/sources/eodhistoricaldata/test/integration/fixtures.ts
@@ -33,6 +33,39 @@ export const mockResponseSuccess = (): nock.Scope =>
       ],
     )
 
+export const mockResponseFail = (): nock.Scope =>
+  nock('https://eodhistoricaldata.com', {
+    encodedQueryParams: true,
+  })
+    .get('/api/real-time/IBTA')
+    .query({ fmt: 'json', api_token: 'fake-api-key' })
+    .reply(
+      200,
+      () => ({
+        code: 'IBTA.US',
+        timestamp: 'NA',
+        gmtoffset: 0,
+        open: 'NA',
+        high: 'NA',
+        low: 'NA',
+        close: 'NA',
+        volume: 'NA',
+        previousClose: 'NA',
+        change: 'NA',
+        change_p: 'NA',
+      }),
+      [
+        'Content-Type',
+        'application/json',
+        'Connection',
+        'close',
+        'Vary',
+        'Accept-Encoding',
+        'Vary',
+        'Origin',
+      ],
+    )
+
 export const mockOverrideResponseSuccess = (): nock.Scope =>
   nock('https://eodhistoricaldata.com', {
     encodedQueryParams: true,

--- a/packages/sources/twelvedata/src/endpoint/closing.ts
+++ b/packages/sources/twelvedata/src/endpoint/closing.ts
@@ -12,7 +12,7 @@ export const description =
 export type TInputParameters = { base: string }
 export const inputParameters: InputParameters<TInputParameters> = {
   base: {
-    aliases: ['from', 'coin', 'market', 'symbol'],
+    aliases: ['from', 'coin', 'market', 'symbol', 'uk_etf'],
     required: true,
     description: 'The symbol of the currency to query',
     type: 'string',

--- a/packages/sources/twelvedata/src/endpoint/price.ts
+++ b/packages/sources/twelvedata/src/endpoint/price.ts
@@ -12,7 +12,7 @@ export const description =
 export type TInputParameters = { base: string }
 export const inputParameters: InputParameters<TInputParameters> = {
   base: {
-    aliases: ['from', 'coin', 'market', 'symbol'],
+    aliases: ['from', 'coin', 'market', 'symbol', 'uk_etf'],
     required: true,
     description: 'The symbol of the currency to query',
     type: 'string',


### PR DESCRIPTION
## Closes #[DF-18800](https://smartcontract-it.atlassian.net/browse/DF-18800)

## Description

Small changes to eod historical and twelve data

## Changes

- Added overrides to eod historical data source
- Added uk_etf alias to all endpoints of eod historical and twelve data 

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. 
```
cd packages/sources/eodhistoricaldata
export API_KEY=secret
yarn start
```
2. 
<img width="690" alt="Screenshot 2023-04-24 at 9 36 32 AM" src="https://user-images.githubusercontent.com/23130126/234060433-7280db6f-2808-4276-9149-e6bd6204182a.png">


3. Repeat for twelve data

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [x] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[DF-18800]: https://smartcontract-it.atlassian.net/browse/DF-18800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ