### PR TITLE
Added group batching calls to Por-address-list

### DIFF
--- a/.changeset/good-fishes-shake.md
+++ b/.changeset/good-fishes-shake.md
@@ -2,4 +2,4 @@
 '@chainlink/por-address-list-adapter': patch
 ---
 
-Added BATCH_GROUP_SIZE config
+Added GROUP_SIZE config

--- a/.changeset/good-fishes-shake.md
+++ b/.changeset/good-fishes-shake.md
@@ -2,4 +2,4 @@
 '@chainlink/por-address-list-adapter': patch
 ---
 
-Added batchGroupSize input parameter
+Added BATCH_GROUP_SIZE config

--- a/.changeset/good-fishes-shake.md
+++ b/.changeset/good-fishes-shake.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/por-address-list-adapter': patch
+---
+
+Added batchGroupSize input parameter

--- a/packages/sources/por-address-list/README.md
+++ b/packages/sources/por-address-list/README.md
@@ -37,6 +37,7 @@ There are no rate limits for this adapter.
 |           |     confirmations     |         |            The number of confirmations to query data from             | number  |         |         |            |                |
 |    ✅     |    contractAddress    |         |         The contract address holding the custodial addresses          | string  |         |         |            |                |
 |           |       batchSize       |         |     The number of addresses to fetch from the contract at a time      | number  |         |  `10`   |            |                |
+|           |    batchGroupSize     |         |   The number of concurrent batched contract calls to make at a time   | number  |         |  `10`   |            |                |
 |    ✅     |        network        |         |           The network name to associate with the addresses            | string  |         |         |            |                |
 |    ✅     |        chainId        |         |             The chain ID to associate with the addresses              | string  |         |         |            |                |
 |           | searchLimboValidators |         | Flag to pass on to the balance adapter to search for limbo validators | boolean |         |         |            |                |

--- a/packages/sources/por-address-list/README.md
+++ b/packages/sources/por-address-list/README.md
@@ -10,6 +10,7 @@ This document was generated automatically. Please see [README Generator](../../s
 | :-------: | :-------------------: | :---------------------------------------------------------------------------------------: | :----: | :-----: | :-----: |
 |    ✅     |        RPC_URL        |   The RPC URL to connect to the EVM chain the address manager contract is deployed to.    | string |         |         |
 |           |       CHAIN_ID        |                                The chain id to connect to                                 | number |         |   `1`   |
+|           |   BATCH_GROUP_SIZE    |             The number of concurrent batched contract calls to make at a time             | number |         |  `10`   |
 |           | BACKGROUND_EXECUTE_MS | The amount of time the background execute should sleep before performing the next request | number |         | `10000` |
 
 ---
@@ -37,7 +38,6 @@ There are no rate limits for this adapter.
 |           |     confirmations     |         |            The number of confirmations to query data from             | number  |         |         |            |                |
 |    ✅     |    contractAddress    |         |         The contract address holding the custodial addresses          | string  |         |         |            |                |
 |           |       batchSize       |         |     The number of addresses to fetch from the contract at a time      | number  |         |  `10`   |            |                |
-|           |    batchGroupSize     |         |   The number of concurrent batched contract calls to make at a time   | number  |         |  `10`   |            |                |
 |    ✅     |        network        |         |           The network name to associate with the addresses            | string  |         |         |            |                |
 |    ✅     |        chainId        |         |             The chain ID to associate with the addresses              | string  |         |         |            |                |
 |           | searchLimboValidators |         | Flag to pass on to the balance adapter to search for limbo validators | boolean |         |         |            |                |

--- a/packages/sources/por-address-list/src/config/index.ts
+++ b/packages/sources/por-address-list/src/config/index.ts
@@ -12,6 +12,11 @@ export const config = new AdapterConfig({
     type: 'number',
     default: 1,
   },
+  BATCH_GROUP_SIZE: {
+    description: 'The number of concurrent batched contract calls to make at a time',
+    type: 'number',
+    default: 10,
+  },
   BACKGROUND_EXECUTE_MS: {
     description:
       'The amount of time the background execute should sleep before performing the next request',

--- a/packages/sources/por-address-list/src/config/index.ts
+++ b/packages/sources/por-address-list/src/config/index.ts
@@ -12,8 +12,9 @@ export const config = new AdapterConfig({
     type: 'number',
     default: 1,
   },
-  BATCH_GROUP_SIZE: {
-    description: 'The number of concurrent batched contract calls to make at a time',
+  GROUP_SIZE: {
+    description:
+      'The number of concurrent batched contract calls to make at a time. Setting this lower than the default may result in lower performance from the adapter.',
     type: 'number',
     default: 10,
   },

--- a/packages/sources/por-address-list/src/endpoint/address.ts
+++ b/packages/sources/por-address-list/src/endpoint/address.ts
@@ -23,11 +23,6 @@ export const inputParameters = new InputParameters({
     type: 'number',
     default: 10,
   },
-  batchGroupSize: {
-    description: 'The number of concurrent batched contract calls to make at a time',
-    type: 'number',
-    default: 10,
-  },
   network: {
     description: 'The network name to associate with the addresses',
     type: 'string',

--- a/packages/sources/por-address-list/src/endpoint/address.ts
+++ b/packages/sources/por-address-list/src/endpoint/address.ts
@@ -23,6 +23,11 @@ export const inputParameters = new InputParameters({
     type: 'number',
     default: 10,
   },
+  batchGroupSize: {
+    description: 'The number of concurrent batched contract calls to make at a time',
+    type: 'number',
+    default: 10,
+  },
   network: {
     description: 'The network name to associate with the addresses',
     type: 'string',

--- a/packages/sources/por-address-list/src/transport/address.ts
+++ b/packages/sources/por-address-list/src/transport/address.ts
@@ -71,7 +71,7 @@ export class AddressTransport extends SubscriptionTransport<AddressTransportType
       latestBlockNum,
       confirmations,
       batchSize,
-      this.settings.BATCH_GROUP_SIZE,
+      this.settings.GROUP_SIZE,
     )
     const addresses: PoRAddress[] = addressList.map((address) => ({
       address,

--- a/packages/sources/por-address-list/src/transport/address.ts
+++ b/packages/sources/por-address-list/src/transport/address.ts
@@ -58,8 +58,15 @@ export class AddressTransport extends SubscriptionTransport<AddressTransportType
   async _handleRequest(
     param: RequestParams,
   ): Promise<AdapterResponse<AddressTransportTypes['Response']>> {
-    const { confirmations, contractAddress, batchSize, network, chainId, searchLimboValidators } =
-      param
+    const {
+      confirmations,
+      contractAddress,
+      batchSize,
+      batchGroupSize,
+      network,
+      chainId,
+      searchLimboValidators,
+    } = param
     const addressManager = new ethers.Contract(contractAddress, POR_ADDRESS_LIST_ABI, this.provider)
     const latestBlockNum = await this.provider.getBlockNumber()
 
@@ -69,6 +76,7 @@ export class AddressTransport extends SubscriptionTransport<AddressTransportType
       latestBlockNum,
       confirmations,
       batchSize,
+      batchGroupSize,
     )
     const addresses: PoRAddress[] = addressList.map((address) => ({
       address,

--- a/packages/sources/por-address-list/src/transport/address.ts
+++ b/packages/sources/por-address-list/src/transport/address.ts
@@ -14,6 +14,7 @@ type RequestParams = typeof inputParameters.validated
 
 export class AddressTransport extends SubscriptionTransport<AddressTransportTypes> {
   provider!: ethers.providers.JsonRpcProvider
+  settings!: AddressTransportTypes['Settings']
 
   async initialize(
     dependencies: TransportDependencies<AddressTransportTypes>,
@@ -26,6 +27,7 @@ export class AddressTransport extends SubscriptionTransport<AddressTransportType
       adapterSettings.RPC_URL,
       adapterSettings.CHAIN_ID,
     )
+    this.settings = adapterSettings
   }
 
   async backgroundHandler(
@@ -58,15 +60,8 @@ export class AddressTransport extends SubscriptionTransport<AddressTransportType
   async _handleRequest(
     param: RequestParams,
   ): Promise<AdapterResponse<AddressTransportTypes['Response']>> {
-    const {
-      confirmations,
-      contractAddress,
-      batchSize,
-      batchGroupSize,
-      network,
-      chainId,
-      searchLimboValidators,
-    } = param
+    const { confirmations, contractAddress, batchSize, network, chainId, searchLimboValidators } =
+      param
     const addressManager = new ethers.Contract(contractAddress, POR_ADDRESS_LIST_ABI, this.provider)
     const latestBlockNum = await this.provider.getBlockNumber()
 
@@ -76,7 +71,7 @@ export class AddressTransport extends SubscriptionTransport<AddressTransportType
       latestBlockNum,
       confirmations,
       batchSize,
-      batchGroupSize,
+      this.settings.BATCH_GROUP_SIZE,
     )
     const addresses: PoRAddress[] = addressList.map((address) => ({
       address,

--- a/packages/sources/por-address-list/src/transport/utils.ts
+++ b/packages/sources/por-address-list/src/transport/utils.ts
@@ -14,11 +14,11 @@ export const fetchAddressList = async (
   let totalRequestedAddressesCount = 0
   let startIdx = ethers.BigNumber.from(0)
   const addresses: string[] = []
-  let batchRequests: Promise<string>[] = []
+  let batchRequests: Promise<string[]>[] = []
 
   while (totalRequestedAddressesCount < numAddresses.toNumber()) {
     const nextEndIdx = startIdx.add(batchSize)
-    const endIdx = nextEndIdx.gt(numAddresses) ? numAddresses.sub(1) : nextEndIdx
+    const endIdx = nextEndIdx.gte(numAddresses) ? numAddresses.sub(1) : nextEndIdx
     const batchCall = addressManager.getPoRAddressList(startIdx, endIdx, { blockTag })
     batchRequests.push(batchCall)
     // element at endIdx is included in result

--- a/packages/sources/por-address-list/src/transport/utils.ts
+++ b/packages/sources/por-address-list/src/transport/utils.ts
@@ -5,22 +5,34 @@ export const fetchAddressList = async (
   latestBlockNum: number,
   confirmations = 0,
   batchSize = 10,
+  batchGroupSize = 10,
 ): Promise<string[]> => {
   const blockTag = latestBlockNum - confirmations
   const numAddresses = await addressManager.getPoRAddressListLength({
     blockTag,
   })
-  let addresses: string[] = []
+  let totalRequestedAddressesCount = 0
   let startIdx = ethers.BigNumber.from(0)
-  while (ethers.BigNumber.from(addresses.length).lt(numAddresses)) {
+  const addresses: string[] = []
+  let batchRequests: Promise<string>[] = []
+
+  while (totalRequestedAddressesCount < numAddresses.toNumber()) {
     const nextEndIdx = startIdx.add(batchSize)
     const endIdx = nextEndIdx.gt(numAddresses) ? numAddresses.sub(1) : nextEndIdx
+    const batchCall = addressManager.getPoRAddressList(startIdx, endIdx, { blockTag })
+    batchRequests.push(batchCall)
     // element at endIdx is included in result
-    const latestAddresses = await addressManager.getPoRAddressList(startIdx, endIdx, {
-      blockTag,
-    })
-    addresses = addresses.concat(latestAddresses)
+    const addressesRequested: number = endIdx.sub(startIdx).add(1).toNumber()
+    totalRequestedAddressesCount += addressesRequested
     startIdx = endIdx.add(1)
+
+    if (
+      batchRequests.length >= batchGroupSize ||
+      totalRequestedAddressesCount >= numAddresses.toNumber()
+    ) {
+      addresses.push(...(await Promise.all(batchRequests)).flat())
+      batchRequests = []
+    }
   }
   return addresses
 }

--- a/packages/sources/por-address-list/test/integration/adapter.test.ts
+++ b/packages/sources/por-address-list/test/integration/adapter.test.ts
@@ -36,7 +36,11 @@ jest.mock('ethers', () => {
       Contract: function () {
         return {
           getPoRAddressListLength: jest.fn().mockReturnValue(mockAddressListLength),
-          getPoRAddressList: jest.fn().mockReturnValue(mockExpectedAddresses),
+          getPoRAddressList: jest.fn().mockImplementation((startIdx, endIdx) => {
+            const start = startIdx.toNumber()
+            const end = endIdx.toNumber() + 1
+            return mockExpectedAddresses.slice(start, end)
+          }),
         }
       },
     },

--- a/packages/sources/por-address-list/test/unit/utils.test.ts
+++ b/packages/sources/por-address-list/test/unit/utils.test.ts
@@ -25,7 +25,7 @@ const AddressManagerMock: jest.Mock<ethers.Contract, string[][]> = jest
       getPoRAddressList: jest
         .fn()
         .mockImplementation((startIdx: ethers.BigNumber, endIdx: ethers.BigNumber) => {
-          const lastIdx = endIdx.gt(ethers.BigNumber.from(addresses.length))
+          const lastIdx = endIdx.gte(ethers.BigNumber.from(addresses.length))
             ? addresses.length - 1
             : endIdx.toNumber()
           return addresses.slice(startIdx.toNumber(), lastIdx + 1)
@@ -47,7 +47,7 @@ describe('address endpoint', () => {
         })
         expect(addressManager.getPoRAddressList).toHaveBeenCalledWith(
           ethers.BigNumber.from(0),
-          ethers.BigNumber.from(DEFAULT_EXPECTED_ADDRESSES.length),
+          ethers.BigNumber.from(DEFAULT_EXPECTED_ADDRESSES.length - 1),
           { blockTag: LATEST_BLOCK_NUM },
         )
       })
@@ -62,7 +62,7 @@ describe('address endpoint', () => {
         })
         expect(addressManager.getPoRAddressList).toHaveBeenCalledWith(
           ethers.BigNumber.from(0),
-          ethers.BigNumber.from(DEFAULT_EXPECTED_ADDRESSES.length),
+          ethers.BigNumber.from(DEFAULT_EXPECTED_ADDRESSES.length - 1),
           { blockTag: LATEST_BLOCK_NUM - confirmations },
         )
       })


### PR DESCRIPTION
[DF-19481](https://smartcontract-it.atlassian.net/browse/DF-19481)

Added support for grouping batch calls in por-address-list EA. 

[DF-19481]: https://smartcontract-it.atlassian.net/browse/DF-19481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ