### PR TITLE
Update Stader social pool balance calculation

### DIFF
--- a/.changeset/strong-hotels-sort.md
+++ b/.changeset/strong-hotels-sort.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/stader-balance-adapter': patch
+---
+
+Updated social pool balance calculation logic

--- a/packages/sources/stader-balance/src/abi/StaderContractAbis.ts
+++ b/packages/sources/stader-balance/src/abi/StaderContractAbis.ts
@@ -113,3 +113,13 @@ export const StaderPenaltyContract_ABI: ethers.ContractInterface = [
     type: 'function',
   },
 ]
+
+export const StaderSocialPool_ABI: ethers.ContractInterface = [
+  {
+    inputs: [],
+    name: 'totalOperatorETHRewardsRemaining',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+]

--- a/packages/sources/stader-balance/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/stader-balance/test/integration/__snapshots__/adapter.test.ts.snap
@@ -50,11 +50,11 @@ exports[`Balance Endpoint should return success 1`] = `
       },
       {
         "address": "0x10f4F0a7aadfB7E79533090508fADD78FB163068",
-        "balance": "4218750000",
+        "balance": "4134375000",
       },
       {
         "address": "0x9CfD5a30DB1B925A92E796e5Ce37Fd0E66390Fe1",
-        "balance": "5279296875",
+        "balance": "5208906250",
       },
       {
         "address": "0x98416f837d457d72f0dd5297898e1225a1e7731c2579f642626fbdc8ee8ce4f1e89ca538b72d5c3b75fdd1e9e10c87c6",

--- a/packages/sources/stader-balance/test/integration/adapter.test.ts
+++ b/packages/sources/stader-balance/test/integration/adapter.test.ts
@@ -115,6 +115,7 @@ jest.mock('ethers', () => {
             .fn()
             .mockReturnValue('0x974Db4Fb26993289CAD9f79Bde4eAE097503064f'),
           getPoolIdArray: jest.fn().mockReturnValue([1, 2, 3, 4, 5]),
+          totalOperatorETHRewardsRemaining: jest.fn().mockReturnValue(100_000_000_000_000_000),
         }
       },
     },


### PR DESCRIPTION
## Description

Updated Stader social pool balance calculations to include `totalOperatorETHRewardsRemaining`

## Changes

- Subtract `totalOperatorETHRewardsRemaining` from address balance prior to calculations

## Steps to Test

1. yarn test packages/sources/stader-balance/test

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
