### PR TITLE
Fix tradingeconomics v3 symbol casing

### DIFF
--- a/.changeset/calm-windows-marry.md
+++ b/.changeset/calm-windows-marry.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/tradingeconomics-test-adapter': patch
+---
+
+Fixed symbol casing

--- a/packages/sources/tradingeconomics-test/src/endpoint/price-router.ts
+++ b/packages/sources/tradingeconomics-test/src/endpoint/price-router.ts
@@ -26,9 +26,8 @@ export const inputParameters = new InputParameters({
 })
 
 export const requestTransform = (req: AdapterRequest<typeof inputParameters.validated>): void => {
-  const base = req.requestContext.data.base
-  const regex = /[a-zA-Z]{6}:CUR/ //BTCUSD:CUR
-
+  const base = req.requestContext.data.base.toUpperCase()
+  const regex = /[A-Z]{6}:CUR/ //BTCUSD:CUR
   if (regex.test(base)) {
     req.requestContext.data.base = base.substring(0, 3)
     req.requestContext.data.quote = base.substring(3, 6)

--- a/packages/sources/tradingeconomics-test/src/endpoint/price.ts
+++ b/packages/sources/tradingeconomics-test/src/endpoint/price.ts
@@ -51,7 +51,7 @@ type HttpEndpointTypes = EndpointTypes & {
 export const httpTransport = new HttpTransport<HttpEndpointTypes>({
   prepareRequests: (params, config) => {
     return params.map((param) => {
-      const symbol = `${param.base}${param.quote}:CUR`
+      const symbol = `${param.base}${param.quote}:CUR`.toUpperCase()
       return {
         params: [param],
         request: {

--- a/packages/sources/tradingeconomics-test/src/endpoint/stock-ws.ts
+++ b/packages/sources/tradingeconomics-test/src/endpoint/stock-ws.ts
@@ -58,7 +58,7 @@ export const wsTransport = new WebSocketTransport<WSEndpointTypes>({
   },
   builders: {
     subscribeMessage: (param) => {
-      return { topic: 'subscribe', to: param.base }
+      return { topic: 'subscribe', to: param.base.toUpperCase() }
     },
   },
 })

--- a/packages/sources/tradingeconomics-test/src/endpoint/stock.ts
+++ b/packages/sources/tradingeconomics-test/src/endpoint/stock.ts
@@ -14,11 +14,12 @@ type HttpEndpointTypes = StockEndpointTypes & {
 export const httpTransport = new HttpTransport<HttpEndpointTypes>({
   prepareRequests: (params, config) => {
     return params.map((param) => {
+      const symbol = param.base.toUpperCase()
       return {
         params: [param],
         request: {
           baseURL: config.API_ENDPOINT,
-          url: `/symbol/${param.base}`,
+          url: `/symbol/${symbol}`,
           params: {
             c: `${config.API_CLIENT_KEY}:${config.API_CLIENT_SECRET}`,
             f: `json`,


### PR DESCRIPTION
## Description

Tradingeconomics requires symbols to be upper case which the adapter was not ensuring.

## Changes

- Upper case symbols in provider requests

## Steps to Test

1. yarn test packages/sources/tradingeconomics-test/test

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
