### PR TITLE
Add usdr endpoint to the-network-firm adapter

### DIFF
--- a/.changeset/rich-emus-agree.md
+++ b/.changeset/rich-emus-agree.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/the-network-firm-adapter': minor
+---
+
+Added the USDR endpoint

--- a/packages/sources/the-network-firm/src/endpoint/index.ts
+++ b/packages/sources/the-network-firm/src/endpoint/index.ts
@@ -1,3 +1,4 @@
 export { endpoint as mco2 } from './mco2'
 export { endpoint as stbt } from './stbt'
 export { endpoint as backed } from './backed'
+export { endpoint as usdr } from './usdr'

--- a/packages/sources/the-network-firm/src/endpoint/usdr.ts
+++ b/packages/sources/the-network-firm/src/endpoint/usdr.ts
@@ -1,0 +1,16 @@
+import { AdapterEndpoint } from '@chainlink/external-adapter-framework/adapter'
+import { SingleNumberResultResponse } from '@chainlink/external-adapter-framework/util'
+import { config } from '../config'
+import { httpTransport } from '../transport/usdr'
+import { EmptyInputParameters } from '@chainlink/external-adapter-framework/validation/input-params'
+
+export type BaseEndpointTypes = {
+  Parameters: EmptyInputParameters
+  Response: SingleNumberResultResponse
+  Settings: typeof config.settings
+}
+
+export const endpoint = new AdapterEndpoint({
+  name: 'usdr',
+  transport: httpTransport,
+})

--- a/packages/sources/the-network-firm/src/index.ts
+++ b/packages/sources/the-network-firm/src/index.ts
@@ -1,13 +1,13 @@
 import { expose, ServerInstance } from '@chainlink/external-adapter-framework'
 import { Adapter } from '@chainlink/external-adapter-framework/adapter'
 import { config } from './config'
-import { backed, mco2, stbt } from './endpoint'
+import { backed, mco2, stbt, usdr } from './endpoint'
 
 export const adapter = new Adapter({
   defaultEndpoint: mco2.name,
   name: 'THE_NETWORK_FIRM',
   config,
-  endpoints: [mco2, stbt, backed],
+  endpoints: [mco2, stbt, backed, usdr],
   rateLimiting: {
     tiers: {
       default: {

--- a/packages/sources/the-network-firm/src/transport/usdr.ts
+++ b/packages/sources/the-network-firm/src/transport/usdr.ts
@@ -1,10 +1,16 @@
 import { HttpTransport } from '@chainlink/external-adapter-framework/transports'
-import { BaseEndpointTypes } from '../endpoint/stbt'
+import { BaseEndpointTypes } from '../endpoint/usdr'
 
 export interface ResponseSchema {
   accountName: string
   totalReserve: number
   totalToken: number
+  detailedReserve: {
+    DAI: number
+    realEstate: number
+    TNGBL: number
+    insuranceFund: number
+  }
   timestamp: string
   ripcord: boolean
   ripcordDetails: string[]
@@ -22,7 +28,7 @@ export const httpTransport = new HttpTransport<HttpTransportTypes>({
       params: params,
       request: {
         baseURL: config.API_ENDPOINT,
-        url: '/STBT',
+        url: '/USDR',
       },
     }
   },

--- a/packages/sources/the-network-firm/test-payload.json
+++ b/packages/sources/the-network-firm/test-payload.json
@@ -1,5 +1,14 @@
 {
- "requests": [{
+ "requests": [
+   {
     "endpoint": "stbt"
- }]
+   },
+   {
+      "endpoint": "backed",
+      "accountName": "IBTA"
+   },
+   {
+      "endpoint": "usdr"
+   }
+]
 }

--- a/packages/sources/the-network-firm/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/the-network-firm/test/integration/__snapshots__/adapter.test.ts.snap
@@ -56,3 +56,18 @@ exports[`execute stbt endpoint should return success 1`] = `
   },
 }
 `;
+
+exports[`execute usdr endpoint should return success 1`] = `
+{
+  "data": {
+    "result": 39138216.32189752,
+  },
+  "result": 39138216.32189752,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 978347471111,
+    "providerDataRequestedUnixMs": 978347471111,
+    "providerIndicatedTimeUnixMs": 1692831653859,
+  },
+}
+`;

--- a/packages/sources/the-network-firm/test/integration/__snapshots__/ripcord.test.ts.snap
+++ b/packages/sources/the-network-firm/test/integration/__snapshots__/ripcord.test.ts.snap
@@ -23,3 +23,15 @@ exports[`execute stbt endpoint when ripcord true  should return error 1`] = `
   },
 }
 `;
+
+exports[`execute usdr endpoint when ripcord true  should return error 1`] = `
+{
+  "errorMessage": "Ripcord indicator true. Details: Balances",
+  "statusCode": 502,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 978347471111,
+    "providerDataRequestedUnixMs": 978347471111,
+    "providerIndicatedTimeUnixMs": 1692831653859,
+  },
+}
+`;

--- a/packages/sources/the-network-firm/test/integration/adapter.test.ts
+++ b/packages/sources/the-network-firm/test/integration/adapter.test.ts
@@ -3,7 +3,12 @@ import {
   setEnvVariables,
 } from '@chainlink/external-adapter-framework/util/testing-utils'
 import * as nock from 'nock'
-import { mockBackedResponseSuccess, mockMCO2Response, mockSTBTResponseSuccess } from './fixtures'
+import {
+  mockBackedResponseSuccess,
+  mockMCO2Response,
+  mockSTBTResponseSuccess,
+  mockUSDRResponseSuccess,
+} from './fixtures'
 
 describe('execute', () => {
   let spy: jest.SpyInstance
@@ -72,6 +77,19 @@ describe('execute', () => {
       mockBackedResponseSuccess()
       const response = await testAdapter.request(data)
       expect(response.statusCode).toBe(502)
+      expect(response.json()).toMatchSnapshot()
+    })
+  })
+
+  describe('usdr endpoint', () => {
+    it('should return success', async () => {
+      const data = {
+        endpoint: 'usdr',
+      }
+      mockUSDRResponseSuccess()
+
+      const response = await testAdapter.request(data)
+      expect(response.statusCode).toBe(200)
       expect(response.json()).toMatchSnapshot()
     })
   })

--- a/packages/sources/the-network-firm/test/integration/fixtures.ts
+++ b/packages/sources/the-network-firm/test/integration/fixtures.ts
@@ -127,3 +127,45 @@ export const mockBackedResponseFailure = (): nock.Scope =>
       ripcordDetails: ['Balances'],
     })
     .persist()
+
+export const mockUSDRResponseSuccess = (): nock.Scope =>
+  nock('https://api.oracle-services.ledgerlens.io/v1/chainlink/proof-of-reserves/', {
+    encodedQueryParams: true,
+  })
+    .get('/USDR')
+    .reply(200, {
+      accountName: 'USDR',
+      totalReserve: 39138216.32189752,
+      totalToken: 8368048.75007513,
+      detailedReserve: {
+        DAI: 1999280.1996740077,
+        realEstate: 24368253.51404984,
+        TNGBL: 8543905.044571292,
+        insuranceFund: 4226777.563602379,
+      },
+      timestamp: '2023-08-23T23:00:53.859Z',
+      ripcord: false,
+      ripcordDetails: [],
+    })
+    .persist()
+
+export const mockUSDRResponseFailure = (): nock.Scope =>
+  nock('https://api.oracle-services.ledgerlens.io/v1/chainlink/proof-of-reserves/', {
+    encodedQueryParams: true,
+  })
+    .get('/USDR')
+    .reply(200, {
+      accountName: 'USDR',
+      totalReserve: 39138216.32189752,
+      totalToken: 8368048.75007513,
+      detailedReserve: {
+        DAI: 1999280.1996740077,
+        realEstate: 24368253.51404984,
+        TNGBL: 8543905.044571292,
+        insuranceFund: 4226777.563602379,
+      },
+      timestamp: '2023-08-23T23:00:53.859Z',
+      ripcord: true,
+      ripcordDetails: ['Balances'],
+    })
+    .persist()

--- a/packages/sources/the-network-firm/test/integration/ripcord.test.ts
+++ b/packages/sources/the-network-firm/test/integration/ripcord.test.ts
@@ -3,7 +3,11 @@ import {
   setEnvVariables,
 } from '@chainlink/external-adapter-framework/util/testing-utils'
 import * as nock from 'nock'
-import { mockBackedResponseFailure, mockSTBTResponseFailure } from './fixtures'
+import {
+  mockBackedResponseFailure,
+  mockSTBTResponseFailure,
+  mockUSDRResponseFailure,
+} from './fixtures'
 
 // The reason why the failure case of 'stbt' endpoint is in a separate file is because of race conditions causing tests to fail
 // as both success and failure cases use the same input params and connect to the same endpoint.
@@ -44,13 +48,25 @@ describe('execute', () => {
     })
   })
 
-  describe('backed endpoint', () => {
-    it('when ripcord true should return error', async () => {
+  describe('backed endpoint when ripcord true', () => {
+    it('should return error', async () => {
       const data = {
         endpoint: 'backed',
         accountName: 'IBTA',
       }
       mockBackedResponseFailure()
+      const response = await testAdapter.request(data)
+      expect(response.statusCode).toBe(502)
+      expect(response.json()).toMatchSnapshot()
+    })
+  })
+
+  describe('usdr endpoint when ripcord true ', () => {
+    it('should return error', async () => {
+      const data = {
+        endpoint: 'usdr',
+      }
+      mockUSDRResponseFailure()
       const response = await testAdapter.request(data)
       expect(response.statusCode).toBe(502)
       expect(response.json()).toMatchSnapshot()


### PR DESCRIPTION
## Closes [PDI-2276](https://smartcontract-it.atlassian.net/browse/PDI-2276)

## Description

Added the USDR endpoint to `the-network-firm` adapter

## Changes

- Added the USDR endpoint

## Steps to Test

1. yarn test packages/sources/the-network-firm/test

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[PDI-2276]: https://smartcontract-it.atlassian.net/browse/PDI-2276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ