### PR TITLE
Add custom request routing for specific pairs to the Finage v3 adapter

### DIFF
--- a/.changeset/long-worms-compare.md
+++ b/.changeset/long-worms-compare.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/finage-test-adapter': patch
+---
+
+Added custom request routing to REST for specific pairs

--- a/packages/sources/finage-test/src/endpoint/crypto.ts
+++ b/packages/sources/finage-test/src/endpoint/crypto.ts
@@ -5,14 +5,33 @@ import { httpTransport } from '../transport/crypto-http'
 import { CryptoBaseEndpointTypes, cryptoPriceInputParameters } from './utils'
 import { wsTransport } from '../transport/crypto-ws'
 
+// List of base to quote arrays that should be routed to REST only
+const assets: Record<string, string[]> = {
+  AUTO: ['USD'],
+  EOS: ['BNB'],
+  USDP: ['USD'],
+  WSTETH: ['ETH'],
+  YFI: ['ETH'],
+}
+
 export const endpoint = new CryptoPriceEndpoint({
   name: 'crypto',
   transportRoutes: new TransportRoutes<CryptoBaseEndpointTypes>()
     .register('ws', wsTransport)
     .register('rest', httpTransport),
   defaultTransport: 'rest',
-  customRouter: (_req, adapterConfig) => {
-    return adapterConfig.WS_ENABLED ? 'ws' : 'rest'
+  customRouter: (req, adapterConfig) => {
+    const { base, quote } = req.requestContext
+      .data as typeof cryptoPriceInputParameters.validated & {
+      transport?: string
+    }
+    // Always route the listed assets to rest since Finage does not provide adequate
+    // updates for them over websocket
+    if (assets[base.toUpperCase()] && assets[base.toUpperCase()].includes(quote.toUpperCase())) {
+      return 'rest'
+    } else {
+      return adapterConfig.WS_ENABLED ? 'ws' : 'rest'
+    }
   },
   inputParameters: cryptoPriceInputParameters,
   overrides: overrides.finage,

--- a/packages/sources/finage-test/src/endpoint/forex.ts
+++ b/packages/sources/finage-test/src/endpoint/forex.ts
@@ -5,14 +5,26 @@ import { httpTransport } from '../transport/forex-http'
 import { ForexBaseEndpointTypes, forexPriceInputParameters } from './utils'
 import { wsTransport } from '../transport/forex-ws'
 
+// List of bases whose pairs should be routed to REST only
+const assets: string[] = ['AED', 'CNY', 'IDR', 'PHP', 'THB', 'TZS', 'VND']
+
 export const endpoint = new ForexPriceEndpoint({
   name: 'forex',
   transportRoutes: new TransportRoutes<ForexBaseEndpointTypes>()
     .register('ws', wsTransport)
     .register('rest', httpTransport),
   defaultTransport: 'rest',
-  customRouter: (_req, adapterConfig) => {
-    return adapterConfig.WS_ENABLED ? 'ws' : 'rest'
+  customRouter: (req, adapterConfig) => {
+    const { base } = req.requestContext.data as typeof forexPriceInputParameters.validated & {
+      transport?: string
+    }
+    // Always route the listed assets to rest since Finage does not provide adequate
+    // updates for them over websocket
+    if (assets.includes(base.toUpperCase())) {
+      return 'rest'
+    } else {
+      return adapterConfig.WS_ENABLED ? 'ws' : 'rest'
+    }
   },
   inputParameters: forexPriceInputParameters,
   overrides: overrides.finage,


### PR DESCRIPTION
## Closes [PDI-192](https://smartcontract-it.atlassian.net/browse/PDI-192)

## Description

Added custom request routing to Finage v3's crypto and forex endpoints. They direct specific pairs that get infrequent updates over websocket always to REST

## Changes

- Direct the following crypto pairs only to REST
  - `AUTO / USD`, `EOS / BNB`, `USDP / USD`, `WSTETH / ETH`, `YFI / ETH`
- Direct the following forex bases only to REST
  - `AED`, `CNY`, `IDR`, `PHP`, `THB`, `TZS`, `VND`

## Steps to Test

1. yarn test packages/sources/finage-test/test

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [X] This is related to a maximum of one Jira story or GitHub issue.
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[PDI-192]: https://smartcontract-it.atlassian.net/browse/PDI-192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ