### PR TITLE
Fix: CFBenchmarks failing if `API_SECONDARY` explicitly set

### DIFF
--- a/.changeset/breezy-tomatoes-melt.md
+++ b/.changeset/breezy-tomatoes-melt.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/cfbenchmarks-adapter': patch
+---
+
+Fix bug where CFBenchmarks Crypto endpoint would fail if `API_SECONDARY` is explicitly set to false.

--- a/packages/sources/cfbenchmarks/src/endpoint/crypto.ts
+++ b/packages/sources/cfbenchmarks/src/endpoint/crypto.ts
@@ -53,11 +53,12 @@ export const additionalInputValidation = ({ index, base, quote }: Params): void 
 
 export const cryptoRequestTransform = (
   req: AdapterRequest<typeof inputParameters.validated>,
+  settings: BaseEndpointTypes['Settings'],
 ): void => {
   // TODO: Move additional input validations to proper location after framework supports it
   additionalInputValidation(req.requestContext.data)
   if (!req.requestContext.data.index) {
-    const isSecondary = process.env.API_SECONDARY
+    const isSecondary = settings.API_SECONDARY
     const type = isSecondary ? 'secondary' : 'primary'
     // If there is no index set
     // we know that base and quote exist from the extra input validation above

--- a/packages/sources/cfbenchmarks/test-payload.json
+++ b/packages/sources/cfbenchmarks/test-payload.json
@@ -1,7 +1,12 @@
 {
-    "requests": [{
-         "index": "ETHUSD_RTI"
-    }]
+    "requests": [
+        {
+            "index": "ETHUSD_RTI"
+        },
+        {
+            "endpoint": "crypto",
+            "from": "BCH",
+            "to": "USD"
+        }
+    ]
 }
-
-


### PR DESCRIPTION
## Closes DF-18888

## Description
* Fix bug where CFBenchmarks Crypto endpoint would fail if `API_SECONDARY` is explicitly set to false.
* Bug was due to using `process.env` directly rather than adapter settings. This resulted in different behaviour if using the default or specifying explicitly, and resulted in the type being a String rather than Boolean when specifying manually.

## Changes

- Use the adapter settings rather than `process.env` directly.
- Add request pattern to soak tests

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. `yarn && yarn setup && (cd packages/sources/cfbenchmarks && export API_USERNAME="***"; export API_PASSWORD="***"; export API_SECONDARY=false; yarn start)`

2. `curl --request POST \ --url http://localhost:8080/ \ --header 'Content-Type: application/json' \ --data '{ "data": { "endpoint": "crypto", "from": "BCH", "to": "USD" } }'`

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [X] This is related to a maximum of one Jira story or GitHub issue.
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
