### PR TITLE
Update Stader adapters with new contracts and logic

### DIFF
--- a/.changeset/fifty-tigers-sip.md
+++ b/.changeset/fifty-tigers-sip.md
@@ -1,0 +1,6 @@
+---
+'@chainlink/stader-address-list-adapter': minor
+'@chainlink/stader-balance-adapter': minor
+---
+
+Updated with new contracts and logic

--- a/packages/composites/proof-of-reserves/README.md
+++ b/packages/composites/proof-of-reserves/README.md
@@ -10,32 +10,39 @@ At least one of each of the following categories must be set as an environment v
 
 1. A protocol adapter to retrieve custodial addresses (if not using `list`)
 
-   | Required? |                Name                |                     Description                     | Options | Defaults to |
-   | :-------: | :--------------------------------: | :-------------------------------------------------: | :-----: | :---------: |
-   |           |         `WBTC_ADAPTER_URL`         |       The location of a WBTC external adapter       |         |             |
-   |           |        `RENVM_ADAPTER_URL`         |      The location of a RenVM external adapter       |         |             |
-   |           |        `GEMINI_ADAPTER_URL`        |      The location of a Gemini external adapter      |         |             |
-   |           | `CELSIUS_ADDRESS_LIST_ADAPTER_URL` |   The location of a Celsius Address List adapter    |         |             |
-   |           | `CHAIN_RESERVE_WALLET_ADAPTER_URL` |   The location of a Chain reserve wallet adapter    |         |             |
-   |           |       `WRAPPED_ADAPTER_URL`        |     The location of a Wrapped external adapter      |         |             |
-   |           |   `POR_ADDRESS_LIST_ADAPTER_URL`   | The location of a PoR Address List external adapter |         |             |
+   | Required? |                Name                 |                       Description                        | Options | Defaults to |
+   | :-------: | :---------------------------------: | :------------------------------------------------------: | :-----: | :---------: |
+   |           | `CELSIUS_ADDRESS_LIST_ADAPTER_URL`  |      The location of a Celsius Address List adapter      |         |             |
+   |           | `CHAIN_RESERVE_WALLET_ADAPTER_URL`  |      The location of a Chain reserve wallet adapter      |         |             |
+   |           |        `GEMINI_ADAPTER_URL`         |        The location of a Gemini external adapter         |         |             |
+   |           | `MOONBEAM_ADDRESS_LIST_ADAPTER_URL` | The location of a Moonbeam Address List external adapter |         |             |
+   |           |   `POR_ADDRESS_LIST_ADAPTER_URL`    |   The location of a PoR Address List external adapter    |         |             |
+   |           |         `RENVM_ADAPTER_URL`         |         The location of a RenVM external adapter         |         |             |
+   |           |  `STADER_ADDRESS_LIST_ADAPTER_URL`  |  The location of a Stader Address List external adapter  |         |             |
+   |           |  `SWELL_ADDRESS_LIST_ADAPTER_URL`   |  The location of a Swell Address List external adapter   |         |             |
+   |           |         `WBTC_ADAPTER_URL`          |         The location of a WBTC external adapter          |         |             |
+   |           |        `WRAPPED_ADAPTER_URL`        |        The location of a Wrapped external adapter        |         |             |
 
 2. An indexer adapter to retrieve account balances for each custodial address
 
-   | Required? |              Name              |                         Description                          | Options | Defaults to |
-   | :-------: | :----------------------------: | :----------------------------------------------------------: | :-----: | :---------: |
-   |           |   `ADA_BALANCE_ADAPTER_URL`    |        The location of a Ada balance external adapter        |         |             |
-   |           |    `AMBERDATA_ADAPTER_URL`     |        The location of an Amberdata external adapter         |         |             |
-   |           | `BITCOIN_JSON_RPC_ADAPTER_URL` |     The location of an Bitcoin JSON RPC external adapter     |         |             |
-   |           |  `BLOCKCHAIN_COM_ADAPTER_URL`  |      The location of a Blockchain.com external adapter       |         |             |
-   |           |    `BLOCKCHAIR_ADAPTER_URL`    |        The location of a Blockchair external adapter         |         |             |
-   |           |   `BLOCKCYPHER_ADAPTER_URL`    |        The location of a Blockcypher external adapter        |         |             |
-   |           |     `BTC_COM_ADAPTER_URL`      |          The location of a BTC.com external adapter          |         |             |
-   |           |    `CRYPTOAPIS_ADAPTER_URL`    |        The location of a Crypto APIs external adapter        |         |             |
-   |           |   `ETH_BALANCE_ADAPTER_URL`    |        The location of a EthBalance external adapter         |         |             |
-   |           |      `LOTUS_ADAPTER_URL`       |           The location of a Lotus external adapter           |         |             |
-   |           |   `POR_INDEXER_ADAPTER_URL`    | The location of a Proof-of-Reserves Indexer external adapter |         |             |
-   |           |     `SOCHAIN_ADAPTER_URL`      |          The location of a SoChain external adapter          |         |             |
+   | Required? |               Name               |                         Description                          | Options | Defaults to |
+   | :-------: | :------------------------------: | :----------------------------------------------------------: | :-----: | :---------: |
+   |           |    `ADA_BALANCE_ADAPTER_URL`     |        The location of a Ada balance external adapter        |         |             |
+   |           |     `AMBERDATA_ADAPTER_URL`      |        The location of an Amberdata external adapter         |         |             |
+   |           | `AVALANCHE_PLATFORM_ADAPTER_URL` |    The location of an Avalance Platform external adapter     |         |             |
+   |           |  `BITCOIN_JSON_RPC_ADAPTER_URL`  |     The location of an Bitcoin JSON RPC external adapter     |         |             |
+   |           |   `BLOCKCHAIN_COM_ADAPTER_URL`   |      The location of a Blockchain.com external adapter       |         |             |
+   |           |     `BLOCKCHAIR_ADAPTER_URL`     |        The location of a Blockchair external adapter         |         |             |
+   |           |    `BLOCKCYPHER_ADAPTER_URL`     |        The location of a Blockcypher external adapter        |         |             |
+   |           |      `BTC_COM_ADAPTER_URL`       |          The location of a BTC.com external adapter          |         |             |
+   |           |     `CRYPTOAPIS_ADAPTER_URL`     |        The location of a Crypto APIs external adapter        |         |             |
+   |           |    `ETH_BALANCE_ADAPTER_URL`     |        The location of a EthBalance external adapter         |         |             |
+   |           |     `ETH_BEACON_ADAPTER_URL`     |        The location of an ETH Beacon external adapter        |         |             |
+   |           |       `LOTUS_ADAPTER_URL`        |           The location of a Lotus external adapter           |         |             |
+   |           |  `POLKADOT_BALANCE_ADAPTER_URL`  |     The location of a Polkadot Balance external adapter      |         |             |
+   |           |    `POR_INDEXER_ADAPTER_URL`     | The location of a Proof-of-Reserves Indexer external adapter |         |             |
+   |           |      `SOCHAIN_ADAPTER_URL`       |          The location of a SoChain external adapter          |         |             |
+   |           |   `STADER_BALANCE_ADAPTER_URL`   |      The location of a Stader Balance external adapter       |         |             |
 
 ## Running
 
@@ -43,14 +50,14 @@ See the [Composite Adapter README](../README.md) for more information on how to 
 
 ### Input Params
 
-| Required? |                Name                |                                             Description                                              |                                                                                 Options                                                                                 | Defaults to |
-| :-------: | :--------------------------------: | :--------------------------------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :---------: |
-|    ✅     |             `protocol`             |                                 The protocol external adapter to use                                 |                            `celsius_address_list`, `chain_reserve_wallet`, `gemini`, `list`, `renvm`, `wbtc`, `wrapped`, `por_address_list`                             |             |
-|    ✅     |             `indexer`              |                                 The indexer external adapter to use                                  | `ada_balance`, `amberdata`, `bitcoin_json_rpc`, `blockchain_com`. `blockchair`, `blockcypher`,`btc_com`, `cryptoapis`, `eth_balance`, `lotus`, `por_indexer`, `sochain` |             |
-|           |          `confirmations`           | The number of confirmations required for a transaction to be counted when getting an address balance |                                                                                                                                                                         |      6      |
-|           |            `addresses`             |           An array of addresses to get the balance from, when "protocol" is set to `list`            |                                                                                                                                                                         |             |
-|           |     `disableAddressValidation`     |               if this parameter is set to `true` address validation will be turned off               |                                                                             `true`, `false`                                                                             |   `false`   |
-|           | `disableDuplicateAddressFiltering` |          if this parameter is set to `true` duplicate address filtering will be turned off           |                                                                             `true`, `false`                                                                             |   `false`   |
+| Required? |                Name                |                                             Description                                              |                                                                                                                      Options                                                                                                                       | Defaults to |
+| :-------: | :--------------------------------: | :--------------------------------------------------------------------------------------------------: | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :---------: |
+|    ✅     |             `protocol`             |                                 The protocol external adapter to use                                 |                               `celsius_address_list`, `chain_reserve_wallet`, `gemini`,`moonbeam_address_list`, `list`, `por_address_list`, `renvm`, `stader_address_list`, `swell_address_list`, `wbtc`, `wrapped`                                |             |
+|    ✅     |             `indexer`              |                                 The indexer external adapter to use                                  | `ada_balance`, `amberdata`, `avalanche_platform`, `bitcoin_json_rpc`, `blockchain_com`. `blockchair`, `blockcypher`, `btc_com`, `cryptoapis`, `eth_balance`, `eth_beacon`, `lotus`, `polkadot_balance`, `por_indexer`, `sochain`, `stader_balance` |             |
+|           |          `confirmations`           | The number of confirmations required for a transaction to be counted when getting an address balance |                                                                                                                                                                                                                                                    |      6      |
+|           |            `addresses`             |           An array of addresses to get the balance from, when "protocol" is set to `list`            |                                                                                                                                                                                                                                                    |             |
+|           |     `disableAddressValidation`     |               if this parameter is set to `true` address validation will be turned off               |                                                                                                                  `true`, `false`                                                                                                                   |   `false`   |
+|           | `disableDuplicateAddressFiltering` |          if this parameter is set to `true` duplicate address filtering will be turned off           |                                                                                                                  `true`, `false`                                                                                                                   |   `false`   |
 
 Additionally the first underlying adapter in the sequence, in this case the protocol adapter, may have parameters.
 

--- a/packages/sources/stader-address-list/src/abi/StaderContractAbis.ts
+++ b/packages/sources/stader-address-list/src/abi/StaderContractAbis.ts
@@ -1,5 +1,22 @@
 import { ethers } from 'ethers'
 
+export const StaderConfigContract_ABI: ethers.ContractInterface = [
+  {
+    inputs: [],
+    name: 'getPermissionlessNodeRegistry',
+    outputs: [{ internalType: 'address', name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'getPoolUtils',
+    outputs: [{ internalType: 'address', name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+]
+
 export const StaderPoolFactoryContract_ABI: ethers.ContractInterface = [
   {
     inputs: [{ internalType: 'uint8', name: '_poolId', type: 'uint8' }],
@@ -9,26 +26,16 @@ export const StaderPoolFactoryContract_ABI: ethers.ContractInterface = [
     type: 'function',
   },
   {
+    inputs: [],
+    name: 'getPoolIdArray',
+    outputs: [{ internalType: 'uint8[]', name: '', type: 'uint8[]' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
     inputs: [{ internalType: 'uint8', name: '_poolId', type: 'uint8' }],
     name: 'getSocializingPoolAddress',
     outputs: [{ internalType: 'address', name: '', type: 'address' }],
-    stateMutability: 'view',
-    type: 'function',
-  },
-  {
-    inputs: [],
-    name: 'poolCount',
-    outputs: [{ internalType: 'uint8', name: '', type: 'uint8' }],
-    stateMutability: 'view',
-    type: 'function',
-  },
-  {
-    inputs: [{ internalType: 'uint8', name: '', type: 'uint8' }],
-    name: 'pools',
-    outputs: [
-      { internalType: 'string', name: 'poolName', type: 'string' },
-      { internalType: 'address', name: 'poolAddress', type: 'address' },
-    ],
     stateMutability: 'view',
     type: 'function',
   },

--- a/packages/sources/stader-address-list/src/utils.ts
+++ b/packages/sources/stader-address-list/src/utils.ts
@@ -4,7 +4,7 @@ const logger = makeLogger('StaderAddressListUtil')
 
 export type NetworkChainMap = {
   [network: string]: {
-    [chain: string]: { poolFactory: string; permissionlessNodeRegistry: string }
+    [chain: string]: { staderConfig: string }
   }
 }
 
@@ -70,16 +70,6 @@ export const filterDuplicateAddresses = <T extends BasicAddress>(addresses: T[])
   return Object.values(addressMap)
 }
 
-export const calculatePages = ({
-  count,
-  batchSize,
-}: {
-  count: number
-  batchSize: number
-}): number => {
-  return count % batchSize === 0 ? count / batchSize : count / batchSize + 1
-}
-
 export async function runAllSequentially<T>({
   count,
   handler,
@@ -88,7 +78,7 @@ export async function runAllSequentially<T>({
   handler: (i: number) => Promise<T>
 }): Promise<T[]> {
   const results: T[] = []
-  for (let i = 1; i <= count; i++) {
+  for (let i = 0; i < count; i++) {
     results.push(await handler(i))
   }
   return results

--- a/packages/sources/stader-address-list/test/integration/adapter.test.ts
+++ b/packages/sources/stader-address-list/test/integration/adapter.test.ts
@@ -89,7 +89,7 @@ jest.mock('ethers', () => {
           getNodeRegistry: jest.fn().mockImplementation((poolId) => {
             return mockNodeRegistryAddresses[poolId]
           }),
-          poolCount: jest.fn().mockReturnValue(2),
+          getPoolIdArray: jest.fn().mockReturnValue([1, 2]),
           getAllActiveValidators: jest.fn().mockImplementation(() => {
             return mockValidatorAddresses[(getAllActiveValidatorsCallCount++ % 2) + 1]
           }),
@@ -101,6 +101,10 @@ jest.mock('ethers', () => {
           }),
           nextValidatorId: jest.fn().mockReturnValue(3),
           nextOperatorId: jest.fn().mockReturnValue(3),
+          getPoolUtils: jest.fn().mockReturnValue('0x9bE5fd05529450c4ABA3c1525b82EF69Af9b3253'),
+          getPermissionlessNodeRegistry: jest
+            .fn()
+            .mockReturnValue('0x28d5FdcE4db361e19FCA420C9b5141bC3DC6aE3B'),
         }
       },
     },

--- a/packages/sources/stader-balance/src/abi/StaderContractAbis.ts
+++ b/packages/sources/stader-balance/src/abi/StaderContractAbis.ts
@@ -24,24 +24,42 @@ export const StaderPoolFactoryContract_ABI: ethers.ContractInterface = [
   },
   {
     inputs: [],
-    name: 'poolCount',
-    outputs: [{ internalType: 'uint8', name: '', type: 'uint8' }],
-    stateMutability: 'view',
-    type: 'function',
-  },
-  {
-    inputs: [{ internalType: 'uint8', name: '', type: 'uint8' }],
-    name: 'pools',
-    outputs: [
-      { internalType: 'string', name: 'poolName', type: 'string' },
-      { internalType: 'address', name: 'poolAddress', type: 'address' },
-    ],
+    name: 'getPoolIdArray',
+    outputs: [{ internalType: 'uint8[]', name: '', type: 'uint8[]' }],
     stateMutability: 'view',
     type: 'function',
   },
 ]
 
 export const StaderConfigContract_ABI = [
+  {
+    inputs: [],
+    name: 'getPenaltyContract',
+    outputs: [{ internalType: 'address', name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'getPermissionedPool',
+    outputs: [{ internalType: 'address', name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'getPoolUtils',
+    outputs: [{ internalType: 'address', name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'getStakePoolManager',
+    outputs: [{ internalType: 'address', name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
   {
     inputs: [],
     name: 'getStakedEthPerNode',
@@ -88,7 +106,7 @@ export const DepositEvent_ABI = [
 
 export const StaderPenaltyContract_ABI: ethers.ContractInterface = [
   {
-    inputs: [{ internalType: 'bytes', name: '', type: 'bytes' }],
+    inputs: [{ internalType: 'bytes32', name: '', type: 'bytes32' }],
     name: 'totalPenaltyAmount',
     outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
     stateMutability: 'view',

--- a/packages/sources/stader-balance/src/endpoint/utils.ts
+++ b/packages/sources/stader-balance/src/endpoint/utils.ts
@@ -21,11 +21,7 @@ export const THIRTY_ONE_ETH_WEI = BigNumber(ethers.utils.parseEther('31').toStri
 export type NetworkChainMap = {
   [network: string]: {
     [chain: string]: {
-      poolFactory: string
-      penalty: string
-      stakePoolsManager: string
       staderConfig: string
-      permissionedPool: string
     }
   }
 }
@@ -36,18 +32,10 @@ export const chainIds = ['mainnet', 'goerli']
 export const staderNetworkChainMap: NetworkChainMap = {
   ethereum: {
     mainnet: {
-      poolFactory: '',
-      penalty: '',
-      stakePoolsManager: '',
       staderConfig: '',
-      permissionedPool: '',
     },
     goerli: {
-      poolFactory: '0x019a7ced1927946eADb28735f15a20e3ed762240',
-      penalty: '0x3A8F47BcE46bB852FB51021ee87f9fA2329cC70E',
-      stakePoolsManager: '0x974Db4Fb26993289CAD9f79Bde4eAE097503064f',
-      staderConfig: '0xe34c84A15326f7980F59DE6b5A77C57ca2043c48',
-      permissionedPool: '0xEc4166439523e8C2FaE395201f04876Cc7C02d68',
+      staderConfig: '0x198C5bC65acce5a35Ae7A8B7AEf4f92FA94C1c6E',
     },
   },
 }
@@ -322,4 +310,8 @@ export const fetchEthDepositContractAddress = async (
     const response = await axios.request<{ data: { chainId: string; address: string } }>(options)
     return response.data.data.address
   })
+}
+
+export const parseBigNumber = (value: ethers.BigNumber): BigNumber => {
+  return BigNumber(value.toString())
 }

--- a/packages/sources/stader-balance/src/model/permissioned-pool.ts
+++ b/packages/sources/stader-balance/src/model/permissioned-pool.ts
@@ -3,23 +3,17 @@ import {
   BalanceResponse,
   fetchAddressBalance,
   formatValueInGwei,
-  staderNetworkChainMap,
   withErrorHandling,
 } from '../endpoint/utils'
 
 export class PermissionedPool {
-  address: string
   balance?: BalanceResponse
 
   constructor(
-    req: { permissionedPoolAddress?: string; network: string; chainId: string },
+    private address: string,
     private blockTag: number,
     private provider: ethers.providers.JsonRpcProvider,
-  ) {
-    this.address =
-      req.permissionedPoolAddress ||
-      staderNetworkChainMap[req.network][req.chainId].permissionedPool
-  }
+  ) {}
 
   // Get the balance from this one specific permissioned pool contract
   async fetchBalance(): Promise<BalanceResponse> {

--- a/packages/sources/stader-balance/src/model/stader-config.ts
+++ b/packages/sources/stader-balance/src/model/stader-config.ts
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js'
 import { ethers } from 'ethers'
 import { StaderConfigContract_ABI } from '../abi/StaderContractAbis'
-import { staderNetworkChainMap, withErrorHandling } from '../endpoint/utils'
+import { RequestParams, staderNetworkChainMap, withErrorHandling } from '../endpoint/utils'
 
 export class StaderConfig {
   address: string
@@ -16,6 +16,42 @@ export class StaderConfig {
     this.address = req.staderConfig || staderNetworkChainMap[req.network][req.chainId].staderConfig
 
     this.addressManager = new ethers.Contract(this.address, StaderConfigContract_ABI, this.provider)
+  }
+
+  async fetchContractAddresses(
+    req: RequestParams,
+    blockTag: number,
+  ): Promise<{
+    poolFactoryAddress: string
+    penaltyAddress: string
+    stakeManagerAddress: string
+    permissionedPoolAddress: string
+  }> {
+    return withErrorHandling(
+      'Fetching contract addresses from the StaderConfig contract',
+      async () => {
+        // Fetch default contract addresses from the StaderConfig contract
+        const [
+          poolFactoryDefault,
+          penaltyDefault,
+          stakePoolsManagerDefault,
+          permissionedPoolDefault,
+        ] = await Promise.all([
+          this.addressManager.getPoolUtils({ blockTag }),
+          this.addressManager.getPenaltyContract({ blockTag }),
+          this.addressManager.getStakePoolManager({ blockTag }),
+          this.addressManager.getPermissionedPool({ blockTag }),
+        ])
+
+        const poolFactoryAddress = req.poolFactoryAddress || poolFactoryDefault
+        const penaltyAddress = req.penaltyAddress || penaltyDefault
+        const stakeManagerAddress = req.stakeManagerAddress || stakePoolsManagerDefault
+        const permissionedPoolAddress = req.permissionedPoolAddress || permissionedPoolDefault
+
+        // Apply overrides to return the
+        return { poolFactoryAddress, penaltyAddress, stakeManagerAddress, permissionedPoolAddress }
+      },
+    )
   }
 
   async fetchValidatorDeposit(): Promise<BigNumber> {

--- a/packages/sources/stader-balance/src/model/stake-manager.ts
+++ b/packages/sources/stader-balance/src/model/stake-manager.ts
@@ -3,22 +3,17 @@ import {
   BalanceResponse,
   fetchAddressBalance,
   formatValueInGwei,
-  staderNetworkChainMap,
   withErrorHandling,
 } from '../endpoint/utils'
 
 export class StakeManager {
-  address: string
   balance?: BalanceResponse
 
   constructor(
-    req: { stakeManagerAddress?: string; network: string; chainId: string },
+    private address: string,
     private blockTag: number,
     private provider: ethers.providers.JsonRpcProvider,
-  ) {
-    this.address =
-      req.stakeManagerAddress || staderNetworkChainMap[req.network][req.chainId].stakePoolsManager
-  }
+  ) {}
 
   // Get inactive pool balance from Stader's StakePoolManager contract
   async fetchBalance(): Promise<BalanceResponse> {

--- a/packages/sources/stader-balance/src/model/validator.ts
+++ b/packages/sources/stader-balance/src/model/validator.ts
@@ -85,7 +85,7 @@ export class ValidatorFactory {
                   provider: params.provider,
                 }
                 logger.debug(
-                  `[Validator ${validatorAddress}] Found address on beacon chain (status: ${state.status} | balance: ${validatorBalance})`,
+                  `[Validator ${validatorAddress.address}] Found address on beacon chain (status: ${state.status} | balance: ${validatorBalance})`,
                 )
 
                 if (

--- a/packages/sources/stader-balance/test/integration/adapter.test.ts
+++ b/packages/sources/stader-balance/test/integration/adapter.test.ts
@@ -100,11 +100,21 @@ jest.mock('ethers', () => {
           totalPenaltyAmount: jest.fn().mockImplementation((address) => {
             return mockPenaltyMap[address]
           }),
-          getStakedEthPerNode: jest.fn().mockReturnValue(32000000000000000000),
+          getStakedEthPerNode: jest.fn().mockReturnValue(32_000_000_000_000_000_000),
           getCollateralETH: jest.fn().mockImplementation((poolId) => {
             return mockCollateralEthMap[poolId]
           }),
-          poolCount: jest.fn().mockReturnValue(5),
+          getPenaltyContract: jest
+            .fn()
+            .mockReturnValue('0x0FB2921fb8ad8C5364a8156693E2D94135d07e02'),
+          getPermissionedPool: jest
+            .fn()
+            .mockReturnValue('0xEc4166439523e8C2FaE395201f04876Cc7C02d68'),
+          getPoolUtils: jest.fn().mockReturnValue('0x019a7ced1927946eADb28735f15a20e3ed762240'),
+          getStakePoolManager: jest
+            .fn()
+            .mockReturnValue('0x974Db4Fb26993289CAD9f79Bde4eAE097503064f'),
+          getPoolIdArray: jest.fn().mockReturnValue([1, 2, 3, 4, 5]),
         }
       },
     },


### PR DESCRIPTION
## Closes [PDI-2119](https://smartcontract-it.atlassian.net/browse/PDI-2119)

## Description

Updated `stader-address-list` and `stader-balance` adapters with new contracts and logic changes. Updated `proof-of-reserves` README since it was well out of date

## Steps to Test

1. yarn test packages/sources/stader-address-list/test
2. yarn test packages/sources/stader-balance/test

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[PDI-2119]: https://smartcontract-it.atlassian.net/browse/PDI-2119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ