### PR TITLE
Add adjustable request grouping to eth-beacon

### DIFF
--- a/.changeset/sixty-ads-dream.md
+++ b/.changeset/sixty-ads-dream.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/eth-beacon-adapter': patch
+---
+
+Added adjustable request grouping to reduce load on the beacon client

--- a/packages/sources/eth-beacon/schemas/env.json
+++ b/packages/sources/eth-beacon/schemas/env.json
@@ -11,8 +11,13 @@
       "required": true
     },
     "BATCH_SIZE": {
-      "type": "string",
-      "description": "The size of batches the addresses are split into for each request to the consensus client",
+      "type": "number",
+      "description": "Number of validators to send in each request to the consensus client. Setting this lower than the default may result in lower performance from the adapter.",
+      "default": "15"
+    },
+    "GROUP_SIZE": {
+      "type": "number",
+      "description": "Number of requests to execute asynchronously before the adapter waits to execute the next group of requests. Setting this lower than the default may result in lower performance from the adapter.",
       "default": "15"
     }
   },

--- a/packages/sources/eth-beacon/src/config/index.ts
+++ b/packages/sources/eth-beacon/src/config/index.ts
@@ -7,8 +7,10 @@ export const DEFAULT_ENDPOINT = 'balance'
 export const ENV_ETHEREUM_RPC_URL = 'ETHEREUM_RPC_URL'
 export const ENV_FALLBACK_RPC_URL = 'RPC_URL'
 export const ENV_BATCH_SIZE = 'BATCH_SIZE'
+export const ENV_GROUP_SIZE = 'GROUP_SIZE'
 
 export const DEFAULT_BATCH_SIZE = 15
+export const DEFAULT_GROUP_SIZE = 15
 
 export const makeConfig = (prefix?: string): Config => {
   const rpcURL = util.getRequiredEnvWithFallback(
@@ -17,6 +19,7 @@ export const makeConfig = (prefix?: string): Config => {
     prefix,
   )
   const batchSize = parseInt(util.getEnv(ENV_BATCH_SIZE, prefix) || '') || DEFAULT_BATCH_SIZE
+  const groupSize = parseInt(util.getEnv(ENV_GROUP_SIZE, prefix) || '') || DEFAULT_GROUP_SIZE
   const defaultConfig = Requester.getDefaultConfig(prefix)
   return {
     ...defaultConfig,
@@ -26,7 +29,8 @@ export const makeConfig = (prefix?: string): Config => {
     },
     defaultEndpoint: DEFAULT_ENDPOINT,
     adapterSpecificParams: {
-      batchSize: batchSize,
+      batchSize,
+      groupSize,
     },
   }
 }


### PR DESCRIPTION
## Closes [PDI-2180](https://smartcontract-it.atlassian.net/browse/PDI-2180)

## Description

Added adjustable request grouping to reduce load on the beacon client

## Changes

- Added `GROUP_SIZE` env var with default of 15
- Used `GROUP_SIZE` env var to break down requests into smaller groups
- Updated logic to fire requests and wait for one group before sending the requests for the next

## Steps to Test

1. yarn test packages/sources/eth-beacon/test

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[PDI-2180]: https://smartcontract-it.atlassian.net/browse/PDI-2180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ