### PR TITLE
Stader-balance balance calculations update

### DIFF
--- a/.changeset/hip-cougars-trade.md
+++ b/.changeset/hip-cougars-trade.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/stader-balance-adapter': patch
+---
+
+Updated balance calculations to include deposited ETH value

--- a/packages/sources/stader-balance/src/endpoint/balance.ts
+++ b/packages/sources/stader-balance/src/endpoint/balance.ts
@@ -230,8 +230,8 @@ export class BalanceTransport extends SubscriptionTransport<EndpointTypes> {
   // Get event logs to find deposit events for addresses not on the beacon chain yet
   // Returns deposit amount in wei
   async calculateLimboEthBalances({
-    limboAddresses,
-    depositedAddresses,
+    limboAddresses = [],
+    depositedAddresses = [],
     ethDepositContractAddress,
     blockTag,
   }: {
@@ -248,6 +248,11 @@ export class BalanceTransport extends SubscriptionTransport<EndpointTypes> {
       async () => {
         let limboBalances: BalanceResponse[] = []
         const depositedBalances: BalanceResponse[] = []
+
+        // Skip fetching logs if no addresses in limbo to search for
+        if (limboAddresses.length === 0 && depositedAddresses.length === 0) {
+          return { limboBalances, depositedBalances }
+        }
 
         // Get all the deposit logs from the last DEPOSIT_EVENT_LOOKBACK_WINDOW blocks
         const logs = await this.provider.getLogs({

--- a/packages/sources/stader-balance/src/endpoint/balance.ts
+++ b/packages/sources/stader-balance/src/endpoint/balance.ts
@@ -2,6 +2,7 @@ import { AdapterEndpoint, EndpointContext } from '@chainlink/external-adapter-fr
 import { TransportDependencies } from '@chainlink/external-adapter-framework/transports'
 import { SubscriptionTransport } from '@chainlink/external-adapter-framework/transports/abstract/subscription'
 import { AdapterResponse, makeLogger, sleep } from '@chainlink/external-adapter-framework/util'
+import BigNumber from 'bignumber.js'
 import { ethers } from 'ethers'
 import { DepositEvent_ABI, StaderPenaltyContract_ABI } from '../abi/StaderContractAbis'
 import { config } from '../config'
@@ -12,23 +13,22 @@ import { StakeManager } from '../model/stake-manager'
 import { ValidatorFactory } from '../model/validator'
 import {
   BalanceResponse,
-  chunkArray,
   DEPOSIT_EVENT_LOOKBACK_WINDOW,
   DEPOSIT_EVENT_TOPIC,
   EndpointTypes,
+  ONE_ETH_WEI,
+  RequestParams,
+  THIRTY_ONE_ETH_WEI,
+  ValidatorAddress,
+  chunkArray,
   fetchAddressBalance,
   fetchEthDepositContractAddress,
   formatValueInGwei,
   inputParameters,
-  ONE_ETH_WEI,
   parseLittleEndian,
-  RequestParams,
   staderNetworkChainMap,
-  THIRTY_ONE_ETH_WEI,
-  ValidatorAddress,
   withErrorHandling,
 } from './utils'
-import BigNumber from 'bignumber.js'
 
 const logger = makeLogger('StaderBalanceLogger')
 export class BalanceTransport extends SubscriptionTransport<EndpointTypes> {
@@ -166,7 +166,9 @@ export class BalanceTransport extends SubscriptionTransport<EndpointTypes> {
     for (const batch of batches) {
       validatorBalances.push(
         ...(await Promise.all(
-          batch.map((v) => v.calculateBalance(validatorDeposit, depositedBalanceMap)),
+          batch.map((v) =>
+            v.calculateBalance(validatorDeposit, depositedBalanceMap[v.addressData.address]),
+          ),
         )),
       )
     }

--- a/packages/sources/stader-balance/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/stader-balance/test/integration/__snapshots__/adapter.test.ts.snap
@@ -46,7 +46,7 @@ exports[`Balance Endpoint should return success 1`] = `
       },
       {
         "address": "0x8af03fc3ba342b625c868325386fd421fa677d87cf96d528f4649cf043ea33b8f1466dd6bce66b0c9d949b8b65d1549c",
-        "balance": "1000000000",
+        "balance": "17000000000",
       },
       {
         "address": "0x10f4F0a7aadfB7E79533090508fADD78FB163068",
@@ -59,10 +59,6 @@ exports[`Balance Endpoint should return success 1`] = `
       {
         "address": "0x98416f837d457d72f0dd5297898e1225a1e7731c2579f642626fbdc8ee8ce4f1e89ca538b72d5c3b75fdd1e9e10c87c6",
         "balance": "1000000000",
-      },
-      {
-        "address": "0x8af03fc3ba342b625c868325386fd421fa677d87cf96d528f4649cf043ea33b8f1466dd6bce66b0c9d949b8b65d1549c",
-        "balance": "31000000000",
       },
     ],
   },


### PR DESCRIPTION
## Description

Previously calculations would only consider the balance found on beacon and report ETH in limbo found in deposit events separately. The logic has been updated to include the ETH found in deposit events in balance calculations.

## Steps to Test

1. yarn test packages/sources/stader-balance/test

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
