### PR TITLE
separated coinmetrics lwba endpoint into 2 transports

### DIFF
--- a/.changeset/coinmetrics-two-transports.md
+++ b/.changeset/coinmetrics-two-transports.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/coinmetrics-adapter': minor
+---
+
+Separated Coinmetrics LWBA endpoint into 2 transports

--- a/packages/sources/coinmetrics/src/endpoint/lwba-ws.ts
+++ b/packages/sources/coinmetrics/src/endpoint/lwba-ws.ts
@@ -3,7 +3,10 @@ import {
   EndpointContext,
   priceEndpointInputParametersDefinition,
 } from '@chainlink/external-adapter-framework/adapter'
-import { WebSocketTransport } from '@chainlink/external-adapter-framework/transports/websocket'
+import {
+  TransportRoutes,
+  WebSocketTransport,
+} from '@chainlink/external-adapter-framework/transports'
 import {
   PartialAdapterResponse,
   ProviderResult,
@@ -95,13 +98,14 @@ type WsPairQuoteMessage =
 export const calculatePairQuotesUrl = (
   context: EndpointContext<WsCryptoLwbaEndpointTypes>,
   desiredSubs: (typeof inputParameters.validated)[],
+  isAssetQuote: boolean,
 ): string => {
   const { API_KEY, WS_API_ENDPOINT } = context.adapterSettings
 
   let generated = new URL('/v4/timeseries-stream/pair-quotes', WS_API_ENDPOINT)
 
   // use asset-quotes api if base=BNB
-  if (desiredSubs.map((subs) => subs.base.toLowerCase()).includes('bnb')) {
+  if (isAssetQuote) {
     generated = new URL('/v4/timeseries-stream/asset-quotes', WS_API_ENDPOINT)
     const assets = [...new Set(desiredSubs.map((pair) => pair.base.toLowerCase()))].sort().join(',')
     generated.searchParams.append('assets', assets)
@@ -163,9 +167,20 @@ export const handleCryptoLwbaMessage = (
   return undefined
 }
 
-export const wsTransport = new WebSocketTransport<WsCryptoLwbaEndpointTypes>({
+export const pairQuoteWebsocketTransport = new WebSocketTransport<WsCryptoLwbaEndpointTypes>({
   url: (context, desiredSubs) => {
-    return calculatePairQuotesUrl(context, desiredSubs)
+    return calculatePairQuotesUrl(context, desiredSubs, false)
+  },
+  handlers: {
+    message(message: WsPairQuoteMessage): ProviderResult<WsCryptoLwbaEndpointTypes>[] | undefined {
+      return handleCryptoLwbaMessage(message)
+    },
+  },
+})
+
+export const assetQuoteWebsocketTransport = new WebSocketTransport<WsCryptoLwbaEndpointTypes>({
+  url: (context, desiredSubs) => {
+    return calculatePairQuotesUrl(context, desiredSubs, true)
   },
   handlers: {
     message(message: WsPairQuoteMessage): ProviderResult<WsCryptoLwbaEndpointTypes>[] | undefined {
@@ -177,6 +192,16 @@ export const wsTransport = new WebSocketTransport<WsCryptoLwbaEndpointTypes>({
 export const endpoint = new AdapterEndpoint<WsCryptoLwbaEndpointTypes>({
   name: 'crypto-lwba',
   aliases: ['cryptolwba', 'crypto_lwba'],
-  transport: wsTransport,
+  transportRoutes: new TransportRoutes<WsCryptoLwbaEndpointTypes>()
+    .register('asset', assetQuoteWebsocketTransport)
+    .register('pair', pairQuoteWebsocketTransport),
+  customRouter: (req, _) => {
+    const { base } = req.requestContext.data as typeof inputParameters.validated & {
+      transport?: string
+    }
+    const route = base.toLowerCase() === 'bnb' ? 'asset' : 'pair'
+
+    return route
+  },
   inputParameters,
 })


### PR DESCRIPTION
## Closes #DF-18918

## Description

We want to separate the Coinmetrics LWBA endpoint into 2 separate transports (asset quotes and pair quotes ws api). We use asset quotes only if base=BNB, otherwise, use pair quotes.

## Changes

- Added custom transport router

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. Start coinmetrics adapter
`yarn build && yarn start`
2. Send request for ETH 
`curl --location 'localhost:8080' \
--header 'Content-Type: application/json' \
--data '{
    "id": "123",
    "data": {
        "from": "ETH",
        "quote": "USD",
        "endpoint": "crypto_lwba"
    }
}'`
3. Check logs to see that pair-quotes endpoint is used 
`"layer":"CoinMetrics Crypto LWBA WS","correlationId":"Endpoint: crypto-lwba - Transport: WebSocketTransport","msg":"Generated URL: wss://api.coinmetrics.io/v4/timeseries-stream/pair-quotes?pairs=eth-usd&api_key=[API_KEY REDACTED]"}`
4. Send request for BNB
`curl --location 'localhost:8080' \
--header 'Content-Type: application/json' \
--data '{
    "id": "123",
    "data": {
        "from": "BNB",
        "quote": "USD",
        "endpoint": "crypto_lwba"
    }
}'`
5. Check logs to see that BOTH asset-quotes and pair-quotes endpoint is used
`"layer":"CoinMetrics Crypto LWBA WS","correlationId":"Endpoint: crypto-lwba - Transport: WebSocketTransport","msg":"Generated URL: wss://api.coinmetrics.io/v4/timeseries-stream/asset-quotes?assets=bnb&api_key=[API_KEY REDACTED]"}`
`"layer":"CoinMetrics Crypto LWBA WS","correlationId":"Endpoint: crypto-lwba - Transport: WebSocketTransport","msg":"Generated URL: wss://api.coinmetrics.io/v4/timeseries-stream/pair-quotes?pairs=eth-usd&api_key=[API_KEY REDACTED]"`
## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [x] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
