### PR TITLE
L2EP: Default Optimism to not use the Transaction check

### DIFF
--- a/.changeset/friendly-cobras-run.md
+++ b/.changeset/friendly-cobras-run.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/layer2-sequencer-health-adapter': patch
+---
+
+L2 Sequencer Health: Default Optimism to not use the Transaction check as final decider of health.

--- a/packages/sources/layer2-sequencer-health/src/endpoint/health.ts
+++ b/packages/sources/layer2-sequencer-health/src/endpoint/health.ts
@@ -20,7 +20,7 @@ const defaultRequireTxFailure = {
   [Networks.Arbitrum]: true,
   [Networks.Base]: false,
   [Networks.Metis]: true,
-  [Networks.Optimism]: true,
+  [Networks.Optimism]: false,
   [Networks.Starkware]: true,
 }
 

--- a/packages/sources/layer2-sequencer-health/test/integration/onchainFailKnown.test.ts
+++ b/packages/sources/layer2-sequencer-health/test/integration/onchainFailKnown.test.ts
@@ -101,6 +101,7 @@ describe('execute', () => {
         id,
         data: {
           network: 'optimism',
+          requireTxFailure: true,
         },
       }
 

--- a/packages/sources/layer2-sequencer-health/test/integration/onchainSuccess.test.ts
+++ b/packages/sources/layer2-sequencer-health/test/integration/onchainSuccess.test.ts
@@ -200,6 +200,7 @@ describe('execute', () => {
         id,
         data: {
           network: 'optimism',
+          requireTxFailure: true,
         },
       }
 


### PR DESCRIPTION
## Closes DF-19198

## Description
* Layer 2 Sequencer Health: Default Optimism to not use the Transaction check as final decider of health.
* Context in https://smartcontract-it.atlassian.net/browse/DF-19198

## Changes

- Set default for Optimism to not require the transaction check

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. `yarn && yarn setup && yarn test packages/sources/layer2-sequencer-health/test/integration/*`

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [X] This is related to a maximum of one Jira story or GitHub issue.
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
