### PR TITLE
Release/v1.69.0 [develop]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/external-adapters-js",
-  "version": "1.68.0",
+  "version": "1.69.0",
   "license": "MIT",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Changelog

### Breaking Changes
- Finnhub, Tiingo & Openexchangerates: Upgraded adapter from v2 to v3 framework

### Features
- intrinio-test: Removed WS_ENABLED env var
- stader-address-list & stader-balance: Updated with new contracts and logic
- tradermade-test: Accounting for credit based rate limiting by unbatching all endpoints
- dxfeed-test: Removed WS_ENABLED env var. Added reasonable rate limit.
- market-closure: Updated implementation to account for Finnhub v3 upgrade
- tradermade-test: Added overrides to the live endpoint

### Bug Fixes
- twosigma: Fix websocket bug

### Notable Adapter Updates

|    Adapter    | Version | Description |
| :-----------: | :-----: | :---------: |
| finnhub  | v2.0.0  | Upgraded adapter from v2 to v3 framework |
| tiingo  | v2.0.0  | Upgraded adapter from v2 to v3 framework |
| openexchangerates  | v2.0.0  | Upgraded adapter from v2 to v3 framework |
| intrinio-test  | v1.3.0  | Removed WS_ENABLED env var |
| stader-address-list  | v2.1.0  | Updated with new contracts and logic |
| stader-balance  | v1.1.0  | Updated with new contracts and logic |
| tradermade-test  | v1.4.0  | Accounting for credit based rate limiting by unbatching all endpoints, Added overrides to the live endpoint |
| dxfeed-test  | v1.3.0  | Removed WS_ENABLED env var. Added reasonable rate limit. |
| dxfeed-secondary-test  | v1.2.0  | Removed WS_ENABLED env var. Added reasonable rate limit. |
| market-closure  | v1.3.0 | Updated implementation to account for Finnhub v3 upgrade |
| twosigma  | v1.2.0 | Fix websocket bug |