### PR TITLE
Bugfix/DF-19169 BIRC log spam

### DIFF
--- a/.changeset/few-poems-beg.md
+++ b/.changeset/few-poems-beg.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/cfbenchmarks-adapter': patch
+---
+
+BIRC noisy log fix

--- a/packages/sources/cfbenchmarks/src/transport/birc.ts
+++ b/packages/sources/cfbenchmarks/src/transport/birc.ts
@@ -4,7 +4,7 @@ import {
 } from '@chainlink/external-adapter-framework/transports'
 import { makeLogger } from '@chainlink/external-adapter-framework/util'
 import { Requester } from '@chainlink/external-adapter-framework/util/requester'
-import { latestUpdateIsCurrentDay, tenorInRange } from './utils'
+import { latestUpdateIsWithinLast24h, tenorInRange } from './utils'
 import { AdapterCustomError } from '@chainlink/external-adapter-framework/validation/error'
 import { BaseEndpointTypes } from '../endpoint/birc'
 
@@ -93,8 +93,8 @@ export const transport = new CfBenchmarksBIRCTransport({
       const key = param.tenor as VALID_TENORS
       const value = Number(latestUpdate.tenors[key])
 
-      if (!latestUpdateIsCurrentDay(latestUpdate.time)) {
-        const warning = 'Latest update from response is not in current day'
+      if (!latestUpdateIsWithinLast24h(latestUpdate.time)) {
+        const warning = 'Latest update from response is not in current day %o'
         logger.warn(warning, { latestUpdate })
       }
 

--- a/packages/sources/cfbenchmarks/src/transport/utils.ts
+++ b/packages/sources/cfbenchmarks/src/transport/utils.ts
@@ -1,4 +1,6 @@
-const LAST_UPDATE_ALLOWANCE_MS = 88_200_000 // 1 day + 30 mins in ms
+// 1 day + 30 mins in ms
+// +30m to account for expected delays between returned time field and posted time.
+const LAST_UPDATE_ALLOWANCE_MS = 88_200_000
 
 // Tenor must be between -1 and 1
 export const tenorInRange = (tenor: number): boolean => tenor >= -1 && tenor <= 1

--- a/packages/sources/cfbenchmarks/src/transport/utils.ts
+++ b/packages/sources/cfbenchmarks/src/transport/utils.ts
@@ -1,15 +1,14 @@
+const LAST_UPDATE_ALLOWANCE_MS = 88200000 // 1 day + 30 mins in ms
+
 // Tenor must be between -1 and 1
 export const tenorInRange = (tenor: number): boolean => tenor >= -1 && tenor <= 1
 // Check if time of latest update is in the current day in UTC time
-export const latestUpdateIsCurrentDay = (utcTimeOfUpdate: number): boolean => {
+export const latestUpdateIsWithinLast24h = (utcTimeOfUpdate: number): boolean => {
   try {
     const latestUpdateDate = new Date(utcTimeOfUpdate)
     const currentDay = new Date()
-    return (
-      latestUpdateDate.getUTCFullYear() === currentDay.getUTCFullYear() &&
-      latestUpdateDate.getUTCMonth() === currentDay.getUTCMonth() &&
-      latestUpdateDate.getUTCDate() === currentDay.getUTCDate()
-    )
+    const timeDiff = currentDay.getTime() - latestUpdateDate.getTime()
+    return LAST_UPDATE_ALLOWANCE_MS > timeDiff
   } catch (error) {
     return false
   }

--- a/packages/sources/cfbenchmarks/src/transport/utils.ts
+++ b/packages/sources/cfbenchmarks/src/transport/utils.ts
@@ -1,4 +1,4 @@
-const LAST_UPDATE_ALLOWANCE_MS = 88200000 // 1 day + 30 mins in ms
+const LAST_UPDATE_ALLOWANCE_MS = 88_200_000 // 1 day + 30 mins in ms
 
 // Tenor must be between -1 and 1
 export const tenorInRange = (tenor: number): boolean => tenor >= -1 && tenor <= 1

--- a/packages/sources/cfbenchmarks/test/unit/adapter.test.ts
+++ b/packages/sources/cfbenchmarks/test/unit/adapter.test.ts
@@ -1,4 +1,4 @@
-import { latestUpdateIsCurrentDay, tenorInRange } from '../../src/transport/utils'
+import { latestUpdateIsWithinLast24h, tenorInRange } from '../../src/transport/utils'
 import { getIdFromBaseQuote } from '../../src/endpoint/utils'
 
 describe('getIdFromBaseQuote', () => {
@@ -70,34 +70,43 @@ describe('latestUpdateIsCurrentDay', () => {
   it('returns true when the latest update is on the current day in UTC time zone', () => {
     const currentDayIsoString = new Date().toISOString()
     const currentDayTimestampMs = new Date(currentDayIsoString).getTime()
-    const latestUpdateIsCurrentDayResult = latestUpdateIsCurrentDay(currentDayTimestampMs)
+    const latestUpdateIsCurrentDayResult = latestUpdateIsWithinLast24h(currentDayTimestampMs)
     expect(latestUpdateIsCurrentDayResult).toBe(true)
-  })
-
-  it('returns false when the latest update is not on the current day in UTC time zone', () => {
-    const yesterdayIsoString = new Date(Date.now() - 86400000).toISOString()
-    const yesterdayTimestampMs = new Date(yesterdayIsoString).getTime()
-    const latestUpdateIsCurrentDayResult = latestUpdateIsCurrentDay(yesterdayTimestampMs)
-    expect(latestUpdateIsCurrentDayResult).toBe(false)
   })
 
   it('returns false when the input timestamp is not valid', () => {
     const invalidTimestamp = NaN
-    const latestUpdateIsCurrentDayResult = latestUpdateIsCurrentDay(invalidTimestamp)
+    const latestUpdateIsCurrentDayResult = latestUpdateIsWithinLast24h(invalidTimestamp)
     expect(latestUpdateIsCurrentDayResult).toBe(false)
   })
 
   it('returns true when the latest update is on the first millisecond of the current day in UTC time zone', () => {
     const currentDayIsoString = new Date().toISOString().substring(0, 10)
     const currentDayFirstMsTimestamp = new Date(`${currentDayIsoString}T00:00:00.000Z`).getTime()
-    const latestUpdateIsCurrentDayResult = latestUpdateIsCurrentDay(currentDayFirstMsTimestamp)
+    const latestUpdateIsCurrentDayResult = latestUpdateIsWithinLast24h(currentDayFirstMsTimestamp)
     expect(latestUpdateIsCurrentDayResult).toBe(true)
   })
 
   it('returns true when the latest update is on the last millisecond of the current day in UTC time zone', () => {
     const currentDayIsoString = new Date().toISOString().substring(0, 10)
     const currentDayLastMsTimestamp = new Date(`${currentDayIsoString}T23:59:59.999Z`).getTime()
-    const latestUpdateIsCurrentDayResult = latestUpdateIsCurrentDay(currentDayLastMsTimestamp)
+    const latestUpdateIsCurrentDayResult = latestUpdateIsWithinLast24h(currentDayLastMsTimestamp)
     expect(latestUpdateIsCurrentDayResult).toBe(true)
+  })
+
+  it('returns true when within 24 hours + 30 mins of latest update', () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date('2023-08-31T15:29:59.999Z'))
+    const yesterdayLastMsTimestamp = new Date(`2023-08-30T15:00:00.000Z`).getTime()
+    const latestUpdateIsCurrentDayResult = latestUpdateIsWithinLast24h(yesterdayLastMsTimestamp)
+    expect(latestUpdateIsCurrentDayResult).toBe(true)
+  })
+
+  it('returns false when past of 24 hours + 30 mins of latest update', () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date('2023-08-31T15:30:00.000Z'))
+    const yesterdayLastMsTimestamp = new Date(`2023-08-30T15:00:00.000Z`).getTime()
+    const latestUpdateIsCurrentDayResult = latestUpdateIsWithinLast24h(yesterdayLastMsTimestamp)
+    expect(latestUpdateIsCurrentDayResult).toBe(false)
   })
 })


### PR DESCRIPTION
## Closes [DF-19169](https://smartcontract-it.atlassian.net/browse/DF-19169)

## Description
Fixing `Latest update from response is not in current day` log spam in CF Benchmarks BIRC endpoint

## Changes

- Changed `last day` check to `last ~24 hrs` check in order to avoid spamming logs as reported by NOPs
- Added %o to log to pick up response that was previously ignored
- Testing with mocked Date

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. run cfbenchmarks unit tests from root dir with `EA_PORT=0 METRICS_ENABLED=false yarn test cfbenchmarks/test/unit`
2. Between 12AM and 3PM GMT, run the EA and verify the log is not seen when querying the BIRC endpoint

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[DF-19169]: https://smartcontract-it.atlassian.net/browse/DF-19169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ