### PR TITLE
Minor cleanup for s3-csv-reader

### DIFF
--- a/.changeset/little-lamps-hug.md
+++ b/.changeset/little-lamps-hug.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/s3-csv-reader-adapter': minor
+---
+
+Minor cleanup for s3-csv-reader. Now returns the LastModifed time of the S3 object as providerIndicatedTimeUnixMs.

--- a/packages/sources/s3-csv-reader/README.md
+++ b/packages/sources/s3-csv-reader/README.md
@@ -9,6 +9,7 @@ This document was generated automatically. Please see [README Generator](../../s
 | Required? |         Name          |                                        Description                                        |  Type  | Options | Default |
 | :-------: | :-------------------: | :---------------------------------------------------------------------------------------: | :----: | :-----: | :-----: |
 |           | BACKGROUND_EXECUTE_MS | The amount of time the background execute should sleep before performing the next request | number |         | `10000` |
+|           |     LOOKBACK_DAYS     |      The number of days to look back when querying for the most recent file by date       | number |         |  `10`   |
 
 ---
 
@@ -30,14 +31,14 @@ There are no rate limits for this adapter.
 
 ### Input Params
 
-| Required? |     Name      | Aliases |                                                    Description                                                    |  Type  | Options | Default | Depends On | Not Valid With |
-| :-------: | :-----------: | :-----: | :---------------------------------------------------------------------------------------------------------------: | :----: | :-----: | :-----: | :--------: | :------------: |
-|    ✅     |    bucket     |         |                                              The S3 bucket to query                                               | string |         |         |            |                |
-|    ✅     |      key      | `path`  |                                         The path of the file stored in S3                                         | string |         |         |            |                |
-|    ✅     |   headerRow   |         |                        The 1-indexed row of the CSV file that contains the column headers                         | number |         |         |            |                |
-|    ✅     | matcherColumn |         |                                 The column field to compare with the matcherValue                                 | string |         |         |            |                |
-|    ✅     | matcherValue  |         |                                       The value to match with matcherField                                        | string |         |         |            |                |
-|    ✅     | resultColumn  |         | The column of the CSV file to return a result for, where the row value for matcherColumn is equal to matcherValue | string |         |         |            |                |
+| Required? |     Name      |   Aliases    |                                                    Description                                                    |  Type  | Options | Default | Depends On | Not Valid With |
+| :-------: | :-----------: | :----------: | :---------------------------------------------------------------------------------------------------------------: | :----: | :-----: | :-----: | :--------: | :------------: |
+|    ✅     |    bucket     |              |                                              The S3 bucket to query                                               | string |         |         |            |                |
+|    ✅     |   keyPrefix   | `pathPrefix` |            The path prefix of the file stored in S3. <Date.csv> is appended to search for older files.            | string |         |         |            |                |
+|    ✅     |   headerRow   |              |                        The 1-indexed row of the CSV file that contains the column headers                         | number |         |         |            |                |
+|    ✅     | matcherColumn |              |                                 The column field to compare with the matcherValue                                 | string |         |         |            |                |
+|    ✅     | matcherValue  |              |                                       The value to match with matcherField                                        | string |         |         |            |                |
+|    ✅     | resultColumn  |              | The column of the CSV file to return a result for, where the row value for matcherColumn is equal to matcherValue | string |         |         |            |                |
 
 ### Example
 
@@ -48,7 +49,7 @@ Request:
   "data": {
     "endpoint": "csv",
     "bucket": "s3_bucket",
-    "key": "path/to/file.csv",
+    "keyPrefix": "path/to/file",
     "headerRow": 2,
     "matcherColumn": "matcherColumn",
     "matcherValue": "value",

--- a/packages/sources/s3-csv-reader/src/endpoint/csv.ts
+++ b/packages/sources/s3-csv-reader/src/endpoint/csv.ts
@@ -17,7 +17,7 @@ export const inputParameters = new InputParameters(
       required: true,
       type: 'string',
       description:
-        'The path prefix of the file stored in S3. <Date.csv> is appended to search for older files.',
+        "The path prefix of the file stored in S3. Will be prefixed onto <DATE>.csv to search for older files, e.g. 'path/prefix-01-02-2024.csv'.",
     },
     headerRow: {
       required: true,

--- a/packages/sources/s3-csv-reader/src/transport/csv.ts
+++ b/packages/sources/s3-csv-reader/src/transport/csv.ts
@@ -79,9 +79,9 @@ export class S3PollerTransport extends SubscriptionTransport<TransportTypes> {
     }
 
     const mostRecentKey = datedKeys[latestKeyIndex]
-    const csvFileAsStr = await getFileFromS3(this.s3Client, bucket, mostRecentKey)
+    const { content, lastModified } = await getFileFromS3(this.s3Client, bucket, mostRecentKey)
     const answer = this.findValueInCSV(
-      csvFileAsStr,
+      content,
       headerRow,
       matcherColumn,
       matcherValue,
@@ -97,7 +97,7 @@ export class S3PollerTransport extends SubscriptionTransport<TransportTypes> {
       timestamps: {
         providerDataRequestedUnixMs,
         providerDataReceivedUnixMs: Date.now(),
-        providerIndicatedTimeUnixMs: undefined,
+        providerIndicatedTimeUnixMs: lastModified?.getTime(),
       },
     }
   }


### PR DESCRIPTION
- Return the `LastModifed` time of the S3 object as `providerIndicatedTimeUnixMs`.
- Tweak config description and re-generate README

## Steps to Test
1. Integ tests
2. Unit tests
