### PR TITLE
Round down in set-token-index to match EVM behaviour + handle 24 decimal tokens

### DIFF
--- a/.changeset/empty-rings-flash.md
+++ b/.changeset/empty-rings-flash.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/set-token-index-adapter': minor
+---
+
+Use floor rounding, and handle tokens with decimals greater than 18.

--- a/packages/composites/set-token-index/src/endpoint/allocations.ts
+++ b/packages/composites/set-token-index/src/endpoint/allocations.ts
@@ -13,9 +13,6 @@ import * as TA from '@chainlink/token-allocation-adapter'
 import { makeExecute } from '../adapter'
 import BigNumber from 'bignumber.js'
 
-// Required to stop BigNumber.js outputting in scientific exponent notation after ~1e21 scale.
-BigNumber.config({ EXPONENTIAL_AT: 1e9 })
-
 export const supportedEndpoints = ['allocations']
 
 export function getToken(
@@ -109,7 +106,7 @@ export const execute: ExecuteWithConfig<Config> = async (input, context, config)
           balance: new BigNumber(balances[i].toString())
             .shiftedBy(-(18 - token.decimals))
             .integerValue(BigNumber.ROUND_FLOOR)
-            .toString(),
+            .toString(10),
           decimals: token.decimals,
           symbol: token.symbol,
         }

--- a/packages/composites/set-token-index/src/endpoint/allocations.ts
+++ b/packages/composites/set-token-index/src/endpoint/allocations.ts
@@ -14,7 +14,7 @@ import { makeExecute } from '../adapter'
 import BigNumber from 'bignumber.js'
 
 // Required to stop BigNumber.js outputting in scientific exponent notation after ~1e21 scale.
-BigNumber.config({ EXPONENTIAL_AT: 52 })
+BigNumber.config({ EXPONENTIAL_AT: 1e9 })
 
 export const supportedEndpoints = ['allocations']
 

--- a/packages/composites/set-token-index/src/endpoint/allocations.ts
+++ b/packages/composites/set-token-index/src/endpoint/allocations.ts
@@ -14,7 +14,7 @@ import { makeExecute } from '../adapter'
 import BigNumber from 'bignumber.js'
 
 // Required to stop BigNumber.js outputting in scientific exponent notation after ~1e21 scale.
-BigNumber.config({ EXPONENTIAL_AT: 38 })
+BigNumber.config({ EXPONENTIAL_AT: 52 })
 
 export const supportedEndpoints = ['allocations']
 

--- a/packages/composites/set-token-index/src/endpoint/allocations.ts
+++ b/packages/composites/set-token-index/src/endpoint/allocations.ts
@@ -13,6 +13,9 @@ import * as TA from '@chainlink/token-allocation-adapter'
 import { makeExecute } from '../adapter'
 import BigNumber from 'bignumber.js'
 
+// Required to stop BigNumber.js outputting in scientific exponent notation after ~1e21 scale.
+BigNumber.config({ EXPONENTIAL_AT: 38 })
+
 export const supportedEndpoints = ['allocations']
 
 export function getToken(
@@ -105,7 +108,7 @@ export const execute: ExecuteWithConfig<Config> = async (input, context, config)
         return {
           balance: new BigNumber(balances[i].toString())
             .shiftedBy(-(18 - token.decimals))
-            .toFixed(0)
+            .integerValue(BigNumber.ROUND_FLOOR)
             .toString(),
           decimals: token.decimals,
           symbol: token.symbol,

--- a/packages/composites/set-token-index/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/composites/set-token-index/test/integration/__snapshots__/adapter.test.ts.snap
@@ -54,12 +54,12 @@ exports[`execute with coinmarketcap source should return success 1`] = `
         },
       },
     },
-    "result": 6844.061754858585,
+    "result": 6844.060452158586,
     "sources": [],
   },
   "jobRunID": "1",
   "providerStatusCode": 200,
-  "result": 6844.061754858585,
+  "result": 6844.060452158586,
   "statusCode": 200,
 }
 `;

--- a/packages/composites/set-token-index/test/integration/fixtures.ts
+++ b/packages/composites/set-token-index/test/integration/fixtures.ts
@@ -219,7 +219,7 @@ export const mockDataProviderResponses = (): void => {
       (_, request: AdapterRequest) => ({
         jsonrpc: '2.0',
         id: request['id'],
-        result: '0x0000000000000000000000000000000000000000000000000000000000000012',
+        result: '0x0000000000000000000000000000000000000000000000000000000000000018',
       }),
       [
         'Content-Type',


### PR DESCRIPTION
## Closes #DF-20071

## Description

Force rounding down for BigNumber conversion in set-token-index, to match EVM behaviour + add properly handle and add test case for 24 decimal tokens.

## Changes

Use .toIntegerValue(BigNumber.ROUND_FLOOR), instead of .toFixed(0), as toFixed by default rounds up or down to the nearest integer, which is not representative of on-chain EVM behaviour when scaling. Also it is generally good practice to round down balances for security reasons.

Also use of BigNumber.toString(10) has been added to stop BigNumber.js using exponential notation when .toString() for larger (~ greater than 1e21) values.

## Steps to Test

yarn test set-token-index