### PR TITLE
Coinmetrics: Return Realized Vol data as number

### DIFF
--- a/.changeset/hot-lemons-invent.md
+++ b/.changeset/hot-lemons-invent.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/coinmetrics-adapter': patch
+---
+
+Coinmetrics: Return Realized Vol data as number

--- a/packages/sources/coinmetrics/src/transport/realized-vol.ts
+++ b/packages/sources/coinmetrics/src/transport/realized-vol.ts
@@ -5,7 +5,7 @@ import { makeLogger } from '@chainlink/external-adapter-framework/util'
 const logger = makeLogger('Coinmetrics RealizedVol HTTP')
 
 interface RealizedVolResponseBody {
-  data: (Record<string, number> & {
+  data: (Record<string, string> & {
     asset: string
     time: string // DateTime (e.g. '2022-12-08T23:50:00.000000000Z')
   })[]
@@ -66,9 +66,9 @@ export const transport = new HttpTransport<HttpTransportTypes>({
       const realizedVolData = res.data.data[0]
 
       const data: ResponseData = {
-        realVol1Day: realizedVolData[constructLookbackMetric(param.quote, '24h')],
-        realVol7Day: realizedVolData[constructLookbackMetric(param.quote, '7d')],
-        realVol30Day: realizedVolData[constructLookbackMetric(param.quote, '30d')],
+        realVol1Day: Number(realizedVolData[constructLookbackMetric(param.quote, '24h')]),
+        realVol7Day: Number(realizedVolData[constructLookbackMetric(param.quote, '7d')]),
+        realVol30Day: Number(realizedVolData[constructLookbackMetric(param.quote, '30d')]),
       }
 
       return {

--- a/packages/sources/coinmetrics/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/coinmetrics/test/integration/__snapshots__/adapter.test.ts.snap
@@ -42,11 +42,11 @@ exports[`http realized-vol endpoint should return error if unsupported resultPat
 exports[`http realized-vol endpoint should return success 1`] = `
 {
   "data": {
-    "realVol1Day": "0.4853062",
-    "realVol30Day": "0.427451",
-    "realVol7Day": "0.3781615",
+    "realVol1Day": 0.4853062,
+    "realVol30Day": 0.427451,
+    "realVol7Day": 0.3781615,
   },
-  "result": "0.3781615",
+  "result": 0.3781615,
   "statusCode": 200,
   "timestamps": {
     "providerDataReceivedUnixMs": 1641035471111,


### PR DESCRIPTION
* Coinmetrics was returning Realized Volatility data as a String, this commit converts to a Number before returning