### PR TITLE
Added cache ttl refresh on heartbeat message for Tiingo IEX endpoint

### DIFF
--- a/.changeset/quick-ravens-switch.md
+++ b/.changeset/quick-ravens-switch.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/tiingo-adapter': patch
+---
+
+Added support for cache TTL refresh on heartbeat messages for IEX endpoint

--- a/packages/sources/tiingo/README.md
+++ b/packages/sources/tiingo/README.md
@@ -4,6 +4,16 @@
 
 This document was generated automatically. Please see [README Generator](../../scripts#readme-generator) for more info.
 
+## Known Issues
+
+### CACHE_MAX_AGE interaction with Heartbeat messages
+
+If `CACHE_MAX_AGE` is set below a current heartbeat interval (120000ms), the extended cache TTL feature for out-of-market-hours in IEX endpoint that relies on heartbeats will not work.
+
+### CACHE_MAX_AGE interaction with WS_SUBSCRIPTION_TTL
+
+If the value of `WS_SUBSCRIPTION_TTL` is less than the value of `CACHE_MAX_AGE`, there will be stale values in the cache.
+
 ## Environment Variables
 
 | Required? |      Name       |          Description          |  Type  | Options |          Default          |
@@ -26,9 +36,9 @@ This document was generated automatically. Please see [README Generator](../../s
 
 ## Input Parameters
 
-| Required? |   Name   |     Description     |  Type  |                                                                                                                                                                                                                                                                                                                                             Options                                                                                                                                                                                                                                                                                                                                             | Default  |
-| :-------: | :------: | :-----------------: | :----: | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :------: |
-|           | endpoint | The endpoint to use | string | [commodities](#forex-endpoint), [crypto-lwba](#crypto-lwba-endpoint), [crypto-synth](#crypto-endpoint), [crypto-vwap](#vwap-endpoint), [crypto](#crypto-endpoint), [crypto_lwba](#crypto-lwba-endpoint), [cryptolwba](#crypto-lwba-endpoint), [cryptoyield](#cryptoyield-endpoint), [eod](#eod-endpoint), [forex](#forex-endpoint), [fx](#forex-endpoint), [iex](#iex-endpoint), [price](#crypto-endpoint), [price](#crypto-lwba-endpoint), [prices](#crypto-endpoint), [realized-vol](#realized-vol-endpoint), [realized-volatility](#realized-vol-endpoint), [stock](#iex-endpoint), [top](#top-endpoint), [volume](#volume-endpoint), [vwap](#vwap-endpoint), [yield](#cryptoyield-endpoint) | `crypto` |
+| Required? |   Name   |     Description     |  Type  |                                                                                                                                                                                                                                                                                                                             Options                                                                                                                                                                                                                                                                                                                             | Default  |
+| :-------: | :------: | :-----------------: | :----: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :------: |
+|           | endpoint | The endpoint to use | string | [commodities](#forex-endpoint), [crypto-lwba](#crypto-lwba-endpoint), [crypto-synth](#crypto-endpoint), [crypto-vwap](#vwap-endpoint), [crypto](#crypto-endpoint), [crypto_lwba](#crypto-lwba-endpoint), [cryptolwba](#crypto-lwba-endpoint), [cryptoyield](#cryptoyield-endpoint), [eod](#eod-endpoint), [forex](#forex-endpoint), [fx](#forex-endpoint), [iex](#iex-endpoint), [price](#crypto-endpoint), [prices](#crypto-endpoint), [realized-vol](#realized-vol-endpoint), [realized-volatility](#realized-vol-endpoint), [stock](#iex-endpoint), [top](#top-endpoint), [volume](#volume-endpoint), [vwap](#vwap-endpoint), [yield](#cryptoyield-endpoint) | `crypto` |
 
 ## Crypto Endpoint
 
@@ -217,7 +227,7 @@ Request:
 
 ## Crypto-lwba Endpoint
 
-Supported names for this endpoint are: `crypto-lwba`, `crypto_lwba`, `cryptolwba`, `price`.
+Supported names for this endpoint are: `crypto-lwba`, `crypto_lwba`, `cryptolwba`.
 
 ### Input Params
 

--- a/packages/sources/tiingo/docs/known-issues.md
+++ b/packages/sources/tiingo/docs/known-issues.md
@@ -1,0 +1,9 @@
+## Known Issues
+
+### CACHE_MAX_AGE interaction with Heartbeat messages
+
+If `CACHE_MAX_AGE` is set below a current heartbeat interval (120000ms), the extended cache TTL feature for out-of-market-hours in IEX endpoint that relies on heartbeats will not work.
+
+### CACHE_MAX_AGE interaction with WS_SUBSCRIPTION_TTL
+
+If the value of `WS_SUBSCRIPTION_TTL` is less than the value of `CACHE_MAX_AGE`, there will be stale values in the cache.

--- a/packages/sources/tiingo/src/config/index.ts
+++ b/packages/sources/tiingo/src/config/index.ts
@@ -1,20 +1,28 @@
 import { AdapterConfig } from '@chainlink/external-adapter-framework/config'
 
-export const config = new AdapterConfig({
-  API_ENDPOINT: {
-    description: 'API endpoint for tiingo',
-    default: 'https://api.tiingo.com/',
-    type: 'string',
+export const config = new AdapterConfig(
+  {
+    API_ENDPOINT: {
+      description: 'API endpoint for tiingo',
+      default: 'https://api.tiingo.com/',
+      type: 'string',
+    },
+    API_KEY: {
+      description: 'API key for tiingo',
+      type: 'string',
+      required: true,
+      sensitive: true,
+    },
+    WS_API_ENDPOINT: {
+      description: 'websocket endpoint for tiingo',
+      default: 'wss://api.tiingo.com',
+      type: 'string',
+    },
   },
-  API_KEY: {
-    description: 'API key for tiingo',
-    type: 'string',
-    required: true,
-    sensitive: true,
+  {
+    envDefaultOverrides: {
+      CACHE_MAX_AGE: 150_000, // see known issues in readme
+      WS_SUBSCRIPTION_TTL: 180_000,
+    },
   },
-  WS_API_ENDPOINT: {
-    description: 'websocket endpoint for tiingo',
-    default: 'wss://api.tiingo.com',
-    type: 'string',
-  },
-})
+)

--- a/packages/sources/tiingo/test/integration/__snapshots__/adapter-ws.test.ts.snap
+++ b/packages/sources/tiingo/test/integration/__snapshots__/adapter-ws.test.ts.snap
@@ -55,7 +55,7 @@ exports[`websocket iex endpoint Q request should return success 1`] = `
   "result": 170.285,
   "statusCode": 200,
   "timestamps": {
-    "providerDataReceivedUnixMs": 4048,
+    "providerDataReceivedUnixMs": 3038,
     "providerDataStreamEstablishedUnixMs": 3030,
     "providerIndicatedTimeUnixMs": 1645032916595,
   },
@@ -70,7 +70,22 @@ exports[`websocket iex endpoint T request should return success 1`] = `
   "result": 106.21,
   "statusCode": 200,
   "timestamps": {
-    "providerDataReceivedUnixMs": 4048,
+    "providerDataReceivedUnixMs": 3038,
+    "providerDataStreamEstablishedUnixMs": 3030,
+    "providerIndicatedTimeUnixMs": 1645032916595,
+  },
+}
+`;
+
+exports[`websocket iex endpoint should update the ttl after heartbeat is received 1`] = `
+{
+  "data": {
+    "result": 170.285,
+  },
+  "result": 170.285,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 3038,
     "providerDataStreamEstablishedUnixMs": 3030,
     "providerIndicatedTimeUnixMs": 1645032916595,
   },

--- a/packages/sources/tiingo/test/integration/fixtures.ts
+++ b/packages/sources/tiingo/test/integration/fixtures.ts
@@ -438,11 +438,21 @@ export const mockIexWebSocketServer = (URL: string): MockWebsocketServer => {
       0,
     ],
   }
+  const wsResponseHeartbeat = {
+    response: { code: 200, message: 'HeartBeat' },
+    messageType: 'H',
+  }
   const mockWsServer = new MockWebsocketServer(URL, { mock: false })
   mockWsServer.on('connection', (socket) => {
+    let counter = 0
     socket.on('message', () => {
-      socket.send(JSON.stringify(wsResponseQ))
-      socket.send(JSON.stringify(wsResponseT))
+      if (counter++ === 0) {
+        socket.send(JSON.stringify(wsResponseQ))
+        socket.send(JSON.stringify(wsResponseT))
+        setTimeout(() => {
+          socket.send(JSON.stringify(wsResponseHeartbeat))
+        }, 10000)
+      }
     })
   })
 


### PR DESCRIPTION
[DF-19515](https://smartcontract-it.atlassian.net/browse/DF-19515)
Added new check in **Tiingo EA's IEX WS transport** that checks if the incoming WS message is a heartbeat message (usually once every 2 minutes) and tries to update the TTL of the cache entries from active subscription set.

Heartbeat message looks like this

```json
{"response": {"code": 200, "message": "HeartBeat" }, "messageType": "H"  }
```
This ensures that as long as there is an active request to EA (in subscription set) and cached entry and heartbeat message from DP, the EA will persist the cache so that the value is available during off-market hours.  

**Two important things to consider**

- Tiingo sends hearbeat messages in every 2 minutes, so the default value for `CACHE_MAX_AGE` is increased from 90 to **150** seconds. 
- `WS_SUBSCRIPTION_TTL` is also increased (because of the increase with cache max age) from 120 to **180** seconds, otherwise there is a chance to have stale values in the cache. 

[DF-19515]: https://smartcontract-it.atlassian.net/browse/DF-19515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ