### PR TITLE
fix/MERC-615-Normalize crypto-lwba response formats

### DIFF
--- a/.changeset/good-avocados-complain.md
+++ b/.changeset/good-avocados-complain.md
@@ -1,0 +1,6 @@
+---
+'@chainlink/coinmetrics-adapter': minor
+'@chainlink/ncfx-adapter': minor
+---
+
+Normalize crypto-lwba response formats

--- a/packages/sources/coinmetrics/src/endpoint/lwba-ws.ts
+++ b/packages/sources/coinmetrics/src/endpoint/lwba-ws.ts
@@ -31,6 +31,9 @@ export type WsCryptoLwbaEndpointTypes = {
     spread: number
     Data: {
       result: number
+      bid: number
+      mid: number
+      ask: number
     }
   }
   Provider: {
@@ -132,6 +135,11 @@ export const handleCryptoLwbaMessage = (
           spread: Number(message.spread),
           data: {
             result: res,
+            // bid, mid, ask included here again.
+            // Also kept outside data for backward compatability
+            bid: Number(message.bid_price),
+            mid: res,
+            ask: Number(message.ask_price),
           },
           timestamps: {
             providerIndicatedTimeUnixMs: new Date(message.time).getTime(),

--- a/packages/sources/coinmetrics/test/integration/adapter-ws.test.ts
+++ b/packages/sources/coinmetrics/test/integration/adapter-ws.test.ts
@@ -73,7 +73,6 @@ describe('websocket', () => {
           .expect(200)
 
       const response = await makeRequest()
-      log(response.body)
       expect(response.body).toMatchSnapshot()
     }, 30000)
     it('should return error (empty body)', async () => {

--- a/packages/sources/coinmetrics/test/integration/adapter-ws.test.ts
+++ b/packages/sources/coinmetrics/test/integration/adapter-ws.test.ts
@@ -11,7 +11,6 @@ import { expose, ServerInstance } from '@chainlink/external-adapter-framework'
 import request, { SuperTest, Test } from 'supertest'
 import { WebSocketClassProvider } from '@chainlink/external-adapter-framework/transports'
 import { Server } from 'mock-socket'
-import { log } from 'console'
 
 describe('websocket', () => {
   let fastify: ServerInstance | undefined

--- a/packages/sources/coinmetrics/test/integration/adapter-ws.test.ts
+++ b/packages/sources/coinmetrics/test/integration/adapter-ws.test.ts
@@ -11,6 +11,7 @@ import { expose, ServerInstance } from '@chainlink/external-adapter-framework'
 import request, { SuperTest, Test } from 'supertest'
 import { WebSocketClassProvider } from '@chainlink/external-adapter-framework/transports'
 import { Server } from 'mock-socket'
+import { log } from 'console'
 
 describe('websocket', () => {
   let fastify: ServerInstance | undefined
@@ -72,6 +73,7 @@ describe('websocket', () => {
           .expect(200)
 
       const response = await makeRequest()
+      log(response.body)
       expect(response.body).toMatchSnapshot()
     }, 30000)
     it('should return error (empty body)', async () => {

--- a/packages/sources/coinmetrics/test/integration/lwba-ws.test.ts
+++ b/packages/sources/coinmetrics/test/integration/lwba-ws.test.ts
@@ -82,6 +82,9 @@ describe('websocket', () => {
         spread: 0.000044756626394287605,
         statusCode: 200,
         data: {
+          ask: 1562.4083581615457,
+          bid: 1562.3384315992228,
+          mid: 1562.3733948803842,
           result: 1562.3733948803842,
         },
         timestamps: {

--- a/packages/sources/ncfx/src/endpoint/crypto.ts
+++ b/packages/sources/ncfx/src/endpoint/crypto.ts
@@ -39,6 +39,9 @@ type Response = {
   ask: number
   Data: {
     result: number
+    bid: number
+    mid: number
+    ask: number
   }
 }
 
@@ -111,6 +114,11 @@ export const cryptoTransport = new WebSocketTransport<EndpointTypes>({
             ask: message.offer || 0, // Already validated in the filter above
             data: {
               result: message.mid || 0, // Already validated in the filter above
+              // bid, mid, ask included here again.
+              // Also kept outside data for backward compatability
+              bid: message.bid || 0,
+              mid: message.mid || 0,
+              ask: message.offer || 0,
             },
             timestamps: {
               providerIndicatedTimeUnixMs: new Date(message.timestamp).getTime(),

--- a/packages/sources/ncfx/src/endpoint/crypto.ts
+++ b/packages/sources/ncfx/src/endpoint/crypto.ts
@@ -113,12 +113,12 @@ export const cryptoTransport = new WebSocketTransport<EndpointTypes>({
             bid: message.bid || 0, // Already validated in the filter above
             ask: message.offer || 0, // Already validated in the filter above
             data: {
-              result: message.mid || 0, // Already validated in the filter above
               // bid, mid, ask included here again.
               // Also kept outside data for backward compatability
               bid: message.bid || 0,
               mid: message.mid || 0,
               ask: message.offer || 0,
+              result: message.mid || 0, // Already validated in the filter above
             },
             timestamps: {
               providerIndicatedTimeUnixMs: new Date(message.timestamp).getTime(),

--- a/packages/sources/ncfx/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/ncfx/test/integration/__snapshots__/adapter.test.ts.snap
@@ -5,6 +5,9 @@ exports[`Crypto Endpoint should return success 1`] = `
   "ask": 3107.1275,
   "bid": 3106.8495,
   "data": {
+    "ask": 3107.1275,
+    "bid": 3106.8495,
+    "mid": 3106.9885,
     "result": 3106.9885,
   },
   "result": 3106.9885,


### PR DESCRIPTION
## Closes MERC-615

## Description
Ensures all crypto lwba endpoints return bid, mid, and ask properties within their data objects.
......

## Changes
Adds mid, bid, and ask properties to crypto-lwba endpoint response data objects as needed

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. yarn & yarn setup
2. yarn test packages/sources/coinmetrics
3. yarn test packages/sources/ncfx

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [x] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.