### PR TITLE
Layer2 Sequencer Health: Support Base chain

### DIFF
--- a/.changeset/kind-insects-happen.md
+++ b/.changeset/kind-insects-happen.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/layer2-sequencer-health-adapter': minor
+---
+
+Layer2 Sequencer Health: Support Base chain

--- a/packages/sources/layer2-sequencer-health/README.md
+++ b/packages/sources/layer2-sequencer-health/README.md
@@ -15,6 +15,9 @@ Adapter that checks the Layer 2 Sequencer status
 |           |      `OPTIMISM_RPC_ENDPOINT`      |                              Optimism RPC Endpoint                              |         |                   https://mainnet.optimism.io                    |
 |           |    `OPTIMISM_HEALTH_ENDPOINT`     |                            Optimism Health Endpoint                             |         |           https://mainnet-sequencer.optimism.io/health           |
 |           |        `OPTIMISM_CHAIN_ID`        |                           The chain id to connect to                            |         |                                10                                |
+|           |        `BASE_RPC_ENDPOINT`        |                                Base RPC Endpoint                                |         |                     https://mainnet.base.org                     |
+|           |      `BASE_HEALTH_ENDPOINT`       |                              Base Health Endpoint                               |         |                                                                  |
+|           |          `BASE_CHAIN_ID`          |                           The chain id to connect to                            |         |                               8453                               |
 |           |       `METIS_RPC_ENDPOINT`        |                               Metis RPC Endpoint                                |         |              https://andromeda.metis.io/?owner=1088              |
 |           |      `METIS_HEALTH_ENDPOINT`      |                              Metis Health Endpoint                              |         |            https://tokenapi.metis.io/andromeda/health            |
 |           |         `METIS_CHAIN_ID`          |                           The chain id to connect to                            |         |                               1088                               |
@@ -29,9 +32,9 @@ For the adapter to be useful on the desired network, at least one endpoint (RPC 
 
 ### Input Parameters
 
-| Required? |  Name   |       Description        |                   Options                    | Defaults to |
-| :-------: | :-----: | :----------------------: | :------------------------------------------: | :---------: |
-|    ✅     | network | Layer 2 Network to check | `arbitrum`, `optimism`, `metis`, `starkware` |             |
+| Required? |  Name   |       Description        |                       Options                        | Defaults to |
+| :-------: | :-----: | :----------------------: | :--------------------------------------------------: | :---------: |
+|    ✅     | network | Layer 2 Network to check | `arbitrum`, `optimism`, `base`, `metis`, `starkware` |             |
 
 ---
 

--- a/packages/sources/layer2-sequencer-health/schemas/env.json
+++ b/packages/sources/layer2-sequencer-health/schemas/env.json
@@ -36,6 +36,20 @@
       "type": "string",
       "default": "10"
     },
+    "BASE_RPC_ENDPOINT": {
+      "type": "string",
+      "default": "https://mainnet.base.org"
+    },
+    "BASE_HEALTH_ENDPOINT": {
+      "type": "string",
+      "default": ""
+    },
+    "BASE_CHAIN_ID": {
+      "required": false,
+      "description": "The blockchain id to connect to",
+      "type": "string",
+      "default": "8453"
+    },
     "METIS_RPC_ENDPOINT": {
       "type": "string",
       "default": "https://andromeda.metis.io/?owner=1088"

--- a/packages/sources/layer2-sequencer-health/src/config/index.ts
+++ b/packages/sources/layer2-sequencer-health/src/config/index.ts
@@ -24,19 +24,23 @@ export const DEFAULT_RETRY_INTERVAL = 5 * 100
 
 export const ENV_ARBITRUM_RPC_ENDPOINT = 'ARBITRUM_RPC_ENDPOINT'
 export const ENV_OPTIMISM_RPC_ENDPOINT = 'OPTIMISM_RPC_ENDPOINT'
+export const ENV_BASE_RPC_ENDPOINT = 'BASE_RPC_ENDPOINT'
 export const ENV_METIS_RPC_ENDPOINT = 'METIS_RPC_ENDPOINT'
 
 export const ENV_ARBITRUM_CHAIN_ID = 'ARBITRUM_CHAIN_ID'
 export const ENV_OPTIMISM_CHAIN_ID = 'OPTIMISM_CHAIN_ID'
+export const ENV_BASE_CHAIN_ID = 'BASE_CHAIN_ID'
 export const ENV_METIS_CHAIN_ID = 'METIS_CHAIN_ID'
 
 export const DEFAULT_ARBITRUM_CHAIN_ID = '42161'
 export const DEFAULT_OPTIMISM_CHAIN_ID = '10'
+export const DEFAULT_BASE_CHAIN_ID = '8453'
 export const DEFAULT_METIS_CHAIN_ID = '1088'
 
 export enum Networks {
   Arbitrum = 'arbitrum',
   Optimism = 'optimism',
+  Base = 'base',
   Metis = 'metis',
   Starkware = 'starkware',
 }
@@ -45,21 +49,26 @@ export type EVMNetworks = Exclude<Networks, Networks.Starkware>
 
 const DEFAULT_ARBITRUM_RPC_ENDPOINT = 'https://arb1.arbitrum.io/rpc'
 const DEFAULT_OPTIMISM_RPC_ENDPOINT = 'https://mainnet.optimism.io'
+const DEFAULT_BASE_RPC_ENDPOINT = 'https://mainnet.base.org'
 const DEFAULT_METIS_RPC_ENDPOINT = 'https://andromeda.metis.io/?owner=1088'
 
 export const RPC_ENDPOINTS: Record<EVMNetworks, string | undefined> = {
   [Networks.Arbitrum]: util.getEnv(ENV_ARBITRUM_RPC_ENDPOINT) || DEFAULT_ARBITRUM_RPC_ENDPOINT,
   [Networks.Optimism]: util.getEnv(ENV_OPTIMISM_RPC_ENDPOINT) || DEFAULT_OPTIMISM_RPC_ENDPOINT,
+  [Networks.Base]: util.getEnv(ENV_BASE_RPC_ENDPOINT) || DEFAULT_BASE_RPC_ENDPOINT,
   [Networks.Metis]: util.getEnv(ENV_METIS_RPC_ENDPOINT) || DEFAULT_METIS_RPC_ENDPOINT,
 }
 
-export const CHAIN_IDS = {
+export const CHAIN_IDS: Record<EVMNetworks, number | undefined | string> = {
   [Networks.Arbitrum]:
     parseInt(util.getEnv(ENV_ARBITRUM_CHAIN_ID) || DEFAULT_ARBITRUM_CHAIN_ID) ||
     util.getEnv(ENV_ARBITRUM_CHAIN_ID),
   [Networks.Optimism]:
     parseInt(util.getEnv(ENV_OPTIMISM_CHAIN_ID) || DEFAULT_OPTIMISM_CHAIN_ID) ||
     util.getEnv(ENV_OPTIMISM_CHAIN_ID),
+  [Networks.Base]:
+    parseInt(util.getEnv(ENV_BASE_CHAIN_ID) || DEFAULT_BASE_CHAIN_ID) ||
+    util.getEnv(ENV_BASE_CHAIN_ID),
   [Networks.Metis]:
     parseInt(util.getEnv(ENV_METIS_CHAIN_ID) || DEFAULT_METIS_CHAIN_ID) ||
     util.getEnv(ENV_METIS_CHAIN_ID),
@@ -67,7 +76,10 @@ export const CHAIN_IDS = {
 
 const DEFAULT_OPTIMISM_HEALTH_ENDPOINT = 'https://mainnet-sequencer.optimism.io/health'
 const DEFAULT_METIS_HEALTH_ENDPOINT = 'https://tokenapi.metis.io/andromeda/health'
-export const HEALTH_ENDPOINTS = {
+export const HEALTH_ENDPOINTS: Record<
+  Networks,
+  { endpoint: string | undefined; responsePath: string[] }
+> = {
   [Networks.Arbitrum]: {
     endpoint: util.getEnv('ARBITRUM_HEALTH_ENDPOINT'),
     responsePath: [],
@@ -75,6 +87,10 @@ export const HEALTH_ENDPOINTS = {
   [Networks.Optimism]: {
     endpoint: util.getEnv('OPTIMISM_HEALTH_ENDPOINT') || DEFAULT_OPTIMISM_HEALTH_ENDPOINT,
     responsePath: ['healthy'],
+  },
+  [Networks.Base]: {
+    endpoint: util.getEnv('BASE_HEALTH_ENDPOINT'),
+    responsePath: [],
   },
   [Networks.Metis]: {
     endpoint: util.getEnv('METIS_HEALTH_ENDPOINT') || DEFAULT_METIS_HEALTH_ENDPOINT,

--- a/packages/sources/layer2-sequencer-health/src/evm.ts
+++ b/packages/sources/layer2-sequencer-health/src/evm.ts
@@ -39,6 +39,12 @@ export const sendEVMDummyTransaction = async (
       gasPrice: 0,
       to: wallet.address,
     },
+    [Networks.Base]: {
+      value: 0,
+      gasLimit: 0,
+      gasPrice: 0,
+      to: wallet.address,
+    },
     [Networks.Metis]: {
       value: 0,
       gasLimit: 0,
@@ -59,6 +65,10 @@ const lastSeenBlock: Record<EVMNetworks, { block: number; timestamp: number }> =
     timestamp: 0,
   },
   [Networks.Optimism]: {
+    block: 0,
+    timestamp: 0,
+  },
+  [Networks.Base]: {
     block: 0,
     timestamp: 0,
   },

--- a/packages/sources/layer2-sequencer-health/src/network.ts
+++ b/packages/sources/layer2-sequencer-health/src/network.ts
@@ -15,6 +15,7 @@ const sequencerOnlineErrors: Record<Networks, string[]> = {
   [Networks.Arbitrum]: ['gas price too low', 'forbidden sender address', 'intrinsic gas too low'],
   // TODO: Optimism error needs to be confirmed by their team
   [Networks.Optimism]: ['cannot accept 0 gas price transaction'],
+  [Networks.Base]: ['transaction underpriced'],
   [Networks.Metis]: ['cannot accept 0 gas price transaction'],
   // Sending an empty transaction to the dummy Starknet address should return one
   // of the following error messages.  The Sequencer is considered healthy if the
@@ -81,9 +82,10 @@ const sendEmptyTransaction = async (network: Networks, config: ExtendedConfig): 
 
 const isExpectedErrorMessage = (network: Networks, e: Error) => {
   const _getErrorMessage = (e: Error): string => {
-    const paths = {
+    const paths: Record<Networks, string[]> = {
       [Networks.Arbitrum]: ['error', 'message'],
       [Networks.Optimism]: ['error', 'message'],
+      [Networks.Base]: ['error', 'message'],
       [Networks.Metis]: ['error', 'message'],
       [Networks.Starkware]: ['errorCode'],
     }

--- a/packages/sources/layer2-sequencer-health/test/integration/__snapshots__/onchainFailKnown.test.ts.snap
+++ b/packages/sources/layer2-sequencer-health/test/integration/__snapshots__/onchainFailKnown.test.ts.snap
@@ -11,6 +11,17 @@ exports[`execute arbitrum network should return success when transaction submiss
 }
 `;
 
+exports[`execute base network should return success when transaction submission is known 1`] = `
+{
+  "data": {
+    "result": 0,
+  },
+  "jobRunID": "1",
+  "result": 0,
+  "statusCode": 200,
+}
+`;
+
 exports[`execute optimism network should return success when transaction submission is known 1`] = `
 {
   "data": {

--- a/packages/sources/layer2-sequencer-health/test/integration/__snapshots__/onchainFailUnknown.test.ts.snap
+++ b/packages/sources/layer2-sequencer-health/test/integration/__snapshots__/onchainFailUnknown.test.ts.snap
@@ -11,6 +11,17 @@ exports[`execute arbitrum network should return failure when transaction submiss
 }
 `;
 
+exports[`execute base network should return failure when transaction submission is unknown 1`] = `
+{
+  "data": {
+    "result": 1,
+  },
+  "jobRunID": "1",
+  "result": 1,
+  "statusCode": 200,
+}
+`;
+
 exports[`execute optimism network should return failure when transaction submission is unknown 1`] = `
 {
   "data": {

--- a/packages/sources/layer2-sequencer-health/test/integration/__snapshots__/onchainSuccess.test.ts.snap
+++ b/packages/sources/layer2-sequencer-health/test/integration/__snapshots__/onchainSuccess.test.ts.snap
@@ -22,6 +22,28 @@ exports[`execute arbitrum network should return transaction submission is succes
 }
 `;
 
+exports[`execute base network should return success when all methods succeed 1`] = `
+{
+  "data": {
+    "result": 0,
+  },
+  "jobRunID": "1",
+  "result": 0,
+  "statusCode": 200,
+}
+`;
+
+exports[`execute base network should return transaction submission is successful 1`] = `
+{
+  "data": {
+    "result": 0,
+  },
+  "jobRunID": "1",
+  "result": 0,
+  "statusCode": 200,
+}
+`;
+
 exports[`execute optimism network should return success when all methods succeed 1`] = `
 {
   "data": {

--- a/packages/sources/layer2-sequencer-health/test/integration/fixtures.ts
+++ b/packages/sources/layer2-sequencer-health/test/integration/fixtures.ts
@@ -44,6 +44,19 @@ export const mockResponseSuccessBlock = (): void => {
       'Vary',
       'Origin',
     ])
+
+  nock('https://mainnet.base.org')
+    .post('/', { jsonrpc: '2.0', method: 'eth_blockNumber', params: [], id: /^\d+$/ })
+    .reply(200, () => ({ jsonrpc: '2.0', id: 1, result: '0x42d293' }), [
+      'Content-Type',
+      'application/json',
+      'Connection',
+      'close',
+      'Vary',
+      'Accept-Encoding',
+      'Vary',
+      'Origin',
+    ])
 }
 
 export const mockResponseSuccessRollup = (): void => {
@@ -85,6 +98,19 @@ export const mockResponseFailureBlock = (): void => {
     ])
 
   nock('https://mainnet.optimism.io')
+    .post('/', { jsonrpc: '2.0', method: 'eth_blockNumber', params: [], id: /^\d+$/ })
+    .reply(200, () => ({ jsonrpc: '2.0', id: 1, result: '0x00' }), [
+      'Content-Type',
+      'application/json',
+      'Connection',
+      'close',
+      'Vary',
+      'Accept-Encoding',
+      'Vary',
+      'Origin',
+    ])
+
+  nock('https://mainnet.base.org')
     .post('/', { jsonrpc: '2.0', method: 'eth_blockNumber', params: [], id: /^\d+$/ })
     .reply(200, () => ({ jsonrpc: '2.0', id: 1, result: '0x00' }), [
       'Content-Type',

--- a/packages/sources/layer2-sequencer-health/test/integration/onchainFailKnown.test.ts
+++ b/packages/sources/layer2-sequencer-health/test/integration/onchainFailKnown.test.ts
@@ -9,6 +9,7 @@ import { SuperTest, Test } from 'supertest'
 const mockMessages = {
   'https://arb1.arbitrum.io/rpc': 'gas price too low',
   'https://mainnet.optimism.io': 'cannot accept 0 gas price transaction',
+  'https://mainnet.base.org': 'transaction underpriced',
 }
 
 jest.mock('ethers', () => {
@@ -72,6 +73,30 @@ describe('execute', () => {
       id,
       data: {
         network: 'optimism',
+      },
+    }
+
+    it('should return success when transaction submission is known', async () => {
+      mockResponseFailureHealth()
+      mockResponseFailureBlock()
+
+      const response = await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+      expect(response.body.result).toEqual(0)
+      expect(response.body).toMatchSnapshot()
+    })
+  })
+
+  describe('base network', () => {
+    const data: AdapterRequest = {
+      id,
+      data: {
+        network: 'base',
       },
     }
 

--- a/packages/sources/layer2-sequencer-health/test/integration/onchainFailUnknown.test.ts
+++ b/packages/sources/layer2-sequencer-health/test/integration/onchainFailUnknown.test.ts
@@ -108,4 +108,28 @@ describe('execute', () => {
       expect(response.body).toMatchSnapshot()
     })
   })
+
+  describe('base network', () => {
+    const data: AdapterRequest = {
+      id,
+      data: {
+        network: 'base',
+      },
+    }
+
+    it('should return failure when transaction submission is unknown', async () => {
+      mockResponseFailureHealth()
+      mockResponseFailureBlock()
+
+      const response = await req
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+      expect(response.body.result).toEqual(1)
+      expect(response.body).toMatchSnapshot()
+    })
+  })
 })

--- a/packages/sources/layer2-sequencer-health/test/integration/onchainSuccess.test.ts
+++ b/packages/sources/layer2-sequencer-health/test/integration/onchainSuccess.test.ts
@@ -177,4 +177,43 @@ describe('execute', () => {
       expect(response.body).toMatchSnapshot()
     })
   })
+
+  describe('base network', () => {
+    const data: AdapterRequest = {
+      id,
+      data: {
+        network: 'base',
+      },
+    }
+
+    it('should return success when all methods succeed', async () => {
+      mockResponseSuccessHealth()
+      mockResponseSuccessBlock()
+
+      const response = await req
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+      expect(response.body.result).toEqual(0)
+      expect(response.body).toMatchSnapshot()
+    })
+
+    it('should return transaction submission is successful', async () => {
+      mockResponseFailureHealth()
+      mockResponseFailureBlock()
+
+      const response = await req
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+      expect(response.body.result).toEqual(0)
+      expect(response.body).toMatchSnapshot()
+    })
+  })
 })


### PR DESCRIPTION
## Closes [DF-19069](https://smartcontract-it.atlassian.net/browse/DF-19069)

## Description
- Add support for Base chain to the Layer2 Sequencer Health EA.
- As the Base Sequencer does not yet have a health endpoint, the health is determined by checking the most recent block is not stale. If that fails, an empty transaction will be submitted to check the sequencer is responding.

## Changes

- Add Base config
- Add types to ensure a Network config is not missed
- Add tests for Base

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. `curl --request POST \ --url http://localhost:8080/ \ --header 'Content-Type: application/json' \ --data '{ "id": "1", "data": { "endpoint": "health", "network": "base" } }'`
2. Manually tested that empty transaction is made when most recent block is stale by intercepting blockNumber request.

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[DF-19069]: https://smartcontract-it.atlassian.net/browse/DF-19069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ