### PR TITLE
Update trueusd default endpoint

### DIFF
--- a/.changeset/fifty-poets-change.md
+++ b/.changeset/fifty-poets-change.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/trueusd-adapter': major
+---
+
+Updated default endpoint

--- a/packages/sources/trueusd/src/config/index.ts
+++ b/packages/sources/trueusd/src/config/index.ts
@@ -4,7 +4,7 @@ import { Config } from '@chainlink/ea-bootstrap'
 export const NAME = 'TRUEUSD'
 
 export const DEFAULT_ENDPOINT = 'trueusd'
-export const DEFAULT_BASE_URL = 'https://api.real-time-attest.trustexplorer.io'
+export const DEFAULT_BASE_URL = 'https://api.real-time-reserves.ledgerlens.io/v1/'
 
 export const makeConfig = (prefix?: string): Config => {
   const config = Requester.getDefaultConfig(prefix)

--- a/packages/sources/trueusd/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/trueusd/test/integration/__snapshots__/adapter.test.ts.snap
@@ -3,11 +3,11 @@
 exports[`execute should return success for token 1`] = `
 {
   "data": {
-    "result": 1213602213.6176918,
+    "result": 3097573780.109635,
   },
   "jobRunID": "1",
   "providerStatusCode": 200,
-  "result": 1213602213.6176918,
+  "result": 3097573780.109635,
   "statusCode": 200,
 }
 `;
@@ -15,11 +15,11 @@ exports[`execute should return success for token 1`] = `
 exports[`execute should return success for trust 1`] = `
 {
   "data": {
-    "result": 1217813909.066,
+    "result": 3117410009.89,
   },
   "jobRunID": "1",
   "providerStatusCode": 200,
-  "result": 1217813909.066,
+  "result": 3117410009.89,
   "statusCode": 200,
 }
 `;
@@ -27,11 +27,11 @@ exports[`execute should return success for trust 1`] = `
 exports[`execute should return success when given a chain 1`] = `
 {
   "data": {
-    "result": 1795,
+    "result": 24268.83,
   },
   "jobRunID": "1",
   "providerStatusCode": 200,
-  "result": 1795,
+  "result": 24268.83,
   "statusCode": 200,
 }
 `;
@@ -39,11 +39,11 @@ exports[`execute should return success when given a chain 1`] = `
 exports[`execute should return success when given a chain and resultPath 1`] = `
 {
   "data": {
-    "result": 3791570.06,
+    "result": 3005274.95,
   },
   "jobRunID": "1",
   "providerStatusCode": 200,
-  "result": 3791570.06,
+  "result": 3005274.95,
   "statusCode": 200,
 }
 `;

--- a/packages/sources/trueusd/test/integration/fixtures.ts
+++ b/packages/sources/trueusd/test/integration/fixtures.ts
@@ -1,7 +1,7 @@
 import nock from 'nock'
 
 export const mockResponseSuccess = (): nock.Scope =>
-  nock('https://api.real-time-attest.trustexplorer.io', {
+  nock('https://api.real-time-reserves.ledgerlens.io/v1/', {
     encodedQueryParams: true,
   })
     .get('/chainlink/proof-of-reserves/TrueUSD')
@@ -9,59 +9,34 @@ export const mockResponseSuccess = (): nock.Scope =>
       200,
       () => ({
         accountName: 'TrueUSD',
-        totalTrust: 1217813909.066,
-        totalToken: 1213602213.6176918,
-        updatedAt: '2022-08-10T14:22:39.011Z',
+        totalTrust: 3117410009.89,
+        totalToken: 3097573780.109635,
+        updatedAt: '2023-06-15T16:59:47.538Z',
         token: [
           {
             tokenName: 'TUSD (AVAX)',
-            bankBalances: {
-              'Prime Trust': 0,
-              'First Digital Trust': 1794,
-              Silvergate: 0,
-              'Signature Bank': 0,
-              Signet: 0,
-              Other: 1,
-            },
-            totalTokenByChain: 3791570.06,
-            totalTrustByChain: 1795,
+            totalTokenByChain: 3005274.95,
+            totalTrustByChain: 24268.83,
           },
           {
             tokenName: 'TUSD (ETH)',
-            bankBalances: {
-              'Prime Trust': 134055616.61,
-              BitGo: 16.12,
-              'First Digital Trust': 594966145.326,
-              Silvergate: 113846225.15,
-              'Signature Bank': 0,
-              Signet: 274940619.86,
-              'Customers Bank': 100000000,
-            },
-            totalTokenByChain: 879902244.54,
-            totalTrustByChain: 1217808623.066,
+            totalTokenByChain: 728134669.6,
+            totalTrustByChain: 2917383739.66,
           },
           {
             tokenName: 'TUSD (TRON)',
-            bankBalances: {
-              'Prime Trust': 0,
-              'First Digital Trust': 1600,
-              Silvergate: 0,
-              'Signature Bank': 0,
-              Signet: 0,
-            },
-            totalTokenByChain: 329515277.3,
-            totalTrustByChain: 1600,
+            totalTokenByChain: 2336157454.81,
+            totalTrustByChain: 200002001.4,
           },
           {
             tokenName: 'TUSD (BNB)',
-            bankBalances: {
-              'Prime Trust': 0,
-              'First Digital Trust': 1891,
-              'Signature Bank': 0,
-              Signet: 0,
-            },
-            totalTokenByChain: 393121.7176917,
-            totalTrustByChain: 1891,
+            totalTokenByChain: 145015.86963478,
+            totalTrustByChain: 0,
+          },
+          {
+            tokenName: 'TUSD (BSC)',
+            totalTokenByChain: 30131364.88,
+            totalTrustByChain: 0,
           },
         ],
       }),


### PR DESCRIPTION
## Closes [PDI-2223](https://smartcontract-it.atlassian.net/browse/PDI-2223)

## Description

Updated `trueusd` default endpoint. The provider is planning to deprecate the old one.

## Steps to Test

1. yarn test packages/sources/trueusd/test

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[PDI-2223]: https://smartcontract-it.atlassian.net/browse/PDI-2223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ