### PR TITLE
Add GIFT endpoint to the-network-firm adapter

### DIFF
--- a/.changeset/six-candles-divide.md
+++ b/.changeset/six-candles-divide.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/the-network-firm-adapter': minor
+---
+
+Added GIFT endpoint

--- a/packages/sources/the-network-firm/src/endpoint/gift.ts
+++ b/packages/sources/the-network-firm/src/endpoint/gift.ts
@@ -1,0 +1,16 @@
+import { AdapterEndpoint } from '@chainlink/external-adapter-framework/adapter'
+import { SingleNumberResultResponse } from '@chainlink/external-adapter-framework/util'
+import { config } from '../config'
+import { httpTransport } from '../transport/gift'
+import { EmptyInputParameters } from '@chainlink/external-adapter-framework/validation/input-params'
+
+export type BaseEndpointTypes = {
+  Parameters: EmptyInputParameters
+  Response: SingleNumberResultResponse
+  Settings: typeof config.settings
+}
+
+export const endpoint = new AdapterEndpoint({
+  name: 'gift',
+  transport: httpTransport,
+})

--- a/packages/sources/the-network-firm/src/endpoint/index.ts
+++ b/packages/sources/the-network-firm/src/endpoint/index.ts
@@ -1,5 +1,6 @@
 export { endpoint as backed } from './backed'
 export { endpoint as eurr } from './eurr'
+export { endpoint as gift } from './gift'
 export { endpoint as mco2 } from './mco2'
 export { endpoint as stbt } from './stbt'
 export { endpoint as usdr } from './usdr'

--- a/packages/sources/the-network-firm/src/index.ts
+++ b/packages/sources/the-network-firm/src/index.ts
@@ -1,13 +1,13 @@
 import { expose, ServerInstance } from '@chainlink/external-adapter-framework'
 import { Adapter } from '@chainlink/external-adapter-framework/adapter'
 import { config } from './config'
-import { backed, eurr, mco2, stbt, usdr } from './endpoint'
+import { backed, eurr, gift, mco2, stbt, usdr } from './endpoint'
 
 export const adapter = new Adapter({
   defaultEndpoint: mco2.name,
   name: 'THE_NETWORK_FIRM',
   config,
-  endpoints: [backed, eurr, mco2, stbt, usdr],
+  endpoints: [backed, eurr, gift, mco2, stbt, usdr],
   rateLimiting: {
     tiers: {
       default: {

--- a/packages/sources/the-network-firm/src/transport/gift.ts
+++ b/packages/sources/the-network-firm/src/transport/gift.ts
@@ -1,0 +1,79 @@
+import { HttpTransport } from '@chainlink/external-adapter-framework/transports'
+import { BaseEndpointTypes } from '../endpoint/gift'
+
+export interface ResponseSchema {
+  accountName: string
+  totalReserve: number
+  totalToken: number
+  timestamp: string
+  ripcord: boolean
+  ripcordDetails: string[]
+}
+
+export type HttpTransportTypes = BaseEndpointTypes & {
+  Provider: {
+    RequestBody: never
+    ResponseBody: ResponseSchema
+  }
+}
+export const httpTransport = new HttpTransport<HttpTransportTypes>({
+  prepareRequests: (params, config) => {
+    return {
+      params: params,
+      request: {
+        baseURL: config.API_ENDPOINT,
+        url: '/GIFT',
+      },
+    }
+  },
+  parseResponse: (params, response) => {
+    // Return error if ripcord indicator true
+    if (response.data.ripcord) {
+      const message = `Ripcord indicator true. Details: ${response.data.ripcordDetails.join(', ')}`
+      return [
+        {
+          params: params[0],
+          response: {
+            errorMessage: message,
+            statusCode: 502,
+            timestamps: {
+              providerIndicatedTimeUnixMs: new Date(response.data.timestamp).getTime(),
+            },
+          },
+        },
+      ]
+    }
+
+    const result = response.data.totalReserve
+
+    if (typeof response.data.totalReserve === 'undefined') {
+      return [
+        {
+          params: params[0],
+          response: {
+            errorMessage: `Response missing totalReserve`,
+            statusCode: 502,
+            timestamps: {
+              providerIndicatedTimeUnixMs: new Date(response.data.timestamp).getTime(),
+            },
+          },
+        },
+      ]
+    }
+
+    return [
+      {
+        params: params[0],
+        response: {
+          result,
+          data: {
+            result,
+          },
+          timestamps: {
+            providerIndicatedTimeUnixMs: new Date(response.data.timestamp).getTime(),
+          },
+        },
+      },
+    ]
+  },
+})

--- a/packages/sources/the-network-firm/test-payload.json
+++ b/packages/sources/the-network-firm/test-payload.json
@@ -1,17 +1,20 @@
 {
- "requests": [
-   {
-    "endpoint": "stbt"
-   },
-   {
-      "endpoint": "backed",
-      "accountName": "IBTA"
-   },
-   {
-      "endpoint": "usdr"
-   },
-   {
-      "endpoint": "eurr"
-   }
-]
+   "requests": [
+      {
+         "endpoint": "stbt"
+      },
+      {
+         "endpoint": "backed",
+         "accountName": "IBTA"
+      },
+      {
+         "endpoint": "usdr"
+      },
+      {
+         "endpoint": "eurr"
+      },
+      {
+         "endpoint": "gift"
+      }
+   ]
 }

--- a/packages/sources/the-network-firm/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/the-network-firm/test/integration/__snapshots__/adapter.test.ts.snap
@@ -42,6 +42,21 @@ exports[`execute eurr endpoint should return success 1`] = `
 }
 `;
 
+exports[`execute gift endpoint should return success 1`] = `
+{
+  "data": {
+    "result": 10000000,
+  },
+  "result": 10000000,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 978347471111,
+    "providerDataRequestedUnixMs": 978347471111,
+    "providerIndicatedTimeUnixMs": 1695648040048,
+  },
+}
+`;
+
 exports[`execute mco2 endpoint should return success 1`] = `
 {
   "data": {

--- a/packages/sources/the-network-firm/test/integration/__snapshots__/ripcord.test.ts.snap
+++ b/packages/sources/the-network-firm/test/integration/__snapshots__/ripcord.test.ts.snap
@@ -24,6 +24,18 @@ exports[`execute eurr endpoint when ripcord true  should return error 1`] = `
 }
 `;
 
+exports[`execute gift endpoint when ripcord true  should return error 1`] = `
+{
+  "errorMessage": "Ripcord indicator true. Details: Balances",
+  "statusCode": 502,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 978347471111,
+    "providerDataRequestedUnixMs": 978347471111,
+    "providerIndicatedTimeUnixMs": 1695648040048,
+  },
+}
+`;
+
 exports[`execute stbt endpoint when ripcord true  should return error 1`] = `
 {
   "errorMessage": "Ripcord indicator true. Details: Balances",

--- a/packages/sources/the-network-firm/test/integration/adapter.test.ts
+++ b/packages/sources/the-network-firm/test/integration/adapter.test.ts
@@ -6,6 +6,7 @@ import * as nock from 'nock'
 import {
   mockBackedResponseSuccess,
   mockEurrResponseSuccess,
+  mockGiftResponseSuccess,
   mockMCO2Response,
   mockSTBTResponseSuccess,
   mockUSDRResponseSuccess,
@@ -101,6 +102,19 @@ describe('execute', () => {
         endpoint: 'eurr',
       }
       mockEurrResponseSuccess()
+
+      const response = await testAdapter.request(data)
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toMatchSnapshot()
+    })
+  })
+
+  describe('gift endpoint', () => {
+    it('should return success', async () => {
+      const data = {
+        endpoint: 'gift',
+      }
+      mockGiftResponseSuccess()
 
       const response = await testAdapter.request(data)
       expect(response.statusCode).toBe(200)

--- a/packages/sources/the-network-firm/test/integration/fixtures.ts
+++ b/packages/sources/the-network-firm/test/integration/fixtures.ts
@@ -199,3 +199,33 @@ export const mockEurrResponseFailure = (): nock.Scope =>
       ripcordDetails: ['Balances'],
     })
     .persist()
+
+export const mockGiftResponseSuccess = (): nock.Scope =>
+  nock('https://api.oracle-services.ledgerlens.io/v1/chainlink/proof-of-reserves/', {
+    encodedQueryParams: true,
+  })
+    .get('/GIFT')
+    .reply(200, {
+      accountName: 'GIFT',
+      totalReserve: 10000000,
+      totalToken: 9999999.58,
+      timestamp: '2023-09-25T13:20:40.048Z',
+      ripcord: false,
+      ripcordDetails: [],
+    })
+    .persist()
+
+export const mockGiftResponseFailure = (): nock.Scope =>
+  nock('https://api.oracle-services.ledgerlens.io/v1/chainlink/proof-of-reserves/', {
+    encodedQueryParams: true,
+  })
+    .get('/GIFT')
+    .reply(200, {
+      accountName: 'GIFT',
+      totalReserve: 10000000,
+      totalToken: 9999999.58,
+      timestamp: '2023-09-25T13:20:40.048Z',
+      ripcord: true,
+      ripcordDetails: ['Balances'],
+    })
+    .persist()

--- a/packages/sources/the-network-firm/test/integration/ripcord.test.ts
+++ b/packages/sources/the-network-firm/test/integration/ripcord.test.ts
@@ -6,6 +6,7 @@ import * as nock from 'nock'
 import {
   mockBackedResponseFailure,
   mockEurrResponseFailure,
+  mockGiftResponseFailure,
   mockSTBTResponseFailure,
   mockUSDRResponseFailure,
 } from './fixtures'
@@ -80,6 +81,18 @@ describe('execute', () => {
         endpoint: 'eurr',
       }
       mockEurrResponseFailure()
+      const response = await testAdapter.request(data)
+      expect(response.statusCode).toBe(502)
+      expect(response.json()).toMatchSnapshot()
+    })
+  })
+
+  describe('gift endpoint when ripcord true ', () => {
+    it('should return error', async () => {
+      const data = {
+        endpoint: 'gift',
+      }
+      mockGiftResponseFailure()
       const response = await testAdapter.request(data)
       expect(response.statusCode).toBe(502)
       expect(response.json()).toMatchSnapshot()


### PR DESCRIPTION
## Closes [PDI-2291](https://smartcontract-it.atlassian.net/browse/PDI-2291)

## Description

Added GIFT endpoint to `the-network-firm` adapter

## Changes

- Added GIFT endpoint

## Steps to Test

1. yarn test packages/sources/the-network-firm/test

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [X] This is related to a maximum of one Jira story or GitHub issue.
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[PDI-2291]: https://smartcontract-it.atlassian.net/browse/PDI-2291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ