### PR TITLE
Fix kaiko v3 input param type

### DIFF
--- a/.changeset/swift-poems-march.md
+++ b/.changeset/swift-poems-march.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/kaiko-test-adapter': patch
+---
+
+Fixed millisecondsAgo input param type

--- a/packages/sources/kaiko-test/src/endpoint/trades.ts
+++ b/packages/sources/kaiko-test/src/endpoint/trades.ts
@@ -27,10 +27,10 @@ const inputParameters = new InputParameters({
   },
   millisecondsAgo: {
     required: false,
-    type: 'number',
+    type: 'string',
     description:
       'Number of milliseconds from the current time that will determine start_time to use in the query',
-    default: 86_400_000, // 24 hours
+    default: '86400000', // 24 hours
   },
   sort: {
     required: false,
@@ -100,7 +100,7 @@ const httpTransport = new HttpTransport<EndpointTypes>({
       const url = `/spot_exchange_rate/${base}/${quote}`
 
       const interval = param.interval
-      const start_time = calculateStartTime(param.millisecondsAgo)
+      const start_time = calculateStartTime(Number(param.millisecondsAgo))
       const sort = param.sort
 
       const requestParams = { interval, sort, start_time }


### PR DESCRIPTION
## Description

Changed `millisecondsAgo` input param to string to conform to existing jobs

## Steps to Test

1. yarn test packages/sources/kaiko-test/test

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
