### PR TITLE
Feature/coinmetrics ws update

### DIFF
--- a/.changeset/fire-water-earth.md
+++ b/.changeset/fire-water-earth.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/coinmetrics-adapter': minor
+---
+
+Updated coinmetrics with new websocket endpoint

--- a/packages/sources/coinmetrics/src/endpoint/lwba-ws.ts
+++ b/packages/sources/coinmetrics/src/endpoint/lwba-ws.ts
@@ -88,16 +88,14 @@ type WsPairQuoteMessage =
   | WsCryptoLwbaErrorResponse
   | WsCryptoLwbaReorgResponse
 
-export const calculatPairQuotesUrl = (
+export const calculatePairQuotesUrl = (
   context: EndpointContext<WsCryptoLwbaEndpointTypes>,
   desiredSubs: WsCryptoLwbaEndpointTypes['Request']['Params'][],
 ): string => {
   const { API_KEY, WS_API_ENDPOINT } = context.adapterSettings
-  const pairs = [
-    ...new Set(desiredSubs.map((sub) => `${sub.base.toLowerCase()}-${sub.quote.toLowerCase()}`)),
-  ].join(',')
-  const generated = new URL('/v4/timeseries-stream/pair-quotes', WS_API_ENDPOINT)
-  generated.searchParams.append('pairs', pairs)
+  const assets = [...new Set(desiredSubs.map((pair) => pair.base))].join(',')
+  const generated = new URL('/v4/timeseries-stream/asset-quotes', WS_API_ENDPOINT)
+  generated.searchParams.append('assets', assets)
   generated.searchParams.append('api_key', API_KEY)
   logger.debug(`Generated URL: ${generated.toString()}`)
   return generated.toString()
@@ -146,7 +144,7 @@ export const handleCryptoLwbaMessage = (
 
 export const wsTransport = new WebSocketTransport<WsCryptoLwbaEndpointTypes>({
   url: (context, desiredSubs) => {
-    return calculatPairQuotesUrl(context, desiredSubs)
+    return calculatePairQuotesUrl(context, desiredSubs)
   },
   handlers: {
     message(message: WsPairQuoteMessage): ProviderResult<WsCryptoLwbaEndpointTypes>[] | undefined {


### PR DESCRIPTION
## Closes #[DF-18778](https://smartcontract-it.atlassian.net/browse/DF-18778)

## Description
Changed coinmetrics websocket endpoint
......

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. Start coinmetrics adapter
2. `curl -N -s --header "Content-Type: application/json" --request POST   --data '{
  "id": "test",
  "data": {
    "from": "eth",
    "quote": "usd",
    "endpoint": "crypto-lwba"
  }
}' localhost:8080`

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [x] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
