### PR TITLE
hard code switch ws endpoint if we see bnb token

### DIFF
--- a/.changeset/coinmetrics-asset-quotes.md
+++ b/.changeset/coinmetrics-asset-quotes.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/coinmetrics': minor
+---
+
+Hardcoded switch to asset quotes api when BNB token is queried

--- a/packages/sources/coinmetrics/src/endpoint/lwba-ws.ts
+++ b/packages/sources/coinmetrics/src/endpoint/lwba-ws.ts
@@ -97,18 +97,19 @@ export const calculatePairQuotesUrl = (
   desiredSubs: (typeof inputParameters.validated)[],
 ): string => {
   const { API_KEY, WS_API_ENDPOINT } = context.adapterSettings
-  const pairs = [
-    ...new Set(desiredSubs.map((sub) => `${sub.base.toLowerCase()}-${sub.quote.toLowerCase()}`)),
-  ].join(',')
 
   let generated = new URL('/v4/timeseries-stream/pair-quotes', WS_API_ENDPOINT)
-  generated.searchParams.append('pairs', pairs)
 
-  // bnb token only available on asset-quotes endpoint
-  if (desiredSubs.map((pair) => pair.base).includes('BNB')) {
-    const assets = [...new Set(desiredSubs.map((pair) => pair.base.toLowerCase()))].sort().join(',')
+  // use asset-quotes api if base=BNB
+  if (desiredSubs.map((subs) => subs.base.toLowerCase()).includes('bnb')) {
     generated = new URL('/v4/timeseries-stream/asset-quotes', WS_API_ENDPOINT)
+    const assets = [...new Set(desiredSubs.map((pair) => pair.base.toLowerCase()))].sort().join(',')
     generated.searchParams.append('assets', assets)
+  } else {
+    const pairs = [
+      ...new Set(desiredSubs.map((sub) => `${sub.base.toLowerCase()}-${sub.quote.toLowerCase()}`)),
+    ].join(',')
+    generated.searchParams.append('pairs', pairs)
   }
 
   generated.searchParams.append('api_key', API_KEY)


### PR DESCRIPTION
<!-- Employees: Please use Clubhouse/Shortcuts's "Open PR" button from the relevant story or include links to relevant Clubhouse/Shortcut stories in your branch name, commit messages, or pull request comments. Do not add links to your pull request description, they will be ignored. https://help.clubhouse.io/hc/en-us/articles/207540323-Using-The-Clubhouse-GitHub-Integration -->

<!-- Employees: Delete this section. -->

## Closes #DF-18913

## Description
The current coinmetrics lwba endpoint uses the pair-quotes api, which does not support the BNB token. In the case the BNB token is queried, we want to switch to the asset-quotes api, which does support the BNB token.

## Changes

- Hard code switch to asset quotes api if we see the BNB token
- Fixed spelling error

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. Start coinmetrics adapter
`yarn build && yarn start`
2. Send request for ETH 
`curl --location 'localhost:8080' \
--header 'Content-Type: application/json' \
--data '{
    "id": "123",
    "data": {
        "from": "ETH",
        "quote": "USD",
        "endpoint": "crypto_lwba"
    }
}'`
3. Check logs to see that pair-quotes endpoint is used 
`"layer":"CoinMetrics Crypto LWBA WS","correlationId":"Endpoint: crypto-lwba - Transport: WebSocketTransport","msg":"Generated URL: wss://api.coinmetrics.io/v4/timeseries-stream/pair-quotes?pairs=eth-usd&api_key=[API_KEY REDACTED]"}`
4. Send request for BNB
`curl --location 'localhost:8080' \
--header 'Content-Type: application/json' \
--data '{
    "id": "123",
    "data": {
        "from": "BNB",
        "quote": "USD",
        "endpoint": "crypto_lwba"
    }
}'`
5. Check logs to see that asset-quotes endpoint is used
`"layer":"CoinMetrics Crypto LWBA WS","correlationId":"Endpoint: crypto-lwba - Transport: WebSocketTransport","msg":"Generated URL: wss://api.coinmetrics.io/v4/timeseries-stream/asset-quotes?assets=bnb&api_key=[API_KEY REDACTED]"}`

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [x] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
