### PR TITLE
fixed issued depth undefined value in synthetix-debt-pool EA

### DIFF
--- a/.changeset/gentle-glasses-brake.md
+++ b/.changeset/gentle-glasses-brake.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/synthetix-debt-pool-adapter': patch
+---
+
+Fixed bug with issued dept being undefined

--- a/packages/sources/synthetix-debt-pool/src/endpoint/debt.ts
+++ b/packages/sources/synthetix-debt-pool/src/endpoint/debt.ts
@@ -75,7 +75,7 @@ export const getDebtIssued = async (
       let debtIssued
       try {
         const debtCache = new ethers.Contract(debtCacheAddress, DEBT_CACHE_ABI, networkProvider)
-        debtIssued = await debtCache.currentDebt({ blockTag: blockNumber })[0]
+        debtIssued = (await debtCache.currentDebt({ blockTag: blockNumber }))[0]
       } catch (e) {
         return errorResponse(
           e,


### PR DESCRIPTION
Fixed a bug where debtIssued was undefined regardless the contract response