### PR TITLE
Feature/Merc-477 Crypto lwba endpoint

### DIFF
--- a/.changeset/shiny-planes-chew.md
+++ b/.changeset/shiny-planes-chew.md
@@ -1,0 +1,7 @@
+---
+'@chainlink/cfbenchmarks-adapter': minor
+'@chainlink/ncfx-adapter': minor
+'@chainlink/tiingo-test-adapter': minor
+---
+
+Normalize crypto-lwba endpoint names

--- a/packages/sources/cfbenchmarks/src/endpoint/websocket/crypto-lwba.ts
+++ b/packages/sources/cfbenchmarks/src/endpoint/websocket/crypto-lwba.ts
@@ -126,8 +126,8 @@ export const lwbaReqTransformer = (req: AdapterRequest<typeof inputParameters.va
 }
 
 export const endpoint = new AdapterEndpoint<WsEndpointTypes>({
-  name: 'crypto_lwba',
-  aliases: ['cryptolwba'],
+  name: 'crypto-lwba',
+  aliases: ['cryptolwba', 'crypto_lwba'],
   transport: wsTransport,
   inputParameters: inputParameters,
   requestTransforms: [lwbaReqTransformer],

--- a/packages/sources/ncfx/src/endpoint/crypto.ts
+++ b/packages/sources/ncfx/src/endpoint/crypto.ts
@@ -138,6 +138,7 @@ const isInfoMessage = (message: WsMessage): message is WsInfoMessage => {
 
 export const cryptoEndpoint = new CryptoPriceEndpoint<EndpointTypes>({
   name: 'crypto',
+  aliases: ['crypto-lwba'],
   transport: cryptoTransport,
   inputParameters,
 })

--- a/packages/sources/tiingo-test/src/endpoint/ws/crypto-lwba.ts
+++ b/packages/sources/tiingo-test/src/endpoint/ws/crypto-lwba.ts
@@ -105,8 +105,8 @@ export const wsTransport: TiingoWebsocketTransport<EndpointTypes> =
   })
 
 export const endpoint = new AdapterEndpoint<EndpointTypes>({
-  name: 'crypto_lwba',
-  aliases: ['cryptolwba'],
+  name: 'crypto-lwba',
+  aliases: ['cryptolwba', 'crypto_lwba'],
   transport: wsTransport,
   inputParameters: inputParameters,
   overrides: overrides.tiingo,


### PR DESCRIPTION
## Closes #ISSUE_NUMBER_GOES_HERE

## Description
Normalizes liquidity weighted bid ask spread endpoint aliases to crypto-lwba
......

## Changes

Update relevant endpoint names/aliases

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. yarn && yarn setup
2. yarn test packages/sources/cfbenchmarks
3. yarn test packages/sources/ncfx
4. yarn test packages/sources/tiingo-test

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [x] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
