### PR TITLE
Refactors layer2-sequencer-health to chain specific delta

### DIFF
--- a/.changeset/twelve-swans-sniff.md
+++ b/.changeset/twelve-swans-sniff.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/layer2-sequencer-health-adapter': minor
+---
+
+Refactors L2EP EA logic to include chain specific delta values

--- a/packages/sources/layer2-sequencer-health/README.md
+++ b/packages/sources/layer2-sequencer-health/README.md
@@ -4,28 +4,33 @@ Adapter that checks the Layer 2 Sequencer status
 
 ### Environment Variables
 
-| Required? |               Name                |                                   Description                                   | Options |                           Defaults to                            |
-| :-------: | :-------------------------------: | :-----------------------------------------------------------------------------: | :-----: | :--------------------------------------------------------------: |
-|           |              `DELTA`              | Maximum time in milliseconds from last seen block to consider sequencer healthy |         |                          120000 (2 min)                          |
-|           |          `DELTA_BLOCKS`           |           Maximum allowed number of blocks that Nodes can fall behind           |         |                                6                                 |
-|           |      `NETWORK_TIMEOUT_LIMIT`      |         Maximum time in milliseconds to wait for a transaction receipt          |         |                          5000 (5 secs)                           |
-|           |      `ARBITRUM_RPC_ENDPOINT`      |                              Arbitrum RPC Endpoint                              |         |                   https://arb1.arbitrum.io/rpc                   |
-|           |    `ARBITRUM_HEALTH_ENDPOINT`     |                            Arbitrum Health Endpoint                             |         |                                                                  |
-|           |        `ARBITRUM_CHAIN_ID`        |                           The chain id to connect to                            |         |                              42161                               |
-|           |      `OPTIMISM_RPC_ENDPOINT`      |                              Optimism RPC Endpoint                              |         |                   https://mainnet.optimism.io                    |
-|           |    `OPTIMISM_HEALTH_ENDPOINT`     |                            Optimism Health Endpoint                             |         |                                                                  |
-|           |        `OPTIMISM_CHAIN_ID`        |                           The chain id to connect to                            |         |                                10                                |
-|           |        `BASE_RPC_ENDPOINT`        |                                Base RPC Endpoint                                |         |                     https://mainnet.base.org                     |
-|           |      `BASE_HEALTH_ENDPOINT`       |                              Base Health Endpoint                               |         |                                                                  |
-|           |          `BASE_CHAIN_ID`          |                           The chain id to connect to                            |         |                               8453                               |
-|           |       `METIS_RPC_ENDPOINT`        |                               Metis RPC Endpoint                                |         |              https://andromeda.metis.io/?owner=1088              |
-|           |      `METIS_HEALTH_ENDPOINT`      |                              Metis Health Endpoint                              |         |        https://andromeda-healthy.metisdevops.link/health         |
-|           |         `METIS_CHAIN_ID`          |                           The chain id to connect to                            |         |                               1088                               |
-|           |       `SCROLL_RPC_ENDPOINT`       |                               Scroll RPC Endpoint                               |         |                      https://rpc.scroll.io                       |
-|           |     `SCROLL_HEALTH_ENDPOINT`      |                             Scroll Health Endpoint                              |         |                                                                  |
-|           |         `SCROLL_CHAIN_ID`         |                           The chain id to connect to                            |         |                              534352                              |
-|           |     `STARKWARE_RPC_ENDPOINT`      |                           The Starkware RPC endpoint                            |         |           https://starknet-mainnet.public.blastapi.io            |
-|           | `STARKWARE_DUMMY_ACCOUNT_ADDRESS` |        The dummy address to use to send dummy transactions to Starkware         |         | 0x00000000000000000000000000000000000000000000000000000000000001 |
+| Required? |               Name                |                                        Description                                        | Options |                           Defaults to                            |
+| :-------: | :-------------------------------: | :---------------------------------------------------------------------------------------: | :-----: | :--------------------------------------------------------------: |
+|           |          `DELTA_BLOCKS`           |                Maximum allowed number of blocks that Nodes can fall behind                |         |                                6                                 |
+|           |      `NETWORK_TIMEOUT_LIMIT`      |              Maximum time in milliseconds to wait for a transaction receipt               |         |                          5000 (5 secs)                           |
+|           |    `ARBITRUM_HEALTH_ENDPOINT`     |                                 Arbitrum Health Endpoint                                  |         |                                                                  |
+|           |        `ARBITRUM_CHAIN_ID`        |                            The chain id to connect to Arbitrum                            |         |                              42161                               |
+|           |         `ARBITRUM_DELTA`          | Maximum time in milliseconds from last seen block to consider Arbitrum sequencer healthy  |         |                          120000 (2 min)                          |
+|           |      `OPTIMISM_RPC_ENDPOINT`      |                                   Optimism RPC Endpoint                                   |         |                   https://mainnet.optimism.io                    |
+|           |    `OPTIMISM_HEALTH_ENDPOINT`     |                                 Optimism Health Endpoint                                  |         |                                                                  |
+|           |        `OPTIMISM_CHAIN_ID`        |                            The chain id to connect to Optimism                            |         |                                10                                |
+|           |         `OPTIMISM_DELTA`          | Maximum time in milliseconds from last seen block to consider Optimism sequencer healthy  |         |                          120000 (2 min)                          |
+|           |        `BASE_RPC_ENDPOINT`        |                                     Base RPC Endpoint                                     |         |                     https://mainnet.base.org                     |
+|           |      `BASE_HEALTH_ENDPOINT`       |                                   Base Health Endpoint                                    |         |                                                                  |
+|           |          `BASE_CHAIN_ID`          |                              The chain id to connect to Base                              |         |                               8453                               |
+|           |           `BASE_DELTA`            |   Maximum time in milliseconds from last seen block to consider Base sequencer healthy    |         |                          120000 (2 min)                          |
+|           |       `METIS_RPC_ENDPOINT`        |                                    Metis RPC Endpoint                                     |         |              https://andromeda.metis.io/?owner=1088              |
+|           |      `METIS_HEALTH_ENDPOINT`      |                                   Metis Health Endpoint                                   |         |        https://andromeda-healthy.metisdevops.link/health         |
+|           |         `METIS_CHAIN_ID`          |                             The chain id to connect to Metis                              |         |                               1088                               |
+|           |           `METIS_DELTA`           |   Maximum time in milliseconds from last seen block to consider Metis sequencer healthy   |         |                         600000 (10 min)                          |
+|           |       `SCROLL_RPC_ENDPOINT`       |                                    Scroll RPC Endpoint                                    |         |                      https://rpc.scroll.io                       |
+|           |     `SCROLL_HEALTH_ENDPOINT`      |                                  Scroll Health Endpoint                                   |         |                                                                  |
+|           |         `SCROLL_CHAIN_ID`         |                             The chain id to connect to Scroll                             |         |                              534352                              |
+|           |          `SCROLL_DELTA`           |  Maximum time in milliseconds from last seen block to consider Scroll sequencer healthy   |         |                          120000 (2 min)                          |
+|           |     `STARKWARE_RPC_ENDPOINT`      |                                  Starkware RPC Endpoint                                   |         |           https://starknet-mainnet.public.blastapi.io            |
+|           | `STARKWARE_DUMMY_ACCOUNT_ADDRESS` |             The dummy address to use to send dummy transactions to Starkware              |         | 0x00000000000000000000000000000000000000000000000000000000000001 |
+|           |         `STARKWARE_DELTA`         | Maximum time in milliseconds from last seen block to consider Starkware sequencer healthy |         |                          120000 (2 min)                          |
+|           | `STARKWARE_DUMMY_ACCOUNT_ADDRESS` |             The dummy address to use to send dummy transactions to Starkware              |         | 0x00000000000000000000000000000000000000000000000000000000000001 |
 
 For the adapter to be useful on the desired network, at least one endpoint (RPC or HEALTH) needs to provided
 

--- a/packages/sources/layer2-sequencer-health/schemas/env.json
+++ b/packages/sources/layer2-sequencer-health/schemas/env.json
@@ -4,9 +4,29 @@
   "required": [],
   "type": "object",
   "properties": {
-    "DELTA": {
+    "ARBITRUM_DELTA": {
       "type": "number",
-      "default": 180000
+      "default": 120000
+    },
+    "OPTIMISM_DELTA": {
+      "type": "number",
+      "default": 120000
+    },
+    "BASE_DELTA": {
+      "type": "number",
+      "default": 120000
+    },
+    "METIS_DELTA": {
+      "type": "number",
+      "default": 600000
+    },
+    "SCROLL_DELTA": {
+      "type": "number",
+      "default": 120000
+    },
+    "STARKWARE_DELTA": {
+      "type": "number",
+      "default": 120000
     },
     "ARBITRUM_RPC_ENDPOINT": {
       "type": "string",

--- a/packages/sources/layer2-sequencer-health/src/config/index.ts
+++ b/packages/sources/layer2-sequencer-health/src/config/index.ts
@@ -13,6 +13,8 @@ export const DEFAULT_ENDPOINT = 'health'
 
 // 2 minutes
 export const DEFAULT_DELTA_TIME = 2 * 60 * 1000
+// 10 minutes
+export const DEFAULT_DELTA_TIME_METIS = 10 * 60 * 1000
 // Blocks that replica nodes can fall behind
 export const DEFAULT_DELTA_BLOCKS = 6
 // milliseconds to consider a timeout transaction (10 secs)
@@ -83,6 +85,15 @@ export const CHAIN_IDS: Record<EVMNetworks, number | undefined | string> = {
     util.getEnv(ENV_SCROLL_CHAIN_ID),
 }
 
+export const CHAIN_DELTA: Record<Networks, number> = {
+  [Networks.Arbitrum]: Number(util.getEnv('ARBITRUM_DELTA')) || DEFAULT_DELTA_TIME,
+  [Networks.Optimism]: Number(util.getEnv('OPTIMISM_DELTA')) || DEFAULT_DELTA_TIME,
+  [Networks.Base]: Number(util.getEnv('BASE_DELTA')) || DEFAULT_DELTA_TIME,
+  [Networks.Metis]: Number(util.getEnv('METIS_DELTA')) || DEFAULT_DELTA_TIME_METIS,
+  [Networks.Scroll]: Number(util.getEnv('SCROLL_DELTA')) || DEFAULT_DELTA_TIME,
+  [Networks.Starkware]: Number(util.getEnv('STARKWARE_DELTA')) || DEFAULT_DELTA_TIME,
+}
+
 const DEFAULT_METIS_HEALTH_ENDPOINT = 'https://andromeda-healthy.metisdevops.link/health'
 export const HEALTH_ENDPOINTS: Record<
   Networks,
@@ -115,8 +126,8 @@ export const HEALTH_ENDPOINTS: Record<
 }
 
 export interface ExtendedConfig extends Config {
-  delta: number
   deltaBlocks: number
+  deltaChain: Record<Networks, number>
   timeoutLimit: number
   retryConfig: {
     numRetries: number
@@ -134,7 +145,7 @@ export const makeConfig = (prefix?: string): ExtendedConfig => {
     throw new AdapterConfigError({ message: 'Cache cannot be enabled on this adapter' })
   }
   const config = Requester.getDefaultConfig(prefix)
-  const delta = Number(util.getEnv('DELTA', prefix)) || DEFAULT_DELTA_TIME
+  const deltaChain = CHAIN_DELTA
   const deltaBlocks = Number(util.getEnv('DELTA_BLOCKS', prefix)) || DEFAULT_DELTA_BLOCKS
   const timeoutLimit = Number(util.getEnv('NETWORK_TIMEOUT_LIMIT', prefix)) || DEFAULT_TIMEOUT_LIMIT
   const numRetries = Number(util.getEnv('NUM_RETRIES')) || DEFAULT_NUM_RETRIES
@@ -146,7 +157,7 @@ export const makeConfig = (prefix?: string): ExtendedConfig => {
     retryInterval,
   }
 
-  return { ...config, delta, deltaBlocks, timeoutLimit, retryConfig, starkwareConfig }
+  return { ...config, deltaChain, deltaBlocks, timeoutLimit, retryConfig, starkwareConfig }
 }
 
 const DEFAULT_STARKWARE_RPC_ENDPOINT = 'https://starknet-mainnet.public.blastapi.io'

--- a/packages/sources/layer2-sequencer-health/src/evm.ts
+++ b/packages/sources/layer2-sequencer-health/src/evm.ts
@@ -87,6 +87,7 @@ const lastSeenBlock: Record<EVMNetworks, { block: number; timestamp: number }> =
     timestamp: 0,
   },
 }
+
 export const checkOptimisticRollupBlockHeight = (
   network: EVMNetworks,
 ): ((config: ExtendedConfig) => Promise<boolean>) => {
@@ -105,7 +106,8 @@ export const checkOptimisticRollupBlockHeight = (
   }
 
   return async (config: ExtendedConfig): Promise<boolean> => {
-    const { delta, deltaBlocks, retryConfig } = config
+    const { deltaBlocks, retryConfig } = config
+    const delta = config.deltaChain[network]
     const block = await retry<number>({
       promise: async () => await requestBlockHeight(network),
       retryConfig,

--- a/packages/sources/layer2-sequencer-health/src/starkware.ts
+++ b/packages/sources/layer2-sequencer-health/src/starkware.ts
@@ -1,5 +1,5 @@
 import { Logger } from '@chainlink/ea-bootstrap'
-import { DEFAULT_PRIVATE_KEY, ExtendedConfig } from './config'
+import { CHAIN_DELTA, DEFAULT_PRIVATE_KEY, ExtendedConfig, Networks } from './config'
 import { ec, Account, InvokeFunctionResponse, RPC } from 'starknet'
 import { race, retry } from './network'
 
@@ -55,7 +55,7 @@ export const checkStarkwareSequencerPendingTransactions = (): ((
     lastBlockResponse: null,
   }
   return async (config: ExtendedConfig): Promise<boolean> => {
-    const delta = config.delta
+    const delta = config.deltaChain[Networks.Starkware]
     const currentTime = Date.now()
     if (state.lastUpdated > 0 && currentTime - state.lastUpdated < delta) {
       Logger.debug(

--- a/packages/sources/layer2-sequencer-health/test/unit/starkware.test.ts
+++ b/packages/sources/layer2-sequencer-health/test/unit/starkware.test.ts
@@ -1,4 +1,4 @@
-import { ExtendedConfig, makeConfig } from '../../src/config'
+import { CHAIN_DELTA, ExtendedConfig, Networks, makeConfig } from '../../src/config'
 import * as starkware from '../../src/starkware'
 import * as network from '../../src/network'
 import { useFakeTimers } from 'sinon'
@@ -39,7 +39,7 @@ describe('starkware', () => {
           )
 
           expect(await fn(config)).toBe(true)
-          const timeToNextCall = config.delta - 10 * 1000
+          const timeToNextCall = CHAIN_DELTA[Networks.Starkware] - 10 * 1000
           clock.tick(timeToNextCall)
           jest.spyOn(network, 'retry').mockReturnValueOnce(
             Promise.resolve({
@@ -67,7 +67,7 @@ describe('starkware', () => {
 
         describe('when there are new transactions', () => {
           it('returns true', async () => {
-            const timeToNextCall = config.delta - 10 * 1000
+            const timeToNextCall = CHAIN_DELTA[Networks.Starkware] - 10 * 1000
             clock.tick(timeToNextCall)
             jest.spyOn(network, 'retry').mockReturnValueOnce(
               Promise.resolve({
@@ -81,7 +81,7 @@ describe('starkware', () => {
 
         describe('when there are no new transactons', () => {
           it('returns false', async () => {
-            const timeToNextCall = config.delta - 10 * 1000
+            const timeToNextCall = CHAIN_DELTA[Networks.Starkware] - 10 * 1000
             clock.tick(timeToNextCall)
             jest.spyOn(network, 'retry').mockReturnValueOnce(
               Promise.resolve({


### PR DESCRIPTION
## Closes [SHIP-1998](https://smartcontract-it.atlassian.net/browse/SHIP-1998)

This PR refactors the layer2-sequencer-health adapter to allow for chain specific delta values.
It also increases the default delta value for Metis to 10 mins.



## Changes

- Refactors the layer2-sequencer-health adapter to allow for chain specific delta values
- Increases the default delta value for Metis from 2 mins to 10 mins




## Steps to Test

1. Unit tests


## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[SHIP-1998]: https://smartcontract-it.atlassian.net/browse/SHIP-1998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ