### PR TITLE
por-indexer: Override MAX_PAYLOAD_SIZE_LIMIT to default to 5MB

### DIFF
--- a/.changeset/mighty-zoos-battle.md
+++ b/.changeset/mighty-zoos-battle.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/por-indexer-adapter': minor
+---
+
+Override MAX_PAYLOAD_SIZE_LIMIT to default to 5MB.

--- a/packages/sources/por-indexer/src/config/index.ts
+++ b/packages/sources/por-indexer/src/config/index.ts
@@ -23,12 +23,19 @@ export const configDefinition = {
   },
 } as const
 
-export const config = new AdapterConfig({
-  ...configDefinition,
-  BACKGROUND_EXECUTE_MS: {
-    description:
-      'The amount of time the background execute should sleep before performing the next request',
-    type: 'number',
-    default: 10_000,
+export const config = new AdapterConfig(
+  {
+    ...configDefinition,
+    BACKGROUND_EXECUTE_MS: {
+      description:
+        'The amount of time the background execute should sleep before performing the next request',
+      type: 'number',
+      default: 10_000,
+    },
   },
-})
+  {
+    envDefaultOverrides: {
+      MAX_PAYLOAD_SIZE_LIMIT: 5000000,
+    },
+  },
+)


### PR DESCRIPTION
- Default `MAX_PAYLOAD_SIZE_LIMIT` to 5MB for `por-indexer`.
  - We have seen cases where PoR address lists exceed 5MB, and so cause issues as requests get blocked by fastify and so are not processed by the EA.
  - This PR increases the default from [1MB](https://github.com/smartcontractkit/ea-framework-js/blob/1a470a20d77ef1d380c38948001cf4d42f588a66/src/config/index.ts#L169) to 5MB, to increase the headroom before we experience these issues. 
- https://smartcontract-it.atlassian.net/browse/DF-20251

## Quality Assurance

- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [X] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [X] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [X] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [X] This is related to a maximum of one Jira story or GitHub issue.
- [X] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [X] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
