### PR TITLE
NCFX: Make clear which credentials are used for Crypto

### DIFF
--- a/.changeset/poor-nails-tie.md
+++ b/.changeset/poor-nails-tie.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/ncfx-adapter': patch
+---
+
+Update README - make clear which credentials are used for Crypto

--- a/packages/sources/ncfx/README.md
+++ b/packages/sources/ncfx/README.md
@@ -8,8 +8,8 @@ This document was generated automatically. Please see [README Generator](../../s
 
 | Required? |         Name          |                    Description                     |  Type  | Options |                     Default                     |
 | :-------: | :-------------------: | :------------------------------------------------: | :----: | :-----: | :---------------------------------------------: |
-|           |     API_USERNAME      |             Username for the NCFX API              | string |         |                                                 |
-|           |     API_PASSWORD      |             Password for the NCFX API              | string |         |                                                 |
+|           |     API_USERNAME      |          Username for the NCFX Crypto API          | string |         |                                                 |
+|           |     API_PASSWORD      |          Password for the NCFX Crypto API          | string |         |                                                 |
 |           |   FOREX_WS_API_KEY    |        API key for Forex websocket endpoint        | string |         |                                                 |
 |           |    WS_API_ENDPOINT    | The WS API endpoint to use for the crypto endpoint | string |         |      `wss://cryptofeed.ws.newchangefx.com`      |
 |           | FOREX_WS_API_ENDPOINT | The WS API endpoint to use for the forex endpoint  | string |         | `wss://fiat.ws.newchangefx.com/sub/fiat/ws/ref` |

--- a/packages/sources/ncfx/src/config/index.ts
+++ b/packages/sources/ncfx/src/config/index.ts
@@ -2,11 +2,11 @@ import { AdapterConfig } from '@chainlink/external-adapter-framework/config'
 
 export const config = new AdapterConfig({
   API_USERNAME: {
-    description: 'Username for the NCFX API',
+    description: 'Username for the NCFX Crypto API',
     type: 'string',
   },
   API_PASSWORD: {
-    description: 'Password for the NCFX API',
+    description: 'Password for the NCFX Crypto API',
     type: 'string',
     sensitive: true,
   },


### PR DESCRIPTION
* Add details on which API each API key is for to the config & README. 