### PR TITLE
add validation for addresses input param (polkadot-balance, avalanche-platform, eth-beacon)

### DIFF
--- a/.changeset/many-rules-draw.md
+++ b/.changeset/many-rules-draw.md
@@ -1,0 +1,7 @@
+---
+'@chainlink/avalanche-platform-adapter': patch
+'@chainlink/eth-beacon-adapter': patch
+'@chainlink/polkadot-balance-adapter': patch
+---
+
+Add validation for 'addresses' input param

--- a/packages/sources/avalanche-platform/src/endpoint/balance.ts
+++ b/packages/sources/avalanche-platform/src/endpoint/balance.ts
@@ -5,6 +5,8 @@ import {
 import { InputParameters } from '@chainlink/external-adapter-framework/validation'
 import { config } from '../config'
 import { httpTransport } from '../transport/balance'
+import { AdapterRequest } from '@chainlink/external-adapter-framework/util'
+import { AdapterInputError } from '@chainlink/external-adapter-framework/validation/error'
 
 export const inputParameters = new InputParameters({
   addresses: {
@@ -38,4 +40,15 @@ export const endpoint = new PoRBalanceEndpoint({
   name: 'balance',
   transport: httpTransport,
   inputParameters,
+  customInputValidation: (
+    req: AdapterRequest<typeof inputParameters.validated>,
+  ): AdapterInputError | undefined => {
+    if (req.requestContext.data.addresses.length === 0) {
+      throw new AdapterInputError({
+        statusCode: 400,
+        message: `Input, at 'addresses' or 'result' path, must be a non-empty array.`,
+      })
+    }
+    return
+  },
 })

--- a/packages/sources/avalanche-platform/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/avalanche-platform/test/integration/__snapshots__/adapter.test.ts.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`execute balance endpoint should return error with empty addresses 1`] = `
+{
+  "error": {
+    "message": "Input, at 'addresses' or 'result' path, must be a non-empty array.",
+    "name": "AdapterError",
+  },
+  "status": "errored",
+  "statusCode": 400,
+}
+`;
+
 exports[`execute balance endpoint should return success 1`] = `
 {
   "data": {

--- a/packages/sources/avalanche-platform/test/integration/adapter.test.ts
+++ b/packages/sources/avalanche-platform/test/integration/adapter.test.ts
@@ -46,5 +46,14 @@ describe('execute', () => {
       expect(response.statusCode).toBe(200)
       expect(response.json()).toMatchSnapshot()
     })
+
+    it('should return error with empty addresses', async () => {
+      const data = {
+        result: [],
+      }
+      const response = await testAdapter.request(data)
+      expect(response.statusCode).toBe(400)
+      expect(response.json()).toMatchSnapshot()
+    })
   })
 })

--- a/packages/sources/eth-beacon/src/endpoint/balance.ts
+++ b/packages/sources/eth-beacon/src/endpoint/balance.ts
@@ -50,6 +50,13 @@ export const endpoint = new PoRBalanceEndpoint({
         message: `ETH_EXECUTION_RPC_URL env var must be set to perform limbo validator search. Please use an archive node.`,
       })
     }
+    if (request.requestContext.data.addresses.length === 0) {
+      throw new AdapterInputError({
+        statusCode: 400,
+        message: `Input, at 'addresses' or 'result' path, must be a non-empty array.`,
+      })
+    }
+
     return
   },
 })

--- a/packages/sources/eth-beacon/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/eth-beacon/test/integration/__snapshots__/adapter.test.ts.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`execute balance endpoint should return error with empty addresses 1`] = `
+{
+  "error": {
+    "message": "Input, at 'addresses' or 'result' path, must be a non-empty array.",
+    "name": "AdapterError",
+  },
+  "status": "errored",
+  "statusCode": 400,
+}
+`;
+
 exports[`execute balance endpoint should return success 1`] = `
 {
   "data": {

--- a/packages/sources/eth-beacon/test/integration/adapter.test.ts
+++ b/packages/sources/eth-beacon/test/integration/adapter.test.ts
@@ -153,5 +153,14 @@ describe('execute', () => {
       expect(response.statusCode).toBe(200)
       expect(response.json()).toMatchSnapshot()
     })
+
+    it('should return error with empty addresses', async () => {
+      const data = {
+        result: [],
+      }
+      const response = await testAdapter.request(data)
+      expect(response.statusCode).toBe(400)
+      expect(response.json()).toMatchSnapshot()
+    })
   })
 })

--- a/packages/sources/polkadot-balance/src/endpoint/balance.ts
+++ b/packages/sources/polkadot-balance/src/endpoint/balance.ts
@@ -6,6 +6,8 @@ import {
 import { InputParameters } from '@chainlink/external-adapter-framework/validation'
 import { config } from '../config'
 import { transport } from '../transport/balance'
+import { AdapterRequest } from '@chainlink/external-adapter-framework/util'
+import { AdapterInputError } from '@chainlink/external-adapter-framework/validation/error'
 
 export const inputParameters = new InputParameters(porBalanceEndpointInputParametersDefinition)
 
@@ -19,4 +21,15 @@ export const balanceEndpoint = new PoRBalanceEndpoint({
   name: 'balance',
   transport,
   inputParameters,
+  customInputValidation: (
+    req: AdapterRequest<typeof inputParameters.validated>,
+  ): AdapterInputError | undefined => {
+    if (req.requestContext.data.addresses.length === 0) {
+      throw new AdapterInputError({
+        statusCode: 400,
+        message: `Input, at 'addresses' or 'result' path, must be a non-empty array.`,
+      })
+    }
+    return
+  },
 })

--- a/packages/sources/polkadot-balance/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/polkadot-balance/test/integration/__snapshots__/adapter.test.ts.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Balance Endpoint should return error (empty addresses) 1`] = `
+{
+  "error": {
+    "message": "Input, at 'addresses' or 'result' path, must be a non-empty array.",
+    "name": "AdapterError",
+  },
+  "status": "errored",
+  "statusCode": 400,
+}
+`;
+
 exports[`Balance Endpoint should return success 1`] = `
 {
   "data": {

--- a/packages/sources/polkadot-balance/test/integration/adapter.test.ts
+++ b/packages/sources/polkadot-balance/test/integration/adapter.test.ts
@@ -134,5 +134,6 @@ describe('Balance Endpoint', () => {
   it('should return error (empty addresses)', async () => {
     const response = await testAdapter.request({ addresses: [] })
     expect(response.statusCode).toEqual(400)
+    expect(response.json()).toMatchSnapshot()
   })
 })

--- a/packages/sources/polkadot-balance/test/integration/adapter.test.ts
+++ b/packages/sources/polkadot-balance/test/integration/adapter.test.ts
@@ -130,4 +130,9 @@ describe('Balance Endpoint', () => {
     const response = await testAdapter.request({})
     expect(response.statusCode).toEqual(400)
   })
+
+  it('should return error (empty addresses)', async () => {
+    const response = await testAdapter.request({ addresses: [] })
+    expect(response.statusCode).toEqual(400)
+  })
 })


### PR DESCRIPTION
Added `customInputValidation` for `polkadot-balance`, `avalanche-platform` and `eth-beacon` that checks and throws an error when `addresses` input array is empty. 