### PR TITLE
Add frxETH-ETH Exchange Rate Adapter.

### DIFF
--- a/.changeset/thin-eggs-wait.md
+++ b/.changeset/thin-eggs-wait.md
@@ -1,0 +1,9 @@
+---
+'@chainlink/frxeth-exchange-rate-adapter': major
+---
+
+Add frxETH-ETH Exchange Rate Adapter.
+
+- Adapter fetches the fraxETH-ETH exchange rate values from frxETH-ETH Dual Oracle contract.
+- Returns either priceHigh or priceLow, depending on the priceType parameter provided.
+- If `isBadData` flag is set in contract response, the EA returns an error.

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -480,6 +480,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         "reference": "workspace:packages/sources/fmpcloud"\
       },\
       {\
+        "name": "@chainlink/frxeth-exchange-rate-adapter",\
+        "reference": "workspace:packages/sources/frxeth-exchange-rate"\
+      },\
+      {\
         "name": "@chainlink/galaxis-adapter",\
         "reference": "workspace:packages/sources/galaxis"\
       },\
@@ -914,6 +918,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
       ["@chainlink/flightaware-adapter", ["workspace:packages/sources/flightaware"]],\
       ["@chainlink/fluent-finance-adapter", ["workspace:packages/sources/fluent-finance"]],\
       ["@chainlink/fmpcloud-adapter", ["workspace:packages/sources/fmpcloud"]],\
+      ["@chainlink/frxeth-exchange-rate-adapter", ["workspace:packages/sources/frxeth-exchange-rate"]],\
       ["@chainlink/galaxis-adapter", ["workspace:packages/sources/galaxis"]],\
       ["@chainlink/galaxy-adapter", ["workspace:packages/sources/galaxy"]],\
       ["@chainlink/gemini-adapter", ["workspace:packages/sources/gemini"]],\
@@ -7350,6 +7355,22 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/supertest", "npm:2.0.12"],\
             ["nock", "npm:13.2.9"],\
             ["supertest", "npm:6.2.4"],\
+            ["tslib", "npm:2.4.1"],\
+            ["typescript", "patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=b5f058"]\
+          ],\
+          "linkType": "SOFT"\
+        }]\
+      ]],\
+      ["@chainlink/frxeth-exchange-rate-adapter", [\
+        ["workspace:packages/sources/frxeth-exchange-rate", {\
+          "packageLocation": "./packages/sources/frxeth-exchange-rate/",\
+          "packageDependencies": [\
+            ["@chainlink/frxeth-exchange-rate-adapter", "workspace:packages/sources/frxeth-exchange-rate"],\
+            ["@chainlink/external-adapter-framework", "npm:0.31.0"],\
+            ["@types/jest", "npm:27.5.2"],\
+            ["@types/node", "npm:16.11.51"],\
+            ["ethers", "npm:5.7.2"],\
+            ["nock", "npm:13.2.9"],\
             ["tslib", "npm:2.4.1"],\
             ["typescript", "patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=b5f058"]\
           ],\

--- a/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts
+++ b/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts
@@ -33,6 +33,7 @@ export const SoakTestBlacklist: string[] = [
   'expert-car-broker',
   'flightaware',
   'fmpcloud',
+  'frxeth-exchange-rate',
   'genesis-volatility',
   'google-bigquery',
   'google-weather',

--- a/packages/sources/frxeth-exchange-rate/README.md
+++ b/packages/sources/frxeth-exchange-rate/README.md
@@ -1,0 +1,71 @@
+# FRXETH-EXCHANGE-RATE
+
+![0.0.0](https://img.shields.io/github/package-json/v/smartcontractkit/external-adapters-js?filename=packages/sources/frxeth-exchange-rate/package.json) ![v3](https://img.shields.io/badge/framework%20version-v3-blueviolet)
+
+This document was generated automatically. Please see [README Generator](../../scripts#readme-generator) for more info.
+
+## Environment Variables
+
+| Required? |          Name           |                                            Description                                            |  Type  | Options |                   Default                    |
+| :-------: | :---------------------: | :-----------------------------------------------------------------------------------------------: | :----: | :-----: | :------------------------------------------: |
+|    ✅     |         RPC_URL         |                              The RPC URL to connect to the EVM chain                              | string |         |                                              |
+|    ✅     |        CHAIN_ID         |                                    The chain id to connect to                                     | number |         |                     `1`                      |
+|    ✅     | FRAX_ETH_PRICE_CONTRACT |                 The address of the deployed Frax Dual Oracle Price Logic contract                 | string |         | `0xb12c19c838499e3447afd9e59274b1be56b1546a` |
+|           |  BACKGROUND_EXECUTE_MS  | The number of milliseconds the background execute should sleep before performing the next request | number |         |                   `10000`                    |
+
+---
+
+## Data Provider Rate Limits
+
+There are no rate limits for this adapter.
+
+---
+
+## Input Parameters
+
+Every EA supports base input parameters from [this list](https://github.com/smartcontractkit/ea-framework-js/blob/main/src/config/index.ts)
+
+| Required? |   Name   |     Description     |  Type  |          Options           | Default  |
+| :-------: | :------: | :-----------------: | :----: | :------------------------: | :------: |
+|           | endpoint | The endpoint to use | string | [crypto](#crypto-endpoint) | `crypto` |
+
+## Crypto Endpoint
+
+`crypto` is the only supported name for this endpoint.
+
+### Input Params
+
+| Required? |   Name    | Aliases |                   Description                    |  Type  | Options | Default | Depends On | Not Valid With |
+| :-------: | :-------: | :-----: | :----------------------------------------------: | :----: | :-----: | :-----: | :--------: | :------------: |
+|    ✅     | priceType |         | The price type to fetch, either 'HIGH' or 'LOW'. | string |         |         |            |                |
+
+### Example
+
+Request:
+
+```json
+{
+  "id": "1",
+  "data": {
+    "priceType": "high",
+    "endpoint": "crypto"
+  }
+}
+```
+
+Response:
+
+```json
+{
+  "jobRunID": "1",
+  "statusCode": 200,
+  "data": {
+    "result": "998705372346160519"
+  },
+  "result": "998705372346160519"
+}
+```
+
+---
+
+MIT License

--- a/packages/sources/frxeth-exchange-rate/package.json
+++ b/packages/sources/frxeth-exchange-rate/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@chainlink/frxeth-exchange-rate-adapter",
+  "version": "0.0.0",
+  "description": "Chainlink frxeth-exchange-rate adapter.",
+  "keywords": [
+    "Chainlink",
+    "LINK",
+    "blockchain",
+    "oracle",
+    "frxeth-exchange-rate"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "url": "https://github.com/smartcontractkit/external-adapters-js",
+    "type": "git"
+  },
+  "license": "MIT",
+  "scripts": {
+    "clean": "rm -rf dist && rm -f tsconfig.tsbuildinfo",
+    "prepack": "yarn build",
+    "build": "tsc -b",
+    "server": "node -e 'require(\"./index.js\").server()'",
+    "server:dist": "node -e 'require(\"./dist/index.js\").server()'",
+    "start": "yarn server:dist"
+  },
+  "devDependencies": {
+    "@types/jest": "27.5.2",
+    "@types/node": "16.11.51",
+    "nock": "13.2.9",
+    "typescript": "5.0.4"
+  },
+  "dependencies": {
+    "@chainlink/external-adapter-framework": "0.31.0",
+    "ethers": "5.7.2",
+    "tslib": "2.4.1"
+  }
+}

--- a/packages/sources/frxeth-exchange-rate/src/abi/IFraxEthDualOracle.json
+++ b/packages/sources/frxeth-exchange-rate/src/abi/IFraxEthDualOracle.json
@@ -1,0 +1,1032 @@
+[
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "baseToken0",
+            "type": "address"
+          },
+          {
+            "internalType": "uint8",
+            "name": "baseToken0Decimals",
+            "type": "uint8"
+          },
+          {
+            "internalType": "address",
+            "name": "quoteToken0",
+            "type": "address"
+          },
+          {
+            "internalType": "uint8",
+            "name": "quoteToken0Decimals",
+            "type": "uint8"
+          },
+          {
+            "internalType": "address",
+            "name": "baseToken1",
+            "type": "address"
+          },
+          {
+            "internalType": "uint8",
+            "name": "baseToken1Decimals",
+            "type": "uint8"
+          },
+          {
+            "internalType": "address",
+            "name": "quoteToken1",
+            "type": "address"
+          },
+          {
+            "internalType": "uint8",
+            "name": "quoteToken1Decimals",
+            "type": "uint8"
+          },
+          {
+            "internalType": "address",
+            "name": "frxEthErc20",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "fraxErc20",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "uniV3PairAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "uint32",
+            "name": "twapDuration",
+            "type": "uint32"
+          },
+          {
+            "internalType": "address",
+            "name": "fraxUsdChainlinkFeedAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "fraxUsdMaximumOracleDelay",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "ethUsdChainlinkFeed",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maxEthUsdOracleDelay",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "curvePoolEmaPriceOracleAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "minimumCurvePoolEma",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maximumCurvePoolEma",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "timelockAddress",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct ConstructorParams",
+        "name": "params",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "OnlyPendingTimelock",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OnlyTimelock",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldMaximum",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newMaximum",
+        "type": "uint256"
+      }
+    ],
+    "name": "SetMaximumCurvePoolEma",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldMaxOracleDelay",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newMaxOracleDelay",
+        "type": "uint256"
+      }
+    ],
+    "name": "SetMaximumEthUsdOracleDelay",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldMaxOracleDelay",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newMaxOracleDelay",
+        "type": "uint256"
+      }
+    ],
+    "name": "SetMaximumFraxUsdOracleDelay",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldMinimum",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newMinimum",
+        "type": "uint256"
+      }
+    ],
+    "name": "SetMinimumCurvePoolEma",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldTwapDuration",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newTwapDuration",
+        "type": "uint256"
+      }
+    ],
+    "name": "SetTwapDuration",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousTimelock",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newTimelock",
+        "type": "address"
+      }
+    ],
+    "name": "TimelockTransferStarted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousTimelock",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newTimelock",
+        "type": "address"
+      }
+    ],
+    "name": "TimelockTransferred",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "BASE_TOKEN_0",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "BASE_TOKEN_0_DECIMALS",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "BASE_TOKEN_1",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "BASE_TOKEN_1_DECIMALS",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "CURVE_POOL_EMA_PRICE_ORACLE",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "CURVE_POOL_EMA_PRICE_ORACLE_PRECISION",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "ETH_USD_CHAINLINK_FEED_ADDRESS",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "ETH_USD_CHAINLINK_FEED_DECIMALS",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "ETH_USD_CHAINLINK_FEED_PRECISION",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "FRAX_USD_CHAINLINK_FEED_ADDRESS",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "FRAX_USD_CHAINLINK_FEED_DECIMALS",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "FRAX_USD_CHAINLINK_FEED_PRECISION",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "FRXETH_ERC20",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "NORMALIZATION_0",
+    "outputs": [
+      {
+        "internalType": "int256",
+        "name": "",
+        "type": "int256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "NORMALIZATION_1",
+    "outputs": [
+      {
+        "internalType": "int256",
+        "name": "",
+        "type": "int256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "ORACLE_PRECISION",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "QUOTE_TOKEN_0",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "QUOTE_TOKEN_0_DECIMALS",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "QUOTE_TOKEN_1",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "QUOTE_TOKEN_1_DECIMALS",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "TWAP_PRECISION",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "UNISWAP_V3_TWAP_BASE_TOKEN",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "UNISWAP_V3_TWAP_QUOTE_TOKEN",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "UNI_V3_PAIR_ADDRESS",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "acceptTransferTimelock",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IPriceSourceReceiver",
+        "name": "fraxOracle",
+        "type": "address"
+      }
+    ],
+    "name": "addRoundData",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "ethPerFrxEthCurveEma",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "fraxPerFrxEthTwap",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "isBadDataEthUsdChainlink",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "usdPerEthChainlink",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "isBadDataFraxUsdChainlink",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "usdPerFraxChainlink",
+        "type": "uint256"
+      }
+    ],
+    "name": "calculatePrices",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "isBadData",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "priceLow",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "priceHigh",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getChainlinkUsdPerFrax",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "isBadData",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "usdPerFrax",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getCurveEmaEthPerFrxEth",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "ethPerFrxEth",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getCurvePoolToken1EmaPrice",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "_emaPrice",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getEthUsdChainlinkPrice",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "_isBadData",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_updatedAt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_usdPerEth",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getFraxUsdChainlinkPrice",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "_isBadData",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_updatedAt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_usdPerFrax",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getPrices",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "isBadData",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "priceLow",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "priceHigh",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getPricesNormalized",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "isBadDataNormal",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "priceLowNormal",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "priceHighNormal",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getUniswapV3Twap",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "_twap",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getUsdPerEthChainlink",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "isBadData",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "usdPerEth",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maximumCurvePoolEma",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maximumEthUsdOracleDelay",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maximumFraxUsdOracleDelay",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "minimumCurvePoolEma",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "_name",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pendingTimelockAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceTimelock",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "maximumPrice",
+        "type": "uint256"
+      }
+    ],
+    "name": "setMaximumCurvePoolEma",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "newMaxOracleDelay",
+        "type": "uint256"
+      }
+    ],
+    "name": "setMaximumEthUsdOracleDelay",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "newMaxOracleDelay",
+        "type": "uint256"
+      }
+    ],
+    "name": "setMaximumFraxUsdOracleDelay",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "minimumPrice",
+        "type": "uint256"
+      }
+    ],
+    "name": "setMinimumCurvePoolEma",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "newTwapDuration",
+        "type": "uint32"
+      }
+    ],
+    "name": "setTwapDuration",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "interfaceId",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "timelockAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_newTimelock",
+        "type": "address"
+      }
+    ],
+    "name": "transferTimelock",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "twapDuration",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/packages/sources/frxeth-exchange-rate/src/config/index.ts
+++ b/packages/sources/frxeth-exchange-rate/src/config/index.ts
@@ -1,0 +1,27 @@
+import { AdapterConfig } from '@chainlink/external-adapter-framework/config'
+
+export const config = new AdapterConfig({
+  RPC_URL: {
+    description: 'The RPC URL to connect to the EVM chain',
+    type: 'string',
+    required: true,
+  },
+  CHAIN_ID: {
+    description: 'The chain id to connect to',
+    type: 'number',
+    required: true,
+    default: 1,
+  },
+  FRAX_ETH_PRICE_CONTRACT: {
+    description: 'The address of the deployed Frax Dual Oracle Price Logic contract',
+    type: 'string',
+    required: true,
+    default: '0xb12c19c838499e3447afd9e59274b1be56b1546a',
+  },
+  BACKGROUND_EXECUTE_MS: {
+    description:
+      'The number of milliseconds the background execute should sleep before performing the next request',
+    type: 'number',
+    default: 1000,
+  },
+})

--- a/packages/sources/frxeth-exchange-rate/src/config/overrides.json
+++ b/packages/sources/frxeth-exchange-rate/src/config/overrides.json
@@ -1,0 +1,3 @@
+{
+  "frxeth-exchange-rate": {}
+}

--- a/packages/sources/frxeth-exchange-rate/src/endpoint/crypto.ts
+++ b/packages/sources/frxeth-exchange-rate/src/endpoint/crypto.ts
@@ -1,0 +1,46 @@
+import {
+  AdapterEndpoint,
+  CustomInputValidator,
+} from '@chainlink/external-adapter-framework/adapter'
+import { exchangeRateTransport } from '../transport/exchange-rate'
+import overrides from '../config/overrides.json'
+import { AdapterInputError } from '@chainlink/external-adapter-framework/validation/error'
+import { InputParameters } from '@chainlink/external-adapter-framework/validation'
+import { SingleNumberResultResponse } from '@chainlink/external-adapter-framework/util'
+import { config } from '../config'
+
+export const inputParameters = new InputParameters({
+  priceType: {
+    description: "The price type to fetch, either 'HIGH' or 'LOW'.",
+    required: true,
+    type: 'string',
+  },
+})
+
+export type BaseEndpointTypes = {
+  Parameters: typeof inputParameters.definition
+  Response: SingleNumberResultResponse
+  Settings: typeof config.settings
+}
+
+const customInputValidation: CustomInputValidator<BaseEndpointTypes> = (
+  request,
+): AdapterInputError | undefined => {
+  const priceType = request.requestContext.data.priceType
+  if (priceType.toUpperCase() != 'HIGH' && priceType.toUpperCase() != 'LOW') {
+    throw new AdapterInputError({
+      message: `priceType input parameter must be one of 'HIGH' or 'LOW'.`,
+    })
+  }
+
+  return
+}
+
+export const endpoint = new AdapterEndpoint({
+  name: 'crypto',
+  aliases: [],
+  transport: exchangeRateTransport,
+  inputParameters: inputParameters,
+  overrides: overrides['frxeth-exchange-rate'],
+  customInputValidation,
+})

--- a/packages/sources/frxeth-exchange-rate/src/endpoint/index.ts
+++ b/packages/sources/frxeth-exchange-rate/src/endpoint/index.ts
@@ -1,0 +1,1 @@
+export { endpoint as crypto } from './crypto'

--- a/packages/sources/frxeth-exchange-rate/src/index.ts
+++ b/packages/sources/frxeth-exchange-rate/src/index.ts
@@ -1,0 +1,13 @@
+import { expose, ServerInstance } from '@chainlink/external-adapter-framework'
+import { Adapter } from '@chainlink/external-adapter-framework/adapter'
+import { config } from './config'
+import { crypto } from './endpoint'
+
+export const adapter = new Adapter({
+  name: 'FRXETH-EXCHANGE-RATE',
+  defaultEndpoint: crypto.name,
+  config,
+  endpoints: [crypto],
+})
+
+export const server = (): Promise<ServerInstance | undefined> => expose(adapter)

--- a/packages/sources/frxeth-exchange-rate/src/transport/exchange-rate.ts
+++ b/packages/sources/frxeth-exchange-rate/src/transport/exchange-rate.ts
@@ -1,0 +1,94 @@
+import { TransportDependencies } from '@chainlink/external-adapter-framework/transports'
+import { SubscriptionTransport } from '@chainlink/external-adapter-framework/transports/abstract/subscription'
+import { BigNumber, ethers } from 'ethers'
+import { EndpointContext } from '@chainlink/external-adapter-framework/adapter'
+import { BaseEndpointTypes, inputParameters } from '../endpoint/crypto'
+import fraxEthDualOracleAbi from '../abi/IFraxEthDualOracle.json'
+import { TimestampedAdapterResponse, sleep } from '@chainlink/external-adapter-framework/util'
+
+type ExchangeRateTransportTypes = BaseEndpointTypes
+type RequestParams = typeof inputParameters.validated
+type GetPricesResponse = {
+  isBadData: boolean
+  priceLow: BigNumber
+  priceHigh: BigNumber
+}
+
+class ExchangeRateTransport extends SubscriptionTransport<ExchangeRateTransportTypes> {
+  async initialize(
+    dependencies: TransportDependencies<ExchangeRateTransportTypes>,
+    adapterSettings: ExchangeRateTransportTypes['Settings'],
+    endpointName: string,
+    transportName: string,
+  ): Promise<void> {
+    await super.initialize(dependencies, adapterSettings, endpointName, transportName)
+  }
+
+  getSubscriptionTtlFromConfig(adapterSettings: ExchangeRateTransportTypes['Settings']): number {
+    return adapterSettings.WARMUP_SUBSCRIPTION_TTL
+  }
+
+  async backgroundHandler(
+    context: EndpointContext<ExchangeRateTransportTypes>,
+    entries: RequestParams[],
+  ) {
+    await Promise.all(
+      entries.map(async (param) => await this.handleRequest(context.adapterSettings, param)),
+    )
+    await sleep(context.adapterSettings.BACKGROUND_EXECUTE_MS)
+  }
+
+  async handleRequest(
+    adapterSettings: ExchangeRateTransportTypes['Settings'],
+    param: RequestParams,
+  ) {
+    const providerDataRequestedUnixMs = Date.now()
+
+    const { RPC_URL, CHAIN_ID, FRAX_ETH_PRICE_CONTRACT } = adapterSettings
+
+    const provider = new ethers.providers.JsonRpcProvider(RPC_URL, CHAIN_ID)
+    const fraxEthPrice = new ethers.Contract(
+      FRAX_ETH_PRICE_CONTRACT,
+      fraxEthDualOracleAbi,
+      provider,
+    )
+
+    const { isBadData, priceLow, priceHigh } = (await fraxEthPrice.getPrices()) as GetPricesResponse
+
+    let response: TimestampedAdapterResponse
+
+    if (isBadData != false) {
+      response = {
+        statusCode: 502,
+        errorMessage: 'Contract is reporting stale or bad data for getPrices.',
+        timestamps: {
+          providerDataRequestedUnixMs,
+          providerDataReceivedUnixMs: Date.now(),
+          providerIndicatedTimeUnixMs: undefined,
+        },
+      }
+    } else {
+      const price = param.priceType.toUpperCase() == 'HIGH' ? priceHigh : priceLow
+      response = {
+        data: {
+          result: price.toString(),
+        },
+        result: price.toString(),
+        timestamps: {
+          providerDataRequestedUnixMs,
+          providerDataReceivedUnixMs: Date.now(),
+          providerIndicatedTimeUnixMs: undefined,
+        },
+      }
+    }
+
+    this.responseCache.write(this.name, [
+      {
+        params: param,
+        response: response as TimestampedAdapterResponse<ExchangeRateTransportTypes['Response']>,
+      },
+    ])
+  }
+}
+
+export const exchangeRateTransport = new ExchangeRateTransport()

--- a/packages/sources/frxeth-exchange-rate/test-payload.json
+++ b/packages/sources/frxeth-exchange-rate/test-payload.json
@@ -1,0 +1,12 @@
+{
+    "requests": [
+        {
+            "priceType": "high",
+            "endpoint": "crypto"
+        },
+        {
+            "priceType": "low",
+            "endpoint": "crypto"
+        }
+    ]
+}

--- a/packages/sources/frxeth-exchange-rate/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/frxeth-exchange-rate/test/integration/__snapshots__/adapter.test.ts.snap
@@ -1,0 +1,51 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`frxETH - ETH exchange rate crypto endpoint should return error for invalid priceType 1`] = `
+{
+  "error": {
+    "message": "priceType input parameter must be one of 'HIGH' or 'LOW'.",
+    "name": "AdapterError",
+  },
+  "status": "errored",
+  "statusCode": 500,
+}
+`;
+
+exports[`frxETH - ETH exchange rate crypto endpoint should return error for missing priceType 1`] = `
+{
+  "error": {
+    "message": "[Param: priceType] param is required but no value was provided",
+    "name": "AdapterError",
+  },
+  "status": "errored",
+  "statusCode": 400,
+}
+`;
+
+exports[`frxETH - ETH exchange rate crypto endpoint should return success for priceType: HIGH 1`] = `
+{
+  "data": {
+    "result": "1000000000000000000",
+  },
+  "result": "1000000000000000000",
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 978347471111,
+    "providerDataRequestedUnixMs": 978347471111,
+  },
+}
+`;
+
+exports[`frxETH - ETH exchange rate crypto endpoint should return success for priceType: LOW 1`] = `
+{
+  "data": {
+    "result": "998800960669793168",
+  },
+  "result": "998800960669793168",
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 978347471111,
+    "providerDataRequestedUnixMs": 978347471111,
+  },
+}
+`;

--- a/packages/sources/frxeth-exchange-rate/test/integration/adapter.test.ts
+++ b/packages/sources/frxeth-exchange-rate/test/integration/adapter.test.ts
@@ -1,0 +1,82 @@
+import {
+  TestAdapter,
+  setEnvVariables,
+} from '@chainlink/external-adapter-framework/util/testing-utils'
+import * as nock from 'nock'
+import { mockRpc } from './fixtures'
+
+describe('frxETH - ETH exchange rate', () => {
+  let spy: jest.SpyInstance
+  let testAdapter: TestAdapter
+  let oldEnv: NodeJS.ProcessEnv
+
+  const mockRpcUrl = 'http://localhost:8545'
+
+  beforeAll(async () => {
+    oldEnv = JSON.parse(JSON.stringify(process.env))
+    process.env.RPC_URL = mockRpcUrl
+    process.env.CHAIN_ID = '1'
+    process.env.FRAX_ETH_PRICE_CONTRACT = '0xb12c19c838499e3447afd9e59274b1be56b1546a'
+    process.env.BACKGROUND_EXECUTE_MS = '1000'
+
+    const mockDate = new Date('2001-01-01T11:11:11.111Z')
+    spy = jest.spyOn(Date, 'now').mockReturnValue(mockDate.getTime())
+
+    const adapter = (await import('./../../src')).adapter
+    adapter.rateLimiting = undefined
+    testAdapter = await TestAdapter.startWithMockedCache(adapter, {
+      testAdapter: {} as TestAdapter<never>,
+    })
+
+    mockRpc(mockRpcUrl)
+  })
+
+  afterAll(async () => {
+    setEnvVariables(oldEnv)
+    await testAdapter.api.close()
+    nock.restore()
+    nock.cleanAll()
+    spy.mockRestore()
+  })
+
+  describe('crypto endpoint', () => {
+    it('should return success for priceType: HIGH', async () => {
+      const data = {
+        priceType: 'high',
+        endpoint: 'crypto',
+      }
+      const response = await testAdapter.request(data)
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toMatchSnapshot()
+    })
+
+    it('should return success for priceType: LOW', async () => {
+      const data = {
+        priceType: 'low',
+        endpoint: 'crypto',
+      }
+      const response = await testAdapter.request(data)
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toMatchSnapshot()
+    })
+
+    it('should return error for missing priceType', async () => {
+      const data = {
+        endpoint: 'crypto',
+      }
+      const response = await testAdapter.request(data)
+      expect(response.statusCode).toBe(400)
+      expect(response.json()).toMatchSnapshot()
+    })
+
+    it('should return error for invalid priceType', async () => {
+      const data = {
+        priceType: 'invalid',
+        endpoint: 'crypto',
+      }
+      const response = await testAdapter.request(data)
+      expect(response.statusCode).toBe(500)
+      expect(response.json()).toMatchSnapshot()
+    })
+  })
+})

--- a/packages/sources/frxeth-exchange-rate/test/integration/fixtures.ts
+++ b/packages/sources/frxeth-exchange-rate/test/integration/fixtures.ts
@@ -1,0 +1,43 @@
+import nock from 'nock'
+
+type JsonRpcPayload = {
+  id: number
+  method: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  params: Array<any> | Record<string, any>
+  jsonrpc: '2.0'
+}
+
+export const mockRpc = (rpcUrl: string): nock.Scope => {
+  return (
+    nock(rpcUrl, { encodedQueryParams: true })
+      .persist()
+      // Fetch chain ID
+      .post('/', { method: 'eth_chainId', params: [], id: /^\d+$/, jsonrpc: '2.0' })
+      .reply(
+        200,
+        (_, request: JsonRpcPayload) => ({ jsonrpc: '2.0', id: request.id, result: '0x1' }),
+        ['Content-Type', 'application/json'],
+      )
+      // Call getPrices on frxETH-ETH contract
+      .post('/', {
+        method: 'eth_call',
+        params: [
+          { to: '0xb12c19c838499e3447afd9e59274b1be56b1546a', data: '0xbd9a548b' },
+          'latest',
+        ],
+        id: /^\d+$/,
+        jsonrpc: '2.0',
+      })
+      .reply(
+        200,
+        (_, request: JsonRpcPayload) => ({
+          jsonrpc: '2.0',
+          id: request['id'],
+          result:
+            '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ddc742e8e0abb900000000000000000000000000000000000000000000000000de0b6b3a7640000',
+        }),
+        ['Content-Type', 'application/json'],
+      )
+  )
+}

--- a/packages/sources/frxeth-exchange-rate/tsconfig.json
+++ b/packages/sources/frxeth-exchange-rate/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*", "src/**/*.json"],
+  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]
+}

--- a/packages/sources/frxeth-exchange-rate/tsconfig.test.json
+++ b/packages/sources/frxeth-exchange-rate/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*", "**/test", "src/**/*.json"],
+  "compilerOptions": {
+    "noEmit": true
+  }
+}

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -339,6 +339,9 @@
       "path": "./sources/fmpcloud"
     },
     {
+      "path": "./sources/frxeth-exchange-rate"
+    },
+    {
       "path": "./sources/galaxis"
     },
     {

--- a/packages/tsconfig.test.json
+++ b/packages/tsconfig.test.json
@@ -339,6 +339,9 @@
       "path": "./sources/fmpcloud/tsconfig.test.json"
     },
     {
+      "path": "./sources/frxeth-exchange-rate/tsconfig.test.json"
+    },
+    {
       "path": "./sources/galaxis/tsconfig.test.json"
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3620,6 +3620,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@chainlink/frxeth-exchange-rate-adapter@workspace:packages/sources/frxeth-exchange-rate":
+  version: 0.0.0-use.local
+  resolution: "@chainlink/frxeth-exchange-rate-adapter@workspace:packages/sources/frxeth-exchange-rate"
+  dependencies:
+    "@chainlink/external-adapter-framework": 0.31.0
+    "@types/jest": 27.5.2
+    "@types/node": 16.11.51
+    ethers: 5.7.2
+    nock: 13.2.9
+    tslib: 2.4.1
+    typescript: 5.0.4
+  languageName: unknown
+  linkType: soft
+
 "@chainlink/galaxis-adapter@workspace:packages/sources/galaxis":
   version: 0.0.0-use.local
   resolution: "@chainlink/galaxis-adapter@workspace:packages/sources/galaxis"


### PR DESCRIPTION
## Closes [DF-19144](https://smartcontract-it.atlassian.net/browse/DF-19144)

## Description
- Adapter fetches the fraxETH-ETH exchange rate values from frxETH-ETH Dual Oracle contract.
- `crypto` endpoint returns either priceHigh or priceLow, depending on the `priceType` parameter provided.
- If `isBadData` flag is set in contract response, the EA returns an error.

## Changes

- Add new fraxETH-ETH exchange rate EA to fetch priceHigh and priceLow values from on-chain contract.
- Add tests

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. Run EA locally: `yarn && yarn setup && (cd packages/sources/frxeth-exchange-rate && export RPC_URL="..."; export CHAIN_ID=1; export FRAX_ETH_PRICE_CONTRACT="0xb12c19c838499e3447afd9e59274b1be56b1546a"; yarn start)`
2. `curl --request POST \ --url http://localhost:8080/ \ --header 'Content-Type: application/json' \ --data '{ "id": "1", "data": { "priceType": "high", "endpoint": "crypto" } }'`
3. `curl --request POST \ --url http://localhost:8080/ \ --header 'Content-Type: application/json' \ --data '{ "id": "1", "data": { "priceType": "low", "endpoint": "crypto" } }'`

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[DF-19144]: https://smartcontract-it.atlassian.net/browse/DF-19144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ