### PR TITLE
Add STBT endpoint to Armanino

### DIFF
--- a/.changeset/fifty-trains-notice.md
+++ b/.changeset/fifty-trains-notice.md
@@ -1,5 +1,5 @@
 ---
-'@chainlink/armanino-adapter': minor
+'@chainlink/armanino-adapter': major
 ---
 
-Added STBT endpoint
+Changed default API endpoint. Added STBT endpoint

--- a/.changeset/fifty-trains-notice.md
+++ b/.changeset/fifty-trains-notice.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/armanino-adapter': minor
+---
+
+Added STBT endpoint

--- a/packages/sources/armanino/schemas/env.json
+++ b/packages/sources/armanino/schemas/env.json
@@ -6,7 +6,7 @@
   "type": "object",
   "properties": {
     "API_ENDPOINT": {
-      "default": "https://api.real-time-attest.trustexplorer.io/chainlink",
+      "default": "https://api.oracle-services.ledgerlens.io/v1/chainlink/proof-of-reserves/",
       "description": "API Endpoint to use",
       "type": "string"
     }

--- a/packages/sources/armanino/schemas/env.json
+++ b/packages/sources/armanino/schemas/env.json
@@ -4,7 +4,13 @@
   "description": "Carbon credit reserves attested by Armanino",
   "required": [],
   "type": "object",
-  "properties": {},
+  "properties": {
+    "API_ENDPOINT": {
+      "default": "https://api.real-time-attest.trustexplorer.io/chainlink",
+      "description": "API Endpoint to use",
+      "type": "string"
+    }
+  },
   "allOf": [
     {
       "$ref": "https://external-adapters.chainlinklabs.com/schemas/ea-bootstrap.json"

--- a/packages/sources/armanino/src/config/index.ts
+++ b/packages/sources/armanino/src/config/index.ts
@@ -5,7 +5,7 @@ export const NAME = 'ARMANINO'
 
 export const DEFAULT_ENDPOINT = 'mco2'
 export const DEFAULT_BASE_URL =
-  ' https://api.oracle-services.ledgerlens.io/v1/chainlink/proof-of-reserves/'
+  'https://api.oracle-services.ledgerlens.io/v1/chainlink/proof-of-reserves/'
 
 export const makeConfig = (prefix?: string): Config => {
   const config = Requester.getDefaultConfig(prefix)

--- a/packages/sources/armanino/src/config/index.ts
+++ b/packages/sources/armanino/src/config/index.ts
@@ -4,7 +4,8 @@ import type { Config } from '@chainlink/ea-bootstrap'
 export const NAME = 'ARMANINO'
 
 export const DEFAULT_ENDPOINT = 'mco2'
-export const DEFAULT_BASE_URL = 'https://api.real-time-attest.trustexplorer.io/chainlink'
+export const DEFAULT_BASE_URL =
+  ' https://api.oracle-services.ledgerlens.io/v1/chainlink/proof-of-reserves/'
 
 export const makeConfig = (prefix?: string): Config => {
   const config = Requester.getDefaultConfig(prefix)

--- a/packages/sources/armanino/src/endpoint/index.ts
+++ b/packages/sources/armanino/src/endpoint/index.ts
@@ -3,3 +3,4 @@ import type { TInputParameters as MCO2InputParameters } from './mco2'
 export type TInputParameters = MCO2InputParameters
 
 export * as mco2 from './mco2'
+export * as stbt from './stbt'

--- a/packages/sources/armanino/src/endpoint/stbt.ts
+++ b/packages/sources/armanino/src/endpoint/stbt.ts
@@ -1,0 +1,29 @@
+import { Requester, Validator } from '@chainlink/ea-bootstrap'
+import type { Config, ExecuteWithConfig, InputParameters } from '@chainlink/ea-bootstrap'
+
+export const supportedEndpoints = ['stbt']
+
+export interface ResponseSchema {
+  accountName: string
+  totalReserve: number
+  totalToken: number
+  timestamp: string
+}
+
+export type TInputParameters = Record<string, never>
+export const inputParameters: InputParameters<TInputParameters> = {}
+
+export const execute: ExecuteWithConfig<Config> = async (request, _, config) => {
+  const validator = new Validator(request, inputParameters)
+
+  const jobRunID = validator.validated.id
+  const url = `STBT`
+  const resultPath = validator.validated.data.resultPath
+
+  const options = { ...config.api, url }
+
+  const response = await Requester.request<ResponseSchema>(options)
+  const result = Requester.validateResultNumber(response.data, resultPath || 'totalReserve')
+
+  return Requester.success(jobRunID, Requester.withResult(response, result), config.verbose)
+}

--- a/packages/sources/armanino/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/armanino/test/integration/__snapshots__/adapter.test.ts.snap
@@ -11,3 +11,15 @@ exports[`execute mco2 endpoint should return success 1`] = `
   "statusCode": 200,
 }
 `;
+
+exports[`execute stbt endpoint should return success 1`] = `
+{
+  "data": {
+    "result": 72178807.56,
+  },
+  "jobRunID": "1",
+  "providerStatusCode": 200,
+  "result": 72178807.56,
+  "statusCode": 200,
+}
+`;

--- a/packages/sources/armanino/test/integration/adapter.test.ts
+++ b/packages/sources/armanino/test/integration/adapter.test.ts
@@ -1,6 +1,6 @@
 import { AdapterRequest } from '@chainlink/ea-bootstrap'
 import { server as startServer } from '../../src'
-import { mockMCO2Response } from './fixtures'
+import { mockMCO2Response, mockSTBTResponse } from './fixtures'
 import { setupExternalAdapterTest } from '@chainlink/ea-test-helpers'
 import type { SuiteContext } from '@chainlink/ea-test-helpers'
 import { SuperTest, Test } from 'supertest'
@@ -18,7 +18,7 @@ describe('execute', () => {
   setupExternalAdapterTest(envVariables, context)
 
   describe('mco2 endpoint', () => {
-    const balanceRequest: AdapterRequest = {
+    const request: AdapterRequest = {
       id: '1',
       data: {},
     }
@@ -28,7 +28,28 @@ describe('execute', () => {
 
       const response = await (context.req as SuperTest<Test>)
         .post('/')
-        .send(balanceRequest)
+        .send(request)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+      expect(response.body).toMatchSnapshot()
+    })
+  })
+  describe('stbt endpoint', () => {
+    const request: AdapterRequest = {
+      id: '1',
+      data: {
+        endpoint: 'stbt',
+      },
+    }
+
+    it('should return success', async () => {
+      mockSTBTResponse()
+
+      const response = await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(request)
         .set('Accept', '*/*')
         .set('Content-Type', 'application/json')
         .expect('Content-Type', /json/)

--- a/packages/sources/armanino/test/integration/fixtures.ts
+++ b/packages/sources/armanino/test/integration/fixtures.ts
@@ -39,3 +39,15 @@ export const mockMCO2Response = (): nock.Scope =>
         'max-age=63072000; includeSubDomains; preload',
       ],
     )
+
+export const mockSTBTResponse = (): nock.Scope =>
+  nock('https://api.real-time-attest.trustexplorer.io:443/chainlink', {
+    encodedQueryParams: true,
+  })
+    .get('/STBT')
+    .reply(200, {
+      accountName: 'STBT',
+      totalReserve: 72178807.56,
+      totalToken: 71932154.99,
+      timestamp: '2023-06-02T12:53:23.604Z',
+    })

--- a/packages/sources/armanino/test/integration/fixtures.ts
+++ b/packages/sources/armanino/test/integration/fixtures.ts
@@ -1,10 +1,10 @@
 import nock from 'nock'
 
 export const mockMCO2Response = (): nock.Scope =>
-  nock('https://api.real-time-attest.trustexplorer.io:443', {
+  nock('https://api.oracle-services.ledgerlens.io/v1/chainlink/proof-of-reserves/', {
     encodedQueryParams: true,
   })
-    .get('/chainlink/MCO2')
+    .get('/MCO2')
     .reply(
       200,
       { totalMCO2: 3041044, totalCarbonCredits: 3041044, timestamp: '2022-04-04T11:00:46.577Z' },
@@ -41,7 +41,7 @@ export const mockMCO2Response = (): nock.Scope =>
     )
 
 export const mockSTBTResponse = (): nock.Scope =>
-  nock('https://api.real-time-attest.trustexplorer.io:443/chainlink', {
+  nock('https://api.oracle-services.ledgerlens.io/v1/chainlink/proof-of-reserves/', {
     encodedQueryParams: true,
   })
     .get('/STBT')


### PR DESCRIPTION
## Closes [PDI-2181](https://smartcontract-it.atlassian.net/browse/PDI-2181)

## Description

Add STBT endpoint to the `armanino` adapter

## Steps to Test

1. yarn test packages/sources/armanino/test

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[PDI-2181]: https://smartcontract-it.atlassian.net/browse/PDI-2181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ