### PR TITLE
Fixed alongside integration tests

### DIFF
--- a/packages/sources/alongside/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/alongside/test/integration/__snapshots__/adapter.test.ts.snap
@@ -3,9 +3,9 @@
 exports[`execute portfolio api should return success 1`] = `
 {
   "data": {
-    "result": 25954.286873113622,
+    "result": 41.03,
   },
-  "result": 25954.286873113622,
+  "result": 41.03,
   "statusCode": 200,
   "timestamps": {
     "providerDataReceivedUnixMs": 1652198967193,

--- a/packages/sources/alongside/test/integration/fixtures.ts
+++ b/packages/sources/alongside/test/integration/fixtures.ts
@@ -1331,3 +1331,29 @@ nock('https://mainnet.infura.io:443/v3/fake-infura-key')
       'Origin',
     ],
   )
+
+nock('https://amkt.infura-ipfs.io/')
+  .get(`/ipfs/QmYwevHbNyUMMpWKgP58qKhguhA6seCVv8TkkdYTRC6Ppr`)
+  .reply(
+    200,
+    () => ({
+      assets: {
+        AAVE: 1,
+        EOS: 2,
+      },
+    }),
+    [
+      'Date',
+      'Fri, 21 Oct 2022 06:39:28 GMT',
+      'Content-Type',
+      'application/json',
+      'Content-Length',
+      '40',
+      'Connection',
+      'close',
+      'Vary',
+      'Accept-Encoding',
+      'Vary',
+      'Origin',
+    ],
+  )


### PR DESCRIPTION
The integration test of Alongside EA somehow didn't have a mock for `infura-ipfs` api. The test was actually calling the real API and getting the data. Presumably the data was always the same therefore the test snapshots were not failing. 

However, in a different PR i noticed alongside integration tests failing and after checking it, it seems that the API that was actually running in the test is now throwing 401 errors. This PR adds the missing mocked response. 
