### PR TITLE
Stader PoR Updates

### DIFF
--- a/.changeset/friendly-turkeys-nail.md
+++ b/.changeset/friendly-turkeys-nail.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/stader-address-list-adapter': minor
+---
+
+Pinned block number to Stader reported block

--- a/.changeset/silly-suits-warn.md
+++ b/.changeset/silly-suits-warn.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/stader-balance-adapter': minor
+---
+
+Pinned block number to Stader reported block. Updated withdrawn validator balance calculations. Added total supply endpoint.

--- a/.changeset/silly-suits-warn.md
+++ b/.changeset/silly-suits-warn.md
@@ -2,4 +2,4 @@
 '@chainlink/stader-balance-adapter': minor
 ---
 
-Pinned block number to Stader reported block. Updated withdrawn validator balance calculations. Added total supply endpoint.
+Pinned block number to Stader reported block. Updated withdrawn validator balance calculations. Added total supply endpoint. Added validation to ensure beacon slot number is finalized.

--- a/.changeset/tidy-kiwis-tease.md
+++ b/.changeset/tidy-kiwis-tease.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/proof-of-reserves-adapter': patch
+---
+
+Added reported block field to pass for stader-balance adapter

--- a/packages/composites/proof-of-reserves/src/utils/balance.ts
+++ b/packages/composites/proof-of-reserves/src/utils/balance.ts
@@ -91,6 +91,7 @@ export const runBalanceAdapter = async (
           stakeManagerAddress: input.data.stakeManagerAddress,
           permissionedPoolAddress: input.data.permissionedPoolAddress,
           staderConfigAddress: input.data.staderConfigAddress,
+          reportedBlock: input.data.reportedBlock,
           network: input.data.network,
           chainId: input.data.chainId,
         },

--- a/packages/sources/stader-address-list/src/abi/StaderContractAbis.ts
+++ b/packages/sources/stader-address-list/src/abi/StaderContractAbis.ts
@@ -15,6 +15,13 @@ export const StaderConfigContract_ABI: ethers.ContractInterface = [
     stateMutability: 'view',
     type: 'function',
   },
+  {
+    inputs: [],
+    name: 'getStaderOracle',
+    outputs: [{ internalType: 'address', name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
 ]
 
 export const StaderPoolFactoryContract_ABI: ethers.ContractInterface = [
@@ -91,6 +98,16 @@ export const StaderPermissionlessNodeRegistryContract_ABI: ethers.ContractInterf
   {
     inputs: [],
     name: 'nextOperatorId',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+]
+
+export const StaderOracle_ABI: ethers.ContractInterface = [
+  {
+    inputs: [],
+    name: 'getERReportableBlock',
     outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
     stateMutability: 'view',
     type: 'function',

--- a/packages/sources/stader-address-list/src/utils.ts
+++ b/packages/sources/stader-address-list/src/utils.ts
@@ -50,6 +50,7 @@ export interface ResponseSchema {
     confirmations: number
     network: string
     chainId: string
+    reportedBlock: number
     result: ValidatorAddress[]
   }
   Result: null

--- a/packages/sources/stader-address-list/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/stader-address-list/test/integration/__snapshots__/adapter.test.ts.snap
@@ -14,6 +14,7 @@ exports[`execute addresses should return success 1`] = `
       },
     ],
     "network": "ethereum",
+    "reportedBlock": 500,
     "result": [
       {
         "address": "0x999d1e56148505251d7a7682996f1d1a7e5ecf4657dcfa9d6d71b97dc1d8755e1cb4451f57f370201c882126e97ca35e",

--- a/packages/sources/stader-address-list/test/integration/adapter.test.ts
+++ b/packages/sources/stader-address-list/test/integration/adapter.test.ts
@@ -105,6 +105,8 @@ jest.mock('ethers', () => {
           getPermissionlessNodeRegistry: jest
             .fn()
             .mockReturnValue('0x28d5FdcE4db361e19FCA420C9b5141bC3DC6aE3B'),
+          getStaderOracle: jest.fn().mockReturnValue('0xAAe724e44766aC7ccaA6f6aA95c8B1659F5FB44D'),
+          getERReportableBlock: jest.fn().mockReturnValue(500),
         }
       },
     },

--- a/packages/sources/stader-balance/src/abi/StaderContractAbis.ts
+++ b/packages/sources/stader-balance/src/abi/StaderContractAbis.ts
@@ -67,6 +67,20 @@ export const StaderConfigContract_ABI = [
     stateMutability: 'view',
     type: 'function',
   },
+  {
+    inputs: [],
+    name: 'getStaderOracle',
+    outputs: [{ internalType: 'address', name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'getETHxToken',
+    outputs: [{ internalType: 'address', name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
 ]
 
 export const DepositEvent_ABI = [
@@ -118,6 +132,26 @@ export const StaderSocialPool_ABI: ethers.ContractInterface = [
   {
     inputs: [],
     name: 'totalOperatorETHRewardsRemaining',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+]
+
+export const StaderOracle_ABI: ethers.ContractInterface = [
+  {
+    inputs: [],
+    name: 'getERReportableBlock',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+]
+
+export const StaderEthX_ABI: ethers.ContractInterface = [
+  {
+    inputs: [],
+    name: 'totalSupply',
     outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
     stateMutability: 'view',
     type: 'function',

--- a/packages/sources/stader-balance/src/endpoint/totalSupply.ts
+++ b/packages/sources/stader-balance/src/endpoint/totalSupply.ts
@@ -1,0 +1,178 @@
+import { SubscriptionTransport } from '@chainlink/external-adapter-framework/transports/abstract/subscription'
+import { config } from '../config'
+import { ethers } from 'ethers'
+import { TransportDependencies } from '@chainlink/external-adapter-framework/transports'
+import { AdapterEndpoint, EndpointContext } from '@chainlink/external-adapter-framework/adapter'
+import { InputParameters } from '@chainlink/external-adapter-framework/validation'
+import { AdapterResponse, makeLogger, sleep } from '@chainlink/external-adapter-framework/util'
+import {
+  StaderConfigContract_ABI,
+  StaderEthX_ABI,
+  StaderOracle_ABI,
+} from '../abi/StaderContractAbis'
+import { chainIds, networks, staderNetworkChainMap } from './utils'
+
+const logger = makeLogger('StaderTotalSupplyLogger')
+
+const inputParameters = new InputParameters({
+  staderConfigAddress: {
+    description: 'The address of the Stader Config contract.',
+    type: 'string',
+  },
+  network: {
+    description: 'The name of the target custodial network protocol',
+    options: networks,
+    type: 'string',
+    default: 'ethereum',
+  },
+  chainId: {
+    description: 'The name of the target custodial chain',
+    options: chainIds,
+    type: 'string',
+    default: 'mainnet',
+  },
+  confirmations: {
+    type: 'number',
+    description: 'The number of confirmations to query data from',
+    default: 0,
+  },
+  syncWindow: {
+    description:
+      "The number of blocks Stader's reported block cannot be within of the current block. Used to ensure the balance and total supply feeds are reporting info from the same block.",
+    default: 300,
+    type: 'number',
+  },
+})
+
+type RequestParams = typeof inputParameters.validated
+
+interface ResponseSchema {
+  Data: {
+    result: string
+  }
+  Result: string
+}
+
+type EndpointTypes = {
+  Parameters: typeof inputParameters.definition
+  Settings: typeof config.settings
+  Response: ResponseSchema
+}
+
+export class TotalSupplyTransport extends SubscriptionTransport<EndpointTypes> {
+  provider!: ethers.providers.JsonRpcProvider
+
+  async initialize(
+    dependencies: TransportDependencies<EndpointTypes>,
+    adapterSettings: typeof config.settings,
+    endpointName: string,
+    transportName: string,
+  ): Promise<void> {
+    await super.initialize(dependencies, adapterSettings, endpointName, transportName)
+    this.provider = new ethers.providers.JsonRpcProvider(
+      adapterSettings.ETHEREUM_RPC_URL,
+      adapterSettings.CHAIN_ID,
+    )
+  }
+
+  getSubscriptionTtlFromConfig(adapterSettings: typeof config.settings): number {
+    return adapterSettings.WARMUP_SUBSCRIPTION_TTL
+  }
+
+  async backgroundHandler(
+    context: EndpointContext<EndpointTypes>,
+    entries: RequestParams[],
+  ): Promise<void> {
+    if (!entries.length) {
+      await sleep(context.adapterSettings.BACKGROUND_EXECUTE_MS)
+      return
+    }
+    await Promise.all(entries.map(async (req) => this.handleRequest(req)))
+  }
+
+  async handleRequest(req: RequestParams): Promise<void> {
+    // We're making a lot of requests in this complex logic, so we start counting the time
+    // it takes for the provider to reply from here, accounting for all requests involved
+    const providerDataRequestedUnixMs = Date.now()
+    let response: AdapterResponse<EndpointTypes['Response']>
+
+    try {
+      // Get data for the latest block in the chain
+      const latestBlockNum = await this.provider.getBlockNumber()
+      const blockTag = latestBlockNum - req.confirmations
+      const staderConfigAddress =
+        req.staderConfigAddress || staderNetworkChainMap[req.network][req.chainId].staderConfig
+      const staderConfig = new ethers.Contract(
+        staderConfigAddress,
+        StaderConfigContract_ABI,
+        this.provider,
+      )
+
+      // Build Stader Oracle contract
+      const staderOracleAddress: string = await staderConfig.getStaderOracle({ blockTag })
+      const staderOracle = new ethers.Contract(staderOracleAddress, StaderOracle_ABI, this.provider)
+
+      // Get the last reported block number from the Stader oracle contract
+      const reportedBlock = Number(await staderOracle.getERReportableBlock({ blockTag }))
+      logger.debug(`Current block: ${blockTag}. Reported block number: ${reportedBlock}`)
+
+      // Return error if reported block number within sync window
+      // Stader wants to sync the block number that both the balance and totalSupply feed report for
+      // Setting this window helps ensure the reported block didn't change between the two feeds reporting
+      if (reportedBlock >= blockTag - req.syncWindow) {
+        const errorMessage = `Reported block number ${reportedBlock} within ${req.syncWindow} blocks of current block ${blockTag}. At risk of being out of sync with balance feed.`
+        logger.error(errorMessage)
+        response = {
+          statusCode: 502,
+          errorMessage,
+          timestamps: {
+            providerDataRequestedUnixMs: 0,
+            providerDataReceivedUnixMs: 0,
+            providerIndicatedTimeUnixMs: undefined,
+          },
+        }
+      } else {
+        // Build the ETHx token contract
+        const ethxAddress = await staderConfig.getETHxToken({ blockTag: reportedBlock })
+        const ethxContract = new ethers.Contract(ethxAddress, StaderEthX_ABI, this.provider)
+
+        // Fetch total supply at the reported block number retrieve from Stader Oracle
+        const totalSupply = (await ethxContract.totalSupply({ blockTag: reportedBlock })).toString()
+
+        logger.debug(`Total supply: ${totalSupply}`)
+        response = {
+          data: {
+            result: totalSupply,
+          },
+          result: totalSupply,
+          statusCode: 200,
+          timestamps: {
+            providerDataRequestedUnixMs,
+            providerDataReceivedUnixMs: Date.now(),
+            providerIndicatedTimeUnixMs: undefined,
+          },
+        }
+      }
+    } catch (e) {
+      const errorMessage = 'Failed to retrieve ETHx total supply'
+      logger.error(errorMessage)
+      response = {
+        statusCode: 502,
+        errorMessage,
+        timestamps: {
+          providerDataRequestedUnixMs: 0,
+          providerDataReceivedUnixMs: 0,
+          providerIndicatedTimeUnixMs: undefined,
+        },
+      }
+    }
+
+    await this.responseCache.write(this.name, [{ params: req, response }])
+  }
+}
+
+export const totalSupplyEndpoint = new AdapterEndpoint<EndpointTypes>({
+  name: 'totalSupply',
+  transport: new TotalSupplyTransport(),
+  inputParameters,
+})

--- a/packages/sources/stader-balance/src/endpoint/utils.ts
+++ b/packages/sources/stader-balance/src/endpoint/utils.ts
@@ -122,6 +122,11 @@ export const inputParameters = new InputParameters({
     required: true,
     array: true,
   },
+  reportedBlock: {
+    type: 'number',
+    description: 'The reported block number retrieved from Stader',
+    required: true,
+  },
   stateId: {
     type: 'string',
     description: 'The beacon chain state ID to query',

--- a/packages/sources/stader-balance/src/index.ts
+++ b/packages/sources/stader-balance/src/index.ts
@@ -2,10 +2,11 @@ import { expose, ServerInstance } from '@chainlink/external-adapter-framework'
 import { Adapter } from '@chainlink/external-adapter-framework/adapter'
 import { config } from './config'
 import { balanceEndpoint } from './endpoint/balance'
+import { totalSupplyEndpoint } from './endpoint/totalSupply'
 
 export const adapter = new Adapter({
   name: 'STADER_BALANCE',
-  endpoints: [balanceEndpoint],
+  endpoints: [balanceEndpoint, totalSupplyEndpoint],
   defaultEndpoint: balanceEndpoint.name,
   config,
 })

--- a/packages/sources/stader-balance/src/model/stader-config.ts
+++ b/packages/sources/stader-balance/src/model/stader-config.ts
@@ -9,11 +9,12 @@ export class StaderConfig {
   validatorDeposit?: BigNumber
 
   constructor(
-    req: { staderConfig?: string; network: string; chainId: string },
+    req: RequestParams,
     private blockTag: number,
     private provider: ethers.providers.JsonRpcProvider,
   ) {
-    this.address = req.staderConfig || staderNetworkChainMap[req.network][req.chainId].staderConfig
+    this.address =
+      req.staderConfigAddress || staderNetworkChainMap[req.network][req.chainId].staderConfig
 
     this.addressManager = new ethers.Contract(this.address, StaderConfigContract_ABI, this.provider)
   }

--- a/packages/sources/stader-balance/src/model/validator.ts
+++ b/packages/sources/stader-balance/src/model/validator.ts
@@ -43,11 +43,7 @@ export class ValidatorFactory {
     // Calculate the slot number to use when querying the beacon chain
     // Ensures an equivalent point of the beacon chain is being queried as the blockTag
     // Reduces risk of state change between queries to EL and CL
-    const slotNumber = await getSlotNumber(
-      params.provider,
-      params.blockTag,
-      params.genesisTimestampInSec,
-    )
+    const slotNumber = await getSlotNumber(params)
     return withErrorHandling(
       `Fetching validator states (slot number: ${slotNumber}) from the beacon chain`,
       async () => {

--- a/packages/sources/stader-balance/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/stader-balance/test/integration/__snapshots__/adapter.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Balance Endpoint should return success 1`] = `
+exports[`Stader Balance balance endpoint should return success 1`] = `
 {
   "data": {
     "result": [
@@ -22,11 +22,11 @@ exports[`Balance Endpoint should return success 1`] = `
       },
       {
         "address": "0x839ca626eccd2edf45ce633e365715bf8610b85c9d24225ac5893d4861e385fb81529880358040bb4b86fea288db4dfc",
-        "balance": "22653125000",
+        "balance": "23403125000",
       },
       {
         "address": "0x84d290ec6a766cef753bcce7b6d75f12b405e5c76171f2a456ae415e872d23ea01f869e8f64629a48f0c21f0f86e37d3",
-        "balance": "29000000000",
+        "balance": "29100000000",
       },
       {
         "address": "0x933ad9491b62059dd065b560d256d8957a8c402cc6e8d8ee7290ae11e8f7329267a8811c397529dac52ae1342ba58c95",
@@ -63,6 +63,20 @@ exports[`Balance Endpoint should return success 1`] = `
     ],
   },
   "result": null,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 1659338094909,
+    "providerDataRequestedUnixMs": 1659338094909,
+  },
+}
+`;
+
+exports[`Stader Balance total supply endpoint should return success 1`] = `
+{
+  "data": {
+    "result": "786000000000000000000",
+  },
+  "result": "786000000000000000000",
   "statusCode": 200,
   "timestamps": {
     "providerDataReceivedUnixMs": 1659338094909,

--- a/packages/sources/stader-balance/test/integration/adapter.test.ts
+++ b/packages/sources/stader-balance/test/integration/adapter.test.ts
@@ -7,6 +7,7 @@ import {
   addressData,
   mockCollateralEthMap,
   mockEthBalanceMap,
+  mockFinalityCheckpoint,
   mockGetEthDepositContract,
   mockGetGenesisBlockInfo,
   mockGetValidatorStates,
@@ -143,6 +144,7 @@ describe('Stader Balance', () => {
     mockGetGenesisBlockInfo()
     mockGetEthDepositContract()
     mockGetValidatorStates()
+    mockFinalityCheckpoint()
     oldEnv = JSON.parse(JSON.stringify(process.env))
     process.env['METRICS_ENABLED'] = 'false'
     process.env['ETHEREUM_RPC_URL'] = 'http://localhost:9091'

--- a/packages/sources/stader-balance/test/integration/adapter.test.ts
+++ b/packages/sources/stader-balance/test/integration/adapter.test.ts
@@ -8,6 +8,7 @@ import {
   mockCollateralEthMap,
   mockEthBalanceMap,
   mockGetEthDepositContract,
+  mockGetGenesisBlockInfo,
   mockGetValidatorStates,
   mockOperatorFeePercentMap,
   mockPenaltyMap,
@@ -119,16 +120,17 @@ jest.mock('ethers', () => {
             .mockReturnValue('0x974Db4Fb26993289CAD9f79Bde4eAE097503064f'),
           getPoolIdArray: jest.fn().mockReturnValue([1, 2, 3, 4, 5]),
           totalOperatorETHRewardsRemaining: jest.fn().mockReturnValue(100_000_000_000_000_000),
+          getStaderOracle: jest.fn().mockReturnValue('0xAAe724e44766aC7ccaA6f6aA95c8B1659F5FB44D'),
+          getETHxToken: jest.fn().mockReturnValue('0xbB83c4735D8c317e058F59289C6CD26da0D121FD'),
+          getERReportableBlock: jest.fn().mockReturnValue(8000),
+          totalSupply: jest.fn().mockReturnValue(786_000_000_000_000_000_000),
         }
       },
     },
   }
 })
 
-mockGetEthDepositContract()
-mockGetValidatorStates()
-
-describe('Balance Endpoint', () => {
+describe('Stader Balance', () => {
   let fastify: ServerInstance | undefined
   let req: SuperTest<Test>
   let spy: jest.SpyInstance
@@ -138,6 +140,9 @@ describe('Balance Endpoint', () => {
   let oldEnv: NodeJS.ProcessEnv
 
   beforeAll(async () => {
+    mockGetGenesisBlockInfo()
+    mockGetEthDepositContract()
+    mockGetValidatorStates()
     oldEnv = JSON.parse(JSON.stringify(process.env))
     process.env['METRICS_ENABLED'] = 'false'
     process.env['ETHEREUM_RPC_URL'] = 'http://localhost:9091'
@@ -156,41 +161,61 @@ describe('Balance Endpoint', () => {
     setEnvVariables(oldEnv)
     fastify?.close(done())
   })
+  describe('balance endpoint', () => {
+    it('should return success', async () => {
+      const makeRequest = () =>
+        req
+          .post('/')
+          .send(addressData)
+          .set('Accept', '*/*')
+          .set('Content-Type', 'application/json')
+          .expect('Content-Type', /json/)
 
-  it('should return success', async () => {
-    const makeRequest = () =>
-      req
-        .post('/')
-        .send(addressData)
-        .set('Accept', '*/*')
-        .set('Content-Type', 'application/json')
-        .expect('Content-Type', /json/)
+      const response = await makeRequest()
+      expect(response.body).toMatchSnapshot()
+    }, 30000)
+    it('should return error (empty body)', async () => {
+      const makeRequest = () =>
+        req
+          .post('/')
+          .send({})
+          .set('Accept', '*/*')
+          .set('Content-Type', 'application/json')
+          .expect('Content-Type', /json/)
 
-    const response = await makeRequest()
-    expect(response.body).toMatchSnapshot()
-  }, 30000)
-  it('should return error (empty body)', async () => {
-    const makeRequest = () =>
-      req
-        .post('/')
-        .send({})
-        .set('Accept', '*/*')
-        .set('Content-Type', 'application/json')
-        .expect('Content-Type', /json/)
+      const response = await makeRequest()
+      expect(response.statusCode).toEqual(400)
+    }, 30000)
+    it('should return error (empty data)', async () => {
+      const makeRequest = () =>
+        req
+          .post('/')
+          .send({ data: {} })
+          .set('Accept', '*/*')
+          .set('Content-Type', 'application/json')
+          .expect('Content-Type', /json/)
 
-    const response = await makeRequest()
-    expect(response.statusCode).toEqual(400)
-  }, 30000)
-  it('should return error (empty data)', async () => {
-    const makeRequest = () =>
-      req
-        .post('/')
-        .send({ data: {} })
-        .set('Accept', '*/*')
-        .set('Content-Type', 'application/json')
-        .expect('Content-Type', /json/)
+      const response = await makeRequest()
+      expect(response.statusCode).toEqual(400)
+    }, 30000)
+  })
+  describe('total supply endpoint', () => {
+    it('should return success', async () => {
+      const makeRequest = () =>
+        req
+          .post('/')
+          .send({
+            data: {
+              endpoint: 'totalSupply',
+              chainId: 'goerli',
+            },
+          })
+          .set('Accept', '*/*')
+          .set('Content-Type', 'application/json')
+          .expect('Content-Type', /json/)
 
-    const response = await makeRequest()
-    expect(response.statusCode).toEqual(400)
-  }, 30000)
+      const response = await makeRequest()
+      expect(response.body).toMatchSnapshot()
+    }, 30000)
+  })
 })

--- a/packages/sources/stader-balance/test/integration/fixture.ts
+++ b/packages/sources/stader-balance/test/integration/fixture.ts
@@ -302,3 +302,26 @@ export const mockGetGenesisBlockInfo = (): void => {
     })
     .persist()
 }
+
+export const mockFinalityCheckpoint = (): void => {
+  nock('http://localhost:9092')
+    .get('/eth/v1/beacon/states/finalized/finality_checkpoints')
+    .reply(200, {
+      execution_optimistic: false,
+      data: {
+        previous_justified: {
+          epoch: '178400',
+          root: '0x65a26398c6649107c272814a00b023e3d0678ab6783757b00e27fde34a222944',
+        },
+        current_justified: {
+          epoch: '178401',
+          root: '0xd4f262b241fcfe0e6d82eae70fd3216a742991d8af703358e139a1b1c3e2aa7f',
+        },
+        finalized: {
+          epoch: '178400',
+          root: '0x65a26398c6649107c272814a00b023e3d0678ab6783757b00e27fde34a222944',
+        },
+      },
+    })
+    .persist()
+}

--- a/packages/sources/stader-balance/test/integration/fixture.ts
+++ b/packages/sources/stader-balance/test/integration/fixture.ts
@@ -79,6 +79,7 @@ export const addressData: AdapterRequestBody = {
       { address: '0x8d86bc475bedcb08179c5e6a4d494ebd3b44ea8b' },
       { address: '0xfc07bcb5c142c7c86c84490f068d31499610ccab' },
     ],
+    reportedBlock: 8000,
   },
 }
 
@@ -143,15 +144,6 @@ export const mockEthBalanceMap: Record<string, string> = {
 
 export const mockGetValidatorStates = (): void => {
   nock('http://localhost:9092', { encodedQueryParams: true })
-    .get('/eth/v1/beacon/genesis')
-    .reply(200, {
-      data: {
-        genesis_time: '1590832934',
-        genesis_validators_root:
-          '0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2',
-        genesis_fork_version: '0x00000000',
-      },
-    })
     .get(
       '/eth/v1/beacon/states/5708763/validators?' +
         'id=0x8cd2726ccd034cf023840c2f76f7bfd4f2e8dbe79ff0e43d2908d1124450ed1c954966a42113787bc930c0e2d73524c0,' +
@@ -294,5 +286,19 @@ export const mockGetEthDepositContract = (): void => {
   nock('http://localhost:9092')
     .get('/eth/v1/config/deposit_contract')
     .reply(200, { data: { chain_id: '5', address: '0x8c5fecdc472e27bc447696f431e425d02dd46a8c' } })
+    .persist()
+}
+
+export const mockGetGenesisBlockInfo = (): void => {
+  nock('http://localhost:9092')
+    .get('/eth/v1/beacon/genesis')
+    .reply(200, {
+      data: {
+        genesis_time: '1590832934',
+        genesis_validators_root:
+          '0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2',
+        genesis_fork_version: '0x00000000',
+      },
+    })
     .persist()
 }

--- a/packages/sources/stader-balance/test/integration/setup.ts
+++ b/packages/sources/stader-balance/test/integration/setup.ts
@@ -4,6 +4,7 @@ import { config } from '../../src/config'
 import { Adapter } from '@chainlink/external-adapter-framework/adapter'
 import { ServerInstance } from '@chainlink/external-adapter-framework'
 import { balanceEndpoint } from '../../src/endpoint/balance'
+import { totalSupplyEndpoint } from '../../src/endpoint/totalSupply'
 
 export type SuiteContext = {
   req: SuperTest<Test> | null
@@ -19,7 +20,7 @@ export const createAdapter = (): Adapter => {
   return new Adapter({
     name: 'TEST',
     defaultEndpoint: 'balance',
-    endpoints: [balanceEndpoint],
+    endpoints: [balanceEndpoint, totalSupplyEndpoint],
     config,
   })
 }


### PR DESCRIPTION
## Closes [PDI-2182](https://smartcontract-it.atlassian.net/browse/PDI-2182)

## Description

- Updated withdrawn validator balance calculation logic to use node balance calculations with penalty like active validators
- Pinned block number retrieved from Stader across all EL calls. Error if pinned block is within 300 block of current block number
- Added total supply endpoint to `stader-balance` that retrieves value from totalSupply call on Stader’s ETHx contract at pinned block number
- Updated `proof-of-reserves` composite adapter to pass the reported block field to `stader-balance`
- Added validation to check if calculated beacon slot number is finalized prior to using for queries.

## Steps to Test

1. yarn test packages/sources/stader-address-list/test
2. yarn test packages/sources/stader-balance/test

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[PDI-2182]: https://smartcontract-it.atlassian.net/browse/PDI-2182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ