### PR TITLE
Set Tiingo stock endpoint default transport to rest

### DIFF
--- a/.changeset/chilled-stingrays-give.md
+++ b/.changeset/chilled-stingrays-give.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/tiingo-adapter': patch
+---
+
+Set stock endpoint default transport to rest

--- a/packages/sources/tiingo/src/endpoint/common/iex-router.ts
+++ b/packages/sources/tiingo/src/endpoint/common/iex-router.ts
@@ -28,7 +28,7 @@ export const endpoint = new AdapterEndpoint({
   transportRoutes: new TransportRoutes<IEXEndpointTypes>()
     .register('ws', wsTransport)
     .register('rest', httpTransport),
-  defaultTransport: 'ws',
+  defaultTransport: 'rest',
   inputParameters: inputParameters,
   overrides: overrides.tiingo,
 })

--- a/packages/sources/tiingo/test/integration/adapter.test.ts
+++ b/packages/sources/tiingo/test/integration/adapter.test.ts
@@ -391,6 +391,7 @@ describe('execute', () => {
       data: {
         endpoint: 'iex',
         base: 'aapl',
+        transport: 'ws',
       },
     }
 
@@ -398,6 +399,7 @@ describe('execute', () => {
       data: {
         endpoint: 'iex',
         base: 'amzn',
+        transport: 'ws',
       },
     }
 


### PR DESCRIPTION
## Description

Tiingo doesn't serve stock data over websocket during market close. Even though this is expected behavior, NOPs started reporting issues with stock tickers after hours. Since Tiingo serves stock data after market hours over rest, the decision was made to default just the stock endpoint to rest.

## Changes

- Updated stock endpoint default transport to `rest`

## Steps to Test

1. yarn test packages/sources/tiingo/test

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
