### PR TITLE
Adjust rate limit defaults for trueusd and armanino

### DIFF
--- a/.changeset/lucky-beans-brush.md
+++ b/.changeset/lucky-beans-brush.md
@@ -1,0 +1,6 @@
+---
+'@chainlink/armanino-adapter': patch
+'@chainlink/trueusd-adapter': patch
+---
+
+Adjusted rate limit defaults

--- a/packages/sources/armanino/src/index.ts
+++ b/packages/sources/armanino/src/index.ts
@@ -11,8 +11,7 @@ export const adapter = new Adapter({
   rateLimiting: {
     tiers: {
       default: {
-        rateLimit1s: 50,
-        note: 'Considered unlimited tier, but setting reasonable limits',
+        rateLimit1m: 6,
       },
     },
   },

--- a/packages/sources/trueusd/src/index.ts
+++ b/packages/sources/trueusd/src/index.ts
@@ -11,8 +11,7 @@ export const adapter = new Adapter({
   rateLimiting: {
     tiers: {
       default: {
-        rateLimit1s: 5,
-        note: 'Considered unlimited tier, but setting reasonable limits',
+        rateLimit1m: 6,
       },
     },
   },


### PR DESCRIPTION
## Description

Reduced rate limit defaults for `armanino` and `trueusd` due to 403 from the providers at current defaults

## Changes

- Reduced default rate limit to 6 req/min

## Steps to Test

1. yarn test packages/sources/armanino/test
2. yarn test packages/sources/trueusd/test

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
