### PR TITLE
Add ripcord indicator check to Armanino STBT endpoint

### DIFF
--- a/.changeset/tiny-weeks-beg.md
+++ b/.changeset/tiny-weeks-beg.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/armanino-adapter': minor
+---
+
+Added ripcord indicator check to STBT endpoint

--- a/packages/sources/armanino/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/armanino/test/integration/__snapshots__/adapter.test.ts.snap
@@ -12,6 +12,25 @@ exports[`execute mco2 endpoint should return success 1`] = `
 }
 `;
 
+exports[`execute stbt endpoint should return error when ripcord true 1`] = `
+{
+  "error": {
+    "errorResponse": {
+      "ripcord": true,
+      "ripcordDetails": [
+        "Balances",
+      ],
+    },
+    "feedID": "{"data":{"endpoint":"stbt"}}",
+    "message": "Ripcord indicator true. Details: Balances",
+    "name": "AdapterError",
+  },
+  "jobRunID": "1",
+  "status": "errored",
+  "statusCode": 502,
+}
+`;
+
 exports[`execute stbt endpoint should return success 1`] = `
 {
   "data": {

--- a/packages/sources/armanino/test/integration/adapter.test.ts
+++ b/packages/sources/armanino/test/integration/adapter.test.ts
@@ -1,6 +1,6 @@
 import { AdapterRequest } from '@chainlink/ea-bootstrap'
 import { server as startServer } from '../../src'
-import { mockMCO2Response, mockSTBTResponse } from './fixtures'
+import { mockMCO2Response, mockSTBTResponseSuccess, mockSTBTResponseFailure } from './fixtures'
 import { setupExternalAdapterTest } from '@chainlink/ea-test-helpers'
 import type { SuiteContext } from '@chainlink/ea-test-helpers'
 import { SuperTest, Test } from 'supertest'
@@ -45,7 +45,7 @@ describe('execute', () => {
     }
 
     it('should return success', async () => {
-      mockSTBTResponse()
+      mockSTBTResponseSuccess()
 
       const response = await (context.req as SuperTest<Test>)
         .post('/')
@@ -54,6 +54,18 @@ describe('execute', () => {
         .set('Content-Type', 'application/json')
         .expect('Content-Type', /json/)
         .expect(200)
+      expect(response.body).toMatchSnapshot()
+    })
+
+    it('should return error when ripcord true', async () => {
+      mockSTBTResponseFailure()
+
+      const response = await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(request)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
       expect(response.body).toMatchSnapshot()
     })
   })

--- a/packages/sources/armanino/test/integration/fixtures.ts
+++ b/packages/sources/armanino/test/integration/fixtures.ts
@@ -40,7 +40,7 @@ export const mockMCO2Response = (): nock.Scope =>
       ],
     )
 
-export const mockSTBTResponse = (): nock.Scope =>
+export const mockSTBTResponseSuccess = (): nock.Scope =>
   nock('https://api.oracle-services.ledgerlens.io/v1/chainlink/proof-of-reserves/', {
     encodedQueryParams: true,
   })
@@ -50,4 +50,20 @@ export const mockSTBTResponse = (): nock.Scope =>
       totalReserve: 72178807.56,
       totalToken: 71932154.99,
       timestamp: '2023-06-02T12:53:23.604Z',
+      ripcord: false,
+      ripcordDetails: [],
+    })
+
+export const mockSTBTResponseFailure = (): nock.Scope =>
+  nock('https://api.oracle-services.ledgerlens.io/v1/chainlink/proof-of-reserves/', {
+    encodedQueryParams: true,
+  })
+    .get('/STBT')
+    .reply(200, {
+      accountName: 'STBT',
+      totalReserve: 72178807.56,
+      totalToken: 71932154.99,
+      timestamp: '2023-06-02T12:53:23.604Z',
+      ripcord: true,
+      ripcordDetails: ['Balances'],
     })


### PR DESCRIPTION
## Closes [PDI-2255](https://smartcontract-it.atlassian.net/browse/PDI-2255)

## Description

Added check for the newly added ripcord indicator. `armanino` adapter's `stbt` endpoint will throw an error if it finds the indicator to be true.

## Changes

- Throw error if new ripcord indicator found to be true in stbt endpoint

## Steps to Test

1. yarn test packages/sources/armanino/test

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[PDI-2255]: https://smartcontract-it.atlassian.net/browse/PDI-2255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ