### PR TITLE
Fix Finage v3 forex endpoint custom routing for inverses

### DIFF
--- a/.changeset/chatty-parents-suffer.md
+++ b/.changeset/chatty-parents-suffer.md
@@ -2,4 +2,4 @@
 '@chainlink/finage-test-adapter': patch
 ---
 
-Fix forex endpoint custom routing to account for inverses
+Fix forex endpoint custom routing to account for inverses. Add pairs to the rest only routing list.

--- a/.changeset/chatty-parents-suffer.md
+++ b/.changeset/chatty-parents-suffer.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/finage-test-adapter': patch
+---
+
+Fix forex endpoint custom routing to account for inverses

--- a/packages/sources/finage-test/src/endpoint/crypto.ts
+++ b/packages/sources/finage-test/src/endpoint/crypto.ts
@@ -8,6 +8,7 @@ import { wsTransport } from '../transport/crypto-ws'
 // List of base to quote arrays that should be routed to REST only
 const assets: Record<string, string[]> = {
   AUTO: ['USD'],
+  BUSD: ['USD'],
   EOS: ['BNB'],
   MIM: ['USD'],
   RAI: ['USD'],

--- a/packages/sources/finage-test/src/endpoint/crypto.ts
+++ b/packages/sources/finage-test/src/endpoint/crypto.ts
@@ -9,6 +9,8 @@ import { wsTransport } from '../transport/crypto-ws'
 const assets: Record<string, string[]> = {
   AUTO: ['USD'],
   EOS: ['BNB'],
+  MIM: ['USD'],
+  RAI: ['USD'],
   USDP: ['USD'],
   WSTETH: ['ETH'],
   YFI: ['ETH'],


### PR DESCRIPTION
## [PDI-192](https://smartcontract-it.atlassian.net/browse/PDI-192)

## Description

Fixes forex endpoint's custom routing to account for inverses. Adds new pairs to the REST only routing list.

## Changes

- Forex endpoint custom router checks the routing map against the request's `base` and `quote`
- Added `BUSD / USD` to the crypto rest only routing list
- Added `MIM / USD` to the crypto rest only routing list
- Added `RAI / USD` to the crypto rest only routing list

## Steps to Test

1. yarn test packages/sources/finage-test/test/integration

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [X] This is related to a maximum of one Jira story or GitHub issue.
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[PDI-192]: https://smartcontract-it.atlassian.net/browse/PDI-192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ