### PR TITLE
Sync EL and CL queries Stader PoR

### DIFF
--- a/.changeset/empty-lies-rhyme.md
+++ b/.changeset/empty-lies-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/stader-balance-adapter': minor
+---
+
+Updated to use slot number when querying beacon chain

--- a/.changeset/strange-keys-heal.md
+++ b/.changeset/strange-keys-heal.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/stader-address-list-adapter': minor
+---
+
+Updated a function name to match new contract

--- a/packages/sources/stader-address-list/src/abi/StaderContractAbis.ts
+++ b/packages/sources/stader-address-list/src/abi/StaderContractAbis.ts
@@ -83,7 +83,7 @@ export const StaderPermissionlessNodeRegistryContract_ABI: ethers.ContractInterf
       { internalType: 'uint256', name: '_pageNumber', type: 'uint256' },
       { internalType: 'uint256', name: '_pageSize', type: 'uint256' },
     ],
-    name: 'getAllSocializingPoolOptOutOperators',
+    name: 'getNodeELVaultAddressForOptOutOperators',
     outputs: [{ internalType: 'address[]', name: '', type: 'address[]' }],
     stateMutability: 'view',
     type: 'function',

--- a/packages/sources/stader-address-list/src/endpoint/address.ts
+++ b/packages/sources/stader-address-list/src/endpoint/address.ts
@@ -384,7 +384,7 @@ export class AddressTransport extends SubscriptionTransport<EndpointTypes> {
         handler: async (index) => {
           const pageNumber = index + 1
           const addresses: string[] =
-            await params.permissionlessNodeRegistryManager.getAllSocializingPoolOptOutOperators(
+            await params.permissionlessNodeRegistryManager.getNodeELVaultAddressForOptOutOperators(
               pageNumber,
               params.batchSize,
               {

--- a/packages/sources/stader-address-list/test/integration/adapter.test.ts
+++ b/packages/sources/stader-address-list/test/integration/adapter.test.ts
@@ -96,7 +96,7 @@ jest.mock('ethers', () => {
           getSocializingPoolAddress: jest.fn().mockImplementation((poolId) => {
             return mockSocialPoolAddresses[poolId]
           }),
-          getAllSocializingPoolOptOutOperators: jest.fn().mockImplementation(() => {
+          getNodeELVaultAddressForOptOutOperators: jest.fn().mockImplementation(() => {
             return mockElRewardAddresses
           }),
           nextValidatorId: jest.fn().mockReturnValue(3),

--- a/packages/sources/stader-balance/src/endpoint/balance.ts
+++ b/packages/sources/stader-balance/src/endpoint/balance.ts
@@ -24,6 +24,7 @@ import {
   fetchAddressBalance,
   fetchEthDepositContractAddress,
   formatValueInGwei,
+  getBeaconGenesisTimestamp,
   inputParameters,
   parseLittleEndian,
   withErrorHandling,
@@ -32,6 +33,7 @@ import {
 const logger = makeLogger('StaderBalanceLogger')
 export class BalanceTransport extends SubscriptionTransport<EndpointTypes> {
   provider!: ethers.providers.JsonRpcProvider
+  genesisTimestampInSec!: Promise<number>
 
   async initialize(
     dependencies: TransportDependencies<EndpointTypes>,
@@ -44,6 +46,7 @@ export class BalanceTransport extends SubscriptionTransport<EndpointTypes> {
       adapterSettings.ETHEREUM_RPC_URL,
       adapterSettings.CHAIN_ID,
     )
+    this.genesisTimestampInSec = getBeaconGenesisTimestamp(adapterSettings.BEACON_RPC_URL)
   }
 
   getSubscriptionTtlFromConfig(adapterSettings: typeof config.settings): number {
@@ -144,6 +147,7 @@ export class BalanceTransport extends SubscriptionTransport<EndpointTypes> {
         penaltyContract: this.buildPenaltyContract(penaltyAddress),
         settings: context.adapterSettings,
         provider: this.provider,
+        genesisTimestampInSec: await this.genesisTimestampInSec,
       }),
     ])
 

--- a/packages/sources/stader-balance/src/endpoint/utils.ts
+++ b/packages/sources/stader-balance/src/endpoint/utils.ts
@@ -331,20 +331,19 @@ export const parseBigNumber = (value: ethers.BigNumber): BigNumber => {
 export const getSlotNumber = async (
   provider: ethers.providers.JsonRpcProvider,
   blockTag: number,
-  beaconRpcUrl: string,
+  genesisTimestampInSec: number,
 ): Promise<number> => {
   return withErrorHandling(
     `Calculating Beacon slot number using execution layer block number ${blockTag}`,
     async () => {
       const blockTimestampInSec = (await provider.getBlock(blockTag)).timestamp
-      const genesisTimestampInSec = await getBeaconGenesisTimestamp(beaconRpcUrl)
       const timeSinceGenesisInSec = blockTimestampInSec - genesisTimestampInSec
       return Math.floor(timeSinceGenesisInSec / SECONDS_PER_SLOT)
     },
   )
 }
 
-const getBeaconGenesisTimestamp = async (beaconRpcUrl: string): Promise<number> => {
+export const getBeaconGenesisTimestamp = async (beaconRpcUrl: string): Promise<number> => {
   return withErrorHandling(`Fetching Beacon genesis info`, async () => {
     const url = `/eth/v1/beacon/genesis`
     const response = await axios.request<GenesisResponse>({

--- a/packages/sources/stader-balance/src/model/validator.ts
+++ b/packages/sources/stader-balance/src/model/validator.ts
@@ -33,6 +33,7 @@ export class ValidatorFactory {
     blockTag: number
     settings: typeof config.settings
     provider: ethers.providers.JsonRpcProvider
+    genesisTimestampInSec: number
   }): Promise<{
     activeValidators: ActiveValidator[]
     withdrawnValidators: WithdrawnValidator[]
@@ -45,7 +46,7 @@ export class ValidatorFactory {
     const slotNumber = await getSlotNumber(
       params.provider,
       params.blockTag,
-      params.settings.BEACON_RPC_URL,
+      params.genesisTimestampInSec,
     )
     return withErrorHandling(
       `Fetching validator states (slot number: ${slotNumber}) from the beacon chain`,

--- a/packages/sources/stader-balance/test/integration/adapter.test.ts
+++ b/packages/sources/stader-balance/test/integration/adapter.test.ts
@@ -28,6 +28,9 @@ jest.mock('ethers', () => {
             getBalance: jest.fn().mockImplementation((address) => {
               return mockEthBalanceMap[address]
             }),
+            getBlock: jest.fn().mockImplementation(() => {
+              return { timestamp: new Date('2022-08-01T07:14:54.909Z').getTime() / 1000 }
+            }),
             getLogs: jest.fn().mockImplementation(() => {
               return [
                 {

--- a/packages/sources/stader-balance/test/integration/fixture.ts
+++ b/packages/sources/stader-balance/test/integration/fixture.ts
@@ -143,8 +143,17 @@ export const mockEthBalanceMap: Record<string, string> = {
 
 export const mockGetValidatorStates = (): void => {
   nock('http://localhost:9092', { encodedQueryParams: true })
+    .get('/eth/v1/beacon/genesis')
+    .reply(200, {
+      data: {
+        genesis_time: '1590832934',
+        genesis_validators_root:
+          '0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2',
+        genesis_fork_version: '0x00000000',
+      },
+    })
     .get(
-      '/eth/v1/beacon/states/finalized/validators?' +
+      '/eth/v1/beacon/states/5708763/validators?' +
         'id=0x8cd2726ccd034cf023840c2f76f7bfd4f2e8dbe79ff0e43d2908d1124450ed1c954966a42113787bc930c0e2d73524c0,' +
         '0xaaea1a72970d9d8cd5fdee9c41437b24b9c49c34e35cd620c87fc8ad270ed822fe550690581422a90d7538e906f61d11,' +
         '0xac41f16bdd583309e5095d475ad1250dabf274045d852bd091e07f03b6de3fc4ad34705c0f1079d516df0b2d8fed0e10,' +


### PR DESCRIPTION
## Closes [PDI-2178](https://smartcontract-it.atlassian.net/browse/PDI-2178)

## Description

Using a slot number to query the beacon chain derived from the execution layer block timestamp. Using slot number calculation logic provider by Stader

```
func ConvertTimestampToEpoch(timestamp time.Time) uint64 {
    genesisTime := time.Unix(int64(genesisTime), 0)
    timeSinceGenesis := timestamp.Sub(genesisTime)
    slotNumber := uint64(timeSinceGenesis.Seconds()) / secondsPerSlot
    return slotNumber
}
```

## Changes

- Query beacon chain using a slot number equivalent to the block number used for EL requests in `stader-balance`
- Changed function name in `stader-address-list`

## Steps to Test

1. yarn test packages/sources/stader-address-list/test
2. yarn test packages/sources/stader-balance/test

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[PDI-2178]: https://smartcontract-it.atlassian.net/browse/PDI-2178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ