### PR TITLE
Change set-token-index EA to return wei balances with order of magnitude matching the underlying tokens decimals.

### DIFF
--- a/.changeset/red-swans-cross.md
+++ b/.changeset/red-swans-cross.md
@@ -1,0 +1,12 @@
+---
+'@chainlink/set-token-index-adapter': major
+---
+
+Critical fix to return allocation balances in the underlyng tokens decimal precision, rather than always 18 decimals.
+
+The on-chain adapter contract e.g. ethereum:0x78733fa5e70e3ab61dc49d93921b289e4b667093, returns token allocations in a normalised 18 decimal format,
+even for non 18 decimal format tokens.
+
+This change makes the EA now handle this appropriately.
+
+Previously it would make non 18 decimal tokens report USD balances which were shifted by multiple order of magnitudes 10^(18-tokenDecimals).

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -8076,10 +8076,12 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@chainlink/set-token-index-adapter", "workspace:packages/composites/set-token-index"],\
             ["@chainlink/ea-bootstrap", "workspace:packages/core/bootstrap"],\
             ["@chainlink/ea-test-helpers", "workspace:packages/core/test-helpers"],\
+            ["@chainlink/external-adapter-framework", "npm:0.33.8"],\
             ["@chainlink/token-allocation-adapter", "workspace:packages/non-deployable/token-allocation"],\
             ["@types/jest", "npm:27.5.2"],\
             ["@types/node", "npm:16.18.96"],\
             ["@types/supertest", "npm:2.0.16"],\
+            ["bignumber.js", "npm:9.1.2"],\
             ["ethers", "npm:5.7.2"],\
             ["nock", "npm:13.5.4"],\
             ["supertest", "npm:6.2.4"],\

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -8076,7 +8076,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@chainlink/set-token-index-adapter", "workspace:packages/composites/set-token-index"],\
             ["@chainlink/ea-bootstrap", "workspace:packages/core/bootstrap"],\
             ["@chainlink/ea-test-helpers", "workspace:packages/core/test-helpers"],\
-            ["@chainlink/external-adapter-framework", "npm:0.33.8"],\
             ["@chainlink/token-allocation-adapter", "workspace:packages/non-deployable/token-allocation"],\
             ["@types/jest", "npm:27.5.2"],\
             ["@types/node", "npm:16.18.96"],\

--- a/packages/composites/set-token-index/package.json
+++ b/packages/composites/set-token-index/package.json
@@ -32,7 +32,9 @@
   "dependencies": {
     "@chainlink/ea-bootstrap": "workspace:*",
     "@chainlink/ea-test-helpers": "workspace:*",
+    "@chainlink/external-adapter-framework": "0.33.8",
     "@chainlink/token-allocation-adapter": "workspace:*",
+    "bignumber.js": "9.1.2",
     "ethers": "^5.4.6",
     "tslib": "^2.3.1"
   },

--- a/packages/composites/set-token-index/package.json
+++ b/packages/composites/set-token-index/package.json
@@ -32,7 +32,6 @@
   "dependencies": {
     "@chainlink/ea-bootstrap": "workspace:*",
     "@chainlink/ea-test-helpers": "workspace:*",
-    "@chainlink/external-adapter-framework": "0.33.8",
     "@chainlink/token-allocation-adapter": "workspace:*",
     "bignumber.js": "9.1.2",
     "ethers": "^5.4.6",

--- a/packages/composites/set-token-index/src/endpoint/allocations.ts
+++ b/packages/composites/set-token-index/src/endpoint/allocations.ts
@@ -105,6 +105,7 @@ export const execute: ExecuteWithConfig<Config> = async (input, context, config)
         return {
           balance: new BigNumber(balances[i].toString())
             .shiftedBy(-(18 - token.decimals))
+            .toFixed(0)
             .toString(),
           decimals: token.decimals,
           symbol: token.symbol,

--- a/packages/composites/set-token-index/src/endpoint/allocations.ts
+++ b/packages/composites/set-token-index/src/endpoint/allocations.ts
@@ -11,6 +11,7 @@ import {
 import { Config } from '../config'
 import * as TA from '@chainlink/token-allocation-adapter'
 import { makeExecute } from '../adapter'
+import BigNumber from 'bignumber.js'
 
 export const supportedEndpoints = ['allocations']
 
@@ -95,10 +96,18 @@ export const execute: ExecuteWithConfig<Config> = async (input, context, config)
     // Token balances are coming already normalized as 18 decimals token
     const allocations = await Promise.all(
       addresses.map(async (address: string, i: number) => {
-        const token = await getToken(context, jobRunID, address)
+        const token = (await getToken(
+          context,
+          jobRunID,
+          address,
+        )) as unknown as TA.types.TokenAllocation
+
         return {
-          balance: balances[i].toString(),
-          ...token,
+          balance: new BigNumber(balances[i].toString())
+            .shiftedBy(-(18 - token.decimals))
+            .toString(),
+          decimals: token.decimals,
+          symbol: token.symbol,
         }
       }),
     )

--- a/packages/composites/set-token-index/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/composites/set-token-index/test/integration/__snapshots__/adapter.test.ts.snap
@@ -54,12 +54,12 @@ exports[`execute with coinmarketcap source should return success 1`] = `
         },
       },
     },
-    "result": 6844.061590000509,
+    "result": 6844.061754858585,
     "sources": [],
   },
   "jobRunID": "1",
   "providerStatusCode": 200,
-  "result": 6844.061590000509,
+  "result": 6844.061754858585,
   "statusCode": 200,
 }
 `;

--- a/packages/composites/set-token-index/test/integration/fixtures.ts
+++ b/packages/composites/set-token-index/test/integration/fixtures.ts
@@ -243,7 +243,7 @@ export const mockDataProviderResponses = (): void => {
       (_, request: AdapterRequest) => ({
         jsonrpc: '2.0',
         id: request['id'],
-        result: '0x0000000000000000000000000000000000000000000000000000000000000012',
+        result: '0x0000000000000000000000000000000000000000000000000000000000000010',
       }),
       [
         'Content-Type',
@@ -267,7 +267,7 @@ export const mockDataProviderResponses = (): void => {
       (_, request: AdapterRequest) => ({
         jsonrpc: '2.0',
         id: request['id'],
-        result: '0x0000000000000000000000000000000000000000000000000000000000000012',
+        result: '0x0000000000000000000000000000000000000000000000000000000000000008',
       }),
       [
         'Content-Type',
@@ -291,7 +291,7 @@ export const mockDataProviderResponses = (): void => {
       (_, request: AdapterRequest) => ({
         jsonrpc: '2.0',
         id: request['id'],
-        result: '0x0000000000000000000000000000000000000000000000000000000000000012',
+        result: '0x0000000000000000000000000000000000000000000000000000000000000005',
       }),
       [
         'Content-Type',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5127,10 +5127,12 @@ __metadata:
   dependencies:
     "@chainlink/ea-bootstrap": "workspace:*"
     "@chainlink/ea-test-helpers": "workspace:*"
+    "@chainlink/external-adapter-framework": 0.33.8
     "@chainlink/token-allocation-adapter": "workspace:*"
     "@types/jest": 27.5.2
     "@types/node": 16.18.96
     "@types/supertest": 2.0.16
+    bignumber.js: 9.1.2
     ethers: ^5.4.6
     nock: 13.5.4
     supertest: 6.2.4

--- a/yarn.lock
+++ b/yarn.lock
@@ -5127,7 +5127,6 @@ __metadata:
   dependencies:
     "@chainlink/ea-bootstrap": "workspace:*"
     "@chainlink/ea-test-helpers": "workspace:*"
-    "@chainlink/external-adapter-framework": 0.33.8
     "@chainlink/token-allocation-adapter": "workspace:*"
     "@types/jest": 27.5.2
     "@types/node": 16.18.96


### PR DESCRIPTION
## Closes #DF-20071

## Description

Fixes the set-token-index EA to provide token balances which are properly scaled to the correct size.


## Changes

Scale down the balance of a token allocations by 10^(18-tokenDecimals), to account for the adapter contract normalising all token balances to 18 decimals:


## Steps to Test
 
yarn && yarn setup && yarn test set-token-index