### PR TITLE
EA Bootstrap: Fix URL construction for logging

### DIFF
--- a/.changeset/cyan-wolves-jam.md
+++ b/.changeset/cyan-wolves-jam.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/ea-bootstrap': minor
+---
+
+Fix URL construction

--- a/packages/core/bootstrap/src/lib/modules/requester.ts
+++ b/packages/core/bootstrap/src/lib/modules/requester.ts
@@ -1,6 +1,5 @@
 import axios, { AxiosError, AxiosResponse } from 'axios'
 import objectPath from 'object-path'
-import { join } from 'path'
 
 import {
   deepType,
@@ -80,7 +79,7 @@ export class Requester {
       }
 
       let response: AxiosResponse<T>
-      const url = join(config.baseURL || '', config.url || '')
+      const url = axios.getUri(config)
       const record = recordDataProviderRequest()
       try {
         const startTime = process.hrtime.bigint()

--- a/packages/sources/binance-dex/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/binance-dex/test/integration/__snapshots__/adapter.test.ts.snap
@@ -30,7 +30,7 @@ exports[`execute rate api with invalid symbol should return failure 1`] = `
     "feedID": "NON/EXISTING",
     "message": "Request failed with status code 400",
     "name": "AdapterError",
-    "url": "https:/dex-asiapacific.binance.org/api/v1/ticker/24hr",
+    "url": "https://dex-asiapacific.binance.org/api/v1/ticker/24hr",
   },
   "jobRunID": "1",
   "providerStatusCode": 400,

--- a/packages/sources/binance/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/binance/test/integration/__snapshots__/adapter.test.ts.snap
@@ -18,7 +18,7 @@ exports[`execute rate api with invalid symbol should return failure 1`] = `
     "feedID": "NON/EXISTING",
     "message": "Request failed with status code 400",
     "name": "AdapterError",
-    "url": "https:/api.binance.com/api/v3/ticker/price",
+    "url": "https://api.binance.com/api/v3/ticker/price",
   },
   "jobRunID": "1",
   "providerStatusCode": 400,

--- a/packages/sources/bitex/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/bitex/test/integration/__snapshots__/adapter.test.ts.snap
@@ -18,7 +18,7 @@ exports[`execute crypto api with invalid symbol should return failure 1`] = `
     "feedID": "NON/EXISTING",
     "message": "Request failed with status code 404",
     "name": "AdapterError",
-    "url": "https:/bitex.la/api/tickers/NON_EXISTING",
+    "url": "https://bitex.la/tickers/NON_EXISTING",
   },
   "jobRunID": "1",
   "providerStatusCode": 404,

--- a/packages/sources/bitso/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/bitso/test/integration/__snapshots__/adapter.test.ts.snap
@@ -22,7 +22,7 @@ exports[`execute crypto api with invalid symbol should return failure 1`] = `
     "feedID": "NON/EXISTING",
     "message": "Request failed with status code 400",
     "name": "AdapterError",
-    "url": "https:/api.bitso.com/v3/ticker",
+    "url": "https://api.bitso.com/ticker",
   },
   "jobRunID": "1",
   "providerStatusCode": 400,

--- a/packages/sources/dns-query/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/dns-query/test/integration/__snapshots__/adapter.test.ts.snap
@@ -19,7 +19,7 @@ exports[`execute dnsProof endpoint error calls when unsuccessfully requests the 
     "feedID": "{"data":{"endpoint":"dnsProof","name":"www5.infernos.io","record":"0xf75519f611776c22275474151a04183665b7feDe"}}",
     "message": "Request failed with status code 500",
     "name": "AdapterError",
-    "url": "https:/dns.google/resolve",
+    "url": "https://dns.google/resolve",
   },
   "jobRunID": "1",
   "providerStatusCode": 500,

--- a/packages/sources/fixer/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/fixer/test/integration/__snapshots__/adapter.test.ts.snap
@@ -18,7 +18,7 @@ exports[`execute convert api with invalid base should return failure 1`] = `
     "feedID": "NON-EXISTING/USD",
     "message": "Could not retrieve valid data from Data Provider. This is likely an issue with the Data Provider or the input params/overrides. Request: {"baseURL":"https://data.fixer.io","url":"/api/convert","params":{"access_key":"fake-api-key","from":"NON-EXISTING","to":"USD","amount":1}}, Response: {"success":false,"error":{"code":402,"type":"invalid_from_currency","info":"You have entered an invalid \\"from\\" property. [Example: from=EUR]"}}.",
     "name": "AdapterError",
-    "url": "https:/data.fixer.io/api/convert",
+    "url": "https://data.fixer.io/api/convert",
   },
   "jobRunID": "1",
   "providerStatusCode": 402,


### PR DESCRIPTION
- Fix URL logged by V2 Requester
- Previously was using `path.join`, which is meant for file paths and not URL paths. This meant that URL's would have double `//` converted to `/`
- Fixing to instead use `axios.getUri` to determine the URL, which will return the same URL that axios will use to make the actual request
