### PR TITLE
Bugfix/df 19324 cc vwap apikey

### DIFF
--- a/.changeset/happy-seals-obey.md
+++ b/.changeset/happy-seals-obey.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/cryptocompare-adapter': patch
+---
+
+Add missing apikey header to vwap request

--- a/packages/sources/cryptocompare/src/transport/vwap.ts
+++ b/packages/sources/cryptocompare/src/transport/vwap.ts
@@ -29,6 +29,9 @@ export const httpTransport = new HttpTransport<HttpTransportTypes>({
         request: {
           baseURL: config.API_ENDPOINT,
           url: '/data/dayAvg',
+          headers: {
+            authorization: `Apikey ${config.API_KEY}`,
+          },
           params: {
             fsym: param.base.toUpperCase(),
             tsym: param.quote.toUpperCase(),


### PR DESCRIPTION
## Closes #[DF-19324](https://smartcontract-it.atlassian.net/browse/DF-19324)

## Description
Adding missing apikey header to cryptocompare vwap request

## Changes
- copy auth header from utils.ts into vwap file

## Steps to Test
1. `yarn test cryptocompare/test/integration`
2. sanity check `vwap` endpoint

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[DF-19324]: https://smartcontract-it.atlassian.net/browse/DF-19324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ