### PR TITLE
Increase default API_TIMEOUT for avalanche-platform

### DIFF
--- a/.changeset/thin-rats-fold.md
+++ b/.changeset/thin-rats-fold.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/avalanche-platform-adapter': patch
+---
+
+Increased default API_TIMEOUT to 60s

--- a/packages/sources/avalanche-platform/src/config/envDefaultOverrides.ts
+++ b/packages/sources/avalanche-platform/src/config/envDefaultOverrides.ts
@@ -1,0 +1,5 @@
+import type { EnvDefaultOverrides } from '@chainlink/ea-bootstrap'
+
+export const envDefaultOverrides: EnvDefaultOverrides = {
+  API_TIMEOUT: '60000',
+}

--- a/packages/sources/avalanche-platform/src/index.ts
+++ b/packages/sources/avalanche-platform/src/index.ts
@@ -2,8 +2,9 @@ import { expose } from '@chainlink/ea-bootstrap'
 import { makeExecute, endpointSelector } from './adapter'
 import * as endpoints from './endpoint'
 import { makeConfig, NAME } from './config'
+import { envDefaultOverrides } from './config/envDefaultOverrides'
 
-const adapterContext = { name: NAME }
+const adapterContext = { name: NAME, envDefaultOverrides }
 
 const { server } = expose(adapterContext, makeExecute(), undefined, endpointSelector)
 export { NAME, makeExecute, makeConfig, server, endpoints }


### PR DESCRIPTION
## Closes [PDI-2249](https://smartcontract-it.atlassian.net/browse/PDI-2249)

## Description

Increased default API timeout on the `avalanche-platform` adapter due to longer response time for the new RPC method `platform.getStake`

## Changes

- Added env default override for `API_TIMEOUT` to 60000

## Steps to Test

1. yarn test packages/sources/avalanche-platform/test

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[PDI-2249]: https://smartcontract-it.atlassian.net/browse/PDI-2249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ