### PR TITLE
L2 sequencer health tx optional

### DIFF
--- a/.changeset/poor-wasps-collect.md
+++ b/.changeset/poor-wasps-collect.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/layer2-sequencer-health-adapter': minor
+---
+
+Add requireTxFailure input param to only require tx if default checks are insufficient

--- a/.changeset/poor-wasps-collect.md
+++ b/.changeset/poor-wasps-collect.md
@@ -2,4 +2,4 @@
 '@chainlink/layer2-sequencer-health-adapter': minor
 ---
 
-Add requireTxFailure input param which has conditional defaults depending on the network. The default behavior is the same as before for all networks except Base, which now does not use a tx call as the final decider of health.
+Add a requireTxFailure input param which has conditional defaults depending on the network. The default behavior is the same as before for all networks except Base, which now does not use a tx call as the final decider of health.

--- a/.changeset/poor-wasps-collect.md
+++ b/.changeset/poor-wasps-collect.md
@@ -2,4 +2,4 @@
 '@chainlink/layer2-sequencer-health-adapter': minor
 ---
 
-Add requireTxFailure input param to only require tx if default checks are insufficient
+Add requireTxFailure input param which has conditional defaults depending on the network. The default behavior is the same as before for all networks except Base, which now does not use a tx call as the final decider of health.

--- a/packages/sources/layer2-sequencer-health/src/endpoint/health.ts
+++ b/packages/sources/layer2-sequencer-health/src/endpoint/health.ts
@@ -88,7 +88,9 @@ export const execute: ExecuteWithConfig<ExtendedConfig> = async (request, _, con
     const isHealthy = await method(network, config)
     if (!isHealthy) {
       if (validator.validated.data.requireTxFailure) {
-        Logger.info(`[${network}] Checking unhealthy network ${network} with transaction submission`)
+        Logger.info(
+          `[${network}] Checking unhealthy network ${network} with transaction submission`,
+        )
         let isHealthyByTransaction
         try {
           isHealthyByTransaction = await getStatusByTransaction(network, config)

--- a/packages/sources/layer2-sequencer-health/src/endpoint/health.ts
+++ b/packages/sources/layer2-sequencer-health/src/endpoint/health.ts
@@ -42,7 +42,7 @@ export const inputParameters: InputParameters<TInputParameters> = {
   requireTxFailure: {
     required: false,
     description:
-      'Require the EA to attempt a tx as final proof whether the chain is healthy. This is `true` by default when `network`=`base`',
+      'Require the EA to attempt a tx as final proof whether the chain is healthy. This is `true` by default except when `network`=`base`',
   },
 }
 

--- a/packages/sources/layer2-sequencer-health/test/integration/__snapshots__/onchainFailKnown.test.ts.snap
+++ b/packages/sources/layer2-sequencer-health/test/integration/__snapshots__/onchainFailKnown.test.ts.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`execute arbitrum network should return failure if tx not required 1`] = `
+{
+  "data": {
+    "result": 1,
+  },
+  "jobRunID": "1",
+  "result": 1,
+  "statusCode": 200,
+}
+`;
+
 exports[`execute arbitrum network should return success when transaction submission is known 1`] = `
 {
   "data": {
@@ -11,6 +22,17 @@ exports[`execute arbitrum network should return success when transaction submiss
 }
 `;
 
+exports[`execute base network should return failure if tx not required 1`] = `
+{
+  "data": {
+    "result": 1,
+  },
+  "jobRunID": "1",
+  "result": 1,
+  "statusCode": 200,
+}
+`;
+
 exports[`execute base network should return success when transaction submission is known 1`] = `
 {
   "data": {
@@ -18,6 +40,17 @@ exports[`execute base network should return success when transaction submission 
   },
   "jobRunID": "1",
   "result": 0,
+  "statusCode": 200,
+}
+`;
+
+exports[`execute optimism network should return failure if tx not required 1`] = `
+{
+  "data": {
+    "result": 1,
+  },
+  "jobRunID": "1",
+  "result": 1,
   "statusCode": 200,
 }
 `;

--- a/packages/sources/layer2-sequencer-health/test/integration/__snapshots__/onchainFailKnown.test.ts.snap
+++ b/packages/sources/layer2-sequencer-health/test/integration/__snapshots__/onchainFailKnown.test.ts.snap
@@ -44,6 +44,28 @@ exports[`execute base network should return success when transaction submission 
 }
 `;
 
+exports[`execute metis network should return failure if tx not required 1`] = `
+{
+  "data": {
+    "result": 1,
+  },
+  "jobRunID": "1",
+  "result": 1,
+  "statusCode": 200,
+}
+`;
+
+exports[`execute metis network should return success when transaction submission is known 1`] = `
+{
+  "data": {
+    "result": 0,
+  },
+  "jobRunID": "1",
+  "result": 0,
+  "statusCode": 200,
+}
+`;
+
 exports[`execute optimism network should return failure if tx not required 1`] = `
 {
   "data": {

--- a/packages/sources/layer2-sequencer-health/test/integration/__snapshots__/onchainFailUnknown.test.ts.snap
+++ b/packages/sources/layer2-sequencer-health/test/integration/__snapshots__/onchainFailUnknown.test.ts.snap
@@ -22,6 +22,17 @@ exports[`execute base network should return failure when transaction submission 
 }
 `;
 
+exports[`execute metis network should return failure when transaction submission is unknown 1`] = `
+{
+  "data": {
+    "result": 1,
+  },
+  "jobRunID": "1",
+  "result": 1,
+  "statusCode": 200,
+}
+`;
+
 exports[`execute optimism network should return failure when transaction submission is unknown 1`] = `
 {
   "data": {

--- a/packages/sources/layer2-sequencer-health/test/integration/__snapshots__/onchainSuccess.test.ts.snap
+++ b/packages/sources/layer2-sequencer-health/test/integration/__snapshots__/onchainSuccess.test.ts.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`execute arbitrum network should return failure if tx not required even if it would be successful 1`] = `
+{
+  "data": {
+    "result": 1,
+  },
+  "jobRunID": "1",
+  "result": 1,
+  "statusCode": 200,
+}
+`;
+
 exports[`execute arbitrum network should return success when all methods succeed 1`] = `
 {
   "data": {
@@ -40,6 +51,17 @@ exports[`execute base network should return transaction submission is successful
   },
   "jobRunID": "1",
   "result": 0,
+  "statusCode": 200,
+}
+`;
+
+exports[`execute optimism network should return failure if tx not required even if it would be successful 1`] = `
+{
+  "data": {
+    "result": 1,
+  },
+  "jobRunID": "1",
+  "result": 1,
   "statusCode": 200,
 }
 `;

--- a/packages/sources/layer2-sequencer-health/test/integration/__snapshots__/onchainSuccess.test.ts.snap
+++ b/packages/sources/layer2-sequencer-health/test/integration/__snapshots__/onchainSuccess.test.ts.snap
@@ -33,6 +33,17 @@ exports[`execute arbitrum network should return transaction submission is succes
 }
 `;
 
+exports[`execute base network should return failure if tx not required even if it would be successful 1`] = `
+{
+  "data": {
+    "result": 1,
+  },
+  "jobRunID": "1",
+  "result": 1,
+  "statusCode": 200,
+}
+`;
+
 exports[`execute base network should return success when all methods succeed 1`] = `
 {
   "data": {
@@ -45,6 +56,39 @@ exports[`execute base network should return success when all methods succeed 1`]
 `;
 
 exports[`execute base network should return transaction submission is successful 1`] = `
+{
+  "data": {
+    "result": 0,
+  },
+  "jobRunID": "1",
+  "result": 0,
+  "statusCode": 200,
+}
+`;
+
+exports[`execute metis network should return failure if tx not required even if it would be successful 1`] = `
+{
+  "data": {
+    "result": 1,
+  },
+  "jobRunID": "1",
+  "result": 1,
+  "statusCode": 200,
+}
+`;
+
+exports[`execute metis network should return success when all methods succeed 1`] = `
+{
+  "data": {
+    "result": 0,
+  },
+  "jobRunID": "1",
+  "result": 0,
+  "statusCode": 200,
+}
+`;
+
+exports[`execute metis network should return transaction submission is successful 1`] = `
 {
   "data": {
     "result": 0,

--- a/packages/sources/layer2-sequencer-health/test/integration/fixtures.ts
+++ b/packages/sources/layer2-sequencer-health/test/integration/fixtures.ts
@@ -15,6 +15,20 @@ export const mockResponseSuccessHealth = (): void => {
       'Vary',
       'Origin',
     ])
+
+  nock('https://tokenapi.metis.io/andromeda/health')
+    .get('')
+    .query(() => true)
+    .reply(200, (_) => ({ healthy: 'true' }), [
+      'Content-Type',
+      'application/json',
+      'Connection',
+      'close',
+      'Vary',
+      'Accept-Encoding',
+      'Vary',
+      'Origin',
+    ])
 }
 
 export const mockResponseSuccessBlock = (): void => {
@@ -57,6 +71,19 @@ export const mockResponseSuccessBlock = (): void => {
       'Vary',
       'Origin',
     ])
+
+  nock('https://andromeda.metis.io/?owner=1088')
+    .post('/', { jsonrpc: '2.0', method: 'eth_blockNumber', params: [], id: /^\d+$/ })
+    .reply(200, () => ({ jsonrpc: '2.0', id: 1, result: '0x42d293' }), [
+      'Content-Type',
+      'application/json',
+      'Connection',
+      'close',
+      'Vary',
+      'Accept-Encoding',
+      'Vary',
+      'Origin',
+    ])
 }
 
 export const mockResponseSuccessRollup = (): void => {
@@ -71,6 +98,20 @@ export const mockResponseFailureHealth = (): void => {
   })
     .get('/')
     .reply(500, () => ({ healthy: 'false' }), [
+      'Content-Type',
+      'application/json',
+      'Connection',
+      'close',
+      'Vary',
+      'Accept-Encoding',
+      'Vary',
+      'Origin',
+    ])
+
+  nock('https://tokenapi.metis.io/andromeda/health')
+    .get('')
+    .query(() => true)
+    .reply(200, (_) => ({ healthy: 'false' }), [
       'Content-Type',
       'application/json',
       'Connection',
@@ -111,6 +152,19 @@ export const mockResponseFailureBlock = (): void => {
     ])
 
   nock('https://mainnet.base.org')
+    .post('/', { jsonrpc: '2.0', method: 'eth_blockNumber', params: [], id: /^\d+$/ })
+    .reply(200, () => ({ jsonrpc: '2.0', id: 1, result: '0x00' }), [
+      'Content-Type',
+      'application/json',
+      'Connection',
+      'close',
+      'Vary',
+      'Accept-Encoding',
+      'Vary',
+      'Origin',
+    ])
+
+  nock('https://andromeda.metis.io/?owner=1088')
     .post('/', { jsonrpc: '2.0', method: 'eth_blockNumber', params: [], id: /^\d+$/ })
     .reply(200, () => ({ jsonrpc: '2.0', id: 1, result: '0x00' }), [
       'Content-Type',

--- a/packages/sources/layer2-sequencer-health/test/integration/onchainFailKnown.test.ts
+++ b/packages/sources/layer2-sequencer-health/test/integration/onchainFailKnown.test.ts
@@ -147,7 +147,7 @@ describe('execute', () => {
         id,
         data: {
           network: 'base',
-          requireTxFailure: true
+          requireTxFailure: true,
         },
       }
 

--- a/packages/sources/layer2-sequencer-health/test/integration/onchainFailKnown.test.ts
+++ b/packages/sources/layer2-sequencer-health/test/integration/onchainFailKnown.test.ts
@@ -45,16 +45,17 @@ describe('execute', () => {
   setupExternalAdapterTest(envVariables, context)
 
   describe('arbitrum network', () => {
-    const data: AdapterRequest = {
-      id,
-      data: {
-        network: 'arbitrum',
-      },
-    }
-
     it('should return success when transaction submission is known', async () => {
       mockResponseFailureHealth()
       mockResponseFailureBlock()
+
+      const data: AdapterRequest = {
+        id,
+        data: {
+          network: 'arbitrum',
+          requireTxFailure: true,
+        },
+      }
 
       const response = await (context.req as SuperTest<Test>)
         .post('/')
@@ -64,21 +65,44 @@ describe('execute', () => {
         .expect('Content-Type', /json/)
         .expect(200)
       expect(response.body.result).toEqual(0)
+      expect(response.body).toMatchSnapshot()
+    })
+
+    it('should return failure if tx not required', async () => {
+      mockResponseFailureHealth()
+      mockResponseFailureBlock()
+
+      const data: AdapterRequest = {
+        id,
+        data: {
+          network: 'arbitrum',
+        },
+      }
+
+      const response = await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+      expect(response.body.result).toEqual(1)
       expect(response.body).toMatchSnapshot()
     })
   })
 
   describe('optimism network', () => {
-    const data: AdapterRequest = {
-      id,
-      data: {
-        network: 'optimism',
-      },
-    }
-
     it('should return success when transaction submission is known', async () => {
       mockResponseFailureHealth()
       mockResponseFailureBlock()
+
+      const data: AdapterRequest = {
+        id,
+        data: {
+          network: 'optimism',
+          requireTxFailure: true,
+        },
+      }
 
       const response = await (context.req as SuperTest<Test>)
         .post('/')
@@ -90,19 +114,42 @@ describe('execute', () => {
       expect(response.body.result).toEqual(0)
       expect(response.body).toMatchSnapshot()
     })
+
+    it('should return failure if tx not required', async () => {
+      mockResponseFailureHealth()
+      mockResponseFailureBlock()
+
+      const data: AdapterRequest = {
+        id,
+        data: {
+          network: 'optimism',
+        },
+      }
+
+      const response = await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+      expect(response.body.result).toEqual(1)
+      expect(response.body).toMatchSnapshot()
+    })
   })
 
   describe('base network', () => {
-    const data: AdapterRequest = {
-      id,
-      data: {
-        network: 'base',
-      },
-    }
-
     it('should return success when transaction submission is known', async () => {
       mockResponseFailureHealth()
       mockResponseFailureBlock()
+
+      const data: AdapterRequest = {
+        id,
+        data: {
+          network: 'base',
+          requireTxFailure: true
+        },
+      }
 
       const response = await (context.req as SuperTest<Test>)
         .post('/')
@@ -112,6 +159,28 @@ describe('execute', () => {
         .expect('Content-Type', /json/)
         .expect(200)
       expect(response.body.result).toEqual(0)
+      expect(response.body).toMatchSnapshot()
+    })
+
+    it('should return failure if tx not required', async () => {
+      mockResponseFailureHealth()
+      mockResponseFailureBlock()
+
+      const data: AdapterRequest = {
+        id,
+        data: {
+          network: 'base',
+        },
+      }
+
+      const response = await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+      expect(response.body.result).toEqual(1)
       expect(response.body).toMatchSnapshot()
     })
   })

--- a/packages/sources/layer2-sequencer-health/test/integration/onchainFailKnown.test.ts
+++ b/packages/sources/layer2-sequencer-health/test/integration/onchainFailKnown.test.ts
@@ -54,7 +54,6 @@ describe('execute', () => {
         id,
         data: {
           network: 'arbitrum',
-          requireTxFailure: true,
         },
       }
 
@@ -77,6 +76,7 @@ describe('execute', () => {
         id,
         data: {
           network: 'arbitrum',
+          requireTxFailure: false,
         },
       }
 
@@ -101,7 +101,6 @@ describe('execute', () => {
         id,
         data: {
           network: 'optimism',
-          requireTxFailure: true,
         },
       }
 
@@ -124,6 +123,7 @@ describe('execute', () => {
         id,
         data: {
           network: 'optimism',
+          requireTxFailure: false,
         },
       }
 
@@ -195,7 +195,6 @@ describe('execute', () => {
         id,
         data: {
           network: 'metis',
-          requireTxFailure: true,
         },
       }
 
@@ -218,6 +217,7 @@ describe('execute', () => {
         id,
         data: {
           network: 'metis',
+          requireTxFailure: false,
         },
       }
 

--- a/packages/sources/layer2-sequencer-health/test/integration/onchainFailKnown.test.ts
+++ b/packages/sources/layer2-sequencer-health/test/integration/onchainFailKnown.test.ts
@@ -10,6 +10,7 @@ const mockMessages = {
   'https://arb1.arbitrum.io/rpc': 'gas price too low',
   'https://mainnet.optimism.io': 'cannot accept 0 gas price transaction',
   'https://mainnet.base.org': 'transaction underpriced',
+  'https://andromeda.metis.io/?owner=1088': 'cannot accept 0 gas price transaction',
 }
 
 jest.mock('ethers', () => {
@@ -170,6 +171,53 @@ describe('execute', () => {
         id,
         data: {
           network: 'base',
+        },
+      }
+
+      const response = await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+      expect(response.body.result).toEqual(1)
+      expect(response.body).toMatchSnapshot()
+    })
+  })
+
+  describe('metis network', () => {
+    it('should return success when transaction submission is known', async () => {
+      mockResponseFailureHealth()
+      mockResponseFailureBlock()
+
+      const data: AdapterRequest = {
+        id,
+        data: {
+          network: 'metis',
+          requireTxFailure: true,
+        },
+      }
+
+      const response = await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+      expect(response.body.result).toEqual(0)
+      expect(response.body).toMatchSnapshot()
+    })
+
+    it('should return failure if tx not required', async () => {
+      mockResponseFailureHealth()
+      mockResponseFailureBlock()
+
+      const data: AdapterRequest = {
+        id,
+        data: {
+          network: 'metis',
         },
       }
 

--- a/packages/sources/layer2-sequencer-health/test/integration/onchainFailUnknown.test.ts
+++ b/packages/sources/layer2-sequencer-health/test/integration/onchainFailUnknown.test.ts
@@ -114,6 +114,7 @@ describe('execute', () => {
       id,
       data: {
         network: 'base',
+        requireTxFailure: true,
       },
     }
 

--- a/packages/sources/layer2-sequencer-health/test/integration/onchainFailUnknown.test.ts
+++ b/packages/sources/layer2-sequencer-health/test/integration/onchainFailUnknown.test.ts
@@ -132,4 +132,28 @@ describe('execute', () => {
       expect(response.body).toMatchSnapshot()
     })
   })
+
+  describe('metis network', () => {
+    const data: AdapterRequest = {
+      id,
+      data: {
+        network: 'metis',
+      },
+    }
+
+    it('should return failure when transaction submission is unknown', async () => {
+      mockResponseFailureHealth()
+      mockResponseFailureBlock()
+
+      const response = await req
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+      expect(response.body.result).toEqual(1)
+      expect(response.body).toMatchSnapshot()
+    })
+  })
 })

--- a/packages/sources/layer2-sequencer-health/test/integration/onchainSuccess.test.ts
+++ b/packages/sources/layer2-sequencer-health/test/integration/onchainSuccess.test.ts
@@ -241,17 +241,17 @@ describe('execute', () => {
   })
 
   describe('base network', () => {
-    const data: AdapterRequest = {
-      id,
-      data: {
-        network: 'base',
-        requireTxFailure: true,
-      },
-    }
-
     it('should return success when all methods succeed', async () => {
       mockResponseSuccessHealth()
       mockResponseSuccessBlock()
+
+      const data: AdapterRequest = {
+        id,
+        data: {
+          network: 'base',
+          requireTxFailure: true,
+        },
+      }
 
       const response = await req
         .post('/')
@@ -268,6 +268,14 @@ describe('execute', () => {
       mockResponseFailureHealth()
       mockResponseFailureBlock()
 
+      const data: AdapterRequest = {
+        id,
+        data: {
+          network: 'base',
+          requireTxFailure: true,
+        },
+      }
+
       const response = await req
         .post('/')
         .send(data)
@@ -276,6 +284,98 @@ describe('execute', () => {
         .expect('Content-Type', /json/)
         .expect(200)
       expect(response.body.result).toEqual(0)
+      expect(response.body).toMatchSnapshot()
+    })
+
+    it('should return failure if tx not required even if it would be successful', async () => {
+      mockResponseFailureHealth()
+      mockResponseFailureBlock()
+
+      const data: AdapterRequest = {
+        id,
+        data: {
+          network: 'base',
+        },
+      }
+
+      const response = await req
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+      expect(response.body.result).toEqual(1)
+      expect(response.body).toMatchSnapshot()
+    })
+  })
+
+  describe('metis network', () => {
+    it('should return success when all methods succeed', async () => {
+      mockResponseSuccessHealth()
+      mockResponseSuccessBlock()
+
+      const data: AdapterRequest = {
+        id,
+        data: {
+          network: 'metis',
+          requireTxFailure: true,
+        },
+      }
+
+      const response = await req
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+      expect(response.body.result).toEqual(0)
+      expect(response.body).toMatchSnapshot()
+    })
+
+    it('should return transaction submission is successful', async () => {
+      mockResponseFailureHealth()
+      mockResponseFailureBlock()
+
+      const data: AdapterRequest = {
+        id,
+        data: {
+          network: 'metis',
+          requireTxFailure: true,
+        },
+      }
+
+      const response = await req
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+      expect(response.body.result).toEqual(0)
+      expect(response.body).toMatchSnapshot()
+    })
+
+    it('should return failure if tx not required even if it would be successful', async () => {
+      mockResponseFailureHealth()
+      mockResponseFailureBlock()
+
+      const data: AdapterRequest = {
+        id,
+        data: {
+          network: 'metis',
+        },
+      }
+
+      const response = await req
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+      expect(response.body.result).toEqual(1)
       expect(response.body).toMatchSnapshot()
     })
   })

--- a/packages/sources/layer2-sequencer-health/test/integration/onchainSuccess.test.ts
+++ b/packages/sources/layer2-sequencer-health/test/integration/onchainSuccess.test.ts
@@ -109,7 +109,6 @@ describe('execute', () => {
         id,
         data: {
           network: 'arbitrum',
-          requireTxFailure: true,
         },
       }
 
@@ -132,7 +131,6 @@ describe('execute', () => {
         id,
         data: {
           network: 'arbitrum',
-          requireTxFailure: true,
         },
       }
 
@@ -155,6 +153,7 @@ describe('execute', () => {
         id,
         data: {
           network: 'arbitrum',
+          requireTxFailure: false,
         },
       }
 
@@ -179,7 +178,6 @@ describe('execute', () => {
         id,
         data: {
           network: 'optimism',
-          requireTxFailure: true,
         },
       }
 
@@ -202,7 +200,6 @@ describe('execute', () => {
         id,
         data: {
           network: 'optimism',
-          requireTxFailure: true,
         },
       }
 
@@ -225,6 +222,7 @@ describe('execute', () => {
         id,
         data: {
           network: 'optimism',
+          requireTxFailure: false,
         },
       }
 
@@ -249,7 +247,6 @@ describe('execute', () => {
         id,
         data: {
           network: 'base',
-          requireTxFailure: true,
         },
       }
 
@@ -319,7 +316,6 @@ describe('execute', () => {
         id,
         data: {
           network: 'metis',
-          requireTxFailure: true,
         },
       }
 
@@ -342,7 +338,6 @@ describe('execute', () => {
         id,
         data: {
           network: 'metis',
-          requireTxFailure: true,
         },
       }
 
@@ -365,6 +360,7 @@ describe('execute', () => {
         id,
         data: {
           network: 'metis',
+          requireTxFailure: false,
         },
       }
 

--- a/packages/sources/layer2-sequencer-health/test/integration/onchainSuccess.test.ts
+++ b/packages/sources/layer2-sequencer-health/test/integration/onchainSuccess.test.ts
@@ -101,17 +101,17 @@ describe('execute', () => {
   })
 
   describe('arbitrum network', () => {
-    const data: AdapterRequest = {
-      id,
-      data: {
-        network: 'arbitrum',
-        requireTxFailure: true,
-      },
-    }
-
     it('should return success when all methods succeed', async () => {
       mockResponseSuccessHealth()
       mockResponseSuccessBlock()
+
+      const data: AdapterRequest = {
+        id,
+        data: {
+          network: 'arbitrum',
+          requireTxFailure: true,
+        },
+      }
 
       const response = await req
         .post('/')
@@ -128,6 +128,14 @@ describe('execute', () => {
       mockResponseFailureHealth()
       mockResponseFailureBlock()
 
+      const data: AdapterRequest = {
+        id,
+        data: {
+          network: 'arbitrum',
+          requireTxFailure: true,
+        },
+      }
+
       const response = await req
         .post('/')
         .send(data)
@@ -136,22 +144,44 @@ describe('execute', () => {
         .expect('Content-Type', /json/)
         .expect(200)
       expect(response.body.result).toEqual(0)
+      expect(response.body).toMatchSnapshot()
+    })
+
+    it('should return failure if tx not required even if it would be successful', async () => {
+      mockResponseFailureHealth()
+      mockResponseFailureBlock()
+
+      const data: AdapterRequest = {
+        id,
+        data: {
+          network: 'arbitrum',
+        },
+      }
+
+      const response = await req
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+      expect(response.body.result).toEqual(1)
       expect(response.body).toMatchSnapshot()
     })
   })
 
   describe('optimism network', () => {
-    const data: AdapterRequest = {
-      id,
-      data: {
-        network: 'optimism',
-        requireTxFailure: true,
-      },
-    }
-
     it('should return success when all methods succeed', async () => {
       mockResponseSuccessHealth()
       mockResponseSuccessBlock()
+
+      const data: AdapterRequest = {
+        id,
+        data: {
+          network: 'optimism',
+          requireTxFailure: true,
+        },
+      }
 
       const response = await req
         .post('/')
@@ -168,6 +198,14 @@ describe('execute', () => {
       mockResponseFailureHealth()
       mockResponseFailureBlock()
 
+      const data: AdapterRequest = {
+        id,
+        data: {
+          network: 'optimism',
+          requireTxFailure: true,
+        },
+      }
+
       const response = await req
         .post('/')
         .send(data)
@@ -176,6 +214,28 @@ describe('execute', () => {
         .expect('Content-Type', /json/)
         .expect(200)
       expect(response.body.result).toEqual(0)
+      expect(response.body).toMatchSnapshot()
+    })
+
+    it('should return failure if tx not required even if it would be successful', async () => {
+      mockResponseFailureHealth()
+      mockResponseFailureBlock()
+
+      const data: AdapterRequest = {
+        id,
+        data: {
+          network: 'optimism',
+        },
+      }
+
+      const response = await req
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+      expect(response.body.result).toEqual(1)
       expect(response.body).toMatchSnapshot()
     })
   })

--- a/packages/sources/layer2-sequencer-health/test/integration/onchainSuccess.test.ts
+++ b/packages/sources/layer2-sequencer-health/test/integration/onchainSuccess.test.ts
@@ -105,6 +105,7 @@ describe('execute', () => {
       id,
       data: {
         network: 'arbitrum',
+        requireTxFailure: true,
       },
     }
 
@@ -144,6 +145,7 @@ describe('execute', () => {
       id,
       data: {
         network: 'optimism',
+        requireTxFailure: true,
       },
     }
 
@@ -183,6 +185,7 @@ describe('execute', () => {
       id,
       data: {
         network: 'base',
+        requireTxFailure: true
       },
     }
 

--- a/packages/sources/layer2-sequencer-health/test/integration/onchainSuccess.test.ts
+++ b/packages/sources/layer2-sequencer-health/test/integration/onchainSuccess.test.ts
@@ -245,7 +245,7 @@ describe('execute', () => {
       id,
       data: {
         network: 'base',
-        requireTxFailure: true
+        requireTxFailure: true,
       },
     }
 

--- a/packages/sources/layer2-sequencer-health/test/unit/health.test.ts
+++ b/packages/sources/layer2-sequencer-health/test/unit/health.test.ts
@@ -111,7 +111,25 @@ describe('adapter', () => {
       expect(response.data.result).toBe(1)
     })
 
-    it('Empty transaction check has the final word on unhealthy method responses', async () => {
+    it('Empty transaction check has the final word on unhealthy method responses if requireTxFailure = true', async () => {
+      jest.spyOn(network, 'checkSequencerHealth').mockReturnValue(Promise.resolve(false))
+      jest.spyOn(network, 'checkNetworkProgress').mockReturnValue(Promise.resolve(false))
+      jest.spyOn(network, 'getStatusByTransaction').mockReturnValue(Promise.resolve(true))
+
+      const response = await execute(
+        {
+          data: {
+            network: 'arbitrum',
+            requireTxFailure: true,
+          },
+        } as AdapterRequest<TInputParameters>,
+        {},
+      )
+
+      expect(response.data.result).toBe(0)
+    })
+
+    it('Empty transaction check does not impact response if requireTxFailure = false (default)', async () => {
       jest.spyOn(network, 'checkSequencerHealth').mockReturnValue(Promise.resolve(false))
       jest.spyOn(network, 'checkNetworkProgress').mockReturnValue(Promise.resolve(false))
       jest.spyOn(network, 'getStatusByTransaction').mockReturnValue(Promise.resolve(true))
@@ -125,7 +143,7 @@ describe('adapter', () => {
         {},
       )
 
-      expect(response.data.result).toBe(0)
+      expect(response.data.result).toBe(1)
     })
 
     it('Empty transaction confirms rest of methods', async () => {

--- a/packages/sources/layer2-sequencer-health/test/unit/health.test.ts
+++ b/packages/sources/layer2-sequencer-health/test/unit/health.test.ts
@@ -138,6 +138,7 @@ describe('adapter', () => {
         {
           data: {
             network: 'arbitrum',
+            requireTxFailure: false,
           },
         } as AdapterRequest<TInputParameters>,
         {},


### PR DESCRIPTION
## Closes [DF-19183](https://smartcontract-it.atlassian.net/browse/DF-19183)

## Description
Do not require a tx call to throw the health alert by default for Base. This ensures that Base does not encounter ambiguous health check behavior.

## Changes
Add optional `requireTxFailure` input param that defaults to `true` for all networks except `base`.

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

`yarn && yarn setup && yarn test packages/sources/layer2-sequencer-health/test/integration/*`

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [x] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [x] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[DF-19183]: https://smartcontract-it.atlassian.net/browse/DF-19183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ