### PR TITLE
Fix Bob EA tsconfig reference

### DIFF
--- a/packages/sources/bob/tsconfig.json
+++ b/packages/sources/bob/tsconfig.json
@@ -6,9 +6,5 @@
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
-  "references": [
-    { "path": "../../core/test-helpers" },
-    { "path": "../../core/bootstrap" },
-    { "path": "../../sources/json-rpc" }
-  ]
+  "references": [{ "path": "../../core/test-helpers" }, { "path": "../../core/bootstrap" }]
 }


### PR DESCRIPTION
Removes unnecessary tsconfig reference to json-rpc EA which actually caused build issues in deploy stage. 