### PR TITLE
Add API timeout override to kaiko

### DIFF
--- a/.changeset/tame-paws-pump.md
+++ b/.changeset/tame-paws-pump.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/kaiko-test-adapter': patch
+---
+
+Added 60s API timeout override

--- a/packages/sources/kaiko-test/src/config/index.ts
+++ b/packages/sources/kaiko-test/src/config/index.ts
@@ -16,6 +16,7 @@ export const config = new AdapterConfig(
   },
   {
     envDefaultOverrides: {
+      API_TIMEOUT: 60_000,
       MAX_HTTP_REQUEST_QUEUE_LENGTH: 300,
     },
   },


### PR DESCRIPTION
## Description

Added 60s API timeout override to kaiko for occasional requests that failed on the default 30s timeout

## Changes

- Set `API_TIMEOUT` to 60s in the adapter config env var overrides

## Steps to Test

1. yarn test packages/sources/kaiko-test/test

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
