### PR TITLE
Finage: Add 'etf' endpoint

### DIFF
--- a/.changeset/hungry-mugs-hope.md
+++ b/.changeset/hungry-mugs-hope.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/finage-adapter': minor
+---
+
+Add ETF endpoint.

--- a/packages/sources/finage/README.md
+++ b/packages/sources/finage/README.md
@@ -31,9 +31,9 @@ This document was generated automatically. Please see [README Generator](../../s
 
 Every EA supports base input parameters from [this list](../../core/bootstrap#base-input-parameters)
 
-| Required? |   Name   |     Description     |  Type  |                                                                                Options                                                                                | Default |
-| :-------: | :------: | :-----------------: | :----: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-----: |
-|           | endpoint | The endpoint to use | string | [commodities](#commodities-endpoint), [crypto](#crypto-endpoint), [eod](#eod-endpoint), [forex](#forex-endpoint), [stock](#stock-endpoint), [uk_etf](#uketf-endpoint) | `stock` |
+| Required? |   Name   |     Description     |  Type  |                                                                                           Options                                                                                           | Default |
+| :-------: | :------: | :-----------------: | :----: | :-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-----: |
+|           | endpoint | The endpoint to use | string | [commodities](#commodities-endpoint), [crypto](#crypto-endpoint), [eod](#eod-endpoint), [etf](#etf-endpoint), [forex](#forex-endpoint), [stock](#stock-endpoint), [uk_etf](#uketf-endpoint) | `stock` |
 
 ## Stock Endpoint
 
@@ -343,6 +343,56 @@ Response:
     "result": 5.276
   },
   "result": 5.276,
+  "statusCode": 200,
+  "providerStatusCode": 200
+}
+```
+
+---
+
+## Etf Endpoint
+
+https://finage.co.uk/docs/api/etf-last-price
+The result will be the price field in response.
+
+`etf` is the only supported name for this endpoint.
+
+### Input Params
+
+| Required? | Name |     Aliases      |          Description           | Type | Options | Default | Depends On | Not Valid With |
+| :-------: | :--: | :--------------: | :----------------------------: | :--: | :-----: | :-----: | :--------: | :------------: |
+|    ✅     | base | `from`, `symbol` | The symbol of the etf to query |      |         |         |            |                |
+
+### Example
+
+Request:
+
+```json
+{
+  "id": "1",
+  "data": {
+    "endpoint": "etf",
+    "base": "C3M"
+  },
+  "debug": {
+    "cacheKey": "0d9256e97e16ac94e4fd9561e32092741958cef4"
+  },
+  "rateLimitMaxAge": 60000
+}
+```
+
+Response:
+
+```json
+{
+  "jobRunID": "1",
+  "data": {
+    "symbol": "C3M",
+    "price": 117.38,
+    "timestamp": 1684403239105,
+    "result": 117.38
+  },
+  "result": 117.38,
   "statusCode": 200,
   "providerStatusCode": 200
 }

--- a/packages/sources/finage/src/adapter.ts
+++ b/packages/sources/finage/src/adapter.ts
@@ -40,6 +40,8 @@ interface Message {
   s: string
 }
 
+const etfEndpoints = [...endpoints.etf.supportedEndpoints, ...endpoints.ukEtf.supportedEndpoints]
+
 export const makeWSHandler = (config?: Config): MakeWSHandler<Message | any> =>
   // TODO : WS message types
   {
@@ -51,9 +53,7 @@ export const makeWSHandler = (config?: Config): MakeWSHandler<Message | any> =>
       }
     }
     const isEtf = (input: AdapterRequest): boolean =>
-      !!input.data.endpoint &&
-      (endpoints.etf.supportedEndpoints.includes(input?.data?.endpoint) ||
-        endpoints.ukEtf.supportedEndpoints.includes(input?.data?.endpoint))
+      !!input.data.endpoint && etfEndpoints.includes(input?.data?.endpoint)
 
     const isStock = (input: AdapterRequest): boolean =>
       !!input.data.endpoint && endpoints.stock.supportedEndpoints.includes(input.data.endpoint)

--- a/packages/sources/finage/src/adapter.ts
+++ b/packages/sources/finage/src/adapter.ts
@@ -51,7 +51,9 @@ export const makeWSHandler = (config?: Config): MakeWSHandler<Message | any> =>
       }
     }
     const isEtf = (input: AdapterRequest): boolean =>
-      !!input.data.endpoint && endpoints.ukEtf.supportedEndpoints.includes(input?.data?.endpoint)
+      !!input.data.endpoint &&
+      (endpoints.etf.supportedEndpoints.includes(input?.data?.endpoint) ||
+        endpoints.ukEtf.supportedEndpoints.includes(input?.data?.endpoint))
 
     const isStock = (input: AdapterRequest): boolean =>
       !!input.data.endpoint && endpoints.stock.supportedEndpoints.includes(input.data.endpoint)
@@ -65,7 +67,7 @@ export const makeWSHandler = (config?: Config): MakeWSHandler<Message | any> =>
     const getEtfSymbol = (input: AdapterRequest) => {
       const validator = new Validator(
         input,
-        endpoints.ukEtf.inputParameters,
+        endpoints.etf.inputParameters,
         {},
         { shouldThrowError: false, overrides },
       )
@@ -158,7 +160,7 @@ export const makeWSHandler = (config?: Config): MakeWSHandler<Message | any> =>
             }
           } else if (isEtf(input)) {
             return {
-              key: 'uk_etf',
+              key: 'etf',
               url: defaultConfig.etfWsEndpoint,
             }
           }

--- a/packages/sources/finage/src/endpoint/etf.ts
+++ b/packages/sources/finage/src/endpoint/etf.ts
@@ -37,13 +37,12 @@ export const makeEtfExecute =
 
     const params = {
       apikey: config.apiKey,
-      country: executeConfig.country,
     }
 
     const options = {
       ...config.api,
       url,
-      params,
+      params: executeConfig.country ? { ...params, country: executeConfig.country } : params,
     }
 
     const response = await Requester.request<ResponseSchema | ResponseSchema[]>(options)

--- a/packages/sources/finage/src/endpoint/etf.ts
+++ b/packages/sources/finage/src/endpoint/etf.ts
@@ -1,0 +1,55 @@
+import type { Config, ExecuteWithConfig, InputParameters } from '@chainlink/ea-bootstrap'
+import { Requester, util, Validator } from '@chainlink/ea-bootstrap'
+import { NAME } from '../config'
+import overrides from '../config/symbols.json'
+
+export const supportedEndpoints = ['etf']
+export const batchablePropertyPath = [{ name: 'base' }]
+
+export const description = `https://finage.co.uk/docs/api/etf-last-price
+The result will be the price field in response.`
+
+export type TInputParameters = { base: string }
+export const inputParameters: InputParameters<TInputParameters> = {
+  base: {
+    required: true,
+    aliases: ['from', 'symbol'],
+    description: 'The symbol of the etf to query',
+  },
+}
+
+export interface ResponseSchema {
+  symbol: string
+  price: number
+  timestamp: number
+}
+
+export const makeEtfExecute =
+  (executeConfig: { country?: string }): ExecuteWithConfig<Config> =>
+  async (request, _, config) => {
+    const validator = new Validator(request, inputParameters, {}, { overrides })
+
+    const jobRunID = validator.validated.id
+    const base = validator.validated.data.base
+    const symbol = validator.overrideSymbol(NAME, base).toUpperCase()
+
+    const url = util.buildUrlPath('/last/etf/:symbol', { symbol })
+
+    const params = {
+      apikey: config.apiKey,
+      country: executeConfig.country,
+    }
+
+    const options = {
+      ...config.api,
+      url,
+      params,
+    }
+
+    const response = await Requester.request<ResponseSchema | ResponseSchema[]>(options)
+
+    const result = Requester.validateResultNumber(response.data, ['price'])
+    return Requester.success(jobRunID, Requester.withResult(response, result), config.verbose)
+  }
+
+export const execute = makeEtfExecute({})

--- a/packages/sources/finage/src/endpoint/index.ts
+++ b/packages/sources/finage/src/endpoint/index.ts
@@ -3,7 +3,7 @@ import type { TInputParameters as EodInputParameters } from './eod'
 import type { TInputParameters as ForexInputParameters } from './forex'
 import type { TInputParameters as CryptoInputParameters } from './crypto'
 import type { TInputParameters as CommoditiesInputParameters } from './commodities'
-import type { TInputParameters as UkEtfInputParameters } from './uk-etf'
+import type { TInputParameters as EtfInputParameters } from './etf'
 
 export type TInputParameters =
   | StockInputParameters
@@ -11,7 +11,7 @@ export type TInputParameters =
   | ForexInputParameters
   | CryptoInputParameters
   | CommoditiesInputParameters
-  | UkEtfInputParameters
+  | EtfInputParameters
 
 export * as stock from './stock'
 export * as eod from './eod'
@@ -19,3 +19,4 @@ export * as forex from './forex'
 export * as crypto from './crypto'
 export * as commodities from './commodities'
 export * as ukEtf from './uk-etf'
+export * as etf from './etf'

--- a/packages/sources/finage/src/endpoint/uk-etf.ts
+++ b/packages/sources/finage/src/endpoint/uk-etf.ts
@@ -1,51 +1,12 @@
-import type { Config, ExecuteWithConfig, InputParameters } from '@chainlink/ea-bootstrap'
-import { Requester, util, Validator } from '@chainlink/ea-bootstrap'
-import { NAME } from '../config'
-import overrides from '../config/symbols.json'
+import { makeEtfExecute } from './etf'
+import { inputParameters as etfInputParameters } from './etf'
 
 export const supportedEndpoints = ['uk_etf']
 export const batchablePropertyPath = [{ name: 'base' }]
 
+export const inputParameters = etfInputParameters
+
 export const description = `https://finage.co.uk/docs/api/etf-last-price
 The result will be the price field in response.`
 
-export type TInputParameters = { base: string }
-export const inputParameters: InputParameters<TInputParameters> = {
-  base: {
-    required: true,
-    aliases: ['from', 'symbol'],
-    description: 'The symbol of the etf to query',
-  },
-}
-
-export interface ResponseSchema {
-  symbol: string
-  price: number
-  timestamp: number
-}
-
-export const execute: ExecuteWithConfig<Config> = async (request, _, config) => {
-  const validator = new Validator(request, inputParameters, {}, { overrides })
-
-  const jobRunID = validator.validated.id
-  const base = validator.validated.data.base
-  const symbol = validator.overrideSymbol(NAME, base).toUpperCase()
-
-  const url = util.buildUrlPath('/last/etf/:symbol', { symbol })
-
-  const params = {
-    apikey: config.apiKey,
-    country: 'uk',
-  }
-
-  const options = {
-    ...config.api,
-    url,
-    params,
-  }
-
-  const response = await Requester.request<ResponseSchema | ResponseSchema[]>(options)
-
-  const result = Requester.validateResultNumber(response.data, ['price'])
-  return Requester.success(jobRunID, Requester.withResult(response, result), config.verbose)
-}
+export const execute = makeEtfExecute({ country: 'uk' })

--- a/packages/sources/finage/test-payload.json
+++ b/packages/sources/finage/test-payload.json
@@ -1,6 +1,16 @@
 {
- "requests": [{
-  "base": "IWM",
-  "endpoint": "stock"
- }]
+    "requests": [
+        {
+            "base": "IWM",
+            "endpoint": "stock"
+        },
+        {
+            "base": "IB01",
+            "endpoint": "uk_etf"
+        },
+        {
+            "base": "C3M",
+            "endpoint": "etf"
+        }
+    ]
 }

--- a/packages/sources/finage/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/finage/test/integration/__snapshots__/adapter.test.ts.snap
@@ -52,6 +52,34 @@ exports[`execute eod api should return success 1`] = `
 }
 `;
 
+exports[`execute etf api should return success 1`] = `
+{
+  "data": {
+    "result": 117.38,
+  },
+  "jobRunID": "1",
+  "providerStatusCode": 200,
+  "result": 117.38,
+  "statusCode": 200,
+}
+`;
+
+exports[`execute etf api with invalid base should return failure 1`] = `
+{
+  "error": {
+    "errorResponse": "Please check the symbol and try again.",
+    "feedID": "{"data":{"endpoint":"etf","base":"NON_EXISTING_ETF"}}",
+    "message": "Request failed with status code 400",
+    "name": "AdapterError",
+    "url": "https:/api.finage.co.uk/last/etf/NON_EXISTING_ETF",
+  },
+  "jobRunID": "1",
+  "providerStatusCode": 400,
+  "status": "errored",
+  "statusCode": 200,
+}
+`;
+
 exports[`execute forex api should return success 1`] = `
 {
   "data": {

--- a/packages/sources/finage/test/integration/adapter.test.ts
+++ b/packages/sources/finage/test/integration/adapter.test.ts
@@ -94,6 +94,52 @@ describe('execute', () => {
     })
   })
 
+  describe('etf api', () => {
+    const data: AdapterRequest = {
+      id,
+      data: {
+        endpoint: 'etf',
+        base: 'C3M',
+      },
+    }
+
+    it('should return success', async () => {
+      mockResponseSuccess()
+
+      const response = await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+      expect(response.body).toMatchSnapshot()
+    })
+  })
+
+  describe('etf api with invalid base', () => {
+    const data: AdapterRequest = {
+      id,
+      data: {
+        endpoint: 'etf',
+        base: 'NON_EXISTING_ETF',
+      },
+    }
+
+    it('should return failure', async () => {
+      mockResponseFailure()
+
+      const response = await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+      expect(response.body).toMatchSnapshot()
+    })
+  })
+
   describe('stock api', () => {
     const data: AdapterRequest = {
       id,

--- a/packages/sources/finage/test/integration/fixtures.ts
+++ b/packages/sources/finage/test/integration/fixtures.ts
@@ -46,6 +46,15 @@ export const mockResponseSuccess = (): nock.Scope =>
       price: 5.276,
       timestamp: 1684403239105,
     })
+    .get('/last/etf/C3M')
+    .query({
+      ...API_KEY_QUERY,
+    })
+    .reply(200, {
+      symbol: 'C3M',
+      price: 117.38,
+      timestamp: 1684403239105,
+    })
 
 export const mockResponseFailure = (): nock.Scope =>
   nock('https://api.finage.co.uk', {
@@ -60,6 +69,11 @@ export const mockResponseFailure = (): nock.Scope =>
     .get('/last/etf/NON_EXISTING_UK_ETF')
     .query({
       country: 'uk',
+      ...API_KEY_QUERY,
+    })
+    .reply(400, () => ({ error: 'Please check the symbol and try again.' }))
+    .get('/last/etf/NON_EXISTING_ETF')
+    .query({
       ...API_KEY_QUERY,
     })
     .reply(400, () => ({ error: 'Please check the symbol and try again.' }))


### PR DESCRIPTION
## Closes DF-19148

## Description
* Adds `etf` endpoint, which allows for fetching ETF data without country codes 
  * Existing endpoint `uk_etf` can only fetch UK ETFs. `uk_etf` kept for backwards compatibility.
* WebSocket is unchanged, as `uk_etf` WS doesn't actually specific a country. Only change is to include both the `etf` and `uk_etf` aliases. 

## Changes

- Add `etf` endpoint.
- Update `uk_etf` to reference `etf`'s makeExecute. 
- Added tests for `etf`.

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. `yarn && yarn setup && (cd packages/sources/finage && export API_KEY="..." export WS_SOCKET_KEY="..." && yarn start`
2. `curl --request POST \ --url http://localhost:8080/ \ --header 'Content-Type: application/json' \ --data '{ "id": "1", "data": { "endpoint": "etf", "base": "C3M" } }'`
3. `curl --request POST \ --url http://localhost:8080/ \ --header 'Content-Type: application/json' \ --data '{ "id": "1", "data": { "endpoint": "uk_etf", "base": "IB01" } }'`

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [X] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
