### PR TITLE
Unbatch cmc requests on quotes

### DIFF
--- a/.changeset/fifty-crabs-accept.md
+++ b/.changeset/fifty-crabs-accept.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/coinmarketcap-adapter': patch
+---
+
+Unbatch requests on quotes for crypto endpoint

--- a/packages/sources/coinmarketcap/src/index.ts
+++ b/packages/sources/coinmarketcap/src/index.ts
@@ -10,25 +10,25 @@ export const adapter = new PriceAdapter({
   rateLimiting: {
     tiers: {
       free: {
-        rateLimit1m: 7.5,
-        rateLimit1h: 3,
-        note: "10k credits/month, 730h in a month, ignoring daily limits since they're soft caps. Divided by 4 to account for multiple credits per request",
+        rateLimit1m: 30,
+        rateLimit1h: 13,
+        note: "10k credits/month, 730h in a month, ignoring daily limits since they're soft caps",
       },
       hobbyist: {
-        rateLimit1m: 7.5,
-        rateLimit1h: 13,
+        rateLimit1m: 30,
+        rateLimit1h: 54,
       },
       startup: {
-        rateLimit1m: 7.5,
-        rateLimit1h: 41,
+        rateLimit1m: 30,
+        rateLimit1h: 164,
       },
       standard: {
-        rateLimit1m: 15,
-        rateLimit1h: 171,
+        rateLimit1m: 60,
+        rateLimit1h: 684,
       },
       professional: {
-        rateLimit1m: 22.5,
-        rateLimit1h: 1027,
+        rateLimit1m: 90,
+        rateLimit1h: 4108,
       },
     },
   },

--- a/packages/sources/coinmarketcap/src/transport/crypto.ts
+++ b/packages/sources/coinmarketcap/src/transport/crypto.ts
@@ -89,7 +89,8 @@ export const httpTransport = new HttpTransport<HttpTransportTypes>({
         )
         // We don't want to batch quotes but only base currencies, so for each unique quote in each list we create a request
         // This could be further optimized to make sure that lists are grouped optimally to avoid sending unnecessary bases
-        ;[...new Set(list.map((p) => p.quote.toUpperCase()))].forEach((uniqueQuote) => {
+        const uniqueQuotes = [...new Set(list.map((p) => p.quote.toUpperCase()))]
+        uniqueQuotes.forEach((uniqueQuote) => {
           requests.push({
             params: list,
             request: {

--- a/packages/sources/coinmarketcap/src/transport/crypto.ts
+++ b/packages/sources/coinmarketcap/src/transport/crypto.ts
@@ -88,6 +88,7 @@ export const httpTransport = new HttpTransport<HttpTransportTypes>({
           ',',
         )
         // We don't want to batch quotes but only base currencies, so for each unique quote in each list we create a request
+        // This could be further optimized to make sure that lists are grouped optimally to avoid sending unnecessary bases
         ;[...new Set(list.map((p) => p.quote.toUpperCase()))].forEach((uniqueQuote) => {
           requests.push({
             params: list,


### PR DESCRIPTION
[PDI-2151](https://smartcontract-it.atlassian.net/browse/PDI-2151)


## Changes

- Changed cmc rate limits
- Changed cmc `crypto` transport to unbatch requests on quotes 

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

`yarn test packages/sources/coinmarketcap/test/integration`

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [x] This is related to a maximum of one Jira story or GitHub issue.
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[PDI-2151]: https://smartcontract-it.atlassian.net/browse/PDI-2151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ