### PR TITLE
Fix Finnhub EA's WebSocket transports

### DIFF
--- a/.changeset/clever-mails-tap.md
+++ b/.changeset/clever-mails-tap.md
@@ -1,0 +1,12 @@
+---
+'@chainlink/finnhub-adapter': minor
+'@chainlink/finnhub-secondary-adapter': minor
+---
+
+Fix Finnhub EA's WebSocket transports
+
+Fixes an issue where Finnhub EA's would fail for certain requests when using WebSockets.
+Previously Finnhub WebSocket requests would succeed for full symbols (e.g. {"base": "OANDA:EUR_USD"}), but fail for requests with separate base and quote (e.g. {"base": "EUR", "quote: "USD"}). This is because the WebSocket message returns a single symbol which is cached as the
+base, and future requests included a quote so did not match the cached key.
+This commit fixes the above by introducing a requestTransform for the endpoint. The requestTransform checks if the symbol is a full symbol (e.g. OANDA:EUR_USD), and if so discards any quote provided as only the base will be used anyway. This keeps the cache key consistent when
+writing and reading for both REST and WS.

--- a/packages/sources/finnhub-secondary/test/integration/__snapshots__/adapter-rest.test.ts.snap
+++ b/packages/sources/finnhub-secondary/test/integration/__snapshots__/adapter-rest.test.ts.snap
@@ -14,7 +14,7 @@ exports[`rest forex endpoint (quote alias) should return success 1`] = `
 }
 `;
 
-exports[`rest quote endpoint should return success 1`] = `
+exports[`rest quote endpoint should return success for full symbol 1`] = `
 {
   "data": {
     "result": 1.15894,
@@ -31,9 +31,23 @@ exports[`rest quote endpoint should return success 1`] = `
 exports[`rest quote endpoint should return success for requests with overrides 1`] = `
 {
   "data": {
-    "result": 1.2357,
+    "result": 1.15894,
   },
-  "result": 1.2357,
+  "result": 1.15894,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 1641035471111,
+    "providerDataRequestedUnixMs": 1641035471111,
+  },
+}
+`;
+
+exports[`rest quote endpoint should return success for requests overriden by default adapter overrides 1`] = `
+{
+  "data": {
+    "result": 1.15894,
+  },
+  "result": 1.15894,
   "statusCode": 200,
   "timestamps": {
     "providerDataReceivedUnixMs": 1641035471111,

--- a/packages/sources/finnhub-secondary/test/integration/__snapshots__/adapter-ws.test.ts.snap
+++ b/packages/sources/finnhub-secondary/test/integration/__snapshots__/adapter-ws.test.ts.snap
@@ -1,6 +1,36 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`websocket should return success 1`] = `
+exports[`websocket should return success for full symbols 1`] = `
+{
+  "data": {
+    "result": 1.098455,
+  },
+  "result": 1.098455,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 1018,
+    "providerDataStreamEstablishedUnixMs": 1010,
+    "providerIndicatedTimeUnixMs": 1641035471111,
+  },
+}
+`;
+
+exports[`websocket should return success for base overriden by default adapter overrides 1`] = `
+{
+  "data": {
+    "result": 1.098455,
+  },
+  "result": 1.098455,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 1018,
+    "providerDataStreamEstablishedUnixMs": 1010,
+    "providerIndicatedTimeUnixMs": 1641035471111,
+  },
+}
+`;
+
+exports[`websocket should return success for base and quote overriden by default adapter overrides 1`] = `
 {
   "data": {
     "result": 1.098455,

--- a/packages/sources/finnhub-secondary/test/integration/adapter-rest.test.ts
+++ b/packages/sources/finnhub-secondary/test/integration/adapter-rest.test.ts
@@ -32,9 +32,9 @@ describe('rest', () => {
   })
 
   describe('quote endpoint', () => {
-    it('should return success', async () => {
+    it('should return success for full symbol', async () => {
       const data = {
-        base: 'EUR',
+        base: 'OANDA:EUR_USD',
       }
       mockResponseSuccess()
       const response = await testAdapter.request(data)
@@ -44,10 +44,20 @@ describe('rest', () => {
 
     it('should return success for requests with overrides', async () => {
       const data = {
-        base: 'GBP',
+        base: 'EUR',
         overrides: {
-          finnhub: { GBP: 'OANDA:GBP_USD' },
+          finnhub: { EUR: 'OANDA:EUR_USD' },
         },
+      }
+      mockResponseSuccess()
+      const response = await testAdapter.request(data)
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toMatchSnapshot()
+    })
+
+    it('should return success for requests overriden by default adapter overrides', async () => {
+      const data = {
+        base: 'EUR',
       }
       mockResponseSuccess()
       const response = await testAdapter.request(data)

--- a/packages/sources/finnhub-secondary/test/integration/adapter-ws.test.ts
+++ b/packages/sources/finnhub-secondary/test/integration/adapter-ws.test.ts
@@ -73,8 +73,28 @@ describe('websocket', () => {
     spy.mockRestore()
   })
 
-  it('should return success', async () => {
-    const response = await testAdapter.request(data)
+  it('should return success for full symbols', async () => {
+    const response = await testAdapter.request({
+      base: 'OANDA:EUR_USD',
+    })
+
+    expect(response.json()).toMatchSnapshot()
+  })
+
+  it('should return success for base overriden by default adapter overrides', async () => {
+    const response = await testAdapter.request({
+      base: 'EUR',
+    })
+
+    expect(response.json()).toMatchSnapshot()
+  })
+
+  it('should return success for base and quote overriden by default adapter overrides', async () => {
+    const response = await testAdapter.request({
+      base: 'EUR',
+      quote: 'USD',
+    })
+
     expect(response.json()).toMatchSnapshot()
   })
 })

--- a/packages/sources/finnhub-secondary/test/integration/fixtures.ts
+++ b/packages/sources/finnhub-secondary/test/integration/fixtures.ts
@@ -55,29 +55,4 @@ export const mockResponseSuccess = (): nock.Scope => {
         'Origin',
       ],
     )
-    .get('/quote')
-    .query({ token: 'fake-api-key', symbol: 'OANDA:GBP_USD' })
-    .reply(
-      200,
-      () => ({
-        c: 1.2357,
-        d: 0.00336,
-        dp: 0.1954,
-        h: 1.23573,
-        l: 1.23577,
-        o: 1.2357,
-        pc: 1.23578,
-        t: 1636322400,
-      }),
-      [
-        'Content-Type',
-        'application/json',
-        'Connection',
-        'close',
-        'Vary',
-        'Accept-Encoding',
-        'Vary',
-        'Origin',
-      ],
-    )
 }

--- a/packages/sources/finnhub/test/integration/__snapshots__/adapter-rest.test.ts.snap
+++ b/packages/sources/finnhub/test/integration/__snapshots__/adapter-rest.test.ts.snap
@@ -14,7 +14,7 @@ exports[`rest forex endpoint (quote alias) should return success 1`] = `
 }
 `;
 
-exports[`rest quote endpoint should return success 1`] = `
+exports[`rest quote endpoint should return success for full symbol 1`] = `
 {
   "data": {
     "result": 1.15894,
@@ -31,9 +31,23 @@ exports[`rest quote endpoint should return success 1`] = `
 exports[`rest quote endpoint should return success for requests with overrides 1`] = `
 {
   "data": {
-    "result": 1.2357,
+    "result": 1.15894,
   },
-  "result": 1.2357,
+  "result": 1.15894,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 1641035471111,
+    "providerDataRequestedUnixMs": 1641035471111,
+  },
+}
+`;
+
+exports[`rest quote endpoint should return success for requests overriden by default adapter overrides 1`] = `
+{
+  "data": {
+    "result": 1.15894,
+  },
+  "result": 1.15894,
   "statusCode": 200,
   "timestamps": {
     "providerDataReceivedUnixMs": 1641035471111,

--- a/packages/sources/finnhub/test/integration/__snapshots__/adapter-ws.test.ts.snap
+++ b/packages/sources/finnhub/test/integration/__snapshots__/adapter-ws.test.ts.snap
@@ -1,6 +1,36 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`websocket should return success 1`] = `
+exports[`websocket should return success for full symbols 1`] = `
+{
+  "data": {
+    "result": 1.098455,
+  },
+  "result": 1.098455,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 1018,
+    "providerDataStreamEstablishedUnixMs": 1010,
+    "providerIndicatedTimeUnixMs": 1641035471111,
+  },
+}
+`;
+
+exports[`websocket should return success for base overriden by default adapter overrides 1`] = `
+{
+  "data": {
+    "result": 1.098455,
+  },
+  "result": 1.098455,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 1018,
+    "providerDataStreamEstablishedUnixMs": 1010,
+    "providerIndicatedTimeUnixMs": 1641035471111,
+  },
+}
+`;
+
+exports[`websocket should return success for base and quote overriden by default adapter overrides 1`] = `
 {
   "data": {
     "result": 1.098455,

--- a/packages/sources/finnhub/test/integration/adapter-rest.test.ts
+++ b/packages/sources/finnhub/test/integration/adapter-rest.test.ts
@@ -32,9 +32,9 @@ describe('rest', () => {
   })
 
   describe('quote endpoint', () => {
-    it('should return success', async () => {
+    it('should return success for full symbol', async () => {
       const data = {
-        base: 'EUR',
+        base: 'FHFX:EUR-USD',
       }
       mockResponseSuccess()
       const response = await testAdapter.request(data)
@@ -44,10 +44,20 @@ describe('rest', () => {
 
     it('should return success for requests with overrides', async () => {
       const data = {
-        base: 'GBP',
+        base: 'EUR',
         overrides: {
-          finnhub: { GBP: 'FHFX:GBP-USD' },
+          finnhub: { EUR: 'FHFX:EUR-USD' },
         },
+      }
+      mockResponseSuccess()
+      const response = await testAdapter.request(data)
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toMatchSnapshot()
+    })
+
+    it('should return success for requests overriden by default adapter overrides', async () => {
+      const data = {
+        base: 'EUR',
       }
       mockResponseSuccess()
       const response = await testAdapter.request(data)

--- a/packages/sources/finnhub/test/integration/adapter-ws.test.ts
+++ b/packages/sources/finnhub/test/integration/adapter-ws.test.ts
@@ -17,7 +17,7 @@ const mockWebSocketServer = (url: string) => {
             {
               c: null,
               p: 1.098455,
-              s: 'OANDA:EUR_USD',
+              s: 'FHFX:EUR-USD',
               t: 1641035471111,
               v: 0,
             },
@@ -34,7 +34,7 @@ describe('websocket', () => {
   const wsEndpoint = 'wss://ws.finnhub.io'
 
   const data = {
-    base: 'OANDA:EUR_USD',
+    base: 'FHFX:EUR-USD',
   }
 
   let spy: jest.SpyInstance
@@ -73,8 +73,28 @@ describe('websocket', () => {
     spy.mockRestore()
   })
 
-  it('should return success', async () => {
-    const response = await testAdapter.request(data)
+  it('should return success for full symbols', async () => {
+    const response = await testAdapter.request({
+      base: 'FHFX:EUR-USD',
+    })
+
+    expect(response.json()).toMatchSnapshot()
+  })
+
+  it('should return success for base overriden by default adapter overrides', async () => {
+    const response = await testAdapter.request({
+      base: 'EUR',
+    })
+
+    expect(response.json()).toMatchSnapshot()
+  })
+
+  it('should return success for base and quote overriden by default adapter overrides', async () => {
+    const response = await testAdapter.request({
+      base: 'EUR',
+      quote: 'USD',
+    })
+
     expect(response.json()).toMatchSnapshot()
   })
 })

--- a/packages/sources/finnhub/test/integration/fixtures.ts
+++ b/packages/sources/finnhub/test/integration/fixtures.ts
@@ -55,29 +55,4 @@ export const mockResponseSuccess = (): nock.Scope => {
         'Origin',
       ],
     )
-    .get('/quote')
-    .query({ token: 'fake-api-key', symbol: 'FHFX:GBP-USD' })
-    .reply(
-      200,
-      () => ({
-        c: 1.2357,
-        d: 0.00336,
-        dp: 0.1954,
-        h: 1.23573,
-        l: 1.23577,
-        o: 1.2357,
-        pc: 1.23578,
-        t: 1636322400,
-      }),
-      [
-        'Content-Type',
-        'application/json',
-        'Connection',
-        'close',
-        'Vary',
-        'Accept-Encoding',
-        'Vary',
-        'Origin',
-      ],
-    )
 }


### PR DESCRIPTION


## Closes [DF-18995](https://smartcontract-it.atlassian.net/browse/DF-18995)

## Description

* Fixes an issue where Finnhub EA's would fail for certain requests when using WebSockets.
* Previously Finnhub WebSocket requests would succeed for full symbols (e.g. {"base": "OANDA:EUR_USD"}), but fail for requests with separate base and quote (e.g. {"base": "EUR", "quote: "USD"}). This is because the WebSocket message returns a single symbol which is cached as the base, and future requests included a quote so did not match the cached key.
* This commit fixes the above by introducing a requestTransform for the endpoint. The requestTransform checks if the symbol is a full symbol (e.g. OANDA:EUR_USD), and if so discards any quote provided as only the base will be used anyway. This keeps the cache key consistent when writing and reading for both REST and WS. The full symbol is expected to be provided, either via the request or derived from adapter/provided overrides. 

## Changes

* Added requestHandler to the Finnhub Quote endpoint, to discard the quote if the full symbol is provided.
* Added new tests to catch the previous issue

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

Tested against both `finnhub` and `finnhub-secondary`, for `WS_ENABLED` = `true` and `false`
* `curl --request POST \ --url http://localhost:8080/ \ --header 'Content-Type: application/json' \ --data '{ "id": "1", "data": { "from": "GBP", "to": "USD" } }'`
* `curl --request POST \ --url http://localhost:8080/ \ --header 'Content-Type: application/json' \ --data '{ "id": "1", "data": { "from": "GBP" } }'`
* `curl --request POST \ --url http://localhost:8080/ \ --header 'Content-Type: application/json' \ --data '{ "id": "1", "data": { "from": "OANDA:GBP_USD" } }'`
* `curl --request POST \ --url http://localhost:8080/ \ --header 'Content-Type: application/json' \ --data '{ "id": "1", "data": { "from": "FHFX:GBP-USD" } }'`
* `curl --request POST \ --url http://localhost:8080/ \ --header 'Content-Type: application/json' \ --data '{ "id": "1", "data": { "from": "AAPL" } }'`

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
