### PR TITLE
[Dont Merge] Updates L2EP staleness threshold to 10 minutes

### DIFF
--- a/.changeset/cold-penguins-hope.md
+++ b/.changeset/cold-penguins-hope.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/layer2-sequencer-health-adapter': minor
+---
+
+Updates block height staleness threshold (delta) to 10 minutes

--- a/packages/sources/layer2-sequencer-health/README.md
+++ b/packages/sources/layer2-sequencer-health/README.md
@@ -6,7 +6,7 @@ Adapter that checks the Layer 2 Sequencer status
 
 | Required? |               Name                |                                   Description                                   | Options |                           Defaults to                            |
 | :-------: | :-------------------------------: | :-----------------------------------------------------------------------------: | :-----: | :--------------------------------------------------------------: |
-|           |              `DELTA`              | Maximum time in milliseconds from last seen block to consider sequencer healthy |         |                          120000 (2 min)                          |
+|           |              `DELTA`              | Maximum time in milliseconds from last seen block to consider sequencer healthy |         |                         600000 (10 min)                          |
 |           |          `DELTA_BLOCKS`           |           Maximum allowed number of blocks that Nodes can fall behind           |         |                                6                                 |
 |           |      `NETWORK_TIMEOUT_LIMIT`      |         Maximum time in milliseconds to wait for a transaction receipt          |         |                          5000 (5 secs)                           |
 |           |      `ARBITRUM_RPC_ENDPOINT`      |                              Arbitrum RPC Endpoint                              |         |                   https://arb1.arbitrum.io/rpc                   |

--- a/packages/sources/layer2-sequencer-health/schemas/env.json
+++ b/packages/sources/layer2-sequencer-health/schemas/env.json
@@ -6,7 +6,7 @@
   "properties": {
     "DELTA": {
       "type": "number",
-      "default": 180000
+      "default": 600000
     },
     "ARBITRUM_RPC_ENDPOINT": {
       "type": "string",

--- a/packages/sources/layer2-sequencer-health/src/config/index.ts
+++ b/packages/sources/layer2-sequencer-health/src/config/index.ts
@@ -11,8 +11,8 @@ export const adapterContext: AdapterContext = { name: NAME, envDefaultOverrides 
 
 export const DEFAULT_ENDPOINT = 'health'
 
-// 2 minutes
-export const DEFAULT_DELTA_TIME = 2 * 60 * 1000
+// 10 minutes
+export const DEFAULT_DELTA_TIME = 10 * 60 * 1000
 // Blocks that replica nodes can fall behind
 export const DEFAULT_DELTA_BLOCKS = 6
 // milliseconds to consider a timeout transaction (10 secs)


### PR DESCRIPTION




## Closes [SHIP-1751](https://smartcontract-it.atlassian.net/browse/SHIP-1751)

## Description

This PR updates the L2EP staleness threshold for block height check from 2 minutes to 10 minutes.

## Changes

- Updates the L2EP staleness threshold for block height check from 2 minutes to 10 minutes.

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1.  Unit test

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[SHIP-1751]: https://smartcontract-it.atlassian.net/browse/SHIP-1751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ