### PR TITLE
Update Polkadot EA to define Supertest dependency.

### DIFF
--- a/.changeset/fast-beers-hide.md
+++ b/.changeset/fast-beers-hide.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/polkadot-balance-adapter': minor
+---
+
+Update dev dependencies

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -8240,7 +8240,9 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@polkadot/api", "npm:9.14.2"],\
             ["@types/jest", "npm:27.5.2"],\
             ["@types/node", "npm:16.11.51"],\
+            ["@types/supertest", "npm:2.0.12"],\
             ["nock", "npm:13.2.9"],\
+            ["supertest", "npm:6.2.4"],\
             ["tslib", "npm:2.4.1"],\
             ["typescript", "patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=b5f058"]\
           ],\

--- a/packages/sources/polkadot-balance/package.json
+++ b/packages/sources/polkadot-balance/package.json
@@ -35,7 +35,9 @@
   "devDependencies": {
     "@types/jest": "27.5.2",
     "@types/node": "16.11.51",
+    "@types/supertest": "2.0.12",
     "nock": "13.2.9",
+    "supertest": "6.2.4",
     "typescript": "5.0.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4410,7 +4410,9 @@ __metadata:
     "@polkadot/api": 9.14.2
     "@types/jest": 27.5.2
     "@types/node": 16.11.51
+    "@types/supertest": 2.0.12
     nock: 13.2.9
+    supertest: 6.2.4
     tslib: ^2.3.1
     typescript: 5.0.4
   languageName: unknown


### PR DESCRIPTION
Previously 'yarn setup-tests' was failing as the dependency on supertest was not defined. Fixed by adding to package.json
