### PR TITLE
Revert "Bump finnhub-secondary version to 0.0.1 (#2861)"

### DIFF
--- a/packages/sources/finnhub-secondary/README.md
+++ b/packages/sources/finnhub-secondary/README.md
@@ -1,6 +1,6 @@
 # FINNHUB-SECONDARY
 
-![0.0.1](https://img.shields.io/github/package-json/v/smartcontractkit/external-adapters-js?filename=packages/sources/finnhub-secondary/package.json) ![v3](https://img.shields.io/badge/framework%20version-v3-blueviolet)
+![0.0.0](https://img.shields.io/github/package-json/v/smartcontractkit/external-adapters-js?filename=packages/sources/finnhub-secondary/package.json) ![v3](https://img.shields.io/badge/framework%20version-v3-blueviolet)
 
 This document was generated automatically. Please see [README Generator](../../scripts#readme-generator) for more info.
 

--- a/packages/sources/finnhub-secondary/package.json
+++ b/packages/sources/finnhub-secondary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/finnhub-secondary-adapter",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This reverts [PR #2861](https://github.com/smartcontractkit/external-adapters-js/pull/2861), which manually bumped the finnhub-secondary EA version. This will instead be handled by the release PR: https://github.com/smartcontractkit/external-adapters-js/pull/2858