### PR TITLE
build all EAs when core package is changed

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -109,9 +109,9 @@ runs:
         BUILD_ALL: ${{ inputs.build-all }}
       # We have to add the core/factories package manually always because the readme generation imports it
       run: |
-        # If the BUILD_ALL env var is set or there are changes to the scripts (because of the readme generation scripts)
+        # If the BUILD_ALL env var is set or there are changes to the scripts or core (because of the readme generation scripts)
         # we need to build every possible adapter and their dependencies
-        diff_output=$(git diff $UPSTREAM_BRANCH -- packages/scripts)
+        diff_output=$(git diff $UPSTREAM_BRANCH -- packages/scripts packages/core)
         if [[ $BUILD_ALL = true ]] || [[ -n $diff_output ]]; then
           cp packages/tsconfig.json packages/tsconfig.tmp.json
           exit 0


### PR DESCRIPTION
## Description

Current readme generator  in CI will try to generate readmes for all EAs when there is change in `core` or `scripts` package, however current setup step in CI build all the EAs only when `scripts` is changed. This PR fixes it so when there is a change in `core` (bootstrap for example), the CI will build all EAs so that readme generator won't fail

......

## Changes

- Modified `Calculate changed EAs` step in `.github/actions/setup/action.yml`. Now instead of only checking if the changes are part of `packages/scripts` to build all EAs it also checks for `packages/core`



