### PR TITLE
Added GM-token support for single sided tokens

### DIFF
--- a/.changeset/honest-turkeys-doubt.md
+++ b/.changeset/honest-turkeys-doubt.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/gm-token-adapter': patch
+---
+
+Added support for single sided tokens

--- a/.changeset/honest-turkeys-doubt.md
+++ b/.changeset/honest-turkeys-doubt.md
@@ -1,5 +1,5 @@
 ---
-'@chainlink/gm-token-adapter': patch
+'@chainlink/gm-token-adapter': minor
 ---
 
 Added support for single sided tokens

--- a/packages/composites/gm-token/README.md
+++ b/packages/composites/gm-token/README.md
@@ -1,6 +1,6 @@
 # GM_TOKEN
 
-![0.0.0](https://img.shields.io/github/package-json/v/smartcontractkit/external-adapters-js?filename=packages/composites/gm-token/package.json) ![v3](https://img.shields.io/badge/framework%20version-v3-blueviolet)
+![1.0.5](https://img.shields.io/github/package-json/v/smartcontractkit/external-adapters-js?filename=packages/composites/gm-token/package.json) ![v3](https://img.shields.io/badge/framework%20version-v3-blueviolet)
 
 This document was generated automatically. Please see [README Generator](../../scripts#readme-generator) for more info.
 
@@ -39,12 +39,12 @@ There are no rate limits for this adapter.
 
 ### Input Params
 
-| Required? |  Name  | Aliases |                                     Description                                      |  Type  |                                 Options                                 | Default | Depends On | Not Valid With |
-| :-------: | :----: | :-----: | :----------------------------------------------------------------------------------: | :----: | :---------------------------------------------------------------------: | :-----: | :--------: | :------------: |
-|    ✅     | index  |         | Index token. Long and short tokens will be opened / closed based on this price feed. | string | `ARB`, `BTC`, `DOGE`, `ETH`, `LINK`, `LTC`, `SOL`, `UNI`, `WETH`, `XRP` |         |            |                |
-|    ✅     |  long  |         |             Long token. This is the token that will back long positions.             | string |          `ARB`, `ETH`, `LINK`, `SOL`, `UNI`, `WBTC.b`, `WETH`           |         |            |                |
-|    ✅     | short  |         |            Short token. This is the token that will back short positions.            | string |                                 `USDC`                                  |         |            |                |
-|    ✅     | market |         |                          Market address of the market pool.                          | string |                                                                         |         |            |                |
+| Required? |  Name  | Aliases |                                     Description                                      |  Type  | Options | Default | Depends On | Not Valid With |
+| :-------: | :----: | :-----: | :----------------------------------------------------------------------------------: | :----: | :-----: | :-----: | :--------: | :------------: |
+|    ✅     | index  |         | Index token. Long and short tokens will be opened / closed based on this price feed. | string |         |         |            |                |
+|    ✅     |  long  |         |             Long token. This is the token that will back long positions.             | string |         |         |            |                |
+|    ✅     | short  |         |            Short token. This is the token that will back short positions.            | string |         |         |            |                |
+|    ✅     | market |         |                          Market address of the market pool.                          | string |         |         |            |                |
 
 ### Example
 

--- a/packages/composites/gm-token/src/transport/price.ts
+++ b/packages/composites/gm-token/src/transport/price.ts
@@ -68,6 +68,7 @@ export class GmTokenTransport extends SubscriptionTransport<GmTokenTransportType
       response = await this._handleRequest(param)
     } catch (e) {
       const errorMessage = e instanceof Error ? e.message : 'Unknown error occurred'
+      logger.error(e, errorMessage)
       response = {
         statusCode: 502,
         errorMessage,
@@ -95,9 +96,9 @@ export class GmTokenTransport extends SubscriptionTransport<GmTokenTransportType
       sources,
     } = await this.fetchPrices(assets, providerDataRequestedUnixMs)
 
-    const indexToken = tokenAddresses.arbitrum[index]
-    const longToken = tokenAddresses.arbitrum[long]
-    const shortToken = tokenAddresses.arbitrum[short]
+    const indexToken = tokenAddresses.arbitrum[index as keyof typeof tokenAddresses.arbitrum]
+    const longToken = tokenAddresses.arbitrum[long as keyof typeof tokenAddresses.arbitrum]
+    const shortToken = tokenAddresses.arbitrum[short as keyof typeof tokenAddresses.arbitrum]
 
     const tokenPriceContractParams = [
       this.settings.DATASTORE_CONTRACT_ADDRESS,


### PR DESCRIPTION
[DF-20055](https://smartcontract-it.atlassian.net/browse/DF-20055)

Removed explicit options for EA input params for GM-TOKEN. This ensures that we don't need to change the EA for new single sided tokens in the future

Current single sided tokens

single sided gmBTC
```json
{
  "data": {
    "index":"BTC",
    "long": "WBTC.b",
    "short": "WBTC.b",
    "market": "0x7C11F78Ce78768518D743E81Fdfa2F860C6b9A77"
  }
}
```

single sided gmETH
```json
{
  "data": {
    "index":"ETH",
    "long": "WETH",
    "short": "WETH",
    "market": "0x450bb6774Dd8a756274E0ab4107953259d2ac541"
  }
}
```

[DF-20055]: https://smartcontract-it.atlassian.net/browse/DF-20055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ