### PR TITLE
Set eth-beacon BACKGROUND_EXECUTE_TIMEOUT default to max

### DIFF
--- a/.changeset/curvy-pets-cheat.md
+++ b/.changeset/curvy-pets-cheat.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/eth-beacon-adapter': patch
+---
+
+Set env default override for BACKGROUND_EXECUTE_TIMEOUT to the max 180s

--- a/packages/sources/eth-beacon/src/config/index.ts
+++ b/packages/sources/eth-beacon/src/config/index.ts
@@ -40,6 +40,7 @@ export const config = new AdapterConfig(
   {
     envDefaultOverrides: {
       API_TIMEOUT: 60000,
+      BACKGROUND_EXECUTE_TIMEOUT: 180_000,
     },
   },
 )


### PR DESCRIPTION
Set `eth-beacon` v3 env default override for `BACKGROUND_EXECUTE_TIMEOUT` to the max 180s since PoR requests take longer to process