### PR TITLE
Fix misconfigured Stader Balance adapter ABI

### DIFF
--- a/.changeset/hip-emus-burn.md
+++ b/.changeset/hip-emus-burn.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/stader-balance-adapter': patch
+---
+
+Fixed misconfigured ABI for penalty contract

--- a/packages/sources/stader-balance/src/abi/StaderContractAbis.ts
+++ b/packages/sources/stader-balance/src/abi/StaderContractAbis.ts
@@ -106,7 +106,7 @@ export const DepositEvent_ABI = [
 
 export const StaderPenaltyContract_ABI: ethers.ContractInterface = [
   {
-    inputs: [{ internalType: 'bytes32', name: '', type: 'bytes32' }],
+    inputs: [{ internalType: 'bytes', name: '', type: 'bytes' }],
     name: 'totalPenaltyAmount',
     outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
     stateMutability: 'view',


### PR DESCRIPTION
## Description

After recent contract changes, the ABI for the `totalPenaltyAmount` mapping was not updated causing some validation issues for certain validator pubkeys.

## Changes

- Changed input type for `totalPenaltyAmount` in ABI from `bytes32` to `bytes`

## Steps to Test

1. yarn test packages/sources/stader-balance/test

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
