### PR TITLE
Added logger and more integration tests to view-function EA

### DIFF
--- a/.changeset/clean-yaks-sell.md
+++ b/.changeset/clean-yaks-sell.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/view-function-adapter': patch
+---
+
+Added logger to FunctionTransport

--- a/packages/sources/view-function/src/transport/function.ts
+++ b/packages/sources/view-function/src/transport/function.ts
@@ -1,9 +1,11 @@
 import { TransportDependencies } from '@chainlink/external-adapter-framework/transports'
-import { AdapterResponse, sleep } from '@chainlink/external-adapter-framework/util'
+import { AdapterResponse, makeLogger, sleep } from '@chainlink/external-adapter-framework/util'
 import { ethers, utils } from 'ethers'
 import { SubscriptionTransport } from '@chainlink/external-adapter-framework/transports/abstract/subscription'
 import { EndpointContext } from '@chainlink/external-adapter-framework/adapter'
 import { BaseEndpointTypes, inputParameters } from '../endpoint/function'
+
+const logger = makeLogger('View Function')
 
 export type FunctionTransportTypes = BaseEndpointTypes
 
@@ -35,6 +37,7 @@ export class FunctionTransport extends SubscriptionTransport<FunctionTransportTy
     try {
       response = await this._handleRequest(param)
     } catch (e) {
+      logger.error(e)
       const errorMessage = e instanceof Error ? e.message : 'Unknown error occurred'
       response = {
         statusCode: 502,

--- a/packages/sources/view-function/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/view-function/test/integration/__snapshots__/adapter.test.ts.snap
@@ -13,3 +13,31 @@ exports[`execute function endpoint should return success 1`] = `
   },
 }
 `;
+
+exports[`execute function endpoint should return success 2 1`] = `
+{
+  "data": {
+    "result": "0x000000000000000000000000000000000000000000000000000000005ad789f8",
+  },
+  "result": "0x000000000000000000000000000000000000000000000000000000005ad789f8",
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 978347471111,
+    "providerDataRequestedUnixMs": 978347471111,
+  },
+}
+`;
+
+exports[`execute function endpoint should return success with parameters 1`] = `
+{
+  "data": {
+    "result": "0x000000000000000000000000000000000000000000000000000000005cf7ff3b",
+  },
+  "result": "0x000000000000000000000000000000000000000000000000000000005cf7ff3b",
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 978347471111,
+    "providerDataRequestedUnixMs": 978347471111,
+  },
+}
+`;

--- a/packages/sources/view-function/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/view-function/test/integration/__snapshots__/adapter.test.ts.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`execute function endpoint should return error for invalid input 1`] = `
+{
+  "errorMessage": "unsupported fragment (argument="value", value="symbol () view returns (string)", code=INVALID_ARGUMENT, version=abi/5.7.0)",
+  "statusCode": 502,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 0,
+    "providerDataRequestedUnixMs": 0,
+  },
+}
+`;
+
 exports[`execute function endpoint should return success 1`] = `
 {
   "data": {

--- a/packages/sources/view-function/test/integration/adapter.test.ts
+++ b/packages/sources/view-function/test/integration/adapter.test.ts
@@ -42,5 +42,28 @@ describe('execute', () => {
       expect(response.statusCode).toBe(200)
       expect(response.json()).toMatchSnapshot()
     })
+
+    it('should return success 2', async () => {
+      const data = {
+        contract: '0x2c1d072e956AFFC0D435Cb7AC38EF18d24d9127c',
+        function: 'function latestAnswer() external view returns (int256)',
+      }
+      mockContractCallResponseSuccess()
+      const response = await testAdapter.request(data)
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toMatchSnapshot()
+    })
+
+    it('should return success with parameters', async () => {
+      const data = {
+        contract: '0x2c1d072e956AFFC0D435Cb7AC38EF18d24d9127c',
+        function: 'function getAnswer(uint256 roundId) external view returns (int256)',
+        inputParams: ['110680464442257317364'],
+      }
+      mockContractCallResponseSuccess()
+      const response = await testAdapter.request(data)
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toMatchSnapshot()
+    })
   })
 })

--- a/packages/sources/view-function/test/integration/adapter.test.ts
+++ b/packages/sources/view-function/test/integration/adapter.test.ts
@@ -65,5 +65,15 @@ describe('execute', () => {
       expect(response.statusCode).toBe(200)
       expect(response.json()).toMatchSnapshot()
     })
+
+    it('should return error for invalid input', async () => {
+      const data = {
+        contract: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+        function: 'symbol() view returns (string)', // missing 'function' keyword
+      }
+      const response = await testAdapter.request(data)
+      expect(response.statusCode).toBe(502)
+      expect(response.json()).toMatchSnapshot()
+    })
   })
 })

--- a/packages/sources/view-function/test/integration/fixtures.ts
+++ b/packages/sources/view-function/test/integration/fixtures.ts
@@ -54,3 +54,59 @@ export const mockContractCallResponseSuccess = (): nock.Scope =>
       ],
     )
     .persist()
+    .post('/', {
+      method: 'eth_call',
+      params: [{ to: '0x2c1d072e956affc0d435cb7ac38ef18d24d9127c', data: '0x50d25bcd' }, 'latest'],
+      id: /^\d+$/,
+      jsonrpc: '2.0',
+    })
+    .reply(
+      200,
+      (_, request: JsonRpcPayload) => ({
+        jsonrpc: '2.0',
+        id: request['id'],
+        result: '0x000000000000000000000000000000000000000000000000000000005ad789f8',
+      }),
+      [
+        'Content-Type',
+        'application/json',
+        'Connection',
+        'close',
+        'Vary',
+        'Accept-Encoding',
+        'Vary',
+        'Origin',
+      ],
+    )
+    .persist()
+    .post('/', {
+      method: 'eth_call',
+      params: [
+        {
+          to: '0x2c1d072e956affc0d435cb7ac38ef18d24d9127c',
+          data: '0xb5ab58dc0000000000000000000000000000000000000000000000060000000000001df4',
+        },
+        'latest',
+      ],
+      id: /^\d+$/,
+      jsonrpc: '2.0',
+    })
+    .reply(
+      200,
+      (_, request: JsonRpcPayload) => ({
+        jsonrpc: '2.0',
+        id: request['id'],
+        result: '0x000000000000000000000000000000000000000000000000000000005cf7ff3b',
+      }),
+      [
+        'Content-Type',
+        'application/json',
+        'Connection',
+        'close',
+        'Vary',
+        'Accept-Encoding',
+        'Vary',
+        'Origin',
+      ],
+    )
+    .persist()


### PR DESCRIPTION
## Closes [DF-19308](https://smartcontract-it.atlassian.net/browse/DF-19308)


View-function EA was reviewed to make sure that it functions properly as it will become a dependency for other feeds. 

Regarding testing
Added more integration tests to make sure that the logic in the EA works as expected (both success and failure). 
Also tested functionally that `function latestAnswer() external view returns (int256)` signature returns a response for given price feed contract. 

Regarding precision/decimals
view-function EA is pretty generic and returns raw encoded hex string as a result. decoding/precision handling needs to be done on consumer side. 

Regarding RPC errors
It is possible that RPC will error (signature mismatch, RPC provider issues, ...), in that case the EA will log the error. The way ea-framework caching works is that if there is a non-error entry in the cache (status=200) the newer error responses will not overwrite it.  This means that even if RPC provider is down for some time, the EA will still provide a value from cache (until cache TTL expires). We can further improve this by increasing cache TTL (up to 20 mins) but this might result in a cache with stale values. 


[DF-19308]: https://smartcontract-it.atlassian.net/browse/DF-19308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ