### PR TITLE
Feature/df 20015

### DIFF
--- a/.changeset/shy-tips-carry.md
+++ b/.changeset/shy-tips-carry.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/view-function-multi-chain-adapter': major
+---
+
+Adding Starknet support for Starnket Sepolia + Mainnet for calling view functions.

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -8693,8 +8693,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@chainlink/external-adapter-framework", "npm:0.33.8"],\
             ["@types/jest", "npm:27.5.2"],\
             ["@types/node", "npm:16.18.96"],\
+            ["bignumber.js", "npm:4.0.4"],\
             ["ethers", "npm:5.7.2"],\
             ["nock", "npm:13.5.4"],\
+            ["starknet", "npm:6.9.0"],\
             ["tslib", "npm:2.4.1"],\
             ["typescript", "patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=b5f058"]\
           ],\
@@ -15948,6 +15950,17 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["yargs", "npm:17.7.2"]\
           ],\
           "linkType": "HARD"\
+        }],\
+        ["npm:2.2.2", {\
+          "packageLocation": "./.yarn/cache/abi-wan-kanabi-npm-2.2.2-1077d098b0-4cf6917188.zip/node_modules/abi-wan-kanabi/",\
+          "packageDependencies": [\
+            ["abi-wan-kanabi", "npm:2.2.2"],\
+            ["ansicolors", "npm:0.3.2"],\
+            ["cardinal", "npm:2.1.1"],\
+            ["fs-extra", "npm:10.1.0"],\
+            ["yargs", "npm:17.7.2"]\
+          ],\
+          "linkType": "HARD"\
         }]\
       ]],\
       ["abort-controller", [\
@@ -17316,6 +17329,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]\
       ]],\
       ["bignumber.js", [\
+        ["npm:4.0.4", {\
+          "packageLocation": "./.yarn/cache/bignumber.js-npm-4.0.4-a6a8fa7ae5-316da1adee.zip/node_modules/bignumber.js/",\
+          "packageDependencies": [\
+            ["bignumber.js", "npm:4.0.4"]\
+          ],\
+          "linkType": "HARD"\
+        }],\
         ["npm:9.1.2", {\
           "packageLocation": "./.yarn/cache/bignumber.js-npm-9.1.2-c2228c6a4a-582c03af77.zip/node_modules/bignumber.js/",\
           "packageDependencies": [\
@@ -22454,6 +22474,17 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "linkType": "HARD"\
         }]\
       ]],\
+      ["fetch-cookie", [\
+        ["npm:3.0.1", {\
+          "packageLocation": "./.yarn/cache/fetch-cookie-npm-3.0.1-ac6f9b826a-01657ccdf6.zip/node_modules/fetch-cookie/",\
+          "packageDependencies": [\
+            ["fetch-cookie", "npm:3.0.1"],\
+            ["set-cookie-parser", "npm:2.6.0"],\
+            ["tough-cookie", "npm:4.1.4"]\
+          ],\
+          "linkType": "HARD"\
+        }]\
+      ]],\
       ["figures", [\
         ["npm:1.7.0", {\
           "packageLocation": "./.yarn/cache/figures-npm-1.7.0-1542644df9-d77206deba.zip/node_modules/figures/",\
@@ -23312,6 +23343,16 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./.yarn/cache/get-params-npm-0.1.2-1df881bfb8-7768710dd5.zip/node_modules/get-params/",\
           "packageDependencies": [\
             ["get-params", "npm:0.1.2"]\
+          ],\
+          "linkType": "HARD"\
+        }]\
+      ]],\
+      ["get-starknet-core", [\
+        ["npm:4.0.0-next.5", {\
+          "packageLocation": "./.yarn/cache/get-starknet-core-npm-4.0.0-next.5-ae89eba523-a305acc589.zip/node_modules/get-starknet-core/",\
+          "packageDependencies": [\
+            ["get-starknet-core", "npm:4.0.0-next.5"],\
+            ["starknet-types", "npm:0.7.2"]\
           ],\
           "linkType": "HARD"\
         }]\
@@ -29578,6 +29619,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["lossless-json", "npm:2.0.8"]\
           ],\
           "linkType": "HARD"\
+        }],\
+        ["npm:4.0.1", {\
+          "packageLocation": "./.yarn/cache/lossless-json-npm-4.0.1-8cb2e90f20-41e89f5b78.zip/node_modules/lossless-json/",\
+          "packageDependencies": [\
+            ["lossless-json", "npm:4.0.1"]\
+          ],\
+          "linkType": "HARD"\
         }]\
       ]],\
       ["loud-rejection", [\
@@ -33644,6 +33692,15 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "linkType": "HARD"\
         }]\
       ]],\
+      ["querystringify", [\
+        ["npm:2.2.0", {\
+          "packageLocation": "./.yarn/cache/querystringify-npm-2.2.0-4e77c9f606-5641ea231b.zip/node_modules/querystringify/",\
+          "packageDependencies": [\
+            ["querystringify", "npm:2.2.0"]\
+          ],\
+          "linkType": "HARD"\
+        }]\
+      ]],\
       ["queue-microtask", [\
         ["npm:1.2.3", {\
           "packageLocation": "./.yarn/cache/queue-microtask-npm-1.2.3-fcc98e4e2d-b676f8c040.zip/node_modules/queue-microtask/",\
@@ -34538,6 +34595,15 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "linkType": "HARD"\
         }]\
       ]],\
+      ["requires-port", [\
+        ["npm:1.0.0", {\
+          "packageLocation": "./.yarn/cache/requires-port-npm-1.0.0-fd036b488a-eee0e303ad.zip/node_modules/requires-port/",\
+          "packageDependencies": [\
+            ["requires-port", "npm:1.0.0"]\
+          ],\
+          "linkType": "HARD"\
+        }]\
+      ]],\
       ["reselect", [\
         ["npm:4.1.8", {\
           "packageLocation": "./.yarn/cache/reselect-npm-4.1.8-cad5f0a3f3-a4ac87ceda.zip/node_modules/reselect/",\
@@ -35407,6 +35473,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["set-cookie-parser", "npm:2.5.1"]\
           ],\
           "linkType": "HARD"\
+        }],\
+        ["npm:2.6.0", {\
+          "packageLocation": "./.yarn/cache/set-cookie-parser-npm-2.6.0-a7dd154236-bf11ebc594.zip/node_modules/set-cookie-parser/",\
+          "packageDependencies": [\
+            ["set-cookie-parser", "npm:2.6.0"]\
+          ],\
+          "linkType": "HARD"\
         }]\
       ]],\
       ["set-delayed-interval", [\
@@ -36176,6 +36249,38 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["pako", "npm:2.0.4"],\
             ["ts-mixer", "npm:6.0.3"],\
             ["url-join", "npm:4.0.1"]\
+          ],\
+          "linkType": "HARD"\
+        }],\
+        ["npm:6.9.0", {\
+          "packageLocation": "./.yarn/cache/starknet-npm-6.9.0-04d9e34f48-3cfe3f550b.zip/node_modules/starknet/",\
+          "packageDependencies": [\
+            ["starknet", "npm:6.9.0"],\
+            ["@noble/curves", "npm:1.4.0"],\
+            ["@noble/hashes", "npm:1.4.0"],\
+            ["@scure/base", "npm:1.1.5"],\
+            ["@scure/starknet", "npm:1.0.0"],\
+            ["abi-wan-kanabi", "npm:2.2.2"],\
+            ["fetch-cookie", "npm:3.0.1"],\
+            ["get-starknet-core", "npm:4.0.0-next.5"],\
+            ["isomorphic-fetch", "npm:3.0.0"],\
+            ["lossless-json", "npm:4.0.1"],\
+            ["pako", "npm:2.0.4"],\
+            ["starknet-types-07", [\
+              "starknet-types",\
+              "npm:0.7.2"\
+            ]],\
+            ["ts-mixer", "npm:6.0.3"],\
+            ["url-join", "npm:4.0.1"]\
+          ],\
+          "linkType": "HARD"\
+        }]\
+      ]],\
+      ["starknet-types", [\
+        ["npm:0.7.2", {\
+          "packageLocation": "./.yarn/cache/starknet-types-npm-0.7.2-2bb7ba28fd-01e1c7440f.zip/node_modules/starknet-types/",\
+          "packageDependencies": [\
+            ["starknet-types", "npm:0.7.2"]\
           ],\
           "linkType": "HARD"\
         }]\
@@ -37340,6 +37445,17 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["punycode", "npm:2.1.1"]\
           ],\
           "linkType": "HARD"\
+        }],\
+        ["npm:4.1.4", {\
+          "packageLocation": "./.yarn/cache/tough-cookie-npm-4.1.4-8293cc8bd5-5815059f01.zip/node_modules/tough-cookie/",\
+          "packageDependencies": [\
+            ["tough-cookie", "npm:4.1.4"],\
+            ["psl", "npm:1.9.0"],\
+            ["punycode", "npm:2.1.1"],\
+            ["universalify", "npm:0.2.0"],\
+            ["url-parse", "npm:1.5.10"]\
+          ],\
+          "linkType": "HARD"\
         }]\
       ]],\
       ["tr46", [\
@@ -38048,6 +38164,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],\
           "linkType": "HARD"\
         }],\
+        ["npm:0.2.0", {\
+          "packageLocation": "./.yarn/cache/universalify-npm-0.2.0-9984e61c10-e86134cb12.zip/node_modules/universalify/",\
+          "packageDependencies": [\
+            ["universalify", "npm:0.2.0"]\
+          ],\
+          "linkType": "HARD"\
+        }],\
         ["npm:2.0.1", {\
           "packageLocation": "./.yarn/cache/universalify-npm-2.0.1-040ba5a21e-ecd8469fe0.zip/node_modules/universalify/",\
           "packageDependencies": [\
@@ -38282,6 +38405,17 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./.yarn/cache/url-join-npm-4.0.1-e1f4415722-f74e868bf2.zip/node_modules/url-join/",\
           "packageDependencies": [\
             ["url-join", "npm:4.0.1"]\
+          ],\
+          "linkType": "HARD"\
+        }]\
+      ]],\
+      ["url-parse", [\
+        ["npm:1.5.10", {\
+          "packageLocation": "./.yarn/cache/url-parse-npm-1.5.10-64fa2bcd6d-fbdba6b1d8.zip/node_modules/url-parse/",\
+          "packageDependencies": [\
+            ["url-parse", "npm:1.5.10"],\
+            ["querystringify", "npm:2.2.0"],\
+            ["requires-port", "npm:1.0.0"]\
           ],\
           "linkType": "HARD"\
         }]\

--- a/packages/sources/view-function-multi-chain/package.json
+++ b/packages/sources/view-function-multi-chain/package.json
@@ -35,7 +35,9 @@
   },
   "dependencies": {
     "@chainlink/external-adapter-framework": "0.33.8",
+    "bignumber.js": "4.0.4",
     "ethers": "^5.4.6",
+    "starknet": "6.9.0",
     "tslib": "2.4.1"
   }
 }

--- a/packages/sources/view-function-multi-chain/test-payload.json
+++ b/packages/sources/view-function-multi-chain/test-payload.json
@@ -3,5 +3,27 @@
   "contract": "0x2c1d072e956AFFC0D435Cb7AC38EF18d24d9127c",
   "function": "function latestAnswer() view returns (int256)",
   "network": "ETHEREUM_MAINNET"
+ },
+ {
+  "contract": "0x0228128e84cdfc51003505dd5733729e57f7d1f7e54da679474e73db4ecaad44",
+  "function": "latest_round_data",
+  "network": "STARKNET_MAINNET"
+ },
+ {
+  "contract": "0x0228128e84cdfc51003505dd5733729e57f7d1f7e54da679474e73db4ecaad44",
+  "function": "round_data",
+  "inputParams": ["340282366920938463463374607431768254460"],
+  "network": "STARKNET_MAINNET"
+ },
+ {
+  "contract": "0x0228128e84cdfc51003505dd5733729e57f7d1f7e54da679474e73db4ecaad44",
+  "function": "latest_round_data",
+  "network": "STARKNET_SEPOLIA"
+ },
+ {
+  "contract": "0x0228128e84cdfc51003505dd5733729e57f7d1f7e54da679474e73db4ecaad44",
+  "function": "round_data",
+  "inputParams": ["340282366920938463463374607431768254460"],
+  "network": "STARKNET_SEPOLIA"
  }]
 }

--- a/packages/sources/view-function-multi-chain/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/view-function-multi-chain/test/integration/__snapshots__/adapter.test.ts.snap
@@ -39,6 +39,62 @@ exports[`execute function endpoint should return success for different network 1
 }
 `;
 
+exports[`execute function endpoint should return success for starknet mainnet 1`] = `
+{
+  "data": {
+    "result": "0x12",
+  },
+  "result": "0x12",
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 978347471111,
+    "providerDataRequestedUnixMs": 978347471111,
+  },
+}
+`;
+
+exports[`execute function endpoint should return success for starknet mainnet with parameters 1`] = `
+{
+  "data": {
+    "result": "0x0",
+  },
+  "result": "0x0",
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 978347471111,
+    "providerDataRequestedUnixMs": 978347471111,
+  },
+}
+`;
+
+exports[`execute function endpoint should return success for starknet sepolia 1`] = `
+{
+  "data": {
+    "result": "0x10000000000000000000000000000a7fc",
+  },
+  "result": "0x10000000000000000000000000000a7fc",
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 978347471111,
+    "providerDataRequestedUnixMs": 978347471111,
+  },
+}
+`;
+
+exports[`execute function endpoint should return success for starknet sepolia with parameters 1`] = `
+{
+  "data": {
+    "result": "0x10000000000000000000000000000a7fc",
+  },
+  "result": "0x10000000000000000000000000000a7fc",
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 978347471111,
+    "providerDataRequestedUnixMs": 978347471111,
+  },
+}
+`;
+
 exports[`execute function endpoint should return success with parameters 1`] = `
 {
   "data": {

--- a/packages/sources/view-function-multi-chain/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/view-function-multi-chain/test/integration/__snapshots__/adapter.test.ts.snap
@@ -70,9 +70,9 @@ exports[`execute function endpoint should return success for starknet mainnet wi
 exports[`execute function endpoint should return success for starknet sepolia 1`] = `
 {
   "data": {
-    "result": "0x10000000000000000000000000000a7fc",
+    "result": "0x8",
   },
-  "result": "0x10000000000000000000000000000a7fc",
+  "result": "0x8",
   "statusCode": 200,
   "timestamps": {
     "providerDataReceivedUnixMs": 978347471111,

--- a/packages/sources/view-function-multi-chain/test/integration/adapter.test.ts
+++ b/packages/sources/view-function-multi-chain/test/integration/adapter.test.ts
@@ -106,7 +106,7 @@ describe('execute', () => {
     it('should return success for starknet sepolia', async () => {
       const data = {
         contract: '0x228128e84cdfc51003505dd5733729e57f7d1f7e54da679474e73db4ecaad44',
-        function: 'latest_round_data',
+        function: 'decimals',
         network: 'starknet_sepolia',
       }
       mockStarknetSepoliaContractCallResponseSuccess()

--- a/packages/sources/view-function-multi-chain/test/integration/adapter.test.ts
+++ b/packages/sources/view-function-multi-chain/test/integration/adapter.test.ts
@@ -26,7 +26,7 @@ describe('execute', () => {
       process.env.ETHEREUM_GOERLI_RPC_URL ?? 'http://localhost:8554'
     process.env.ETHEREUM_GOERLI_CHAIN_ID = process.env.ETHEREUM_GOERLI_CHAIN_ID ?? '5'
 
-    process.env.SARKNET_MAINNET_RPC_URL =
+    process.env.STARKNET_MAINNET_RPC_URL =
       process.env.SARKNET_MAINNET_RPC_URL ?? 'http://localhost:8560'
     process.env.SARKNET_MAINNET_CHAIN_ID =
       process.env.SARKNET_MAINNET_CHAIN_ID ?? constants.StarknetChainId.SN_MAIN

--- a/packages/sources/view-function-multi-chain/test/integration/adapter.test.ts
+++ b/packages/sources/view-function-multi-chain/test/integration/adapter.test.ts
@@ -6,8 +6,11 @@ import * as nock from 'nock'
 import {
   mockETHGoerliContractCallResponseSuccess,
   mockETHMainnetContractCallResponseSuccess,
+  mockStarknetMainnetContractCallResponseSuccess,
+  mockStarknetSepoliaContractCallResponseSuccess,
 } from './fixtures'
 import * as process from 'process'
+import { constants } from 'starknet'
 
 describe('execute', () => {
   let spy: jest.SpyInstance
@@ -22,6 +25,16 @@ describe('execute', () => {
     process.env.ETHEREUM_GOERLI_RPC_URL =
       process.env.ETHEREUM_GOERLI_RPC_URL ?? 'http://localhost:8554'
     process.env.ETHEREUM_GOERLI_CHAIN_ID = process.env.ETHEREUM_GOERLI_CHAIN_ID ?? '5'
+
+    process.env.SARKNET_MAINNET_RPC_URL =
+      process.env.SARKNET_MAINNET_RPC_URL ?? 'http://localhost:8560'
+    process.env.SARKNET_MAINNET_CHAIN_ID =
+      process.env.SARKNET_MAINNET_CHAIN_ID ?? constants.StarknetChainId.SN_MAIN
+    process.env.SARKNET_SEPOLIA_RPC_URL =
+      process.env.SARKNET_SEPOLIA_RPC_URL ?? 'http://localhost:8506'
+    process.env.SARKNET_SEPOLIA_CHAIN_ID =
+      process.env.SARKNET_SEPOLIA_CHAIN_ID ?? constants.StarknetChainId.SN_SEPOLIA
+
     process.env.BACKGROUND_EXECUTE_MS = '0'
     const mockDate = new Date('2001-01-01T11:11:11.111Z')
     spy = jest.spyOn(Date, 'now').mockReturnValue(mockDate.getTime())
@@ -73,6 +86,56 @@ describe('execute', () => {
         network: 'ethereum_mainnet',
       }
       mockETHMainnetContractCallResponseSuccess()
+      const response = await testAdapter.request(data)
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toMatchSnapshot()
+    })
+
+    it('should return success for starknet mainnet', async () => {
+      const data = {
+        contract: '0x07c2e1e733f28daa23e78be3a4f6c724c0ab06af65f6a95b5e0545215f1abc1b',
+        function: 'decimals',
+        network: 'starknet_mainnet',
+      }
+      mockStarknetMainnetContractCallResponseSuccess()
+      const response = await testAdapter.request(data)
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toMatchSnapshot()
+    })
+
+    it('should return success for starknet sepolia', async () => {
+      const data = {
+        contract: '0x228128e84cdfc51003505dd5733729e57f7d1f7e54da679474e73db4ecaad44',
+        function: 'latest_round_data',
+        network: 'starknet_sepolia',
+      }
+      mockStarknetSepoliaContractCallResponseSuccess()
+      const response = await testAdapter.request(data)
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toMatchSnapshot()
+    })
+
+    it('should return success for starknet mainnet with parameters', async () => {
+      const data = {
+        contract: '0x07c2e1e733f28daa23e78be3a4f6c724c0ab06af65f6a95b5e0545215f1abc1b',
+        function: 'balance_of',
+        inputParams: ['0x00048b2ef72cb3a91a7bf332de7e6fdba249dd48d7fa23e7f395fe621a93b38a'],
+        network: 'starknet_mainnet',
+      }
+      mockStarknetMainnetContractCallResponseSuccess()
+      const response = await testAdapter.request(data)
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toMatchSnapshot()
+    })
+
+    it('should return success for starknet sepolia with parameters', async () => {
+      const data = {
+        contract: '0x228128e84cdfc51003505dd5733729e57f7d1f7e54da679474e73db4ecaad44',
+        function: 'round_data',
+        inputParams: ['340282366920938463463374607431768254460'],
+        network: 'starknet_sepolia',
+      }
+      mockStarknetSepoliaContractCallResponseSuccess()
       const response = await testAdapter.request(data)
       expect(response.statusCode).toBe(200)
       expect(response.json()).toMatchSnapshot()

--- a/packages/sources/view-function-multi-chain/test/integration/fixtures.ts
+++ b/packages/sources/view-function-multi-chain/test/integration/fixtures.ts
@@ -190,7 +190,7 @@ export const mockStarknetMainnetContractCallResponseSuccess = (): nock.Scope =>
     .persist()
     .post('/', {
       method: 'eth_call',
-      // balanceOf
+      // balance_of
       params: [
         {
           to: '0x07c2e1e733f28daa23e78be3a4f6c724c0ab06af65f6a95b5e0545215f1abc1b',
@@ -247,11 +247,11 @@ export const mockStarknetSepoliaContractCallResponseSuccess = (): nock.Scope =>
     .persist()
     .post('/', {
       method: 'eth_call',
-      // latest_round_data
+      // decimals
       params: [
         {
           to: '0x228128e84cdfc51003505dd5733729e57f7d1f7e54da679474e73db4ecaad44',
-          data: '0x3934bf435e1b98555ff170fde2c4b1ed8116018f1aa953022c2b6f54d4bfaab',
+          data: '0x4c4fb1ab068f6039d5780c68dd0fa2f8742cceb3426d19667778ca7f3518a9',
         },
       ],
       id: /^\d+$/,
@@ -262,7 +262,7 @@ export const mockStarknetSepoliaContractCallResponseSuccess = (): nock.Scope =>
       (_, request: JsonRpcPayload) => ({
         jsonrpc: '2.0',
         id: request['id'],
-        result: '0x10000000000000000000000000000a7fc',
+        result: '0x8',
       }),
       [
         'Content-Type',

--- a/packages/sources/view-function-multi-chain/test/integration/fixtures.ts
+++ b/packages/sources/view-function-multi-chain/test/integration/fixtures.ts
@@ -131,3 +131,179 @@ export const mockETHGoerliContractCallResponseSuccess = (): nock.Scope =>
         'Origin',
       ],
     )
+
+export const mockStarknetMainnetContractCallResponseSuccess = (): nock.Scope =>
+  nock('http://localhost:8560', {
+    encodedQueryParams: true,
+  })
+    .persist()
+    .post('/', { method: 'starknet_chainId', params: [], id: /^\d+$/, jsonrpc: '2.0' })
+    .reply(
+      200,
+      (_, request: JsonRpcPayload) => ({
+        jsonrpc: '2.0',
+        id: request['id'],
+        result: '0x534e5f4d41494e',
+      }),
+      [
+        'Content-Type',
+        'application/json',
+        'Connection',
+        'close',
+        'Vary',
+        'Accept-Encoding',
+        'Vary',
+        'Origin',
+      ],
+    )
+    .persist()
+    .post('/', {
+      method: 'eth_call',
+      // decimals
+      params: [
+        {
+          to: '0x07c2e1e733f28daa23e78be3a4f6c724c0ab06af65f6a95b5e0545215f1abc1b',
+          data: '0x4c4fb1ab068f6039d5780c68dd0fa2f8742cceb3426d19667778ca7f3518a9',
+        },
+      ],
+      id: /^\d+$/,
+      jsonrpc: '2.0',
+    })
+    .reply(
+      200,
+      (_, request: JsonRpcPayload) => ({
+        jsonrpc: '2.0',
+        id: request['id'],
+        result: '0x12',
+      }),
+      [
+        'Content-Type',
+        'application/json',
+        'Connection',
+        'close',
+        'Vary',
+        'Accept-Encoding',
+        'Vary',
+        'Origin',
+      ],
+    )
+    .persist()
+    .post('/', {
+      method: 'eth_call',
+      // balanceOf
+      params: [
+        {
+          to: '0x07c2e1e733f28daa23e78be3a4f6c724c0ab06af65f6a95b5e0545215f1abc1b',
+          data: '0x35a73cd311a05d46deda634c5ee045db92f811b4e74bca4437fcb5302b7af33',
+        },
+      ],
+      id: /^\d+$/,
+      jsonrpc: '2.0',
+    })
+    .reply(
+      200,
+      (_, request: JsonRpcPayload) => ({
+        jsonrpc: '2.0',
+        id: request['id'],
+        result: '0x0',
+      }),
+      [
+        'Content-Type',
+        'application/json',
+        'Connection',
+        'close',
+        'Vary',
+        'Accept-Encoding',
+        'Vary',
+        'Origin',
+      ],
+    )
+    .persist()
+
+export const mockStarknetSepoliaContractCallResponseSuccess = (): nock.Scope =>
+  nock('http://localhost:8506', {
+    encodedQueryParams: true,
+  })
+    .persist()
+    .post('/', { method: 'starknet_chainId', params: [], id: /^\d+$/, jsonrpc: '2.0' })
+    .reply(
+      200,
+      (_, request: JsonRpcPayload) => ({
+        jsonrpc: '2.0',
+        id: request['id'],
+        result: '0x534e5f5345504f4c4941',
+      }),
+      [
+        'Content-Type',
+        'application/json',
+        'Connection',
+        'close',
+        'Vary',
+        'Accept-Encoding',
+        'Vary',
+        'Origin',
+      ],
+    )
+    .persist()
+    .post('/', {
+      method: 'eth_call',
+      // latest_round_data
+      params: [
+        {
+          to: '0x228128e84cdfc51003505dd5733729e57f7d1f7e54da679474e73db4ecaad44',
+          data: '0x3934bf435e1b98555ff170fde2c4b1ed8116018f1aa953022c2b6f54d4bfaab',
+        },
+      ],
+      id: /^\d+$/,
+      jsonrpc: '2.0',
+    })
+    .reply(
+      200,
+      (_, request: JsonRpcPayload) => ({
+        jsonrpc: '2.0',
+        id: request['id'],
+        result: '0x10000000000000000000000000000a7fc',
+      }),
+      [
+        'Content-Type',
+        'application/json',
+        'Connection',
+        'close',
+        'Vary',
+        'Accept-Encoding',
+        'Vary',
+        'Origin',
+      ],
+    )
+    .persist()
+    .post('/', {
+      method: 'eth_call',
+      // round_data
+      params: [
+        {
+          to: '0x228128e84cdfc51003505dd5733729e57f7d1f7e54da679474e73db4ecaad44',
+          data: '0x273ba5642716a1849325412cb3b360aeb087c6cef3d8ee4bf25c42814248516',
+        },
+      ],
+      id: /^\d+$/,
+      jsonrpc: '2.0',
+    })
+    .reply(
+      200,
+      (_, request: JsonRpcPayload) => ({
+        jsonrpc: '2.0',
+        id: request['id'],
+        result: '0x10000000000000000000000000000a7fc',
+      }),
+      [
+        'Content-Type',
+        'application/json',
+        'Connection',
+        'close',
+        'Vary',
+        'Accept-Encoding',
+        'Vary',
+        'Origin',
+      ],
+    )
+    .persist()

--- a/yarn.lock
+++ b/yarn.lock
@@ -5686,8 +5686,10 @@ __metadata:
     "@chainlink/external-adapter-framework": 0.33.8
     "@types/jest": 27.5.2
     "@types/node": 16.18.96
+    bignumber.js: 4.0.4
     ethers: ^5.4.6
     nock: 13.5.4
+    starknet: 6.9.0
     tslib: 2.4.1
     typescript: 5.0.4
   languageName: unknown
@@ -9072,7 +9074,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:1.4.0, @noble/hashes@npm:^1.3.3, @noble/hashes@npm:~1.4.0":
+"@noble/hashes@npm:1.4.0, @noble/hashes@npm:^1.3.3, @noble/hashes@npm:^1.4.0, @noble/hashes@npm:~1.4.0":
   version: 1.4.0
   resolution: "@noble/hashes@npm:1.4.0"
   checksum: 8ba816ae26c90764b8c42493eea383716396096c5f7ba6bea559993194f49d80a73c081f315f4c367e51bd2d5891700bcdfa816b421d24ab45b41cb03e4f3342
@@ -12153,6 +12155,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"abi-wan-kanabi@npm:^2.2.2":
+  version: 2.2.2
+  resolution: "abi-wan-kanabi@npm:2.2.2"
+  dependencies:
+    ansicolors: ^0.3.2
+    cardinal: ^2.1.1
+    fs-extra: ^10.0.0
+    yargs: ^17.7.2
+  bin:
+    generate: dist/generate.js
+  checksum: 4cf69171887c243a4b5857653f791f3b2042eba93a7326fe03120355cb9f0e29944b91650f96ad739bffad7d8ec9d88c71eeb0debe57df3cd905a1b7c9c2c4a8
+  languageName: node
+  linkType: hard
+
 "abort-controller@npm:^3.0.0":
   version: 3.0.0
   resolution: "abort-controller@npm:3.0.0"
@@ -13223,6 +13239,13 @@ __metadata:
     bindings: ^1.3.0
     node-gyp: latest
   checksum: d010c9f57758bcdaccb435d88b483ffcc95fe8bbc6e7fb3a44fb5221f29c894ffaf4a3c5a4a530e0e7d6608203c2cde9b79ee4f2386cd6d4462d1070bc8c9f4e
+  languageName: node
+  linkType: hard
+
+"bignumber.js@npm:4.0.4":
+  version: 4.0.4
+  resolution: "bignumber.js@npm:4.0.4"
+  checksum: 316da1adee992f3ba12cbe0f4c3c25bb4164638674358e1b3744de4c166924dc4a36d883e0d154c6ad44426be301b59cfe84361f09a3a85c6cdf920f2b11d028
   languageName: node
   linkType: hard
 
@@ -17892,6 +17915,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fetch-cookie@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "fetch-cookie@npm:3.0.1"
+  dependencies:
+    set-cookie-parser: ^2.4.8
+    tough-cookie: ^4.0.0
+  checksum: 01657ccdf6305c3bf9b2375a9aedd6930f803acc77583c02e96a0b3d84068cc9406d2ad4d061a8c4d9c106c021de51dd2aa505a0a05a4477a1a859052f2537a0
+  languageName: node
+  linkType: hard
+
 "figures@npm:^1.3.5":
   version: 1.7.0
   resolution: "figures@npm:1.7.0"
@@ -18695,6 +18728,15 @@ __metadata:
   version: 0.1.2
   resolution: "get-params@npm:0.1.2"
   checksum: 7768710dd5e68805b51981a6fbb0a689728d280357f5dd1a080fd7e732d9b4ccf7fc5e0fc792ff482022d8af37242ff5e72b2b50dbafccb21db4f77eb9c646c4
+  languageName: node
+  linkType: hard
+
+"get-starknet-core@npm:^4.0.0-next.3":
+  version: 4.0.0-next.5
+  resolution: "get-starknet-core@npm:4.0.0-next.5"
+  dependencies:
+    starknet-types: ^0.7.1
+  checksum: a305acc58990f313425a185c28f4d5281e4a72fabefeb3f688c8d188cb2087e76ac1fd101287c0b490ab9646995ad37fe402427b0763371f4fc8b64f09890911
   languageName: node
   linkType: hard
 
@@ -24382,6 +24424,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lossless-json@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "lossless-json@npm:4.0.1"
+  checksum: 41e89f5b7800cf5f863776542c82d8a19a696e5537865699d5ee062726d069561f7b857e838195496f2a43afe64a7dce475be5a2565822881f39feb0eda5d218
+  languageName: node
+  linkType: hard
+
 "loud-rejection@npm:^1.0.0":
   version: 1.6.0
   resolution: "loud-rejection@npm:1.6.0"
@@ -27933,7 +27982,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"psl@npm:^1.1.28":
+"psl@npm:^1.1.28, psl@npm:^1.1.33":
   version: 1.9.0
   resolution: "psl@npm:1.9.0"
   checksum: 20c4277f640c93d393130673f392618e9a8044c6c7bf61c53917a0fddb4952790f5f362c6c730a9c32b124813e173733f9895add8d26f566ed0ea0654b2e711d
@@ -28054,6 +28103,13 @@ __metadata:
   version: 0.2.1
   resolution: "querystring@npm:0.2.1"
   checksum: 7b83b45d641e75fd39cd6625ddfd44e7618e741c61e95281b57bbae8fde0afcc12cf851924559e5cc1ef9baa3b1e06e22b164ea1397d65dd94b801f678d9c8ce
+  languageName: node
+  linkType: hard
+
+"querystringify@npm:^2.1.1":
+  version: 2.2.0
+  resolution: "querystringify@npm:2.2.0"
+  checksum: 5641ea231bad7ef6d64d9998faca95611ed4b11c2591a8cae741e178a974f6a8e0ebde008475259abe1621cb15e692404e6b6626e927f7b849d5c09392604b15
   languageName: node
   linkType: hard
 
@@ -28858,6 +28914,13 @@ __metadata:
   version: 2.0.0
   resolution: "require-main-filename@npm:2.0.0"
   checksum: e9e294695fea08b076457e9ddff854e81bffbe248ed34c1eec348b7abbd22a0d02e8d75506559e2265e96978f3c4720bd77a6dad84755de8162b357eb6c778c7
+  languageName: node
+  linkType: hard
+
+"requires-port@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "requires-port@npm:1.0.0"
+  checksum: eee0e303adffb69be55d1a214e415cf42b7441ae858c76dfc5353148644f6fd6e698926fc4643f510d5c126d12a705e7c8ed7e38061113bdf37547ab356797ff
   languageName: node
   linkType: hard
 
@@ -29716,6 +29779,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"set-cookie-parser@npm:^2.4.8":
+  version: 2.6.0
+  resolution: "set-cookie-parser@npm:2.6.0"
+  checksum: bf11ebc594c53d84588f1b4c04f1b8ce14e0498b1c011b3d76b5c6d5aac481bbc3f7c5260ec4ce99bdc1d9aed19f9fc315e73166a36ca74d0f12349a73f6bdc9
+  languageName: node
+  linkType: hard
+
 "set-delayed-interval@npm:^1.0.0":
   version: 1.0.0
   resolution: "set-delayed-interval@npm:1.0.0"
@@ -30411,6 +30481,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"starknet-types-07@npm:starknet-types@^0.7.2, starknet-types@npm:^0.7.1":
+  version: 0.7.2
+  resolution: "starknet-types@npm:0.7.2"
+  checksum: 01e1c7440f086438e72b8b2498a337c541a70acf168aa96927a5dda208c777ef12918e9fdd5c0fca44089cdfc57de27f404078239dd92394c0656905c3b09821
+  languageName: node
+  linkType: hard
+
 "starknet@npm:6.0.0":
   version: 6.0.0
   resolution: "starknet@npm:6.0.0"
@@ -30426,6 +30503,27 @@ __metadata:
     ts-mixer: ^6.0.3
     url-join: ^4.0.1
   checksum: 8254753e6b425ae4ae206d26c5fbb9fe769783db52824527770730ab84d218577044ab04bb5141db5e10f81f01020ddfcac38d600f8cdaad535b8df4a191cc69
+  languageName: node
+  linkType: hard
+
+"starknet@npm:6.9.0":
+  version: 6.9.0
+  resolution: "starknet@npm:6.9.0"
+  dependencies:
+    "@noble/curves": ~1.4.0
+    "@noble/hashes": ^1.4.0
+    "@scure/base": ~1.1.3
+    "@scure/starknet": ~1.0.0
+    abi-wan-kanabi: ^2.2.2
+    fetch-cookie: ^3.0.0
+    get-starknet-core: ^4.0.0-next.3
+    isomorphic-fetch: ^3.0.0
+    lossless-json: ^4.0.1
+    pako: ^2.0.4
+    starknet-types-07: "npm:starknet-types@^0.7.2"
+    ts-mixer: ^6.0.3
+    url-join: ^4.0.1
+  checksum: 3cfe3f550bfac12dc60268be94c7f193ae45a30baa9fd7b232f66d95cc67079f23df1d19a7e54b7e01fbd9242bf41a52e9eca9f9a4e9e9d588aedb1c0f39a5f6
   languageName: node
   linkType: hard
 
@@ -31479,6 +31577,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tough-cookie@npm:^4.0.0":
+  version: 4.1.4
+  resolution: "tough-cookie@npm:4.1.4"
+  dependencies:
+    psl: ^1.1.33
+    punycode: ^2.1.1
+    universalify: ^0.2.0
+    url-parse: ^1.5.3
+  checksum: 5815059f014c31179a303c673f753f7899a6fce94ac93712c88ea5f3c26e0c042b5f0c7a599a00f8e0feeca4615dba75c3dffc54f3c1a489978aa8205e09307c
+  languageName: node
+  linkType: hard
+
 "tough-cookie@npm:~2.5.0":
   version: 2.5.0
   resolution: "tough-cookie@npm:2.5.0"
@@ -32127,6 +32237,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"universalify@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "universalify@npm:0.2.0"
+  checksum: e86134cb12919d177c2353196a4cc09981524ee87abf621f7bc8d249dbbbebaec5e7d1314b96061497981350df786e4c5128dbf442eba104d6e765bc260678b5
+  languageName: node
+  linkType: hard
+
 "universalify@npm:^2.0.0":
   version: 2.0.1
   resolution: "universalify@npm:2.0.1"
@@ -32309,6 +32426,16 @@ __metadata:
   dependencies:
     prepend-http: ^2.0.0
   checksum: 1040e357750451173132228036aff1fd04abbd43eac1fb3e4fca7495a078bcb8d33cb765fe71ad7e473d9c94d98fd67adca63bd2716c815a2da066198dd37217
+  languageName: node
+  linkType: hard
+
+"url-parse@npm:^1.5.3":
+  version: 1.5.10
+  resolution: "url-parse@npm:1.5.10"
+  dependencies:
+    querystringify: ^2.1.1
+    requires-port: ^1.0.0
+  checksum: fbdba6b1d83336aca2216bbdc38ba658d9cfb8fc7f665eb8b17852de638ff7d1a162c198a8e4ed66001ddbf6c9888d41e4798912c62b4fd777a31657989f7bdf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Closes #DF-20015

N.B. useful Starknet constants can be found here:
https://github.com/starknet-io/starknet.js/blob/66a5c0341eccfef0dcdf1312c15627b7d4f6b675/src/constants.ts#L43

## Description

Adds Starknet Sepolia + Mainnet support to the view-function-multi-chain EA. Using the starknet.js library

## Changes

-Created a separate flow to detect and handle Starknet chains based on the chainId.
-Starknet chainIds can be larger than the javascript Number type can handle. Therefore this patch uses BigNumber.js to handle chainIds now.
-Adds new integration tests + test-payload.json test cases.
-Previous EVM functionality is aimed to be unchanged

## Steps to Test

The correct environment variables must be defined for the Starknet RPC and chainID e.g.:
export STARKNET_SEPOLIA_RPC_URL=https://starknet-sepolia.public.blastapi.io/rpc/v0_7
export STARKNET_SEPOLIA_CHAIN_ID=0x534e5f5345504f4c4941

export export STARKNET_MAINNET_RPC_URL=https://starknet-mainnet.public.blastapi.io/rpc/v0_7
export STARKNET_MAINNET_CHAIN_ID=0x534e5f4d41494e 

**For integration tests:**
yarn test view-function-multi-chain/test/integration

**The EA can also be ran outside of testings with:**
yarn && yarn setup && cd packages/sources/view-function-multi-chain && yarn start

Then in another process something like:
curl --location 'localhost:8080' \                                                  
--header 'Content-Type: application/json' \
--data '{
        "data": {
  "contract": "0x0228128e84cdfc51003505dd5733729e57f7d1f7e54da679474e73db4ecaad44",
  "function": "round_data",
  "inputParams": ["340282366920938463463374607431768254460"],
  "network": "STARKNET_SEPOLIA"
 }
}