### PR TITLE
Update avalanche-platform logic to return staked value

### DIFF
--- a/.changeset/gentle-terms-beam.md
+++ b/.changeset/gentle-terms-beam.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/avalanche-platform-adapter': minor
+---
+
+Updated logic to return staked value

--- a/packages/sources/avalanche-platform/test/e2e/balance.test.ts
+++ b/packages/sources/avalanche-platform/test/e2e/balance.test.ts
@@ -18,6 +18,7 @@ describe('execute', () => {
             addresses: [
               {
                 address: 'P-fuji1vd9sddlllrlk9fvj9lhntpw8t00lmvtnqkl2jt',
+                network: 'avalanche-fuji',
               },
             ],
           },
@@ -31,6 +32,7 @@ describe('execute', () => {
             addresses: [
               {
                 address: 'P-fuji1vd9sddlllrlk9fvj9lhntpw8t00lmvtnqkl2jt',
+                network: 'avalanche-fuji',
               },
             ],
           },
@@ -44,9 +46,11 @@ describe('execute', () => {
             result: [
               {
                 address: 'P-fuji1vd9sddlllrlk9fvj9lhntpw8t00lmvtnqkl2jt',
+                network: 'avalanche-fuji',
               },
               {
                 address: 'P-fuji1wycv8n7d2fg9aq6unp23pnj4q0arv03ysya8jw',
+                network: 'avalanche-fuji',
               },
             ],
           },

--- a/packages/sources/avalanche-platform/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/avalanche-platform/test/integration/__snapshots__/adapter.test.ts.snap
@@ -8,7 +8,7 @@ exports[`execute balance api (stakeAmount) should return success 1`] = `
         "addresses": [
           "P-fuji1vd9sddlllrlk9fvj9lhntpw8t00lmvtnqkl2jt",
         ],
-        "balance": "1606136960057",
+        "balance": "2000000000000",
       },
     ],
   },
@@ -18,7 +18,7 @@ exports[`execute balance api (stakeAmount) should return success 1`] = `
       "addresses": [
         "P-fuji1vd9sddlllrlk9fvj9lhntpw8t00lmvtnqkl2jt",
       ],
-      "balance": "1606136960057",
+      "balance": "2000000000000",
     },
   ],
   "statusCode": 200,

--- a/packages/sources/avalanche-platform/test/integration/adapter.test.ts
+++ b/packages/sources/avalanche-platform/test/integration/adapter.test.ts
@@ -27,6 +27,7 @@ describe('execute', () => {
           result: [
             {
               address: 'P-fuji1vd9sddlllrlk9fvj9lhntpw8t00lmvtnqkl2jt',
+              network: 'avalanche-fuji',
             },
           ],
         },

--- a/packages/sources/avalanche-platform/test/integration/fixtures.ts
+++ b/packages/sources/avalanche-platform/test/integration/fixtures.ts
@@ -4,7 +4,7 @@ export const mockBalanceSuccess = (): nock.Scope =>
   nock('http://localhost:3500')
     .post('/ext/bc/P', {
       jsonrpc: '2.0',
-      method: 'platform.getBalance',
+      method: 'platform.getStake',
       params: {
         addresses: ['P-fuji1vd9sddlllrlk9fvj9lhntpw8t00lmvtnqkl2jt'],
       },
@@ -15,30 +15,16 @@ export const mockBalanceSuccess = (): nock.Scope =>
       {
         jsonrpc: '2.0',
         result: {
-          balance: '1606136960057',
-          unlocked: '1606136960057',
-          lockedStakeable: '0',
-          lockedNotStakeable: '0',
-          balances: {
-            U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK: '1606136960057',
+          staked: '2000000000000',
+          stakeds: {
+            U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK: '2000000000000',
           },
-          unlockeds: {
-            U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK: '1606136960057',
-          },
-          lockedStakeables: {},
-          lockedNotStakeables: {},
-          utxoIDs: [
-            {
-              txID: '2E9jBifwAKMajtgrwmJxwuW4UtYmTauAggCgRQv2wWF7PiXwgD',
-              outputIndex: 1,
-            },
-            {
-              txID: '2E9jBifwAKMajtgrwmJxwuW4UtYmTauAggCgRQv2wWF7PiXwgD',
-              outputIndex: 0,
-            },
+          stakedOutputs: [
+            '0x000021e67317cbc4be2aeb00677ad6462778a8f52274b9d605df2591b23027a87dff00000007000001d1a94a200000000000000000000000000100000001737eefad3f40b3b87736c0fa8d91e0845091ad8f7a73fe74',
           ],
+          encoding: 'hex',
         },
-        id: '1',
+        id: 2,
       },
       [
         'content-type',


### PR DESCRIPTION
## Closes [PDI-2224](https://smartcontract-it.atlassian.net/browse/PDI-2224)

## Description

Updated `avalanche-platform` logic to return staked value instead of address balance

## Changes

- Moved from using the `platform.getBalance` call to the `platform.getStake` call

## Steps to Test

1. yarn test packages/sources/avalanche-platform/test

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[PDI-2224]: https://smartcontract-it.atlassian.net/browse/PDI-2224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ