### PR TITLE
Feature/DF-19167 add blocksize capital bid ask subscribe method to existing ea

### DIFF
--- a/.changeset/chatty-radios-smoke.md
+++ b/.changeset/chatty-radios-smoke.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/blocksize-capital-adapter': minor
+---
+
+Add LWBA endpoint for blocksize-capital

--- a/packages/sources/blocksize-capital/README.md
+++ b/packages/sources/blocksize-capital/README.md
@@ -21,9 +21,9 @@ There are no rate limits for this adapter.
 
 ## Input Parameters
 
-| Required? |   Name   |     Description     |  Type  |                       Options                       | Default |
-| :-------: | :------: | :-----------------: | :----: | :-------------------------------------------------: | :-----: |
-|           | endpoint | The endpoint to use | string | [crypto](#price-endpoint), [price](#price-endpoint) | `price` |
+| Required? |   Name   |     Description     |  Type  |                                                                               Options                                                                                | Default |
+| :-------: | :------: | :-----------------: | :----: | :------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-----: |
+|           | endpoint | The endpoint to use | string | [crypto-lwba](#crypto-lwba-endpoint), [crypto](#price-endpoint), [crypto_lwba](#crypto-lwba-endpoint), [cryptolwba](#crypto-lwba-endpoint), [price](#price-endpoint) | `price` |
 
 ## Price Endpoint
 
@@ -46,6 +46,33 @@ Request:
     "endpoint": "price",
     "base": "ETH",
     "quote": "EUR"
+  }
+}
+```
+
+---
+
+## Crypto-lwba Endpoint
+
+Supported names for this endpoint are: `crypto-lwba`, `crypto_lwba`, `cryptolwba`.
+
+### Input Params
+
+| Required? | Name  |    Aliases     |                  Description                   |  Type  | Options | Default | Depends On | Not Valid With |
+| :-------: | :---: | :------------: | :--------------------------------------------: | :----: | :-----: | :-----: | :--------: | :------------: |
+|    ✅     | base  | `coin`, `from` | The symbol of symbols of the currency to query | string |         |         |            |                |
+|    ✅     | quote | `market`, `to` |    The symbol of the currency to convert to    | string |         |         |            |                |
+
+### Example
+
+Request:
+
+```json
+{
+  "data": {
+    "endpoint": "crypto-lwba",
+    "base": "ETH",
+    "quote": "USD"
   }
 }
 ```

--- a/packages/sources/blocksize-capital/src/endpoint/crypto-lwba.ts
+++ b/packages/sources/blocksize-capital/src/endpoint/crypto-lwba.ts
@@ -1,0 +1,27 @@
+import {
+  LwbaEndpoint,
+  LwbaResponseDataFields,
+  lwbaEndpointInputParametersDefinition,
+} from '@chainlink/external-adapter-framework/adapter'
+import { InputParameters } from '@chainlink/external-adapter-framework/validation'
+import { config } from '../config'
+import { transport } from '../transport/crypto-lwba'
+
+const inputParameters = new InputParameters(lwbaEndpointInputParametersDefinition, [
+  {
+    base: 'ETH',
+    quote: 'USD',
+  },
+])
+
+export type BaseEndpointTypes = {
+  Parameters: typeof inputParameters.definition
+  Settings: typeof config.settings
+  Response: LwbaResponseDataFields
+}
+
+export const endpoint = new LwbaEndpoint({
+  name: 'crypto-lwba',
+  transport,
+  inputParameters,
+})

--- a/packages/sources/blocksize-capital/src/endpoint/index.ts
+++ b/packages/sources/blocksize-capital/src/endpoint/index.ts
@@ -1,1 +1,2 @@
 export { endpoint as price } from './price'
+export { endpoint as cryptolwba } from './crypto-lwba'

--- a/packages/sources/blocksize-capital/src/index.ts
+++ b/packages/sources/blocksize-capital/src/index.ts
@@ -1,11 +1,11 @@
 import { expose, ServerInstance } from '@chainlink/external-adapter-framework'
 import { PriceAdapter } from '@chainlink/external-adapter-framework/adapter'
 import { config } from './config'
-import { price } from './endpoint'
+import { cryptolwba, price } from './endpoint'
 
 export const adapter = new PriceAdapter({
   name: 'BLOCKSIZE_CAPITAL',
-  endpoints: [price],
+  endpoints: [price, cryptolwba],
   defaultEndpoint: price.name,
   config,
 })

--- a/packages/sources/blocksize-capital/src/transport/crypto-lwba.ts
+++ b/packages/sources/blocksize-capital/src/transport/crypto-lwba.ts
@@ -1,7 +1,7 @@
 import { BaseEndpointTypes } from '../endpoint/crypto-lwba'
 import { WebsocketReverseMappingTransport } from '@chainlink/external-adapter-framework/transports/websocket'
 import { makeLogger, ProviderResult } from '@chainlink/external-adapter-framework/util'
-import { BaseMessage, blocksizeDefaultWebsocketOpenHandler } from './transportutils'
+import { BaseMessage, blocksizeDefaultWebsocketOpenHandler } from './utils'
 
 const logger = makeLogger('BlocksizeCapitalLwbaWebsocketEndpoint')
 
@@ -28,11 +28,10 @@ export type WsTransportTypes = BaseEndpointTypes & {
 
 export const transport: WebsocketReverseMappingTransport<WsTransportTypes, string> =
   new WebsocketReverseMappingTransport<WsTransportTypes, string>({
-    url: ({ adapterSettings: { WS_API_ENDPOINT } }) => {
-      return WS_API_ENDPOINT
-    },
+    url: (context) => context.adapterSettings.WS_API_ENDPOINT,
     handlers: {
-      open: blocksizeDefaultWebsocketOpenHandler,
+      open: (connection, context) =>
+        blocksizeDefaultWebsocketOpenHandler(connection, context.adapterSettings.API_KEY),
       message: (message) => {
         if (message.method !== 'bidask') return []
         const updates = message.params.updates

--- a/packages/sources/blocksize-capital/src/transport/crypto-lwba.ts
+++ b/packages/sources/blocksize-capital/src/transport/crypto-lwba.ts
@@ -1,19 +1,21 @@
-import { BaseEndpointTypes } from '../endpoint/price'
+import { BaseEndpointTypes } from '../endpoint/crypto-lwba'
 import { WebsocketReverseMappingTransport } from '@chainlink/external-adapter-framework/transports/websocket'
 import { makeLogger, ProviderResult } from '@chainlink/external-adapter-framework/util'
 import { BaseMessage, blocksizeDefaultWebsocketOpenHandler } from './transportutils'
 
-const logger = makeLogger('BlocksizeCapitalWebsocketEndpoint')
+const logger = makeLogger('BlocksizeCapitalLwbaWebsocketEndpoint')
 
 export interface Message extends BaseMessage {
-  method: 'vwap'
+  method: 'bidask'
   params: {
     updates: {
       ticker: string
-      price?: number
-      size?: number
-      volume?: number
-      ts: number
+      agg_ask_price: string
+      agg_ask_size: string
+      agg_bid_price: string
+      agg_bid_size: string
+      agg_mid_price: string
+      ts: string
     }[]
   }
 }
@@ -32,7 +34,7 @@ export const transport: WebsocketReverseMappingTransport<WsTransportTypes, strin
     handlers: {
       open: blocksizeDefaultWebsocketOpenHandler,
       message: (message) => {
-        if (message.method !== 'vwap') return []
+        if (message.method !== 'bidask') return []
         const updates = message.params.updates
         const results: ProviderResult<WsTransportTypes>[] = []
         for (const update of updates) {
@@ -40,8 +42,8 @@ export const transport: WebsocketReverseMappingTransport<WsTransportTypes, strin
           if (!params) {
             continue
           }
-          if (!update.price) {
-            const errorMessage = `The data provider didn't return any value for ${params.base}/${params.quote}`
+          if (!update.agg_ask_price || !update.agg_bid_price || !update.agg_mid_price) {
+            const errorMessage = `The data provider bid/ask update is incomplete for ${params.base}/${params.quote}`
             logger.info(errorMessage)
             results.push({
               params,
@@ -54,12 +56,14 @@ export const transport: WebsocketReverseMappingTransport<WsTransportTypes, strin
             results.push({
               params,
               response: {
-                result: update.price,
+                result: null,
                 data: {
-                  result: update.price,
+                  ask: Number(update.agg_ask_price),
+                  bid: Number(update.agg_bid_price),
+                  mid: Number(update.agg_mid_price),
                 },
                 timestamps: {
-                  providerIndicatedTimeUnixMs: update.ts,
+                  providerIndicatedTimeUnixMs: Number(update.ts),
                 },
               },
             })
@@ -74,7 +78,7 @@ export const transport: WebsocketReverseMappingTransport<WsTransportTypes, strin
         transport.setReverseMapping(pair, params)
         return {
           jsonrpc: '2.0',
-          method: 'vwap_subscribe',
+          method: 'bidask_subscribe',
           params: { tickers: [pair] },
         }
       },
@@ -83,7 +87,7 @@ export const transport: WebsocketReverseMappingTransport<WsTransportTypes, strin
         const pair = `${params.base}${params.quote}`.toUpperCase()
         return {
           jsonrpc: '2.0',
-          method: 'vwap_unsubscribe',
+          method: 'bidask_subscribe',
           params: { tickers: [pair] },
         }
       },

--- a/packages/sources/blocksize-capital/src/transport/price.ts
+++ b/packages/sources/blocksize-capital/src/transport/price.ts
@@ -1,7 +1,7 @@
 import { BaseEndpointTypes } from '../endpoint/price'
 import { WebsocketReverseMappingTransport } from '@chainlink/external-adapter-framework/transports/websocket'
 import { makeLogger, ProviderResult } from '@chainlink/external-adapter-framework/util'
-import { BaseMessage, blocksizeDefaultWebsocketOpenHandler } from './transportutils'
+import { BaseMessage, blocksizeDefaultWebsocketOpenHandler } from './utils'
 
 const logger = makeLogger('BlocksizeCapitalWebsocketEndpoint')
 
@@ -26,11 +26,10 @@ export type WsTransportTypes = BaseEndpointTypes & {
 
 export const transport: WebsocketReverseMappingTransport<WsTransportTypes, string> =
   new WebsocketReverseMappingTransport<WsTransportTypes, string>({
-    url: ({ adapterSettings: { WS_API_ENDPOINT } }) => {
-      return WS_API_ENDPOINT
-    },
+    url: (context) => context.adapterSettings.WS_API_ENDPOINT,
     handlers: {
-      open: blocksizeDefaultWebsocketOpenHandler,
+      open: (connection, context) =>
+        blocksizeDefaultWebsocketOpenHandler(connection, context.adapterSettings.API_KEY),
       message: (message) => {
         if (message.method !== 'vwap') return []
         const updates = message.params.updates

--- a/packages/sources/blocksize-capital/src/transport/transportutils.ts
+++ b/packages/sources/blocksize-capital/src/transport/transportutils.ts
@@ -1,0 +1,35 @@
+import { EndpointContext } from '@chainlink/external-adapter-framework/adapter'
+import { WsTransportTypes } from './price'
+import { makeLogger } from '@chainlink/external-adapter-framework/util'
+
+const logger = makeLogger('BlocksizeCapitalTransportUtils')
+
+export interface BaseMessage {
+  jsonrpc: string
+  id?: string | number | null
+  method: string
+}
+
+// use as open handler for standard WS connections
+export const blocksizeDefaultWebsocketOpenHandler = (
+  connection: WebSocket,
+  context: EndpointContext<WsTransportTypes>,
+): Promise<void> | void => {
+  return new Promise((resolve, reject) => {
+    connection.addEventListener('message', (event: MessageEvent<any>) => {
+      const parsed = JSON.parse(event.data.toString())
+      if (parsed.result?.user_id) {
+        logger.debug('Got logged in response, connection is ready')
+        resolve()
+      } else {
+        reject(new Error('Failed to make WS connection'))
+      }
+    })
+    const options = {
+      jsonrpc: '2.0',
+      method: 'authentication_logon',
+      params: { api_key: context.adapterSettings.API_KEY },
+    }
+    connection.send(JSON.stringify(options))
+  })
+}

--- a/packages/sources/blocksize-capital/src/transport/utils.ts
+++ b/packages/sources/blocksize-capital/src/transport/utils.ts
@@ -1,5 +1,3 @@
-import { EndpointContext } from '@chainlink/external-adapter-framework/adapter'
-import { WsTransportTypes } from './price'
 import { makeLogger } from '@chainlink/external-adapter-framework/util'
 
 const logger = makeLogger('BlocksizeCapitalTransportUtils')
@@ -13,10 +11,10 @@ export interface BaseMessage {
 // use as open handler for standard WS connections
 export const blocksizeDefaultWebsocketOpenHandler = (
   connection: WebSocket,
-  context: EndpointContext<WsTransportTypes>,
+  apiKey: string,
 ): Promise<void> | void => {
   return new Promise((resolve, reject) => {
-    connection.addEventListener('message', (event: MessageEvent<any>) => {
+    connection.addEventListener('message', (event: MessageEvent<BaseMessage>) => {
       const parsed = JSON.parse(event.data.toString())
       if (parsed.result?.user_id) {
         logger.debug('Got logged in response, connection is ready')
@@ -28,7 +26,7 @@ export const blocksizeDefaultWebsocketOpenHandler = (
     const options = {
       jsonrpc: '2.0',
       method: 'authentication_logon',
-      params: { api_key: context.adapterSettings.API_KEY },
+      params: { api_key: apiKey },
     }
     connection.send(JSON.stringify(options))
   })

--- a/packages/sources/blocksize-capital/test-payload.json
+++ b/packages/sources/blocksize-capital/test-payload.json
@@ -1,6 +1,13 @@
 {
- "requests": [{
-  "from": "LINK",
-  "to": "USD"
- }]
+ "requests": [
+    {
+      "from": "LINK",
+      "to": "USD"
+    },
+    {
+      "from": "LINK",
+      "to": "USD",
+      "endpoint": "cryptolwba"
+    }
+  ]
 }

--- a/packages/sources/blocksize-capital/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/blocksize-capital/test/integration/__snapshots__/adapter.test.ts.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`websocket lwba endpoint should return success 1`] = `
+{
+  "data": {
+    "ask": 1702.223427255888,
+    "bid": 1701.844873967814,
+    "mid": 1702.034150611851,
+  },
+  "result": null,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 2032,
+    "providerDataStreamEstablishedUnixMs": 2020,
+    "providerIndicatedTimeUnixMs": 1693425803028,
+  },
+}
+`;
+
 exports[`websocket price endpoint should return success 1`] = `
 {
   "data": {

--- a/packages/sources/blocksize-capital/test/integration/adapter.test.ts
+++ b/packages/sources/blocksize-capital/test/integration/adapter.test.ts
@@ -51,4 +51,15 @@ describe('websocket', () => {
       expect(response.json()).toMatchSnapshot()
     })
   })
+  describe('lwba endpoint', () => {
+    it('should return success', async () => {
+      const lwbaData = {
+        base: 'ETH',
+        quote: 'USD',
+        endpoint: 'crypto-lwba',
+      }
+      const response = await testAdapter.request(lwbaData)
+      expect(response.json()).toMatchSnapshot()
+    })
+  })
 })

--- a/packages/sources/blocksize-capital/test/integration/fixtures.ts
+++ b/packages/sources/blocksize-capital/test/integration/fixtures.ts
@@ -1,5 +1,5 @@
 import { MockWebsocketServer } from '@chainlink/external-adapter-framework/util/testing-utils'
-export const mockSubscribeResponse = {
+export const mockPriceResponse = {
   jsonrpc: '2.0',
   method: 'vwap',
   params: {
@@ -20,6 +20,33 @@ export const mockSubscribeResponse = {
   },
 }
 
+export const mockLwbaResponse = {
+  jsonrpc: '2.0',
+  method: 'bidask',
+  params: {
+    updates: [
+      {
+        ticker: 'BTCUSD',
+        agg_bid_price: '27202.99036601005',
+        agg_bid_size: '36.57941309',
+        agg_ask_price: '27206.54222704013',
+        agg_ask_size: '6.76037062',
+        agg_mid_price: '27204.76629652509',
+        ts: 1693425803031,
+      },
+      {
+        ticker: 'ETHUSD',
+        agg_bid_price: '1701.844873967814',
+        agg_bid_size: '208.51838798',
+        agg_ask_price: '1702.223427255888',
+        agg_ask_size: '11.44083383',
+        agg_mid_price: '1702.034150611851',
+        ts: 1693425803028,
+      },
+    ],
+  },
+}
+
 export const mockLoginResponse = {
   jsonrpc: '2.0',
   id: 0,
@@ -31,12 +58,16 @@ export const mockLoginResponse = {
 export const mockWebSocketServer = (URL: string): MockWebsocketServer => {
   const mockWsServer = new MockWebsocketServer(URL, { mock: false })
   mockWsServer.on('connection', (socket) => {
-    const data = JSON.stringify(mockSubscribeResponse)
+    const data = JSON.stringify(mockPriceResponse)
+    const lwbaData = JSON.stringify(mockLwbaResponse)
     socket.on('message', (message) => {
       const parsed = JSON.parse(message.toString())
       if (parsed.params?.api_key) {
         socket.send(JSON.stringify(mockLoginResponse))
+      } else if (parsed?.method === 'bidask_subscribe') {
+        socket.send(lwbaData)
       } else {
+        // method === 'vwap'
         socket.send(data)
       }
     })


### PR DESCRIPTION
## Closes #[DF-19167](https://smartcontract-it.atlassian.net/browse/DF-19167)

## Description
Adding cryptolwba endpoint for blocksize-capital EA
Note: since this is a separate WS connection and subscription than the existing `price` endpoint, it necessitates a separate LWBA endpoint altogether, rather than adding this as an additional alias to the `price` endpoint as we have done in other EAs.

## Changes
- Added new LWBA endpoint using framework `LwbaEndpoint` class
- Small refactor to reuse some existing logic from the `price` endpoint for the `open` ws handler
- Related tests and doc

## Steps to Test

1. Unit/integration using `EA_PORT=0 METRICS_ENABLED=false yarn test blocksize-capital/test`
2. Regression sanity test price endpoint for ws auth success
3. General LWBA endpoint testing with test payload similar to
```json
{
  "id": "1",
  "data": {
    "from": "LINK",
    "to": "USD",
    "endpoint": "cryptolwba"
  }
}
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [x] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [x] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[DF-19167]: https://smartcontract-it.atlassian.net/browse/DF-19167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ