### PR TITLE
📝 docs: fix WS_ENABLED default value in cryptocompare readme

### DIFF
--- a/packages/sources/cryptocompare/README.md
+++ b/packages/sources/cryptocompare/README.md
@@ -12,7 +12,7 @@ This document was generated automatically. Please see [README Generator](../../s
 |           | WS_API_ENDPOINT |                   The WS URL to retrieve data from                    | string  |         | `wss://data-streamer.cryptocompare.com` |
 |    ✅     |     API_KEY     |                       The CryptoCompare API key                       | string  |         |                                         |
 |           |   WS_API_KEY    | The websocket API key to authenticate with, if different from API_KEY | string  |         |                   ``                    |
-|           |   WS_ENABLED    |         Whether data should be returned from websocket or not         | boolean |         |                 `false`                 |
+|           |   WS_ENABLED    |         Whether data should be returned from websocket or not         | boolean |         |                 `true`                  |
 
 ---
 


### PR DESCRIPTION
match the code implementation https://github.com/smartcontractkit/external-adapters-js/pull/3277/files#diff-553cc053783edcae2556217edd958628cd0a486fef3d5859a9d2b1bd524d15adR13
