### PR TITLE
Add accurate rate limit tiers to intrinio v3

### DIFF
--- a/.changeset/modern-coins-shake.md
+++ b/.changeset/modern-coins-shake.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/intrinio-test-adapter': patch
+---
+
+Added accurate rate limit tiers

--- a/packages/sources/intrinio-test/src/index.ts
+++ b/packages/sources/intrinio-test/src/index.ts
@@ -10,8 +10,14 @@ export const adapter = new Adapter({
   endpoints: [price],
   rateLimiting: {
     tiers: {
-      free: {
-        rateLimit1s: 100,
+      bronze: {
+        rateLimit1m: 300,
+      },
+      silver: {
+        rateLimit1m: 2000,
+      },
+      gold: {
+        rateLimit1m: 2000,
       },
     },
   },


### PR DESCRIPTION
## Description

The rate limit tier for `intrinio` ported from v2 was not accurate. This change adds the tiers described on Intrinio's pricing [page](https://intrinio.com/financial-market-data)

## Changes

- Added bronze (300 req/min), silver (2000 req/min), and gold (2000 req/min) tiers

## Steps to Test

1. yarn test packages/sources/intrinio-test/test

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
