### PR TITLE
Convert cfbenchmarks and polygon to price adapter

### DIFF
--- a/.changeset/forty-clocks-deny.md
+++ b/.changeset/forty-clocks-deny.md
@@ -1,0 +1,6 @@
+---
+'@chainlink/cfbenchmarks-adapter': patch
+'@chainlink/polygon-adapter': patch
+---
+
+EA converted to PriceAdapter

--- a/packages/sources/cfbenchmarks/src/index.ts
+++ b/packages/sources/cfbenchmarks/src/index.ts
@@ -1,9 +1,9 @@
 import { expose, ServerInstance } from '@chainlink/external-adapter-framework'
-import { Adapter } from '@chainlink/external-adapter-framework/adapter'
+import { PriceAdapter } from '@chainlink/external-adapter-framework/adapter'
 import { config } from './config'
 import { birc, crypto, cryptolwba } from './endpoint'
 
-export const adapter = new Adapter({
+export const adapter = new PriceAdapter({
   name: 'CFBENCHMARKS',
   endpoints: [crypto, birc, cryptolwba],
   defaultEndpoint: crypto.name,

--- a/packages/sources/polygon/src/endpoint/tickers.ts
+++ b/packages/sources/polygon/src/endpoint/tickers.ts
@@ -1,31 +1,18 @@
-import { PriceEndpoint } from '@chainlink/external-adapter-framework/adapter'
+import {
+  ForexPriceEndpoint,
+  priceEndpointInputParametersDefinition,
+} from '@chainlink/external-adapter-framework/adapter'
 import { SingleNumberResultResponse } from '@chainlink/external-adapter-framework/util'
 import { config } from '../config'
 import { InputParameters } from '@chainlink/external-adapter-framework/validation'
 import { transport } from '../transport/tickers'
 
-export const inputParameters = new InputParameters(
+export const inputParameters = new InputParameters(priceEndpointInputParametersDefinition, [
   {
-    base: {
-      aliases: ['from', 'coin'],
-      type: 'string',
-      description: 'The symbol of symbols of the currency to query',
-      required: true,
-    },
-    quote: {
-      aliases: ['to', 'market'],
-      type: 'string',
-      description: 'The symbol of the currency to convert to',
-      required: true,
-    },
+    base: 'USD',
+    quote: 'GBP',
   },
-  [
-    {
-      base: 'USD',
-      quote: 'GBP',
-    },
-  ],
-)
+])
 
 export type BaseEndpointTypes = {
   Parameters: typeof inputParameters.definition
@@ -33,7 +20,7 @@ export type BaseEndpointTypes = {
   Settings: typeof config.settings
 }
 
-export const endpoint = new PriceEndpoint({
+export const endpoint = new ForexPriceEndpoint({
   name: 'tickers',
   aliases: ['forex', 'price'],
   transport,


### PR DESCRIPTION
[DF-19064](https://smartcontract-it.atlassian.net/browse/DF-19064)

- Changed cfbenchmarks EA to `PriceAdapter`
- Changed `conversion` and `ticker` endpoints of polygon EA to `PriceEndpoint`
- Changed polygon EA to `PriceAdapter`

[DF-19064]: https://smartcontract-it.atlassian.net/browse/DF-19064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ