### PR TITLE
Fix changeset conflict

### DIFF
--- a/.changeset/two-balloons-dance.md
+++ b/.changeset/two-balloons-dance.md
@@ -74,7 +74,6 @@
 '@chainlink/ccip-read-adapter': patch
 '@chainlink/celsius-address-list-adapter': patch
 '@chainlink/cfbenchmarks-adapter': patch
-'@chainlink/cfbenchmarks-test-adapter': patch
 '@chainlink/chain-reserve-wallet-adapter': patch
 '@chainlink/coinapi-adapter': patch
 '@chainlink/coinbase-adapter': patch


### PR DESCRIPTION
Fixed changeset conflict. Existing changeset included `cfbenchmarks-test` which was removed in a later PR. 