### PR TITLE
Finnhub: Use PriceAdapter interface

### DIFF
--- a/.changeset/sharp-snakes-push.md
+++ b/.changeset/sharp-snakes-push.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/finnhub-adapter': minor
+---
+
+Update Finnhub EA to use the PriceAdapter interface

--- a/packages/sources/finnhub/src/endpoint/quote.ts
+++ b/packages/sources/finnhub/src/endpoint/quote.ts
@@ -1,4 +1,4 @@
-import { AdapterEndpoint } from '@chainlink/external-adapter-framework/adapter'
+import { PriceEndpoint } from '@chainlink/external-adapter-framework/adapter'
 import { HttpTransport } from '@chainlink/external-adapter-framework/transports'
 import { SingleNumberResultResponse, makeLogger } from '@chainlink/external-adapter-framework/util'
 import { InputParameters } from '@chainlink/external-adapter-framework/validation'
@@ -9,10 +9,15 @@ const logger = makeLogger('Finnhub quote endpoint')
 
 export const inputParameters = new InputParameters({
   base: {
-    aliases: ['quote', 'asset', 'from'],
+    aliases: ['from', 'coin'],
     type: 'string',
-    description: 'The symbol of the currency or asset to query',
+    description: 'The symbol of symbols of the currency to query',
     required: true,
+  },
+  quote: {
+    aliases: ['to', 'market'],
+    type: 'string',
+    description: 'The symbol of the currency to convert to',
   },
 })
 
@@ -90,7 +95,7 @@ export const httpTransport = new HttpTransport<EndpointTypes>({
   },
 })
 
-export const endpoint = new AdapterEndpoint<EndpointTypes>({
+export const endpoint = new PriceEndpoint<EndpointTypes>({
   name: 'quote',
   aliases: ['common', 'stock', 'forex'],
   transport: httpTransport,

--- a/packages/sources/finnhub/src/index.ts
+++ b/packages/sources/finnhub/src/index.ts
@@ -1,9 +1,9 @@
 import { expose, ServerInstance } from '@chainlink/external-adapter-framework'
-import { Adapter } from '@chainlink/external-adapter-framework/adapter'
+import { PriceAdapter } from '@chainlink/external-adapter-framework/adapter'
 import { quote } from './endpoint'
 import { config } from './config'
 
-export const adapter = new Adapter({
+export const adapter = new PriceAdapter({
   defaultEndpoint: quote.name,
   name: 'FINNHUB',
   config,

--- a/packages/sources/finnhub/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/finnhub/test/integration/__snapshots__/adapter.test.ts.snap
@@ -27,3 +27,17 @@ exports[`rest quote endpoint should return success 1`] = `
   },
 }
 `;
+
+exports[`rest quote endpoint should return success for requests with overrides 1`] = `
+{
+  "data": {
+    "result": 1.2357,
+  },
+  "result": 1.2357,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 1641035471111,
+    "providerDataRequestedUnixMs": 1641035471111,
+  },
+}
+`;

--- a/packages/sources/finnhub/test/integration/adapter.test.ts
+++ b/packages/sources/finnhub/test/integration/adapter.test.ts
@@ -41,6 +41,19 @@ describe('rest', () => {
       expect(response.statusCode).toBe(200)
       expect(response.json()).toMatchSnapshot()
     })
+
+    it('should return success for requests with overrides', async () => {
+      const data = {
+        base: 'GBP',
+        overrides: {
+          finnhub: { GBP: 'FHFX:GBP-USD' },
+        },
+      }
+      mockResponseSuccess()
+      const response = await testAdapter.request(data)
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toMatchSnapshot()
+    })
   })
 
   describe('forex endpoint (quote alias)', () => {

--- a/packages/sources/finnhub/test/integration/fixtures.ts
+++ b/packages/sources/finnhub/test/integration/fixtures.ts
@@ -4,6 +4,7 @@ export const mockResponseSuccess = (): nock.Scope => {
   return nock('https://finnhub.io/api/v1', {
     encodedQueryParams: true,
   })
+    .persist()
     .get('/quote')
     .query({ token: 'fake-api-key', symbol: 'OANDA:EUR_USD' })
     .reply(
@@ -29,7 +30,6 @@ export const mockResponseSuccess = (): nock.Scope => {
         'Origin',
       ],
     )
-    .persist()
     .get('/quote')
     .query({ token: 'fake-api-key', symbol: 'AAPL' })
     .reply(
@@ -55,5 +55,29 @@ export const mockResponseSuccess = (): nock.Scope => {
         'Origin',
       ],
     )
-    .persist()
+    .get('/quote')
+    .query({ token: 'fake-api-key', symbol: 'FHFX:GBP-USD' })
+    .reply(
+      200,
+      () => ({
+        c: 1.2357,
+        d: 0.00336,
+        dp: 0.1954,
+        h: 1.23573,
+        l: 1.23577,
+        o: 1.2357,
+        pc: 1.23578,
+        t: 1636322400,
+      }),
+      [
+        'Content-Type',
+        'application/json',
+        'Connection',
+        'close',
+        'Vary',
+        'Accept-Encoding',
+        'Vary',
+        'Origin',
+      ],
+    )
 }


### PR DESCRIPTION
## Closes [DF-18946](https://smartcontract-it.atlassian.net/browse/DF-18946)

## Description
* Update Finnhub EA so that it follows the PriceAdapter interface, with separate base and quote params

## Changes

1. Updates adapter to use PriceAdapter interface
2. Updates endpoint to use PriceEndpoint interface, with separate `base` and `quote` params

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test
1. `curl --location 'localhost:8080' --header 'Content-Type: application/json' --data '{ "id": "123", "data": { "base": "FHFX:GBP-USD", "endpoint": "forex" } }'`

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[DF-18946]: https://smartcontract-it.atlassian.net/browse/DF-18946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ