### PR TITLE
Overrides updates for dxfeed and dxfeed-secondary

### DIFF
--- a/.changeset/tame-mails-learn.md
+++ b/.changeset/tame-mails-learn.md
@@ -1,0 +1,6 @@
+---
+'@chainlink/dxfeed-secondary-adapter': patch
+'@chainlink/dxfeed-adapter': patch
+---
+
+Updated overrides

--- a/packages/sources/dxfeed-secondary/src/config/overrides.json
+++ b/packages/sources/dxfeed-secondary/src/config/overrides.json
@@ -1,5 +1,5 @@
 {
-  "dxfeed": {
+  "dxfeed-secondary": {
     "WTI": "USO/USD:AFX"
   }
 }

--- a/packages/sources/dxfeed-secondary/src/endpoint/price.ts
+++ b/packages/sources/dxfeed-secondary/src/endpoint/price.ts
@@ -7,6 +7,7 @@ import {
 } from '@chainlink/dxfeed-adapter'
 import { AdapterEndpoint } from '@chainlink/external-adapter-framework/adapter'
 import { TransportRoutes } from '@chainlink/external-adapter-framework/transports'
+import overrides from '../config/overrides.json'
 
 export const endpoint = new AdapterEndpoint({
   name: 'price',
@@ -17,4 +18,16 @@ export const endpoint = new AdapterEndpoint({
   defaultTransport: 'rest',
   inputParameters,
   customInputValidation,
+  overrides: overrides['dxfeed-secondary'],
+  requestTransforms: [
+    (req) => {
+      const { base } = req.requestContext.data
+      const rawRequestData = req.body.data
+      // If `base` is not overriden, append ':BFX' suffix to `base`
+      const baseAliases = ['base', ...inputParameters.definition.base.aliases]
+      if (baseAliases.some((alias) => base === rawRequestData[alias])) {
+        req.requestContext.data.base = `${req.requestContext.data.base}:BFX`
+      }
+    },
+  ],
 })

--- a/packages/sources/dxfeed-secondary/test/integration/fixtures.ts
+++ b/packages/sources/dxfeed-secondary/test/integration/fixtures.ts
@@ -3,14 +3,14 @@ import nock from 'nock'
 export function mockPriceEndpoint(): nock.Scope {
   return nock('https://tools.dxfeed.com:443', { encodedQueryParams: true })
     .get('/webservice/rest/events.json')
-    .query({ events: 'Trade,Quote', symbols: 'FTSE' })
+    .query({ events: 'Trade,Quote', symbols: 'FTSE:BFX' })
     .reply(
       200,
       {
         status: 'OK',
         Trade: {
-          FTSE: {
-            eventSymbol: 'FTSE',
+          'FTSE:BFX': {
+            eventSymbol: 'FTSE:BFX',
             eventTime: 0,
             time: 1636750796767,
             timeNanoPart: 0,

--- a/packages/sources/dxfeed-secondary/test/integration/setup.ts
+++ b/packages/sources/dxfeed-secondary/test/integration/setup.ts
@@ -99,7 +99,7 @@ export const mockWebSocketServer = (URL: string): Server => {
     {
       data: [
         'Quote',
-        ['TSLA', 0, 0, 0, 1670868378000, 'V', 170.0, 148.0, 1670868370000, 'V', 172.0, 100.0],
+        ['TSLA:BFX', 0, 0, 0, 1670868378000, 'V', 170.0, 148.0, 1670868370000, 'V', 172.0, 100.0],
       ],
       channel: '/service/data',
     },

--- a/packages/sources/dxfeed/test/integration/fixtures.ts
+++ b/packages/sources/dxfeed/test/integration/fixtures.ts
@@ -3,14 +3,14 @@ import { MockWebsocketServer } from '@chainlink/external-adapter-framework/util/
 export function mockPriceEndpoint(): nock.Scope {
   return nock('https://tools.dxfeed.com/webservice/rest', { encodedQueryParams: true })
     .get('/events.json')
-    .query({ events: 'Trade,Quote', symbols: 'TSLA:BFX' })
+    .query({ events: 'Trade,Quote', symbols: 'TSLA' })
     .reply(
       200,
       {
         status: 'OK',
         Trade: {
-          'TSLA:BFX': {
-            eventSymbol: 'TSLA:BFX',
+          TSLA: {
+            eventSymbol: 'TSLA',
             eventTime: 0,
             time: 1636744209248,
             timeNanoPart: 0,
@@ -57,7 +57,7 @@ export const mockWebSocketServer = (URL: string): MockWebsocketServer => {
     {
       data: [
         'Quote',
-        ['TSLA:BFX', 0, 0, 0, 1670868378000, 'V', 170.0, 148.0, 1670868370000, 'V', 172.0, 100.0],
+        ['TSLA', 0, 0, 0, 1670868378000, 'V', 170.0, 148.0, 1670868370000, 'V', 172.0, 100.0],
       ],
       channel: '/service/data',
     },


### PR DESCRIPTION
## Closes [DF-19516](https://smartcontract-it.atlassian.net/browse/DF-19516)

## Description

Updated overrides for `dxfeed` and overrides logic for `dxfeed-secondary`. 

- `dxfeed` uses ordinary overrides logic. 
- For `dxfeed-secondary` if `base` is overriden (either from EA or from request), it will be used as a value, otherwise `:BFX` suffix will be appended to `base`.  


## Changes

- Removed all override values in overrides.json from `dxfeed` except  `"WTI": "USO/USD:AFX"`
- Added new override value in overrrides.json in `dxfeed-secondary` - `"WTI": "USO/USD:AFX"`
- Added new requestTransformer to `dxfeed-secondary`. It checks if the value for `base` is overriden and uses that value, otherwise appends `:BFX`  to base. For example `{base: WTI}` will change the `base` to `USO/USD:AFX`, but `{base: AAPL}` changes to `AAPL:BFX`. **Considers both EA hardcoded overrides and request overrides**
- Updated tests and fixtures.


## Steps to Test

yarn test packages/sources/dxfeed
yarn test packages/sources/dxfeed-secondary


## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [x] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ x The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [x] This is related to a maximum of one Jira story or GitHub issue.
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
