### PR TITLE
Add pair to Finage forex exclude inverse list

### DIFF
--- a/.changeset/short-waves-travel.md
+++ b/.changeset/short-waves-travel.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/finage-test-adapter': patch
+---
+
+Added pair to the forex endpoint exclude inverse list

--- a/packages/sources/finage-test/src/endpoint/forex.ts
+++ b/packages/sources/finage-test/src/endpoint/forex.ts
@@ -16,7 +16,7 @@ On receiving FOO/USD request, if FOO is on the list of assets that are queried i
 excludesMap includes currency pairs {quote: [base ...]} which should not be inverted.
 */
 const excludesMap: Record<string, string[]> = {
-  USD: ['EUR', 'GBP', 'AUD', 'NZD', 'XAG', 'XAU', 'XPT', 'XPD', 'XCU'],
+  USD: ['EUR', 'GBP', 'AUD', 'NZD', 'XAG', 'XAU', 'XPT', 'XPD', 'XCU', 'PLN'],
 }
 
 export const forexReqTransformer = (


### PR DESCRIPTION
## Closes [PDI-192](https://smartcontract-it.atlassian.net/browse/PDI-192)

## Description

Added `PLN / USD` forex pair to the exclude inverse list. Finage serves the data for this pair in the standard direction with USD as the quote.

## Changes

- Added `PLN / USD` to the exclude inverse list in the forex endpoint.

## Steps to Test

1. yarn test packages/sources/finage-test/test

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [X] This is related to a maximum of one Jira story or GitHub issue.
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[PDI-192]: https://smartcontract-it.atlassian.net/browse/PDI-192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ