### PR TITLE
Add `etf` alias to EODHistoricalData and TwelveData. 

### DIFF
--- a/.changeset/fuzzy-carrots-cough.md
+++ b/.changeset/fuzzy-carrots-cough.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/twelvedata-adapter': minor
+---
+
+Add ETF alias for TwelveData.

--- a/.changeset/sour-lizards-rush.md
+++ b/.changeset/sour-lizards-rush.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/eodhistoricaldata-adapter': minor
+---
+
+Add ETF alias to EODHistoricalData.

--- a/packages/sources/eodhistoricaldata/README.md
+++ b/packages/sources/eodhistoricaldata/README.md
@@ -37,9 +37,9 @@ Supported names for this endpoint are: `price`, `stock`, `uk_etf`.
 
 ### Input Params
 
-| Required? | Name |               Aliases               |                                                       Description                                                        |  Type  | Options | Default | Depends On | Not Valid With |
-| :-------: | :--: | :---------------------------------: | :----------------------------------------------------------------------------------------------------------------------: | :----: | :-----: | :-----: | :--------: | :------------: |
-|    ✅     | base | `asset`, `from`, `symbol`, `uk_etf` | The symbol of the currency to query taken from [here](https://eodhistoricaldata.com/financial-apis/category/data-feeds/) | string |         |         |            |                |
+| Required? | Name |                  Aliases                   |                                                       Description                                                        |  Type  | Options | Default | Depends On | Not Valid With |
+| :-------: | :--: | :----------------------------------------: | :----------------------------------------------------------------------------------------------------------------------: | :----: | :-----: | :-----: | :--------: | :------------: |
+|    ✅     | base | `asset`, `etf`, `from`, `symbol`, `uk_etf` | The symbol of the currency to query taken from [here](https://eodhistoricaldata.com/financial-apis/category/data-feeds/) | string |         |         |            |                |
 
 ### Example
 

--- a/packages/sources/eodhistoricaldata/src/endpoint/stock.ts
+++ b/packages/sources/eodhistoricaldata/src/endpoint/stock.ts
@@ -11,7 +11,7 @@ export type TInputParameters = { base: string }
 export const inputParameters: InputParameters<TInputParameters> = {
   base: {
     required: true,
-    aliases: ['asset', 'from', 'symbol', 'uk_etf'],
+    aliases: ['asset', 'from', 'symbol', 'uk_etf', 'etf'],
     type: 'string',
     description:
       'The symbol of the currency to query taken from [here](https://eodhistoricaldata.com/financial-apis/category/data-feeds/)',

--- a/packages/sources/eodhistoricaldata/test-payload.json
+++ b/packages/sources/eodhistoricaldata/test-payload.json
@@ -1,5 +1,25 @@
 {
- "requests": [{
-  "from": "N225"
- }]
+    "requests": [
+        {
+            "from": "N225"
+        },
+        {
+            "base": "IB01",
+            "endpoint": "uk_etf",
+            "overrides": {
+             "eodhistoricaldata": { 
+                "IB01": "IB01.LSE"
+             }
+            }
+        },
+        {
+            "base": "C3M",
+            "endpoint": "etf",
+            "overrides": {
+             "eodhistoricaldata": {
+              "C3M": "C3M.MI"
+             }
+            }
+        }
+    ]
 }

--- a/packages/sources/twelvedata/README.md
+++ b/packages/sources/twelvedata/README.md
@@ -38,9 +38,9 @@ This document was generated automatically. Please see [README Generator](../../s
 
 Every EA supports base input parameters from [this list](../../core/bootstrap#base-input-parameters)
 
-| Required? |   Name   |     Description     |  Type  |                                                                                          Options                                                                                           |  Default  |
-| :-------: | :------: | :-----------------: | :----: | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-------: |
-|           | endpoint | The endpoint to use | string | [closing](#closing-endpoint), [crypto](#price-endpoint), [eod](#closing-endpoint), [forex](#price-endpoint), [price](#price-endpoint), [stock](#price-endpoint), [uk_etf](#price-endpoint) | `closing` |
+| Required? |   Name   |     Description     |  Type  |                                                                                                      Options                                                                                                       |  Default  |
+| :-------: | :------: | :-----------------: | :----: | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-------: |
+|           | endpoint | The endpoint to use | string | [closing](#closing-endpoint), [crypto](#price-endpoint), [eod](#closing-endpoint), [etf](#price-endpoint), [forex](#price-endpoint), [price](#price-endpoint), [stock](#price-endpoint), [uk_etf](#price-endpoint) | `closing` |
 
 ## Closing Endpoint
 
@@ -96,7 +96,7 @@ Response:
 
 This `price` endpoint provides the real-time price as detailed in [Twelvedata documentation](https://twelvedata.com/docs#real-time-price).
 
-Supported names for this endpoint are: `crypto`, `forex`, `price`, `stock`, `uk_etf`.
+Supported names for this endpoint are: `crypto`, `etf`, `forex`, `price`, `stock`, `uk_etf`.
 
 ### Input Params
 

--- a/packages/sources/twelvedata/src/endpoint/price.ts
+++ b/packages/sources/twelvedata/src/endpoint/price.ts
@@ -7,7 +7,7 @@ import {
 } from '@chainlink/ea-bootstrap'
 import { NAME as AdapterName } from '../config'
 
-export const supportedEndpoints = ['price', 'crypto', 'stock', 'forex', 'uk_etf']
+export const supportedEndpoints = ['price', 'crypto', 'stock', 'forex', 'uk_etf', 'etf']
 
 const customError = (data: ResponseSchema) => data.status === 'error'
 

--- a/packages/sources/twelvedata/test-payload.json
+++ b/packages/sources/twelvedata/test-payload.json
@@ -1,5 +1,20 @@
 {
-    "requests": [{
-        "base": "VXX"
-    }]
+    "requests": [
+        {
+            "base": "VXX"
+        },
+        {
+            "base": "IB01",
+            "endpoint": "uk_etf",
+            "overrides": {
+             "twelvedata": { 
+                "IB01": "IB01.LSE"
+             }
+            }
+        },
+        {
+            "base": "C3M",
+            "endpoint": "etf"
+        }
+    ]
 }


### PR DESCRIPTION

## Closes DF-19185, DF-19186

## Description
* Add `etf` alias to EODHistoricalData and TwelveData. 
  * This is functionally identical to the `uk_etf` endpoint, but is required as a feed needs to use a consistent alias. Other EAs (Finage specifically) in this feed support `uk_etf` and `etf` separately, and so we need consistent aliases.
  * This is a stepping stone towards deprecating the `uk_etf` endpoint, and instead consolidating the behaviour in an `etf` endpoint. 

## Changes
* Add `etf` alias
* Add soak test payloads

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. Call new `etf` alias

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `<ADAPTER_PACKAGE>/schemas/env.json` and `<ADAPTER_PACKAGE>/README.md`
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Clubhouse/Shortcut
- [ ] This is related to a maximum of one Clubhouse/Shortcut story or GitHub issue
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
