### PR TITLE
Add sleep to bg execute on eth-beacon and view-function v3

### DIFF
--- a/.changeset/eight-ducks-cheat.md
+++ b/.changeset/eight-ducks-cheat.md
@@ -1,0 +1,6 @@
+---
+'@chainlink/eth-beacon-adapter': patch
+'@chainlink/view-function-adapter': patch
+---
+
+Added sleep to background execute to limit request processing

--- a/packages/sources/eth-beacon/src/transport/balance.ts
+++ b/packages/sources/eth-beacon/src/transport/balance.ts
@@ -79,11 +79,8 @@ export class BalanceTransport extends SubscriptionTransport<BalanceTransportType
   }
 
   async backgroundHandler(context: EndpointContext<BaseEndpointTypes>, entries: RequestParams[]) {
-    if (!entries.length) {
-      await sleep(context.adapterSettings.BACKGROUND_EXECUTE_MS)
-      return
-    }
     await Promise.all(entries.map(async (param) => this.handleRequest(param)))
+    await sleep(context.adapterSettings.BACKGROUND_EXECUTE_MS)
   }
 
   async handleRequest(param: RequestParams) {

--- a/packages/sources/view-function/src/transport/function.ts
+++ b/packages/sources/view-function/src/transport/function.ts
@@ -26,11 +26,8 @@ export class FunctionTransport extends SubscriptionTransport<FunctionTransportTy
   }
 
   async backgroundHandler(context: EndpointContext<BaseEndpointTypes>, entries: RequestParams[]) {
-    if (!entries.length) {
-      await sleep(context.adapterSettings.BACKGROUND_EXECUTE_MS)
-      return
-    }
     await Promise.all(entries.map(async (param) => this.handleRequest(param)))
+    await sleep(context.adapterSettings.BACKGROUND_EXECUTE_MS)
   }
 
   async handleRequest(param: RequestParams) {


### PR DESCRIPTION
## Description

Added sleep to the end of background executes to limit request processing. Otherwise the adapter moves onto the next cycle immediately resulting in excessive processing.

## Changes

- Added sleep at the end of background execute
- Default to 10s but configurable through the env var `BACKGROUND_EXECUTE_MS` 

## Steps to Test

1. yarn test packages/sources/eth-beacon/test
2. yarn test packages/sources/view-function/test

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
