### PR TITLE
Add xbto input param alias

### DIFF
--- a/.changeset/sharp-buckets-attack.md
+++ b/.changeset/sharp-buckets-attack.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/xbto-adapter': patch
+---
+
+Added market input param alias "base"

--- a/packages/sources/xbto/src/endpoint/price.ts
+++ b/packages/sources/xbto/src/endpoint/price.ts
@@ -4,6 +4,7 @@ import { Requester, util, Validator } from '@chainlink/ea-bootstrap'
 export type TInputParameters = { market: string }
 export const inputParameters: InputParameters<TInputParameters> = {
   market: {
+    aliases: ['base'],
     required: false,
     type: 'string',
     options: ['brent', 'wti'],


### PR DESCRIPTION
## Description

Added `market` input param alias `base` to `xbto` to make it consistent with other adapters

## Steps to Test

1. yarn test packages/sources/xbto/test

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
