### PR TITLE
Changed ncfx forex WS auth flow

### DIFF
--- a/.changeset/violet-dogs-prove.md
+++ b/.changeset/violet-dogs-prove.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/ncfx-adapter': minor
+---
+
+FOREX_WS_USERNAME and FOREX_WS_PASSWORD env vars replaced with FOREX_WS_API_KEY

--- a/packages/sources/ncfx/src/config/index.ts
+++ b/packages/sources/ncfx/src/config/index.ts
@@ -4,20 +4,14 @@ export const config = new AdapterConfig({
   API_USERNAME: {
     description: 'Username for the NCFX API',
     type: 'string',
-    required: true,
   },
   API_PASSWORD: {
     description: 'Password for the NCFX API',
     type: 'string',
-    required: true,
     sensitive: true,
   },
-  FOREX_WS_USERNAME: {
-    description: 'Username for Forex websocket endpoint',
-    type: 'string',
-  },
-  FOREX_WS_PASSWORD: {
-    description: 'Password for the Forex websocket endpoint',
+  FOREX_WS_API_KEY: {
+    description: 'API key for Forex websocket endpoint',
     type: 'string',
     sensitive: true,
   },
@@ -29,6 +23,6 @@ export const config = new AdapterConfig({
   FOREX_WS_API_ENDPOINT: {
     type: 'string',
     description: 'The WS API endpoint to use for the forex endpoint',
-    default: 'wss://fiat-ws.eu-west-2.apingxelb.v1.newchangefx.com/sub/fiat/ws/ref',
+    default: 'wss://fiat.ws.newchangefx.com/sub/fiat/ws/ref',
   },
 })

--- a/packages/sources/ncfx/src/endpoint/crypto.ts
+++ b/packages/sources/ncfx/src/endpoint/crypto.ts
@@ -7,7 +7,14 @@ import {
 import { config } from '../config'
 import { InputParameters } from '@chainlink/external-adapter-framework/validation'
 import { transport } from '../transport/crypto'
-import { SingleNumberResultResponse } from '@chainlink/external-adapter-framework/util'
+import {
+  AdapterRequest,
+  SingleNumberResultResponse,
+} from '@chainlink/external-adapter-framework/util'
+import {
+  AdapterError,
+  AdapterInputError,
+} from '@chainlink/external-adapter-framework/validation/error'
 
 // Note: this adapter is intended for the API with endpoint 'wss://cryptofeed.ws.newchangefx.com'.
 // There is another API with endpoint 'wss://feed.newchangefx.com/cryptodata' that has slightly
@@ -29,9 +36,23 @@ export type BaseEndpointTypes = {
   Settings: typeof config.settings
 }
 
+export function customInputValidation(
+  _: AdapterRequest<typeof inputParameters.validated>,
+  settings: typeof config.settings,
+): AdapterError | undefined {
+  if (!settings.API_PASSWORD || !settings.API_USERNAME) {
+    return new AdapterInputError({
+      statusCode: 400,
+      message: 'API_PASSWORD and/or API_USERNAME is not set',
+    })
+  }
+  return
+}
+
 export const cryptoEndpoint = new CryptoPriceEndpoint({
   name: 'crypto',
   aliases: DEFAULT_LWBA_ALIASES,
   transport,
+  customInputValidation,
   inputParameters,
 })

--- a/packages/sources/ncfx/src/endpoint/forex.ts
+++ b/packages/sources/ncfx/src/endpoint/forex.ts
@@ -31,10 +31,10 @@ export function customInputValidation(
   _: AdapterRequest<typeof inputParameters.validated>,
   settings: typeof config.settings,
 ): AdapterError | undefined {
-  if (!settings.FOREX_WS_USERNAME || !settings.FOREX_WS_PASSWORD) {
+  if (!settings.FOREX_WS_API_KEY) {
     return new AdapterInputError({
       statusCode: 400,
-      message: 'Forex endpoint credentials are not set',
+      message: 'FOREX_WS_API_KEY is not set',
     })
   }
   return

--- a/packages/sources/ncfx/src/transport/forex.ts
+++ b/packages/sources/ncfx/src/transport/forex.ts
@@ -17,17 +17,7 @@ type WsTransportTypes = BaseEndpointTypes & {
 export const transport = new WebSocketTransport<WsTransportTypes>({
   url: (context) => context.adapterSettings.FOREX_WS_API_ENDPOINT,
   options: (context) => {
-    const forexEncodedCreds =
-      context.adapterSettings.FOREX_WS_USERNAME && context.adapterSettings.FOREX_WS_PASSWORD
-        ? Buffer.from(
-            JSON.stringify({
-              grant_type: 'password',
-              username: context.adapterSettings.FOREX_WS_USERNAME,
-              password: context.adapterSettings.FOREX_WS_PASSWORD,
-            }),
-          ).toString('base64')
-        : ''
-    return { headers: { ncfxauth: forexEncodedCreds } }
+    return { headers: { 'x-api-key': context.adapterSettings.FOREX_WS_API_KEY } }
   },
   handlers: {
     message(message): ProviderResult<WsTransportTypes>[] {

--- a/packages/sources/ncfx/test/integration/adapter.test.ts
+++ b/packages/sources/ncfx/test/integration/adapter.test.ts
@@ -36,8 +36,7 @@ describe('websocket', () => {
     process.env['FOREX_WS_API_ENDPOINT'] = wsEndpointForex
     process.env['API_USERNAME'] = 'test-api-username'
     process.env['API_PASSWORD'] = 'test-api-password'
-    process.env['FOREX_WS_USERNAME'] = 'test-api-password'
-    process.env['FOREX_WS_PASSWORD'] = 'test-api-password'
+    process.env['FOREX_WS_API_KEY'] = 'test-api-key'
 
     mockWebSocketProvider(WebSocketClassProvider)
     mockWsServer = mockCryptoWebSocketServer(wsEndpoint)


### PR DESCRIPTION
[DF-19295](https://smartcontract-it.atlassian.net/browse/DF-19295)

1. Changed forex WS default endpoint.
2. Changed forex WS auth flow. We used to generate the api key via encoding the username and password. Now the api key should be directly provided as env var.
3. Added `customInputValidation` for crypto and forex endpoints. 