### PR TITLE
Add env var default override to eth-beacon

### DIFF
--- a/.changeset/tall-ducks-lie.md
+++ b/.changeset/tall-ducks-lie.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/eth-beacon-adapter': patch
+---
+
+Added env var default override to set MAX_PAYLOAD_SIZE_LIMIT to 5MB

--- a/packages/sources/eth-beacon/src/config/index.ts
+++ b/packages/sources/eth-beacon/src/config/index.ts
@@ -40,6 +40,7 @@ export const config = new AdapterConfig(
   {
     envDefaultOverrides: {
       API_TIMEOUT: 60000,
+      MAX_PAYLOAD_SIZE_LIMIT: 5000000,
     },
   },
 )


### PR DESCRIPTION
## Closes [DF-19482](https://smartcontract-it.atlassian.net/browse/DF-19482)

## Description

Recent job using `eth-beacon` had a payload exceed the default limit (1MB) set in the Fastify server. Added an env var default override to set the payload limit to 5MB to allow for the growing request size the adapter is used for.

## Changes

- Set `MAX_PAYLOAD_SIZE_LIMIT` to 5000000 in `envDefaultOverrides`

## Steps to Test

1. yarn test packages/sources/eth-beacon/test

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [X] This is related to a maximum of one Jira story or GitHub issue.
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
