### PR TITLE
Fix avalanche-platform request to DP, change rate limit

### DIFF
--- a/.changeset/clever-dryers-switch.md
+++ b/.changeset/clever-dryers-switch.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/avalanche-platform-adapter': patch
+---
+
+Changed rate limit config, fixed a bug related to request to DP

--- a/packages/sources/avalanche-platform/src/index.ts
+++ b/packages/sources/avalanche-platform/src/index.ts
@@ -11,7 +11,7 @@ export const adapter = new PoRAdapter({
   rateLimiting: {
     tiers: {
       default: {
-        rateLimit1s: 5,
+        rateLimit1m: 6,
         note: 'Considered unlimited tier, but setting reasonable limits',
       },
     },

--- a/packages/sources/avalanche-platform/src/transport/balance.ts
+++ b/packages/sources/avalanche-platform/src/transport/balance.ts
@@ -40,6 +40,7 @@ export const httpTransport = new HttpTransport<HttpTransportTypes>({
             jsonrpc: '2.0',
             method: 'platform.getStake',
             params: { addresses: param.addresses.map(({ address }) => address) },
+            id: '1',
           },
         },
       }

--- a/packages/sources/avalanche-platform/test/integration/fixtures.ts
+++ b/packages/sources/avalanche-platform/test/integration/fixtures.ts
@@ -9,6 +9,7 @@ export const mockBalanceSuccess = (): nock.Scope =>
       params: {
         addresses: ['P-fuji1vd9sddlllrlk9fvj9lhntpw8t00lmvtnqkl2jt'],
       },
+      id: '1',
     })
     .reply(
       200,


### PR DESCRIPTION
Changed rate limit from 5 in one second to 6 in one minute. 
Added `id: '1'` to the request to DP

yarn test packages/sources/avalanche-platform