### PR TITLE
Add `stock` and `forex` aliases for Finnhub EA.

### DIFF
--- a/.changeset/silly-lemons-joke.md
+++ b/.changeset/silly-lemons-joke.md
@@ -1,0 +1,9 @@
+---
+'@chainlink/finnhub-adapter': minor
+---
+
+Add `stock` and `forex` aliases for Finnhub EA.
+
+- Adding `stock` and `forex` aliases for the existing `quote` endpoint.
+- Feeds pull data from mutliple data providers using the same endpoint name, adding these alises allows feeds to pull stock and forex data from the Finnhub EA.
+- Enables auto-generation for Finnhub EA README.

--- a/packages/scripts/src/generate-readme/readmeBlacklist.json
+++ b/packages/scripts/src/generate-readme/readmeBlacklist.json
@@ -30,7 +30,6 @@
     "enzyme",
     "ethwrite",
     "fcsapi",
-    "finnhub",
     "flightaware",
     "geodb",
     "google-bigquery",

--- a/packages/sources/finnhub/README.md
+++ b/packages/sources/finnhub/README.md
@@ -1,13 +1,49 @@
-# Chainlink External Adapter for Finnhub
+# FINNHUB
 
-This external adapter is used to connect to [Finnhub's](https://finnhub.io/docs/api) API for stock data.
+![2.0.0](https://img.shields.io/github/package-json/v/smartcontractkit/external-adapters-js?filename=packages/sources/finnhub/package.json) ![v3](https://img.shields.io/badge/framework%20version-v3-blueviolet)
 
-## Input Params
+This document was generated automatically. Please see [README Generator](../../scripts#readme-generator) for more info.
 
-- `base`, `asset` or `from`: The target currency to query (required)
-- `endpoint`: The endpoint to call (optional)
+## Environment Variables
 
-## Output Format
+| Required? |     Name     |            Description             |  Type  | Options |           Default           |
+| :-------: | :----------: | :--------------------------------: | :----: | :-----: | :-------------------------: |
+|           | API_ENDPOINT | The HTTP URL to retrieve data from | string |         | `https://finnhub.io/api/v1` |
+|    ✅     |   API_KEY    |         A Finnhub API key          | string |         |                             |
+
+---
+
+## Input Parameters
+
+Every EA supports base input parameters from [this list](https://github.com/smartcontractkit/ea-framework-js/blob/main/src/config/index.ts)
+
+| Required? |   Name   |     Description     |  Type  |                                                 Options                                                 | Default |
+| :-------: | :------: | :-----------------: | :----: | :-----------------------------------------------------------------------------------------------------: | :-----: |
+|           | endpoint | The endpoint to use | string | [common](#quote-endpoint), [forex](#quote-endpoint), [quote](#quote-endpoint), [stock](#quote-endpoint) | `quote` |
+
+## Quote Endpoint
+
+Supported names for this endpoint are: `common`, `forex`, `quote`, `stock`.
+
+### Input Params
+
+| Required? | Name |         Aliases          |                 Description                  |  Type  | Options | Default | Depends On | Not Valid With |
+| :-------: | :--: | :----------------------: | :------------------------------------------: | :----: | :-----: | :-----: | :--------: | :------------: |
+|    ✅     | base | `asset`, `from`, `quote` | The symbol of the currency or asset to query | string |         |         |            |                |
+
+### Example
+
+Request:
+
+```json
+{
+  "data": {
+    "base": "AAPL"
+  }
+}
+```
+
+Response:
 
 ```json
 {
@@ -25,3 +61,7 @@ This external adapter is used to connect to [Finnhub's](https://finnhub.io/docs/
   "statusCode": 200
 }
 ```
+
+---
+
+MIT License

--- a/packages/sources/finnhub/src/endpoint/quote.ts
+++ b/packages/sources/finnhub/src/endpoint/quote.ts
@@ -11,7 +11,7 @@ export const inputParameters = new InputParameters({
   base: {
     aliases: ['quote', 'asset', 'from'],
     type: 'string',
-    description: 'The symbol of symbols of the currency to query',
+    description: 'The symbol of the currency or asset to query',
     required: true,
   },
 })
@@ -92,7 +92,7 @@ export const httpTransport = new HttpTransport<EndpointTypes>({
 
 export const endpoint = new AdapterEndpoint<EndpointTypes>({
   name: 'quote',
-  aliases: ['common'],
+  aliases: ['common', 'stock', 'forex'],
   transport: httpTransport,
   inputParameters: inputParameters,
   overrides: overrides.finnhub,

--- a/packages/sources/finnhub/test-payload.json
+++ b/packages/sources/finnhub/test-payload.json
@@ -1,5 +1,15 @@
 {
-    "requests": [{
+    "requests": [
+    {
         "base": "EUR"
-    }]
+    },
+    {
+        "base": "EUR",
+        "endpoint": "forex"
+    },
+    {
+        "base": "AAPL",
+        "endpoint": "stock"
+    }
+]
 }

--- a/packages/sources/finnhub/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/finnhub/test/integration/__snapshots__/adapter.test.ts.snap
@@ -1,11 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`rest forex endpoint (quote alias) should return success 1`] = `
+{
+  "data": {
+    "result": 1.15894,
+  },
+  "result": 1.15894,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 1641035471111,
+    "providerDataRequestedUnixMs": 1641035471111,
+  },
+}
+`;
+
 exports[`rest quote endpoint should return success 1`] = `
 {
   "data": {
     "result": 1.15894,
   },
   "result": 1.15894,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 1641035471111,
+    "providerDataRequestedUnixMs": 1641035471111,
+  },
+}
+`;
+
+exports[`rest stock endpoint (quote alias) should return success 1`] = `
+{
+  "data": {
+    "result": 175.43,
+  },
+  "result": 175.43,
   "statusCode": 200,
   "timestamps": {
     "providerDataReceivedUnixMs": 1641035471111,

--- a/packages/sources/finnhub/test/integration/fixtures.ts
+++ b/packages/sources/finnhub/test/integration/fixtures.ts
@@ -1,9 +1,11 @@
 import nock from 'nock'
 
-export const mockResponseSuccess = (): nock.Scope =>
-  nock('https://finnhub.io/api/v1', {
+export const mockResponseSuccess = (): nock.Scope => {
+  const mockServer = nock('https://finnhub.io/api/v1', {
     encodedQueryParams: true,
   })
+
+  mockServer
     .get('/quote')
     .query({ token: 'fake-api-key', symbol: 'OANDA:EUR_USD' })
     .reply(
@@ -29,3 +31,33 @@ export const mockResponseSuccess = (): nock.Scope =>
         'Origin',
       ],
     )
+
+  mockServer
+    .get('/quote')
+    .query({ token: 'fake-api-key', symbol: 'AAPL' })
+    .reply(
+      200,
+      () => ({
+        c: 175.43,
+        d: 2.44,
+        dp: 1.4105,
+        h: 175.77,
+        l: 173.11,
+        o: 173.32,
+        pc: 172.99,
+        t: 1636322400,
+      }),
+      [
+        'Content-Type',
+        'application/json',
+        'Connection',
+        'close',
+        'Vary',
+        'Accept-Encoding',
+        'Vary',
+        'Origin',
+      ],
+    )
+
+  return mockServer
+}


### PR DESCRIPTION
## Description
- Adding `stock` and `forex` aliases for the existing `quote` endpoint.
- Feeds pull data from mutliple data providers using the same endpoint name, adding these alises allows feeds to pull stock and forex data from the Finnhub EA.
- Enables auto-generation for Finnhub EA README.


## Changes
* Add `stock` and `forex` alias for Finnhub `quote` endpoint.
* Add integration tests
* Enable auto-generation for Finnhub README, add README. 

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. Check README displays correctly
2. Check that `stock` and `forex` endpoints return correct data.

**Stock** 
```
// Request
curl --location 'localhost:8080' --header 'Content-Type: application/json' --data '{
    "id": "123",
    "data": {
        "base": "AAPL",
        "endpoint": "stock" 
    }
}'

// Response
{
    "data": {
        "result": 175.43
    },
    "result": 175.43,
    "timestamps": {
        "providerDataRequestedUnixMs": 1685365543248,
        "providerDataReceivedUnixMs": 1685365543419
    },
    "statusCode": 200,
    "meta": {
        "adapterName": "FINNHUB",
        "metrics": {
            "feedId": "{\"base\":\"aapl\"}"
        }
    }
}
```


**Forex**
```
// Request
curl --location 'localhost:8080' --header 'Content-Type: application/json' --data '{
    "id": "123",
    "data": {
        "base": "FHFX:GBP-USD",
        "endpoint": "forex" 
    }
}'

// Response
{
    "data": {
        "result": 1.23474
    },
    "result": 1.23474,
    "timestamps": {
        "providerDataRequestedUnixMs": 1685365618306,
        "providerDataReceivedUnixMs": 1685365618704
    },
    "statusCode": 200,
    "meta": {
        "adapterName": "FINNHUB",
        "metrics": {
            "feedId": "{\"base\":\"fhfx:gbp-usd\"}"
        }
    }
}
```

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
