### PR TITLE
Dar fixes

### DIFF
--- a/.changeset/few-dryers-study.md
+++ b/.changeset/few-dryers-study.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/dar-adapter': minor
+---
+
+Remove heartbeat timeout from DAR WS

--- a/packages/sources/dar/src/config/index.ts
+++ b/packages/sources/dar/src/config/index.ts
@@ -34,4 +34,4 @@ export const config = new AdapterConfig(
   },
 )
 
-export const WS_HEARTBEAT_MS = 60000
+//export const WS_HEARTBEAT_MS = 60000

--- a/packages/sources/dar/src/config/index.ts
+++ b/packages/sources/dar/src/config/index.ts
@@ -33,5 +33,3 @@ export const config = new AdapterConfig(
     },
   },
 )
-
-//export const WS_HEARTBEAT_MS = 60000

--- a/packages/sources/dar/src/endpoint/price.ts
+++ b/packages/sources/dar/src/endpoint/price.ts
@@ -1,7 +1,6 @@
 import { PriceEndpoint } from '@chainlink/external-adapter-framework/adapter'
 import { WebSocketTransport } from '@chainlink/external-adapter-framework/transports'
 import { makeLogger } from '@chainlink/external-adapter-framework/util'
-//import { WS_HEARTBEAT_MS } from '../config'
 import { PriceEndpointTypes, inputParameters } from '../types'
 import { getAuthToken } from '../util'
 
@@ -20,14 +19,6 @@ const hitTrackingLevels: { [level: string]: boolean } = {
   trace: true,
 }
 
-// function heartbeat(connection: WebSocket): NodeJS.Timeout | undefined {
-//   if (!connection) return
-//   if (connection.readyState !== 1) return
-//   logger.debug('pinging....')
-//   connection.send('Ping')
-//   return setTimeout(() => heartbeat(connection), WS_HEARTBEAT_MS)
-// }
-
 export const priceTransport = new WebSocketTransport<PriceEndpointTypes>({
   url: (context) => context.adapterSettings.WS_API_ENDPOINT,
   options: async (context) => {
@@ -37,12 +28,6 @@ export const priceTransport = new WebSocketTransport<PriceEndpointTypes>({
     }
   },
   handlers: {
-    open(connection) {
-      //const heartbeatTimeout = heartbeat(connection)
-      connection.addEventListener('close', async () => {
-        //clearTimeout(heartbeatTimeout)
-      })
-    },
     message(message, context) {
       if (message.errors) {
         logger.error(`Got error from DP: ${message.errors}`)

--- a/packages/sources/dar/src/endpoint/price.ts
+++ b/packages/sources/dar/src/endpoint/price.ts
@@ -1,7 +1,7 @@
 import { PriceEndpoint } from '@chainlink/external-adapter-framework/adapter'
 import { WebSocketTransport } from '@chainlink/external-adapter-framework/transports'
 import { makeLogger } from '@chainlink/external-adapter-framework/util'
-import { WS_HEARTBEAT_MS } from '../config'
+//import { WS_HEARTBEAT_MS } from '../config'
 import { PriceEndpointTypes, inputParameters } from '../types'
 import { getAuthToken } from '../util'
 
@@ -20,13 +20,13 @@ const hitTrackingLevels: { [level: string]: boolean } = {
   trace: true,
 }
 
-function heartbeat(connection: WebSocket): NodeJS.Timeout | undefined {
-  if (!connection) return
-  if (connection.readyState !== 1) return
-  logger.debug('pinging....')
-  connection.send('Ping')
-  return setTimeout(() => heartbeat(connection), WS_HEARTBEAT_MS)
-}
+// function heartbeat(connection: WebSocket): NodeJS.Timeout | undefined {
+//   if (!connection) return
+//   if (connection.readyState !== 1) return
+//   logger.debug('pinging....')
+//   connection.send('Ping')
+//   return setTimeout(() => heartbeat(connection), WS_HEARTBEAT_MS)
+// }
 
 export const priceTransport = new WebSocketTransport<PriceEndpointTypes>({
   url: (context) => context.adapterSettings.WS_API_ENDPOINT,
@@ -38,9 +38,9 @@ export const priceTransport = new WebSocketTransport<PriceEndpointTypes>({
   },
   handlers: {
     open(connection) {
-      const heartbeatTimeout = heartbeat(connection)
+      //const heartbeatTimeout = heartbeat(connection)
       connection.addEventListener('close', async () => {
-        clearTimeout(heartbeatTimeout)
+        //clearTimeout(heartbeatTimeout)
       })
     },
     message(message, context) {


### PR DESCRIPTION
## Closes #DF-18878

## Description
DAR removed the possibility to send a ping as livelihood check. Therefore the heartbeat checks always fail causing unnecessary reconnects every 3 minutes and partial disruption of service. For further details refer to https://smartcontract-it.atlassian.net/browse/CS-20

## Changes

Removed heartbeat logic.

## Steps to Test

`export adapter=dar`
`yarn test $adapter/test/integration`
