### PR TITLE
Fix Github Action for calculating changed EAs

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -115,7 +115,7 @@ runs:
               }' \
         > packages/tsconfig.tmp.json
 
-        echo "CHANGED_ADAPTERS=$(jq -r '.references' packages/tsconfig.tmp.json)" >> $GITHUB_ENV
+        echo "CHANGED_ADAPTERS=$(jq -c '.references' packages/tsconfig.tmp.json)" >> $GITHUB_ENV
     - name: Build files
       if: |
         inputs.skip-setup != 'true'


### PR DESCRIPTION
Fixes Github Action for calculating the changed EAs.

Previously failed as Github Actions failed to parse the pretty-printed JSON. Fix is to output in a single line using JQ's compact output.

Can see an example of the workflow failure on [PR 2789](https://github.com/smartcontractkit/external-adapters-js/pull/2789), and the fix working on [test PR 2799](https://github.com/smartcontractkit/external-adapters-js/actions/runs/5186727219).