### PR TITLE
Fix iex overrides and add override for BRK.B to Tiingo

### DIFF
--- a/.changeset/slow-ties-hang.md
+++ b/.changeset/slow-ties-hang.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/tiingo-adapter': patch
+---
+
+Fixed iex endpoint overrides and added BRK.B override

--- a/packages/sources/tiingo/src/config/overrides.json
+++ b/packages/sources/tiingo/src/config/overrides.json
@@ -2,6 +2,7 @@
   "tiingo": {
     "MIOTA": "IOTA",
     "WTI": "usoil",
-    "RENFIL": "FIL"
+    "RENFIL": "FIL",
+    "BRK.B": "BRK-B"
   }
 }

--- a/packages/sources/tiingo/src/endpoint/common/iex-router.ts
+++ b/packages/sources/tiingo/src/endpoint/common/iex-router.ts
@@ -8,8 +8,8 @@ import { httpTransport } from '../http/iex'
 import { wsTransport } from '../ws/iex'
 
 const inputParameters = new InputParameters({
-  ticker: {
-    aliases: ['base', 'from', 'coin'],
+  base: {
+    aliases: ['ticker', 'from', 'coin'],
     required: true,
     type: 'string',
     description: 'The stock ticker to query',

--- a/packages/sources/tiingo/src/endpoint/http/iex.ts
+++ b/packages/sources/tiingo/src/endpoint/http/iex.ts
@@ -37,7 +37,7 @@ export const httpTransport = new HttpTransport<HttpIEXEndpointTypes>({
         url: 'iex',
         params: {
           token: config.API_KEY,
-          tickers: [...new Set(params.map((p) => `${p.ticker.toLowerCase()}`))].join(','),
+          tickers: [...new Set(params.map((p) => `${p.base.toLowerCase()}`))].join(','),
         },
       },
     }
@@ -45,7 +45,7 @@ export const httpTransport = new HttpTransport<HttpIEXEndpointTypes>({
   parseResponse: (_, res) => {
     return res.data.map((entry) => {
       return {
-        params: { ticker: entry.ticker },
+        params: { base: entry.ticker },
         response: {
           data: {
             result: entry.tngoLast,

--- a/packages/sources/tiingo/src/endpoint/ws/iex.ts
+++ b/packages/sources/tiingo/src/endpoint/ws/iex.ts
@@ -70,7 +70,7 @@ export const wsTransport: TiingoWebsocketTransport<EndpointTypes> =
         }
         return [
           {
-            params: { ticker: message.data[tickerIndex] },
+            params: { base: message.data[tickerIndex] },
             response: {
               data: {
                 result,
@@ -90,14 +90,14 @@ export const wsTransport: TiingoWebsocketTransport<EndpointTypes> =
         return {
           eventName: 'subscribe',
           authorization: wsTransport.apiKey,
-          eventData: { thresholdLevel: 5, tickers: [params.ticker] },
+          eventData: { thresholdLevel: 5, tickers: [params.base] },
         }
       },
       unsubscribeMessage: (params) => {
         return {
           eventName: 'unsubscribe',
           authorization: wsTransport.apiKey,
-          eventData: { thresholdLevel: 5, tickers: [params.ticker] },
+          eventData: { thresholdLevel: 5, tickers: [params.base] },
         }
       },
     },


### PR DESCRIPTION
## Description

Fixed `iex` endpoint overrides which would not apply due to the input param being named `ticker` instead of `base`. Updated the implementation to use `base` as the input param name and `ticker` as the alias. Also added an override for `BRK.B` -> `BRK-B` to `tiingo`

## Changes

- Switched iex input param name to `base` with `ticker` as an alias
- Added the override for `BRK.B` -> `BRK-B`

## Steps to Test

1. yarn test packages/sources/tiingo/test

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
