### PR TITLE
Changed cryptocompare WS transport

### DIFF
--- a/.changeset/spicy-bees-smoke.md
+++ b/.changeset/spicy-bees-smoke.md
@@ -2,4 +2,4 @@
 '@chainlink/cryptocompare-adapter': major
 ---
 
-Changed websocket default endpoint and WS transport implementation of crypto endpoint
+Changed websocket default endpoint and WS transport implementation of crypto endpoint. Changed crypto endpoint's default transport to 'ws'

--- a/.changeset/spicy-bees-smoke.md
+++ b/.changeset/spicy-bees-smoke.md
@@ -1,5 +1,5 @@
 ---
-'@chainlink/cryptocompare-adapter': patch
+'@chainlink/cryptocompare-adapter': major
 ---
 
 Changed websocket default endpoint and WS transport implementation of crypto endpoint

--- a/.changeset/spicy-bees-smoke.md
+++ b/.changeset/spicy-bees-smoke.md
@@ -2,4 +2,4 @@
 '@chainlink/cryptocompare-adapter': patch
 ---
 
-Changed websocket default endpoint and WS transport implementation
+Changed websocket default endpoint and WS transport implementation of crypto endpoint

--- a/.changeset/spicy-bees-smoke.md
+++ b/.changeset/spicy-bees-smoke.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/cryptocompare-adapter': patch
+---
+
+Changed websocket default endpoint and WS transport implementation

--- a/packages/sources/cryptocompare/src/config/index.ts
+++ b/packages/sources/cryptocompare/src/config/index.ts
@@ -9,7 +9,7 @@ export const config = new AdapterConfig({
   WS_API_ENDPOINT: {
     description: 'The WS URL to retrieve data from',
     type: 'string',
-    default: 'wss://streamer.cryptocompare.com/v2',
+    default: 'wss://data-streamer.cryptocompare.com',
   },
   API_KEY: {
     description: 'The CryptoCompare API key',

--- a/packages/sources/cryptocompare/src/endpoint/crypto.ts
+++ b/packages/sources/cryptocompare/src/endpoint/crypto.ts
@@ -17,7 +17,7 @@ export const endpoint = new CryptoPriceEndpoint({
   requestTransforms: [
     (req) => {
       req.requestContext.data.base = req.requestContext.data.base.toUpperCase()
-      req.requestContext.data.quote = req.requestContext.data.quote?.toUpperCase()
+      req.requestContext.data.quote = req.requestContext.data.quote.toUpperCase()
     },
   ],
   inputParameters: cryptoInputParams,

--- a/packages/sources/cryptocompare/src/endpoint/crypto.ts
+++ b/packages/sources/cryptocompare/src/endpoint/crypto.ts
@@ -10,7 +10,7 @@ export const endpoint = new CryptoPriceEndpoint({
   transportRoutes: new TransportRoutes<BaseEndpointTypes>()
     .register('ws', wsTransport)
     .register('rest', httpTransport),
-  defaultTransport: 'rest',
+  defaultTransport: 'ws',
   customRouter: (_req, adapterConfig) => {
     return adapterConfig.WS_ENABLED ? 'ws' : 'rest'
   },

--- a/packages/sources/cryptocompare/src/transport/crypto-ws.ts
+++ b/packages/sources/cryptocompare/src/transport/crypto-ws.ts
@@ -92,7 +92,7 @@ export const wsTransport = new WebSocketTransport<WsEndpointTypes>({
             logger.info('Got logged in response, connection is ready')
             resolve()
           } else if (parsed.TYPE === MessageTypes.INVALID_API_KEY) {
-            logger.info(
+            logger.warn(
               parsed,
               'You have connected with an invalid API key, IP address rate limits will now be applied. Please check if your key is correct',
             )

--- a/packages/sources/cryptocompare/src/transport/crypto-ws.ts
+++ b/packages/sources/cryptocompare/src/transport/crypto-ws.ts
@@ -4,28 +4,72 @@ import { BaseEndpointTypes } from '../endpoint/utils'
 
 const logger = makeLogger('CryptoCompare WS')
 
+const MessageTypes = {
+  // Issued when a new socket connection is made.
+  SESSION_WELCOME: '4000',
+  // Issued when the user sends invalid message data (not JSON) or when a user tried to remove
+  // subscriptions with no assigned socket.
+  STREAMER_ERROR: '4001',
+  // Issued when: connections are opened too fast, we cannot validate rate limits or when a user exceeds
+  // their limits.
+  RATELIMIT_ERROR: '4002',
+  //Issued when an unexpected error occurs or when all subscriptions are invalid.
+  SUB_ERROR: '4003',
+  // Issued when an invalid subscription is provided (missing keys, invalid markets, etc).
+  SUB_VALIDATION_ERROR: '4004',
+  // Issued when a subscription is loaded successfully.
+  SUB_ACCEPTED: '4005',
+  // Issued when a subscription cannot be added successfully.
+  SUB_REJECTED: '4006',
+  // Issued when a subscription is removed.
+  SUB_REMOVE_COMPLETE: '4008',
+  // Issued when a user makes a subscription and should be aware of something (e.g: instrument not
+  // trading yet).
+  SUB_WARNING: '4010',
+  // Issued when a user provides an invalid API key and we fall back to IP rate limits
+  INVALID_API_KEY: '4011',
+  // Issued when a user provides a message that does not match the types above.
+  INVALID_MESSAGE: '4012',
+  // Heartbeat message, every 30 seconds
+  HEARTBEAT_MESSAGE: '4013',
+  // Issued when receiving CADLI updates
+  CADLI_RESPONSE: '1101',
+} as const
+
 interface WSSuccessType {
-  PRICE?: number // Cryptocompare does not provide the price in updates from all exchanges
-  TYPE: string
+  TYPE: (typeof MessageTypes)[keyof typeof MessageTypes]
+  INSTRUMENT: string
+  CCSEQ: number
   MARKET: string
-  FLAGS: number
-  FROMSYMBOL: string
-  TOSYMBOL: string
-  VOLUMEDAY: number
-  VOLUME24HOUR: number
-  VOLUMEDAYTO: number
-  VOLUME24HOURTO: number
-  MESSAGE?: string
+  VALUE: number
+  VALUE_FLAG: string
+  VALUE_LAST_UPDATE_TS: number
+  VALUE_LAST_UPDATE_TS_NS: number
+  CURRENT_HOUR_VOLUME: number
+  CURRENT_HOUR_QUOTE_VOLUME: number
+  CURRENT_HOUR_VOLUME_TOP_TIER: number
+  CURRENT_HOUR_QUOTE_VOLUME_TOP_TIER: number
+  CURRENT_HOUR_VOLUME_DIRECT: number
+  CURRENT_HOUR_QUOTE_VOLUME_DIRECT: number
+  CURRENT_HOUR_VOLUME_TOP_TIER_DIRECT: number
+  CURRENT_HOUR_QUOTE_VOLUME_TOP_TIER_DIRECT: number
+  CURRENT_HOUR_OPEN: number
+  CURRENT_HOUR_HIGH: number
+  CURRENT_HOUR_LOW: number
+  CURRENT_HOUR_TOTAL_INDEX_UPDATES: number
+  CURRENT_HOUR_CHANGE: number
+  CURRENT_HOUR_CHANGE_PERCENTAGE: number
 }
 
 interface WSErrorType {
-  TYPE: string
+  TYPE: (typeof MessageTypes)[keyof typeof MessageTypes]
   MESSAGE: string
-  PARAMETER: string
   INFO: string
+  SUBSCRIPTION_ID?: string
+  SOCKET_ID?: string
 }
 
-export type WsMessage = WSSuccessType | WSErrorType
+export type WsMessage = WSSuccessType & WSErrorType
 
 type WsEndpointTypes = BaseEndpointTypes & {
   Provider: {
@@ -44,8 +88,14 @@ export const wsTransport = new WebSocketTransport<WsEndpointTypes>({
         // Set up listener
         connection.addEventListener('message', (event: MessageEvent) => {
           const parsed = JSON.parse(event.data.toString())
-          if (parsed.MESSAGE === 'STREAMERWELCOME') {
+          if (parsed.TYPE === MessageTypes.SESSION_WELCOME) {
             logger.info('Got logged in response, connection is ready')
+            resolve()
+          } else if (parsed.TYPE === MessageTypes.INVALID_API_KEY) {
+            logger.info(
+              parsed,
+              'You have connected with an invalid API key, IP address rate limits will now be applied. Please check if your key is correct',
+            )
             resolve()
           } else {
             reject(new Error('Unexpected message after WS connection open'))
@@ -56,49 +106,23 @@ export const wsTransport = new WebSocketTransport<WsEndpointTypes>({
     message(message): ProviderResult<WsEndpointTypes>[] {
       logger.trace(message, 'Got response from websocket')
 
-      if (message.MESSAGE === 'INVALID_SUB') {
-        // message.PARAMETER looks like 5~CCCAGG~BASE~QUOTE
-        const parameters = (message as WSErrorType).PARAMETER.split('~')
-        const base = parameters[2]
-        const quote = parameters[3]
-        logger.error(message, 'asset not supported by data provider')
+      if (message.TYPE === MessageTypes.SUB_VALIDATION_ERROR) {
+        logger.error(message, 'Assets are not supported by data provider')
+        return []
+      }
+
+      if (message.INSTRUMENT && message.MARKET) {
+        const [base, quote] = message.INSTRUMENT.split('-')
         return [
           {
             params: { base, quote },
             response: {
-              errorMessage: `Requested asset - ${base}/${quote} is not supported or there is no price for it.`,
-              statusCode: 502,
-            },
-          },
-        ]
-      }
-
-      if (message.TYPE === '5' && !('PRICE' in message)) {
-        // message.PARAMETER looks like 5~CCCAGG~BASE~QUOTE
-        const parameters = (message as WSErrorType).PARAMETER.split('~')
-        const base = parameters[2]
-        const quote = parameters[3]
-        logger.error(message, 'price not provided')
-        return [
-          {
-            params: { base, quote },
-            response: {
-              errorMessage: `Cryptocompare provided no price data for ${base}/${quote}`,
-              statusCode: 502,
-            },
-          },
-        ]
-      }
-
-      if (message.TYPE === '5') {
-        message = message as WSSuccessType
-        return [
-          {
-            params: { base: message.FROMSYMBOL, quote: message.TOSYMBOL },
-            response: {
-              result: message.PRICE as number,
+              result: message.VALUE,
               data: {
-                result: message.PRICE as number,
+                result: message.VALUE,
+              },
+              timestamps: {
+                providerIndicatedTimeUnixMs: message.VALUE_LAST_UPDATE_TS * 1000,
               },
             },
           },
@@ -110,12 +134,19 @@ export const wsTransport = new WebSocketTransport<WsEndpointTypes>({
   },
   builders: {
     subscribeMessage: (params) => {
-      return { action: 'SubAdd', subs: [`5~CCCAGG~${params.base}~${params.quote}`.toUpperCase()] }
+      return {
+        action: 'SUB_ADD',
+        type: '1101',
+        groups: ['VALUE', 'CURRENT_HOUR'],
+        subscriptions: [{ market: 'cadli', instrument: `${params.base}-${params.quote}` }],
+      }
     },
     unsubscribeMessage: (params) => {
       return {
-        action: 'SubRemove',
-        subs: [`5~CCCAGG~${params.base}~${params.quote}`.toUpperCase()],
+        action: 'SUB_REMOVE',
+        type: '1101',
+        groups: ['VALUE', 'CURRENT_HOUR'],
+        subscriptions: [{ market: 'cadli', instrument: `${params.base}-${params.quote}` }],
       }
     },
   },

--- a/packages/sources/cryptocompare/test/integration/__snapshots__/adapter-ws.test.ts.snap
+++ b/packages/sources/cryptocompare/test/integration/__snapshots__/adapter-ws.test.ts.snap
@@ -3,13 +3,14 @@
 exports[`websocket crypto endpoint should return success 1`] = `
 {
   "data": {
-    "result": 1234,
+    "result": 0.0492344509006993,
   },
-  "result": 1234,
+  "result": 0.0492344509006993,
   "statusCode": 200,
   "timestamps": {
     "providerDataReceivedUnixMs": 1018,
     "providerDataStreamEstablishedUnixMs": 1010,
+    "providerIndicatedTimeUnixMs": 1713975478000,
   },
 }
 `;

--- a/packages/sources/cryptocompare/test/integration/fixtures.ts
+++ b/packages/sources/cryptocompare/test/integration/fixtures.ts
@@ -173,16 +173,52 @@ export const mockWebSocketServer = (URL: string) => {
   mockWsServer.on('connection', (socket) => {
     socket.send(
       JSON.stringify({
-        MESSAGE: 'STREAMERWELCOME',
+        TYPE: '4000',
+        MESSAGE: 'SESSIONWELCOME',
       }),
     )
     const parseMessage = () => {
       socket.send(
         JSON.stringify({
-          TYPE: '5',
-          FROMSYMBOL: base,
-          TOSYMBOL: quote,
-          PRICE: price,
+          TYPE: '4005',
+          MESSAGE: 'SUBSCRIPTION_ACCEPTED',
+          SUPPORTED_MESSAGE_TYPES: ['1101', '266', '985', '987'],
+          SUBSCRIPTION_ID: `1101~{cadli~${base}-${quote}}`,
+        }),
+      )
+      socket.send(
+        JSON.stringify({
+          TYPE: '4007',
+          MESSAGE: 'SUBSCRIPTION_ADD_COMPLETE',
+          INFO: 'All valid subscriptions have been added.',
+          ACCEPTED_SUBSCRIPTIONS: 1,
+          REJECTED_SUBSCRIPTIONS: 0,
+        }),
+      )
+      socket.send(
+        JSON.stringify({
+          TYPE: '985',
+          INSTRUMENT: 'ETH-BTC',
+          CCSEQ: 20735164,
+          MARKET: 'cadli',
+          VALUE: 0.0492344509006993,
+          VALUE_FLAG: 'DOWN',
+          VALUE_LAST_UPDATE_TS: 1713975478,
+          VALUE_LAST_UPDATE_TS_NS: 603000000,
+          CURRENT_HOUR_VOLUME: 64381.2572711617,
+          CURRENT_HOUR_QUOTE_VOLUME: 3166.48328711479,
+          CURRENT_HOUR_VOLUME_TOP_TIER: 36224.9797102,
+          CURRENT_HOUR_QUOTE_VOLUME_TOP_TIER: 1781.54419073824,
+          CURRENT_HOUR_VOLUME_DIRECT: 0,
+          CURRENT_HOUR_QUOTE_VOLUME_DIRECT: 0,
+          CURRENT_HOUR_VOLUME_TOP_TIER_DIRECT: 0,
+          CURRENT_HOUR_QUOTE_VOLUME_TOP_TIER_DIRECT: 0,
+          CURRENT_HOUR_OPEN: 0.0491456586967143,
+          CURRENT_HOUR_HIGH: 0.0493759104685501,
+          CURRENT_HOUR_LOW: 0.0490585113292235,
+          CURRENT_HOUR_TOTAL_INDEX_UPDATES: 0,
+          CURRENT_HOUR_CHANGE: 0.000088792203985,
+          CURRENT_HOUR_CHANGE_PERCENTAGE: 0.180671510647463,
         }),
       )
     }


### PR DESCRIPTION
## Closes [DF-19886](https://smartcontract-it.atlassian.net/browse/DF-19886)

## Description
Modified cryptcompare `crypto` endpoint  websocket transport to use `CADLI` index instead of `CCCAGG`

## Changes

- Changed default WS api url for `crypto` endpoint
- Changed crypto ws transport to use CADLI index 

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

yarn test packages/sources/cryptocompare/test/integration

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [x] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [x] This is related to a maximum of one Jira story or GitHub issue.
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[DF-19886]: https://smartcontract-it.atlassian.net/browse/DF-19886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ