### PR TITLE
Cryptocompare: Revert setting default transport to WS

### DIFF
--- a/.changeset/rare-candles-poke.md
+++ b/.changeset/rare-candles-poke.md
@@ -1,5 +1,0 @@
----
-'@chainlink/cryptocompare-adapter': minor
----
-
-Change default value of WS_ENABLED config to true

--- a/packages/sources/cryptocompare/src/config/index.ts
+++ b/packages/sources/cryptocompare/src/config/index.ts
@@ -26,6 +26,6 @@ export const config = new AdapterConfig({
   WS_ENABLED: {
     description: 'Whether data should be returned from websocket or not',
     type: 'boolean',
-    default: true,
+    default: false,
   },
 })

--- a/packages/sources/cryptocompare/test/integration/adapter.test.ts
+++ b/packages/sources/cryptocompare/test/integration/adapter.test.ts
@@ -13,7 +13,6 @@ describe('execute', () => {
   beforeAll(async () => {
     oldEnv = JSON.parse(JSON.stringify(process.env))
     process.env['API_KEY'] = 'API_KEY'
-    process.env['WS_ENABLED'] = 'false'
     const mockDate = new Date('2022-01-01T11:11:11.111Z')
     spy = jest.spyOn(Date, 'now').mockReturnValue(mockDate.getTime())
 


### PR DESCRIPTION
This reverts commit 1444fd44d2251a72e66c2143b8fea866abee61c8, to avoid setting the default connection type for Cryptocompare to Websocket until we've root caused socket rate limits. 


---
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
