### PR TITLE
Update Stader PoR logic for requested changes

### DIFF
--- a/.changeset/big-parrots-run.md
+++ b/.changeset/big-parrots-run.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/stader-address-list-adapter': minor
+---
+
+Updated with Stader contract function name change

--- a/.changeset/fresh-cows-peel.md
+++ b/.changeset/fresh-cows-peel.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/stader-balance-adapter': patch
+---
+
+Updated logic to determine deposited validator

--- a/packages/sources/stader-address-list/src/abi/StaderContractAbis.ts
+++ b/packages/sources/stader-address-list/src/abi/StaderContractAbis.ts
@@ -90,7 +90,7 @@ export const StaderPermissionlessNodeRegistryContract_ABI: ethers.ContractInterf
       { internalType: 'uint256', name: '_pageNumber', type: 'uint256' },
       { internalType: 'uint256', name: '_pageSize', type: 'uint256' },
     ],
-    name: 'getNodeELVaultAddressForOptOutOperators',
+    name: 'getAllNodeELVaultAddress',
     outputs: [{ internalType: 'address[]', name: '', type: 'address[]' }],
     stateMutability: 'view',
     type: 'function',

--- a/packages/sources/stader-address-list/src/endpoint/address.ts
+++ b/packages/sources/stader-address-list/src/endpoint/address.ts
@@ -439,7 +439,7 @@ export class AddressTransport extends SubscriptionTransport<EndpointTypes> {
         handler: async (index) => {
           const pageNumber = index + 1
           const addresses: string[] =
-            await params.permissionlessNodeRegistryManager.getNodeELVaultAddressForOptOutOperators(
+            await params.permissionlessNodeRegistryManager.getAllNodeELVaultAddress(
               pageNumber,
               params.batchSize,
               {

--- a/packages/sources/stader-address-list/test/integration/adapter.test.ts
+++ b/packages/sources/stader-address-list/test/integration/adapter.test.ts
@@ -96,7 +96,7 @@ jest.mock('ethers', () => {
           getSocializingPoolAddress: jest.fn().mockImplementation((poolId) => {
             return mockSocialPoolAddresses[poolId]
           }),
-          getNodeELVaultAddressForOptOutOperators: jest.fn().mockImplementation(() => {
+          getAllNodeELVaultAddress: jest.fn().mockImplementation(() => {
             return mockElRewardAddresses
           }),
           nextValidatorId: jest.fn().mockReturnValue(3),

--- a/packages/sources/stader-balance/src/endpoint/utils.ts
+++ b/packages/sources/stader-balance/src/endpoint/utils.ts
@@ -15,11 +15,13 @@ const SECONDS_PER_SLOT = 12
 const SLOTS_PER_EPOCH = 32
 
 export const WITHDRAWAL_DONE_STATUS = 'withdrawal_done'
+export const PENDING_INITIALIZED = 'pending_initialized'
 export const DEPOSIT_EVENT_TOPIC =
   '0x649bbc62d0e31342afea4e5cd82d4049e7e1ee912fc0889aa790803be39038c5'
 export const DEPOSIT_EVENT_LOOKBACK_WINDOW = 10_000 // blocks
 export const ONE_ETH_WEI = BigNumber(ethers.utils.parseEther('1').toString())
 export const THIRTY_ONE_ETH_WEI = BigNumber(ethers.utils.parseEther('31').toString())
+export const THIRTY_TWO_ETH_WEI = BigNumber(ethers.utils.parseEther('32').toString())
 
 export type NetworkChainMap = {
   [network: string]: {

--- a/packages/sources/stader-balance/src/model/validator.ts
+++ b/packages/sources/stader-balance/src/model/validator.ts
@@ -10,9 +10,10 @@ import {
   fetchAddressBalance,
   formatValueInGwei,
   getSlotNumber,
-  ONE_ETH_WEI,
+  PENDING_INITIALIZED,
   ProviderResponse,
   StaderValidatorStatus,
+  THIRTY_TWO_ETH_WEI,
   ValidatorAddress,
   ValidatorState,
   WITHDRAWAL_DONE_STATUS,
@@ -175,7 +176,8 @@ abstract class Validator {
   isDeposited(): boolean {
     return (
       this.addressData.status === StaderValidatorStatus.DEPOSITED &&
-      this.validatorBalance.eq(ONE_ETH_WEI)
+      this.state.status === PENDING_INITIALIZED &&
+      this.validatorBalance.lt(THIRTY_TWO_ETH_WEI)
     )
   }
 

--- a/packages/sources/stader-balance/test/integration/fixture.ts
+++ b/packages/sources/stader-balance/test/integration/fixture.ts
@@ -263,7 +263,7 @@ export const mockGetValidatorStates = (): void => {
         {
           index: '416580',
           balance: '1000000000',
-          status: 'active_ongoing',
+          status: 'pending_initialized',
           validator: {
             pubkey:
               '0x8af03fc3ba342b625c868325386fd421fa677d87cf96d528f4649cf043ea33b8f1466dd6bce66b0c9d949b8b65d1549c',


### PR DESCRIPTION
## Closes [PDI-2197](https://smartcontract-it.atlassian.net/browse/PDI-2197)

## Description

- Stader contract function name change
- Updated logic to identify deposited validator

## Steps to Test

1. yarn test packages/sources/stader-address-list/test
2. yarn test packages/sources/stader-balance/test

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
