### PR TITLE
Stop using ea-bootstrap type in V3 EA test

### DIFF
--- a/.changeset/chilled-queens-bake.md
+++ b/.changeset/chilled-queens-bake.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/view-function-adapter': patch
+---
+
+Stop using EA Bootstrap type in V3 EA tests.

--- a/packages/sources/view-function/test/integration/fixtures.ts
+++ b/packages/sources/view-function/test/integration/fixtures.ts
@@ -1,5 +1,12 @@
-import { AdapterRequest } from '@chainlink/ea-bootstrap'
 import nock from 'nock'
+
+type JsonRpcPayload = {
+  id: number
+  method: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  params: Array<any> | Record<string, any>
+  jsonrpc: '2.0'
+}
 
 export const mockContractCallResponseSuccess = (): nock.Scope =>
   nock('http://localhost:8545', {
@@ -9,7 +16,7 @@ export const mockContractCallResponseSuccess = (): nock.Scope =>
     .post('/', { method: 'eth_chainId', params: [], id: /^\d+$/, jsonrpc: '2.0' })
     .reply(
       200,
-      (_, request: AdapterRequest) => ({ jsonrpc: '2.0', id: request['id'], result: '0x1' }),
+      (_, request: JsonRpcPayload) => ({ jsonrpc: '2.0', id: request['id'], result: '0x1' }),
       [
         'Content-Type',
         'application/json',
@@ -29,7 +36,7 @@ export const mockContractCallResponseSuccess = (): nock.Scope =>
     })
     .reply(
       200,
-      (_, request: AdapterRequest) => ({
+      (_, request: JsonRpcPayload) => ({
         jsonrpc: '2.0',
         id: request['id'],
         result:


### PR DESCRIPTION
* Fixes broken import for `view-function` tests - was using an ea-bootstrap import despite being a V3 EA. 