### PR TITLE
Include the network in L2 Sequencer Health logs

### DIFF
--- a/.changeset/chatty-trainers-trade.md
+++ b/.changeset/chatty-trainers-trade.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/layer2-sequencer-health-adapter': patch
+---
+
+Include the network in L2 Sequencer Health logs

--- a/packages/sources/layer2-sequencer-health/src/adapter.ts
+++ b/packages/sources/layer2-sequencer-health/src/adapter.ts
@@ -34,7 +34,7 @@ export const makeExecute: ExecuteFactory<ExtendedConfig, endpoints.TInputParamet
   // Disclaimer on startup
   Object.keys(HEALTH_ENDPOINTS).forEach((network) => {
     if (!HEALTH_ENDPOINTS[network as Networks]?.endpoint)
-      Logger.info(`Health endpoint not available for network: ${network}`)
+      Logger.info(`[${network}] Health endpoint not available for network: ${network}`)
   })
   return async (request, context) => execute(request, context, config || makeConfig())
 }

--- a/packages/sources/layer2-sequencer-health/src/endpoint/health.ts
+++ b/packages/sources/layer2-sequencer-health/src/endpoint/health.ts
@@ -54,14 +54,14 @@ export const execute: ExecuteWithConfig<ExtendedConfig> = async (request, _, con
         const isHealthy = await fn(network, config)
         if (isHealthy === false) {
           Logger.warn(
-            `Method ${fn.name} reported an unhealthy response. Network ${network} considered unhealthy`,
+            `[${network}] Method ${fn.name} reported an unhealthy response. Network ${network} considered unhealthy`,
           )
           return false
         }
       } catch (e: any) {
         const error = e as Error
         Logger.error(
-          `Method ${fn.name} failed: ${error.message}. Network ${network} considered unhealthy`,
+          `[${network}] Method ${fn.name} failed: ${error.message}. Network ${network} considered unhealthy`,
         )
         return false
       }
@@ -79,7 +79,7 @@ export const execute: ExecuteWithConfig<ExtendedConfig> = async (request, _, con
     const method = wrappedMethods[i]
     const isHealthy = await method(network, config)
     if (!isHealthy) {
-      Logger.info(`Checking unhealthy network ${network} with transaction submission`)
+      Logger.info(`[${network}] Checking unhealthy network ${network} with transaction submission`)
       let isHealthyByTransaction
       try {
         isHealthyByTransaction = await getStatusByTransaction(network, config)
@@ -92,7 +92,7 @@ export const execute: ExecuteWithConfig<ExtendedConfig> = async (request, _, con
       }
       if (isHealthyByTransaction) {
         Logger.info(
-          `Transaction submission check succeeded. Network ${network} can be considered healthy`,
+          `[${network}] Transaction submission check succeeded. Network ${network} can be considered healthy`,
         )
         return _respond(true)
       }

--- a/packages/sources/layer2-sequencer-health/src/evm.ts
+++ b/packages/sources/layer2-sequencer-health/src/evm.ts
@@ -107,14 +107,14 @@ export const checkOptimisticRollupBlockHeight = (
     if (!_isStaleBlock(block, delta)) {
       if (!_isPastBlock(block)) _updateLastSeenBlock(block)
       Logger.info(
-        `Block #${block} is not considered stale at ${Date.now()}. Last seen block #${
+        `[${network}] Block #${block} is not considered stale at ${Date.now()}. Last seen block #${
           lastSeenBlock[network].block
         } was at ${lastSeenBlock[network].timestamp}`,
       )
       return true
     }
     Logger.warn(
-      `Block #${block} is considered stale at ${Date.now()}. Last seen block #${
+      `[${network}] Block #${block} is considered stale at ${Date.now()}. Last seen block #${
         lastSeenBlock[network].block
       } was at ${lastSeenBlock[network].timestamp}, more than ${delta} milliseconds ago.`,
     )

--- a/packages/sources/layer2-sequencer-health/src/network.ts
+++ b/packages/sources/layer2-sequencer-health/src/network.ts
@@ -49,7 +49,7 @@ export const checkSequencerHealth: NetworkHealthCheck = async (
   })
   const isHealthy = !!Requester.getResult(response.data, HEALTH_ENDPOINTS[network]?.responsePath)
   Logger.info(
-    `Health endpoint for network ${network} returned a ${
+    `[${network}] Health endpoint for network ${network} returned a ${
       isHealthy ? 'healthy' : 'unhealthy'
     } response`,
   )
@@ -62,7 +62,7 @@ export const getStatusByTransaction = async (
 ): Promise<boolean> => {
   let isSequencerHealthy = true
   try {
-    Logger.info(`Submitting empty transaction for network: ${network}`)
+    Logger.info(`[${network}] Submitting empty transaction for network: ${network}`)
     await sendEmptyTransaction(network, config)
   } catch (e) {
     isSequencerHealthy = isExpectedErrorMessage(network, e as Error)
@@ -92,12 +92,15 @@ const isExpectedErrorMessage = (network: Networks, e: Error) => {
     return (Requester.getResult(e, paths[network]) as string) || ''
   }
   const error = e as Error
-  if (sequencerOnlineErrors[network].includes(_getErrorMessage(error))) {
-    Logger.debug(`Transaction submission failed with an expected error ${_getErrorMessage(error)}.`)
+  const errorMessage = _getErrorMessage(error)
+  if (sequencerOnlineErrors[network].includes(errorMessage)) {
+    Logger.debug(
+      `[${network}] Transaction submission failed with an expected error ${errorMessage}.`,
+    )
     return true
   }
   Logger.error(
-    `Transaction submission failed with an unexpected error. ${NO_ISSUE_MSG} Error Message: ${error.message}`,
+    `[${network}] Transaction submission failed with an unexpected error. ${NO_ISSUE_MSG} Error Message: ${error.message}`,
   )
   return false
 }

--- a/packages/sources/layer2-sequencer-health/src/starkware.ts
+++ b/packages/sources/layer2-sequencer-health/src/starkware.ts
@@ -59,7 +59,7 @@ export const checkStarkwareSequencerPendingTransactions = (): ((
     const currentTime = Date.now()
     if (state.lastUpdated > 0 && currentTime - state.lastUpdated < delta) {
       Logger.debug(
-        `Skipping check for Starkware Sequencer health as it has been less than ${delta} seconds since last check`,
+        `[starkware] Skipping check for Starkware Sequencer health as it has been less than ${delta} seconds since last check`,
       )
       return state.isSequencerHealthy
     }
@@ -94,7 +94,7 @@ const getPendingBlockFromGateway = async (
   } catch (e: any) {
     if (e.providerStatusCode === 504) {
       Logger.warn(
-        `Request to fetch pending block timed out.  Status Code: ${e.providerStatusCode}.  Sequencer: UNHEALTHY`,
+        `[starkware] Request to fetch pending block timed out.  Status Code: ${e.providerStatusCode}.  Sequencer: UNHEALTHY`,
       )
     } else {
       throw e
@@ -114,19 +114,19 @@ const checkBatcherHealthy = (
   }
   if (previousBlock.parent_hash !== currentBlock.parent_hash) {
     Logger.info(
-      `New pending Starkware block found with parent hash ${currentBlock.parent_hash}.  Sequencer: HEALTHY`,
+      `[starkware] New pending Starkware block found with parent hash ${currentBlock.parent_hash}.  Sequencer: HEALTHY`,
     )
     return true
   }
   Logger.info(
-    `Pending Starkware block still has parent hash of ${currentBlock.parent_hash}.  Checking to see if it is still processing transactions...`,
+    `[starkware] Pending Starkware block still has parent hash of ${currentBlock.parent_hash}.  Checking to see if it is still processing transactions...`,
   )
   const hasNewTxns =
     Object.keys(currentBlock.transactions).length > previousBlock.transactions.length
   if (hasNewTxns) {
-    Logger.info(`Found new transactions in pending block.  Sequencer: HEALTHY`)
+    Logger.info(`[starkware] Found new transactions in pending block.  Sequencer: HEALTHY`)
   } else {
-    Logger.info(`Did not find new transactions in pending block.  Sequencer: UNHEALTHY`)
+    Logger.info(`[starkware] Did not find new transactions in pending block.  Sequencer: UNHEALTHY`)
   }
   return hasNewTxns
 }


### PR DESCRIPTION
* Currently debugging can be challenging if an EA is checking the health for multiple networks, as you can't tell which network a log line is for. This commit adds a prefix to all logs to include the network, for easier debugging. 