### PR TITLE
chore: github action version bumps

### DIFF
--- a/.github/actions/publish-image/action.yml
+++ b/.github/actions/publish-image/action.yml
@@ -36,11 +36,12 @@ runs:
   using: 'composite'
   steps:
     - name: Configure AWS Credentials for SDLC Private ECR
-      uses: aws-actions/configure-aws-credentials@v2
+      uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
       with:
         role-to-assume: ${{ inputs.aws-role }}
         aws-region: ${{ inputs.aws-region }}
         role-duration-seconds: 1200
+        mask-aws-account-id: true
     - name: Authenticate to ECR
       shell: bash
       run: |

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -50,7 +50,7 @@ runs:
     - name: Restore yarn cache
       id: restore-yarn-cache
       if: inputs.skip-cache != 'true'
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
       with:
         # Restrict it to the run and attempt for debugging purposes, but in theory
         # these should be fine to persist between runs as well
@@ -80,7 +80,7 @@ runs:
     # Build TS files unless it's been specified otherwise
     - name: Restore TS built files if present
       id: restore-ts-build
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
       if: |
         inputs.skip-setup != 'true'
         && inputs.skip-cache != 'true'

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -36,7 +36,7 @@ runs:
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
     # First, we want to install yarn since our base image doesn't have it installed
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
       with:
         # This doesn't use cache: 'yarn' as the base image doesn't have it, and we're caching node_modules
         node-version: 22

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -70,7 +70,7 @@ runs:
       shell: bash
     - name: Cache yarn cache
       if: steps.restore-yarn-cache.outputs.cache-hit != 'true' && inputs.skip-cache != 'true'
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
       with:
         key: yarn_cache-${{ hashFiles('./yarn.lock') }}-${{ github.run_id }}-${{ github.run_attempt }}
         path: |
@@ -157,7 +157,7 @@ runs:
       if: |
         inputs.skip-setup != 'true'
         && inputs.skip-cache != 'true'
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
       with:
         key: tsbuild-${{ github.sha }}-${{ github.run_id }}
         path: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -34,7 +34,7 @@ jobs:
   # Set up yarn and install dependencies, caching them to be reused across other steps in this workflow
   install-packages:
     name: Install and verify dependencies
-    runs-on: [ubuntu-latest] # TODO change back to [self-hosted, sdlc-ghr-prod] runners after they are upgraded to support Node 22 libraries
+    runs-on: [ubuntu-latest]
     outputs:
       changed-packages: ${{ steps.changed-adapters.outputs.CHANGED_PACKAGES }}
       adapter-list: ${{ steps.changed-adapters.outputs.CHANGED_ADAPTERS }}
@@ -56,7 +56,7 @@ jobs:
   # Run unit tests
   unit-tests:
     name: Run unit tests for changed adapters
-    runs-on: [ubuntu-latest] # TODO change back to [self-hosted, sdlc-ghr-prod] runners after they are upgraded to support Node 22 libraries
+    runs-on: [ubuntu-latest]
     if: needs.install-packages.outputs.changed-packages != '[]'
     needs:
       - check-changesets
@@ -74,7 +74,7 @@ jobs:
   # Run integration tests
   integration-tests:
     name: Run integration tests for changed adapters
-    runs-on: [ubuntu-latest] # TODO change back to [self-hosted, sdlc-ghr-prod] runners after they are upgraded to support Node 22 libraries
+    runs-on: [ubuntu-latest]
     if: needs.install-packages.outputs.changed-packages != '[]'
     needs:
       - check-changesets
@@ -92,7 +92,7 @@ jobs:
   # Run linters
   linters:
     name: Run linters and formatters
-    runs-on: [ubuntu-latest] # TODO change back to [self-hosted, sdlc-ghr-prod] runners after they are upgraded to support Node 22 libraries
+    runs-on: [ubuntu-latest]
     needs:
       - check-changesets
       - install-packages
@@ -109,7 +109,7 @@ jobs:
   # Run documentation tests (check that the doc generation succeeds to avoid problems downstream)
   run-documentation-check:
     name: Documentation generation test
-    runs-on: [ubuntu-latest] # TODO change back to [self-hosted, sdlc-ghr-prod] runners after they are upgraded to support Node 22 libraries
+    runs-on: [ubuntu-latest]
     if: needs.install-packages.outputs.changed-packages != '[]'
     needs:
       - check-changesets
@@ -131,7 +131,7 @@ jobs:
   # Run a script to check that modified v3 adapters have the latest framework version
   ea-framework-version-check:
     name: Check that changed adapters have the latest EA framework version
-    runs-on: [ubuntu-latest] # TODO change back to [self-hosted, sdlc-ghr-prod] runners after they are upgraded to support Node 22 libraries
+    runs-on: [ubuntu-latest]
     if: needs.install-packages.outputs.changed-packages != '[]'
     needs:
       - check-changesets
@@ -153,31 +153,31 @@ jobs:
           packages=$(find packages -name 'package.json')
           latest_version=$(curl -sH "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/smartcontractkit/ea-framework-js/contents/package.json" | jq -r '.content' | base64 -d | jq -r '.version')
 
-           # get the list of v3 EAs
-           for file in $(echo $packages); do
+          # get the list of v3 EAs
+          for file in $(echo $packages); do
               if jq -e ".dependencies[\"$dependency\"]" "$file" >/dev/null; then
                 v3_packages+=("$(dirname $file)")
               fi
-           done
+          done
 
-           # check if changed code is part of any v3 EA
-            for changedFile in $changed_packages; do
-             for package in "${v3_packages[@]}"; do
-                if [[ "$changedFile" == "$package"* ]]; then
-                  # found change in v3 EA, comparing versions
-                  local_version=$(jq -r ".dependencies[\"$dependency\"]" "$package/package.json")
-                  if [ "$local_version" != "$latest_version" ] && ! grep -q "^$package$" <<< "${outdated_packages[@]}"; then
-                    outdated_packages+=("$package")
-                  fi
+          # check if changed code is part of any v3 EA
+          for changedFile in $changed_packages; do
+            for package in "${v3_packages[@]}"; do
+              if [[ "$changedFile" == "$package"* ]]; then
+                # found change in v3 EA, comparing versions
+                local_version=$(jq -r ".dependencies[\"$dependency\"]" "$package/package.json")
+                if [ "$local_version" != "$latest_version" ] && ! grep -q "^$package$" <<< "${outdated_packages[@]}"; then
+                  outdated_packages+=("$package")
                 fi
-             done
+              fi
             done
+          done
 
-            # print and error if there are outdated adapters
-            if [ ${#outdated_packages[@]} -gt 0 ]; then
-              echo "The following packages have an outdated \"$dependency\" dependency:"
-              for file in "${outdated_packages[@]}"; do
-                echo "- $file"
-              done
+          # print and error if there are outdated adapters
+          if [ ${#outdated_packages[@]} -gt 0 ]; then
+            echo "The following packages have an outdated \"$dependency\" dependency:"
+            for file in "${outdated_packages[@]}"; do
+              echo "- $file"
+            done
             exit 1
-            fi
+          fi

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: [self-hosted, sdlc-ghr-prod]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
         with:
           fetch-depth: 2
       - name: Check whether adapter change also has a changeset
@@ -40,7 +40,7 @@ jobs:
       adapter-list: ${{ steps.changed-adapters.outputs.CHANGED_ADAPTERS }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
         with:
           fetch-depth: 0
       - name: Set up and install dependencies
@@ -63,7 +63,7 @@ jobs:
       - install-packages
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - name: Set up and install dependencies
         uses: ./.github/actions/setup
       - name: Run unit tests
@@ -81,7 +81,7 @@ jobs:
       - install-packages
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - name: Set up and install dependencies
         uses: ./.github/actions/setup
       - name: Run integration tests
@@ -98,7 +98,7 @@ jobs:
       - install-packages
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - name: Set up and install dependencies
         uses: ./.github/actions/setup
       - name: Lint all files
@@ -118,7 +118,7 @@ jobs:
       METRICS_ENABLED: false
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
         with:
           fetch-depth: 0
       - name: Set up and install dependencies
@@ -138,7 +138,7 @@ jobs:
       - install-packages
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - name: Set up and install dependencies
         uses: ./.github/actions/setup
       - name: Check for outdated ea-framework dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,7 +93,7 @@ jobs:
         with:
           ref: ${{ needs.calculate-changes.outputs.tmp-branch }}
       - name: Build the adapter image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
         with:
           context: .
           push: false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
       tmp-branch: ${{ steps.push-branch.outputs.TMP_BRANCH }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
         with:
           fetch-depth: 2
       - name: Set up and install dependencies
@@ -89,7 +89,7 @@ jobs:
       IMAGE_VERSION: ${{ matrix.adapter.version }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
         with:
           ref: ${{ needs.calculate-changes.outputs.tmp-branch }}
       - name: Build the adapter image
@@ -146,7 +146,7 @@ jobs:
     if: always() && needs.calculate-changes.outputs.adapter-list != '[]'
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
         with:
           ref: ${{ needs.calculate-changes.outputs.tmp-branch }}
       - name: Delete ephemeral branch

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   calculate-changes:
     name: Compute changed adapters
-    runs-on: [ubuntu-latest] # TODO change back to [self-hosted, sdlc-ghr-prod] runners after they are upgraded to support Node 22 libraries
+    runs-on: [ubuntu-latest]
     outputs:
       adapter-list: ${{ steps.changed-adapters.outputs.CHANGED_ADAPTERS }}
       tmp-branch: ${{ steps.push-branch.outputs.TMP_BRANCH }}
@@ -129,10 +129,10 @@ jobs:
     steps:
       - name: Trigger Image Dispatcher
         run: >
-          gh workflow run 
+          gh workflow run
           --repo smartcontractkit/infra-k8s
-          --ref main "Infra-k8s Image Dispatcher" 
-          -F imageRepos="$(echo $CHANGED_ADAPTERS | jq -r "\"$ECR_URL/adapters/\" + (.adapter | .[].shortName) + \"-adapter\"" | tr '\n' ' ')" 
+          --ref main "Infra-k8s Image Dispatcher"
+          -F imageRepos="$(echo $CHANGED_ADAPTERS | jq -r "\"$ECR_URL/adapters/\" + (.adapter | .[].shortName) + \"-adapter\"" | tr '\n' ' ')"
           -F gitRepo=${{ github.event.repository.name }}
         env:
           GITHUB_TOKEN: ${{ secrets.INFRA_K8s_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,8 +104,8 @@ jobs:
           # Get the PR body to use in the GH release body
           gh pr list --search "$(git rev-parse HEAD)" --state merged --json number,body --jq '"This release was merged in PR #" + (.[0].number | tostring) + "\n" + (.[0].body | split("\n\n\n# Releases") | .[1])' > pr_body.tmp
       - name: Create release
-        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1.1.4
+        uses: softprops/action-gh-release@69320dbe05506a9a39fc8ae11030b214ec2d1f87 # v2.0.5
         with:
           tag_name: v${{ steps.get-version.outputs.result }}
-          release_name: Release v${{ steps.get-version.outputs.result }}
+          name: Release v${{ steps.get-version.outputs.result }}
           body_path: pr_body.tmp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   calculate-changes:
     name: Compute changed adapters
-    runs-on: [ubuntu-latest] # TODO change back to [self-hosted, sdlc-ghr-prod] runners after they are upgraded to support Node 22 libraries
+    runs-on: [ubuntu-latest]
     env:
       BUILD_ALL: ${{ inputs.build-all }}
     outputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
           # Get the PR body to use in the GH release body
           gh pr list --search "$(git rev-parse HEAD)" --state merged --json number,body --jq '"This release was merged in PR #" + (.[0].number | tostring) + "\n" + (.[0].body | split("\n\n\n# Releases") | .[1])' > pr_body.tmp
       - name: Create release
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1.1.4
         with:
           tag_name: v${{ steps.get-version.outputs.result }}
           release_name: Release v${{ steps.get-version.outputs.result }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       adapter-list: ${{ steps.changed-adapters.outputs.CHANGED_ADAPTERS }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
         with:
           fetch-depth: 2
       - name: Set up and install dependencies
@@ -61,7 +61,7 @@ jobs:
       ECR_REPO: adapters/${{ matrix.adapter.shortName }}-adapter
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - name: Configure AWS Credentials for SDLC Private ECR
         uses: aws-actions/configure-aws-credentials@v2
         with:
@@ -93,7 +93,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - name: Get release version
         id: get-version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,10 +63,11 @@ jobs:
       - name: Check out code
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - name: Configure AWS Credentials for SDLC Private ECR
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_IAM_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_REGION_ECR_PRIVATE }}
+          mask-aws-account-id: true
       - name: Authenticate to ECR
         run: aws ecr get-login-password --region ${{ secrets.AWS_REGION_ECR_PRIVATE }} | docker login --username AWS --password-stdin ${{ env.PRIVATE_ECR_URL }}/adapters/
       - name: Pull adapter image from private ECR and retag with public ecr details

--- a/.github/workflows/soak-test-cleanup.yml
+++ b/.github/workflows/soak-test-cleanup.yml
@@ -29,7 +29,7 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
       - name: Set Kubernetes Context
-        uses: azure/k8s-set-context@v1
+        uses: azure/k8s-set-context@27bfb387305b8f0ab5495d692e4a3304db7d0669 # v4.0.0
         with:
           method: kubeconfig
           kubeconfig: ${{ secrets.QA_SDLC_KUBECONFIG }}

--- a/.github/workflows/soak-test-cleanup.yml
+++ b/.github/workflows/soak-test-cleanup.yml
@@ -26,7 +26,7 @@ jobs:
           role-duration-seconds: 3600
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
       - name: Set Kubernetes Context
         uses: azure/k8s-set-context@v1
         with:

--- a/.github/workflows/soak-test-cleanup.yml
+++ b/.github/workflows/soak-test-cleanup.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: QA
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/soak-test-cleanup.yml
+++ b/.github/workflows/soak-test-cleanup.yml
@@ -17,13 +17,14 @@ jobs:
     steps:
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
           aws-access-key-id: ${{ secrets.QA_SDLC_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.QA_SDLC_AWS_SECRET_KEY }}
           aws-region: ${{ secrets.QA_SDLC_AWS_REGION }}
           role-to-assume: ${{ secrets.QA_SDLC_AWS_ROLE_TO_ASSUME }}
           role-duration-seconds: 3600
+          mask-aws-account-id: true
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1

--- a/.github/workflows/soak-test-start.yml
+++ b/.github/workflows/soak-test-start.yml
@@ -158,7 +158,7 @@ jobs:
 
           echo "::set-output name=BUILD_ADAPTERS::${BUILD_ADAPTERS}"
 
-      - uses: webiny/action-post-run@2.0.1
+      - uses: webiny/action-post-run@2a0e96f0e55f0e698cf2a3d85670e3577ae30a30 # 3.1.0
         if: steps.get-pr-info.outputs.TEST_ADAPTERS != ''
         name: Clean up deployments
         env:

--- a/.github/workflows/soak-test-start.yml
+++ b/.github/workflows/soak-test-start.yml
@@ -23,7 +23,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
         with:
           fetch-depth: 2
 

--- a/.github/workflows/soak-test-start.yml
+++ b/.github/workflows/soak-test-start.yml
@@ -46,7 +46,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
 
       - name: Set Kubernetes Context
-        uses: azure/k8s-set-context@v2
+        uses: azure/k8s-set-context@27bfb387305b8f0ab5495d692e4a3304db7d0669 # v4.0.0
         with:
           method: kubeconfig
           kubeconfig: ${{ secrets.QA_KUBECONFIG }}

--- a/.github/workflows/soak-test-start.yml
+++ b/.github/workflows/soak-test-start.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: jwalton/gh-find-current-pr@v1
+      - uses: jwalton/gh-find-current-pr@89ee5799558265a1e0e31fab792ebb4ee91c016b # v1.3.3
         id: findPr
         with:
           # Can be "open", "closed", or "all".  Defaults to "open".

--- a/.github/workflows/soak-test-start.yml
+++ b/.github/workflows/soak-test-start.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
 
       - name: Set Kubernetes Context
         uses: azure/k8s-set-context@v2

--- a/.github/workflows/soak-test-start.yml
+++ b/.github/workflows/soak-test-start.yml
@@ -213,7 +213,7 @@ jobs:
 
       - name: Wait 15 Minutes for tests to run
         if: steps.get-pr-info.outputs.TEST_ADAPTERS != ''
-        uses: jakejarvis/wait-action@master
+        uses: jakejarvis/wait-action@919fc193e07906705e5b7a50f90ea9e74d20b2b0 # v0.1.1
         with:
           time: '15m'
       - name: Assert tests passed

--- a/.github/workflows/soak-test-start.yml
+++ b/.github/workflows/soak-test-start.yml
@@ -34,11 +34,12 @@ jobs:
           state: all
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
           aws-region: ${{ secrets.QA_AWS_REGION }}
           role-to-assume: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
           role-duration-seconds: 3600
+          mask-aws-account-id: true
 
       - name: Login to Amazon ECR
         id: login-ecr
@@ -183,7 +184,7 @@ jobs:
               if test -f "$HELM_SECRETS_PATH"
                 then
                   HELM_SECRETS_PATH=${HELM_SECRETS_PATH} yarn qa:adapter start ${adapter} ${PR_NUMBER} ${IMAGE_TAG}
-                else 
+                else
                   yarn qa:adapter start ${adapter} ${PR_NUMBER} ${IMAGE_TAG}
               fi
             done

--- a/.github/workflows/upsert-release-pr.yml
+++ b/.github/workflows/upsert-release-pr.yml
@@ -35,7 +35,7 @@ jobs:
       BUILD_ALL: ${{ github.event.inputs.build-all }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0

--- a/.github/workflows/upsert-release-pr.yml
+++ b/.github/workflows/upsert-release-pr.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           git stash
       - name: Create Release Pull Request
-        uses: smartcontractkit/.github/actions/signed-commits@95b6030f4d23d5d87f53eb0f018f51806afa4da3 # changesets-signed-commits@1.0.1
+        uses: smartcontractkit/.github/actions/signed-commits@ff80d56f5301dc8a65f66c4d47d746ee956beed9 # changesets-signed-commits@1.2.3
         with:
           # This version command is not only necessary because of yarn pnp, but because the changeset action
           # performs git resets and we want to keep those changes, so we stash and then pop them here.


### PR DESCRIPTION
## Description

https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
> Node16 has been out of support since [September 2023](https://github.com/nodejs/Release/#end-of-life-releases). As a result we have started the deprecation process of Node16 for GitHub Actions. We plan to migrate all actions to run on Node20 by Spring 2024.
>  Following on from our [warning in workflows using Node16](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) we will start enforcing the use of Node20 rather than Node16 on the 3rd of June.

There is one more dependency to be updated to node20. Will fix that once complete.

## Changes

- Updated all actions dependencies to their latest
- Use `softprops/action-gh-release` instead of `actions/create-release` (deprecated/archived)
- Formatting, cleanup comments

## Steps to Test

Let workflows run.

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.

---

RE-2561
