### PR TITLE
Kaiko v3 price validation

### DIFF
--- a/.changeset/curly-mirrors-talk.md
+++ b/.changeset/curly-mirrors-talk.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/kaiko-test-adapter': patch
+---
+
+Added 0 price validation

--- a/packages/sources/kaiko-test/src/endpoint/trades.ts
+++ b/packages/sources/kaiko-test/src/endpoint/trades.ts
@@ -121,7 +121,7 @@ const httpTransport = new HttpTransport<EndpointTypes>({
     return params.map((param) => {
       const data = res.data.data.filter((x) => x.price !== null)
       if (data.length === 0) {
-        const errorMessage = `Kaiko is not returning any price data for ${param.base}/${param.quote}, likely due to too low trading volume for the requested interval. This is not an issue with the external adapter.`
+        const errorMessage = `Kaiko is not returning any price data for ${param.base}/${param.quote}, likely due to too low trading volume for the requested interval (${param.interval}). This is not an issue with the external adapter.`
         logger.info(errorMessage)
         return {
           params: param,

--- a/packages/sources/kaiko-test/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/kaiko-test/test/integration/__snapshots__/adapter.test.ts.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`execute trades endpoint should return error 1`] = `
+{
+  "errorMessage": "Kaiko returned price of 0 for LTC/ETH",
+  "statusCode": 502,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 1641035471111,
+    "providerDataRequestedUnixMs": 1641035471111,
+  },
+}
+`;
+
 exports[`execute trades endpoint should return success 1`] = `
 {
   "data": {

--- a/packages/sources/kaiko-test/test/integration/adapter.test.ts
+++ b/packages/sources/kaiko-test/test/integration/adapter.test.ts
@@ -55,6 +55,27 @@ describe('execute', () => {
       expect(response.body).toMatchSnapshot()
     })
 
+    it('should return error', async () => {
+      mockRateResponseSuccess()
+
+      const data = {
+        id,
+        data: {
+          base: 'LTC',
+          quote: 'ETH',
+        },
+      }
+
+      const response = await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(502)
+      expect(response.body).toMatchSnapshot()
+    })
+
     xit('should return failure', async () => {
       mockRateResponseFailure()
 

--- a/packages/sources/kaiko-test/test/integration/fixtures.ts
+++ b/packages/sources/kaiko-test/test/integration/fixtures.ts
@@ -278,6 +278,7 @@ export const mockRateResponseSuccess = (): nock.Scope =>
         'Origin',
       ],
     )
+    .persist()
 
 export const mockRateResponseFailure = (): nock.Scope =>
   nock('https://us.market-api.kaiko.io/v2/data/trades.v1', {

--- a/packages/sources/kaiko-test/test/integration/fixtures.ts
+++ b/packages/sources/kaiko-test/test/integration/fixtures.ts
@@ -151,7 +151,7 @@ export const mockRateResponseSuccess = (): nock.Scope =>
         time: '2021-10-21T20:57:28.316Z',
         timestamp: 1634849848316,
         data: [
-          { timestamp: 1634849820000, price: '0.0485267900742041', volume: '12.533', count: 2 },
+          { timestamp: 1634849820000, price: '0', volume: '12.533', count: 2 },
           {
             timestamp: 1634849760000,
             price: '0.048497889663599435',


### PR DESCRIPTION
## Description

Noticed price intermittently getting overridden to 0. Noticed specifically for UST/USD internally and by NOP. v2 result validation included a check for 0 price. Added validation to the v3 adapter to maintain the same behavior.

## Changes

- Added 0 price validation to `kaiko-test`

## Steps to Test

1. yarn test packages/sources/kaiko-test/test

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
