### PR TITLE
Removes Optimism healthcheck endpoint

### DIFF
--- a/.changeset/brown-crabs-cheer.md
+++ b/.changeset/brown-crabs-cheer.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/layer2-sequencer-health-adapter': patch
+---
+
+Removes Optimism healthcheck endpoint

--- a/packages/sources/layer2-sequencer-health/README.md
+++ b/packages/sources/layer2-sequencer-health/README.md
@@ -13,7 +13,7 @@ Adapter that checks the Layer 2 Sequencer status
 |           |    `ARBITRUM_HEALTH_ENDPOINT`     |                            Arbitrum Health Endpoint                             |         |                                                                  |
 |           |        `ARBITRUM_CHAIN_ID`        |                           The chain id to connect to                            |         |                              42161                               |
 |           |      `OPTIMISM_RPC_ENDPOINT`      |                              Optimism RPC Endpoint                              |         |                   https://mainnet.optimism.io                    |
-|           |    `OPTIMISM_HEALTH_ENDPOINT`     |                            Optimism Health Endpoint                             |         |           https://mainnet-sequencer.optimism.io/health           |
+|           |    `OPTIMISM_HEALTH_ENDPOINT`     |                            Optimism Health Endpoint                             |         |                                                                  |
 |           |        `OPTIMISM_CHAIN_ID`        |                           The chain id to connect to                            |         |                                10                                |
 |           |        `BASE_RPC_ENDPOINT`        |                                Base RPC Endpoint                                |         |                     https://mainnet.base.org                     |
 |           |      `BASE_HEALTH_ENDPOINT`       |                              Base Health Endpoint                               |         |                                                                  |
@@ -33,9 +33,9 @@ For the adapter to be useful on the desired network, at least one endpoint (RPC 
 
 ### Input Parameters
 
-| Required? |  Name   |       Description        |                       Options                        | Defaults to |
-| :-------: | :-----: | :----------------------: | :--------------------------------------------------: | :---------: |
-|    ✅     | network | Layer 2 Network to check | `arbitrum`, `optimism`, `base`, `metis`, `starkware` |             |
+| Required? |  Name   |       Description        |                            Options                             | Defaults to |
+| :-------: | :-----: | :----------------------: | :------------------------------------------------------------: | :---------: |
+|    ✅     | network | Layer 2 Network to check | `arbitrum`, `optimism`, `base`, `metis`, `scroll`, `starkware` |             |
 
 ---
 

--- a/packages/sources/layer2-sequencer-health/schemas/env.json
+++ b/packages/sources/layer2-sequencer-health/schemas/env.json
@@ -28,7 +28,7 @@
     },
     "OPTIMISM_HEALTH_ENDPOINT": {
       "type": "string",
-      "default": "https://mainnet-sequencer.optimism.io/health"
+      "default": ""
     },
     "OPTIMISM_CHAIN_ID": {
       "required": false,

--- a/packages/sources/layer2-sequencer-health/src/config/index.ts
+++ b/packages/sources/layer2-sequencer-health/src/config/index.ts
@@ -83,7 +83,6 @@ export const CHAIN_IDS: Record<EVMNetworks, number | undefined | string> = {
     util.getEnv(ENV_SCROLL_CHAIN_ID),
 }
 
-const DEFAULT_OPTIMISM_HEALTH_ENDPOINT = 'https://mainnet-sequencer.optimism.io/health'
 const DEFAULT_METIS_HEALTH_ENDPOINT = 'https://tokenapi.metis.io/andromeda/health'
 export const HEALTH_ENDPOINTS: Record<
   Networks,
@@ -94,7 +93,7 @@ export const HEALTH_ENDPOINTS: Record<
     responsePath: [],
   },
   [Networks.Optimism]: {
-    endpoint: util.getEnv('OPTIMISM_HEALTH_ENDPOINT') || DEFAULT_OPTIMISM_HEALTH_ENDPOINT,
+    endpoint: util.getEnv('OPTIMISM_HEALTH_ENDPOINT'),
     responsePath: ['healthy'],
   },
   [Networks.Base]: {

--- a/packages/sources/layer2-sequencer-health/test/integration/fixtures.ts
+++ b/packages/sources/layer2-sequencer-health/test/integration/fixtures.ts
@@ -2,20 +2,6 @@ import nock from 'nock'
 
 export const mockResponseSuccessHealth = (): void => {
   // #1 Option: Direct check on health endpoint
-  nock('https://mainnet-sequencer.optimism.io/health')
-    .get('')
-    .query(() => true)
-    .reply(200, (_) => ({ healthy: 'true' }), [
-      'Content-Type',
-      'application/json',
-      'Connection',
-      'close',
-      'Vary',
-      'Accept-Encoding',
-      'Vary',
-      'Origin',
-    ])
-
   nock('https://tokenapi.metis.io/andromeda/health')
     .get('')
     .query(() => true)
@@ -107,21 +93,6 @@ export const mockResponseSuccessRollup = (): void => {
 
 export const mockResponseFailureHealth = (): void => {
   // #1 Option: Direct check on health endpoint
-  nock('https://mainnet-sequencer.optimism.io/health', {
-    encodedQueryParams: true,
-  })
-    .get('/')
-    .reply(500, () => ({ healthy: 'false' }), [
-      'Content-Type',
-      'application/json',
-      'Connection',
-      'close',
-      'Vary',
-      'Accept-Encoding',
-      'Vary',
-      'Origin',
-    ])
-
   nock('https://tokenapi.metis.io/andromeda/health')
     .get('')
     .query(() => true)


### PR DESCRIPTION




## Description
Removes Optimism healthcheck endpoint from layer2-health adapter as the endpoint is being deprecated by the Optimism team.


## Motivation
[SHIP-690](https://smartcontract-it.atlassian.net/browse/SHIP-690)

## Changes

- Removes Optimism healthcheck endpoint from layer2-health adapter as the endpoint is being deprecated by the Optimism team.
- Adds Scroll to the supported chains in the layer2 README



## Steps to Test

1.  Unit tests

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [x] This is related to a maximum of one Jira story or GitHub issue.
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[SHIP-690]: https://smartcontract-it.atlassian.net/browse/SHIP-690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ