### PR TITLE
Remove WS_ENABLED env var from intrinio v3

### DIFF
--- a/.changeset/cold-onions-argue.md
+++ b/.changeset/cold-onions-argue.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/intrinio-test-adapter': minor
+---
+
+Removed WS_ENABLED env var

--- a/packages/sources/intrinio-test/src/config/index.ts
+++ b/packages/sources/intrinio-test/src/config/index.ts
@@ -12,9 +12,4 @@ export const config = new AdapterConfig({
     require: true,
     sensitive: true,
   },
-  WS_ENABLED: {
-    description: 'Whether data should be returned from websocket or not',
-    type: 'boolean',
-    default: false,
-  },
 })

--- a/packages/sources/intrinio-test/src/endpoint/price-router.ts
+++ b/packages/sources/intrinio-test/src/endpoint/price-router.ts
@@ -32,8 +32,5 @@ export const endpoint = new AdapterEndpoint<EndpointTypes>({
     .register('ws', wsTransport)
     .register('rest', httpTransport),
   defaultTransport: 'rest',
-  customRouter: (_req, adapterConfig) => {
-    return adapterConfig.WS_ENABLED ? 'ws' : 'rest'
-  },
   inputParameters: inputParameters,
 })

--- a/packages/sources/intrinio-test/test/integration/adapter.test.ts
+++ b/packages/sources/intrinio-test/test/integration/adapter.test.ts
@@ -87,7 +87,6 @@ describe('execute', () => {
       process.env['CACHE_POLLING_MAX_RETRIES'] = '0'
       process.env['METRICS_ENABLED'] = 'false'
       process.env['API_KEY'] = 'fake-api-key'
-      process.env['WS_ENABLED'] = 'true'
 
       const mockDate = new Date('2022-11-11T11:11:11.111Z')
       spy = jest.spyOn(Date, 'now').mockReturnValue(mockDate.getTime())


### PR DESCRIPTION
## Description

Removed the `WS_ENABLED` env var from `intrinio-test`. Defaulting to `rest` transport is confirmed to be the expected behavior in all cases.

## Steps to Test

1. yarn test packages/sources/intrinio-test/test

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
