### PR TITLE
Update Etherchain gas price API

### DIFF
--- a/.changeset/plenty-windows-fix.md
+++ b/.changeset/plenty-windows-fix.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/etherchain-adapter': minor
+---
+
+Update Etherchain API endpoint

--- a/packages/sources/etherchain/README.md
+++ b/packages/sources/etherchain/README.md
@@ -8,9 +8,9 @@ This document was generated automatically. Please see [README Generator](../../s
 
 ## Environment Variables
 
-| Required? |     Name     | Description |  Type  | Options |           Default            |
-| :-------: | :----------: | :---------: | :----: | :-----: | :--------------------------: |
-|           | API_ENDPOINT |             | string |         | `https://www.etherchain.org` |
+| Required? |     Name     | Description |  Type  | Options |                    Default                     |
+| :-------: | :----------: | :---------: | :----: | :-----: | :--------------------------------------------: |
+|           | API_ENDPOINT |             | string |         | `https://beaconcha.in/api/v1/execution/gasnow` |
 
 ---
 

--- a/packages/sources/etherchain/src/config/index.ts
+++ b/packages/sources/etherchain/src/config/index.ts
@@ -4,7 +4,7 @@ import { Config } from '@chainlink/ea-bootstrap'
 export const NAME = 'ETHERCHAIN'
 
 export const DEFAULT_ENDPOINT = 'gasprice'
-export const DEFAULT_BASE_URL = 'https://www.etherchain.org'
+export const DEFAULT_BASE_URL = 'https://www.beaconcha.in/api/v1/execution/gasnow'
 
 export const makeConfig = (prefix?: string): Config => {
   const config = Requester.getDefaultConfig(prefix)

--- a/packages/sources/etherchain/src/endpoint/gasprice.ts
+++ b/packages/sources/etherchain/src/endpoint/gasprice.ts
@@ -31,11 +31,9 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
 
   const jobRunID = validator.validated.id
   const speed = validator.validated.data.speed
-  const url = `/api/gasnow`
 
   const options = {
     ...config.api,
-    url,
   }
 
   const response = await Requester.request<ResponseSchema>(options)

--- a/packages/sources/etherchain/test/integration/fixtures.ts
+++ b/packages/sources/etherchain/test/integration/fixtures.ts
@@ -1,8 +1,8 @@
 import nock from 'nock'
 
 export const mockResponseSuccess = (): nock.Scope =>
-  nock('https://www.etherchain.org')
-    .get('/api/gasnow')
+  nock('https://www.beaconcha.in')
+    .get('/api/v1/execution/gasnow')
     .reply(
       200,
       {


### PR DESCRIPTION
- Etherchain has rebranded to [Beaconcha.in](http://beaconcha.in/), and as part of this their Gas endpoint has moved from https://www.etherchain.org/api/gasnow to https://beaconcha.in/api/v1/execution/gasnow
- This commit updates the API url, and also extracts it to an env var so that NOPs can configure this for any future changes
- https://smartcontract-it.atlassian.net/browse/DF-19779

## Steps to Test

1. Local query to EA

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [X] This is related to a maximum of one Jira story or GitHub issue.
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
