### PR TITLE
fix masterlist.md

### DIFF
--- a/.github/workflows/upsert-release-pr.yml
+++ b/.github/workflows/upsert-release-pr.yml
@@ -58,6 +58,8 @@ jobs:
         uses: ./.github/actions/setup
         with:
           base-branch: ${{ env.UPSTREAM_BRANCH }}
+          # We want to build all packages for the documentation generation step so that the Masterlist is up to date for all EAs
+          build-all: 'true'
       - name: Increase monorepo version
         run: |
           BUMPED_VERSION=$(jq -r '.version | split(".")[1] | tonumber | . + 1 | tostring | "1." + . + ".0"' package.json)


### PR DESCRIPTION
Masterlist.md contains missing information for packages that are not part of a changeset. As the script relies on built files, we need to build all packages before running the masterlist and readme scripts