### PR TITLE
Clean up v3 adapter tsconfigs

### DIFF
--- a/.changeset/hot-beds-think.md
+++ b/.changeset/hot-beds-think.md
@@ -1,0 +1,18 @@
+---
+'@chainlink/avalanche-platform-adapter': patch
+'@chainlink/bank-frick-adapter': patch
+'@chainlink/coinmarketcap-adapter': patch
+'@chainlink/coinpaprika-adapter': patch
+'@chainlink/dar-adapter': patch
+'@chainlink/eth-beacon-adapter': patch
+'@chainlink/finage-test-adapter': patch
+'@chainlink/galaxy-adapter': patch
+'@chainlink/gemini-adapter': patch
+'@chainlink/gramchain-adapter': patch
+'@chainlink/lotus-adapter': patch
+'@chainlink/trueusd-adapter': patch
+'@chainlink/twosigma-adapter': patch
+'@chainlink/wbtc-address-set-adapter': patch
+---
+
+Cleaned up tsconfig

--- a/packages/sources/avalanche-platform/tsconfig.json
+++ b/packages/sources/avalanche-platform/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*", "src/**/*.json"],
-  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
-  "references": [{ "path": "../../core/test-helpers" }, { "path": "../../core/bootstrap" }]
+  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]
 }

--- a/packages/sources/bank-frick/tsconfig.json
+++ b/packages/sources/bank-frick/tsconfig.json
@@ -5,10 +5,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*", "src/**/*.json"],
-  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
-  "references": [
-    { "path": "../../core/test-helpers" },
-    { "path": "../../core/bootstrap" },
-    { "path": "../../core/test-helpers" }
-  ]
+  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]
 }

--- a/packages/sources/coinmarketcap/tsconfig.json
+++ b/packages/sources/coinmarketcap/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*", "src/**/*.json"],
-  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
-  "references": [{ "path": "../../core/test-helpers" }, { "path": "../../core/bootstrap" }]
+  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]
 }

--- a/packages/sources/coinpaprika/tsconfig.json
+++ b/packages/sources/coinpaprika/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*", "src/**/*.json"],
-  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
-  "references": [{ "path": "../../core/test-helpers" }, { "path": "../../core/bootstrap" }]
+  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]
 }

--- a/packages/sources/dar/tsconfig.json
+++ b/packages/sources/dar/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*", "src/**/*.json"],
-  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
-  "references": [{ "path": "../../core/test-helpers" }, { "path": "../../core/bootstrap" }]
+  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]
 }

--- a/packages/sources/eth-beacon/tsconfig.json
+++ b/packages/sources/eth-beacon/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*", "src/**/*.json"],
-  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
-  "references": [{ "path": "../../core/test-helpers" }, { "path": "../../core/bootstrap" }]
+  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]
 }

--- a/packages/sources/finage-test/tsconfig.json
+++ b/packages/sources/finage-test/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*", "src/**/*.json"],
-  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
-  "references": [{ "path": "../../core/test-helpers" }, { "path": "../../core/bootstrap" }]
+  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]
 }

--- a/packages/sources/galaxy/tsconfig.json
+++ b/packages/sources/galaxy/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*", "src/**/*.json"],
-  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
-  "references": [{ "path": "../../core/test-helpers" }, { "path": "../../core/bootstrap" }]
+  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]
 }

--- a/packages/sources/gemini/tsconfig.json
+++ b/packages/sources/gemini/tsconfig.json
@@ -5,10 +5,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
-  "references": [
-    { "path": "../../core/test-helpers" },
-    { "path": "../../core/bootstrap" },
-    { "path": "../../core/test-helpers" }
-  ]
+  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]
 }

--- a/packages/sources/gramchain/tsconfig.json
+++ b/packages/sources/gramchain/tsconfig.json
@@ -5,10 +5,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
-  "references": [
-    { "path": "../../core/test-helpers" },
-    { "path": "../../core/bootstrap" },
-    { "path": "../../core/test-helpers" }
-  ]
+  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]
 }

--- a/packages/sources/lotus/tsconfig.json
+++ b/packages/sources/lotus/tsconfig.json
@@ -5,10 +5,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
-  "references": [
-    { "path": "../../core/test-helpers" },
-    { "path": "../../core/bootstrap" },
-    { "path": "../../sources/json-rpc" }
-  ]
+  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]
 }

--- a/packages/sources/trueusd/tsconfig.json
+++ b/packages/sources/trueusd/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
-  "references": [{ "path": "../../core/test-helpers" }, { "path": "../../core/bootstrap" }]
+  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]
 }

--- a/packages/sources/twosigma/tsconfig.json
+++ b/packages/sources/twosigma/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*", "src/**/*.json"],
-  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
-  "references": [{ "path": "../../core/test-helpers" }, { "path": "../../core/bootstrap" }]
+  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]
 }

--- a/packages/sources/wbtc-address-set/tsconfig.json
+++ b/packages/sources/wbtc-address-set/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
-  "references": [{ "path": "../../core/test-helpers" }, { "path": "../../core/bootstrap" }]
+  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]
 }


### PR DESCRIPTION
## Description

References to `core/bootstrap` and `core/test-helpers` were left behind after some v3 adapter migrations. This PR cleans those up