### PR TITLE
Merc 5642 LWBA invariant validation crypto EAs

### DIFF
--- a/.changeset/stupid-mugs-complain.md
+++ b/.changeset/stupid-mugs-complain.md
@@ -1,0 +1,7 @@
+---
+'@chainlink/elwood-adapter': minor
+'@chainlink/ncfx-adapter': minor
+'@chainlink/gsr-adapter': minor
+---
+
+Added LWBA invariant violation detection

--- a/packages/sources/elwood/src/endpoint/crypto.ts
+++ b/packages/sources/elwood/src/endpoint/crypto.ts
@@ -3,11 +3,13 @@ import {
   DEFAULT_LWBA_ALIASES,
   LwbaResponseDataFields,
   priceEndpointInputParametersDefinition,
+  validateLwbaResponse,
 } from '@chainlink/external-adapter-framework/adapter'
 import { SingleNumberResultResponse } from '@chainlink/external-adapter-framework/util'
 import { InputParameters } from '@chainlink/external-adapter-framework/validation'
 import { config } from '../config'
 import { transport } from '../transport/crypto'
+import { AdapterLWBAError } from '@chainlink/external-adapter-framework/validation/error'
 
 const inputParameters = new InputParameters(priceEndpointInputParametersDefinition, [
   {
@@ -29,4 +31,14 @@ export const cryptoEndpoint = new CryptoPriceEndpoint({
   aliases: ['crypto', ...DEFAULT_LWBA_ALIASES],
   inputParameters,
   transport,
+  customOutputValidation: (output) => {
+    const data = output.data as LwbaResponseDataFields['Data']
+    const error = validateLwbaResponse(data.bid, data.mid, data.ask)
+
+    if (error) {
+      throw new AdapterLWBAError({ statusCode: 500, message: error })
+    }
+
+    return undefined
+  },
 })

--- a/packages/sources/elwood/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/elwood/test/integration/__snapshots__/adapter.test.ts.snap
@@ -11,15 +11,26 @@ exports[`websocket price endpoint should return cached subscribe error 1`] = `
 }
 `;
 
+exports[`websocket price endpoint should return error (LWBA invariant violation) 1`] = `
+{
+  "error": {
+    "message": "Invariant violation. Mid price must be between bid and ask prices. Got: (bid: 10001, mid: 10000, ask: 10002)",
+    "name": "AdapterLWBAError",
+  },
+  "status": "errored",
+  "statusCode": 500,
+}
+`;
+
 exports[`websocket price endpoint should return success 1`] = `
 {
   "data": {
     "ask": 10002,
-    "bid": 10001,
-    "mid": 10000,
-    "result": 10000,
+    "bid": 10000,
+    "mid": 10001,
+    "result": 10001,
   },
-  "result": 10000,
+  "result": 10001,
   "statusCode": 200,
   "timestamps": {
     "providerDataReceivedUnixMs": 1024,

--- a/packages/sources/elwood/test/integration/fixtures.ts
+++ b/packages/sources/elwood/test/integration/fixtures.ts
@@ -1,37 +1,37 @@
 import nock from 'nock'
 import { MockWebsocketServer } from '@chainlink/external-adapter-framework/util/testing-utils'
 
-export const mockSubscribeResponse = (apiKey: string) => {
+export const mockSubscribeResponse = (apiKey: string, symbol: string) => {
   nock(`https://api.chk.elwood.systems`, { encodedQueryParams: true })
     .persist()
     .post(`/v1/stream?apiKey=${apiKey}`, {
       action: 'subscribe',
       stream: 'index',
-      symbol: 'ETH-USD',
+      symbol,
       index_freq: 1000,
     })
     .reply(200, {}, [])
 }
 
-export const mockUnsubscribeResponse = (apiKey: string) => {
+export const mockUnsubscribeResponse = (apiKey: string, symbol: string) => {
   nock(`https://api.chk.elwood.systems`, { encodedQueryParams: true })
     .persist()
     .post(`/v1/stream?apiKey=${apiKey}`, {
       action: 'unsubscribe',
       stream: 'index',
-      symbol: 'ETH-USD',
+      symbol,
       index_freq: 1000,
     })
     .reply(200, {}, [])
 }
 
-export const mockSubscribeError = (apiKey: string) => {
+export const mockSubscribeError = (apiKey: string, symbol: string) => {
   nock(`https://api.chk.elwood.systems`, { encodedQueryParams: true })
     .persist()
     .post(`/v1/stream?apiKey=${apiKey}`, {
       action: 'subscribe',
       stream: 'index',
-      symbol: 'XXX-USD',
+      symbol,
       index_freq: 1000,
     })
     .reply(400, {
@@ -57,11 +57,28 @@ export const mockWebSocketServer = (URL: string) => {
             JSON.stringify({
               type: 'Index',
               data: {
-                price: '10000',
-                bid: '10001',
+                bid: '10000',
+                price: '10001',
                 ask: '10002',
                 symbol: 'ETH-USD',
                 timestamp: '2022-11-08T04:18:18.736534617Z',
+              },
+              sequence: 123,
+            }),
+          ),
+        10,
+      )
+      setTimeout(
+        () =>
+          socket.send(
+            JSON.stringify({
+              type: 'Index',
+              data: {
+                bid: '10001',
+                price: '10000',
+                ask: '10002',
+                symbol: 'BTC-USD',
+                timestamp: '2022-11-08T04:18:19.736534617Z',
               },
               sequence: 123,
             }),

--- a/packages/sources/gsr/src/endpoint/price.ts
+++ b/packages/sources/gsr/src/endpoint/price.ts
@@ -3,11 +3,13 @@ import {
   DEFAULT_LWBA_ALIASES,
   LwbaResponseDataFields,
   priceEndpointInputParametersDefinition,
+  validateLwbaResponse,
 } from '@chainlink/external-adapter-framework/adapter'
 import { SingleNumberResultResponse } from '@chainlink/external-adapter-framework/util'
 import { InputParameters } from '@chainlink/external-adapter-framework/validation'
 import { config } from '../config'
 import { transport } from '../transport/price'
+import { AdapterLWBAError } from '@chainlink/external-adapter-framework/validation/error'
 
 const inputParameters = new InputParameters(priceEndpointInputParametersDefinition, [
   {
@@ -29,4 +31,14 @@ export const endpoint = new CryptoPriceEndpoint({
   aliases: ['price-ws', 'crypto', ...DEFAULT_LWBA_ALIASES],
   transport,
   inputParameters,
+  customOutputValidation: (output) => {
+    const data = output.data as LwbaResponseDataFields['Data']
+    const error = validateLwbaResponse(data.bid, data.mid, data.ask)
+
+    if (error) {
+      throw new AdapterLWBAError({ statusCode: 500, message: error })
+    }
+
+    return undefined
+  },
 })

--- a/packages/sources/gsr/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/gsr/test/integration/__snapshots__/adapter.test.ts.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`websocket websocket endpoint lwba endpoint should return error (invariant violation) 1`] = `
+{
+  "error": {
+    "message": "Invariant violation. LWBA response must contain mid, bid and ask prices. Got: (bid: 1233, mid: 1234, ask: undefined)",
+    "name": "AdapterLWBAError",
+  },
+  "status": "errored",
+  "statusCode": 500,
+}
+`;
+
 exports[`websocket websocket endpoint lwba endpoint should return success 1`] = `
 {
   "data": {

--- a/packages/sources/gsr/test/integration/adapter.test.ts
+++ b/packages/sources/gsr/test/integration/adapter.test.ts
@@ -23,6 +23,11 @@ describe('websocket', () => {
     quote: 'USD',
     endpoint: 'crypto-lwba',
   }
+  const lwbaDataInvariantViolation = {
+    base: 'BTC',
+    quote: 'USD',
+    endpoint: 'crypto-lwba',
+  }
 
   beforeAll(async () => {
     oldEnv = JSON.parse(JSON.stringify(process.env))
@@ -76,6 +81,11 @@ describe('websocket', () => {
           providerDataStreamEstablishedUnixMs: expect.any(Number),
         },
       })
+    })
+
+    it('lwba endpoint should return error (invariant violation)', async () => {
+      const response = await testAdapter.request(lwbaDataInvariantViolation)
+      expect(response.json()).toMatchSnapshot()
     })
 
     it('should return error (empty data)', async () => {

--- a/packages/sources/gsr/test/integration/fixtures.ts
+++ b/packages/sources/gsr/test/integration/fixtures.ts
@@ -41,6 +41,9 @@ const bidPrice = 1233
 const askPrice = 1235
 const time = 1669345393482
 
+const basewLwbaInvariantViolation = 'BTC'
+const askPriceLwbaInvariantViolation = 1222
+
 export const mockWebSocketServer = (URL: string) => {
   const mockWsServer = new MockWebsocketServer(URL, { mock: false })
   mockWsServer.on('connection', (socket) => {
@@ -53,6 +56,18 @@ export const mockWebSocketServer = (URL: string) => {
             price,
             bidPrice,
             askPrice,
+            ts: time * 1e6,
+          },
+        }),
+      )
+      socket.send(
+        JSON.stringify({
+          type: 'ticker',
+          data: {
+            symbol: `${basewLwbaInvariantViolation.toUpperCase()}.${quote.toUpperCase()}`,
+            price,
+            bidPrice,
+            askPriceLwbaInvariantViolation,
             ts: time * 1e6,
           },
         }),

--- a/packages/sources/ncfx/src/endpoint/crypto.ts
+++ b/packages/sources/ncfx/src/endpoint/crypto.ts
@@ -3,6 +3,7 @@ import {
   LwbaResponseDataFields,
   DEFAULT_LWBA_ALIASES,
   priceEndpointInputParametersDefinition,
+  validateLwbaResponse,
 } from '@chainlink/external-adapter-framework/adapter'
 import { config } from '../config'
 import { InputParameters } from '@chainlink/external-adapter-framework/validation'
@@ -14,6 +15,7 @@ import {
 import {
   AdapterError,
   AdapterInputError,
+  AdapterLWBAError,
 } from '@chainlink/external-adapter-framework/validation/error'
 
 // Note: this adapter is intended for the API with endpoint 'wss://cryptofeed.ws.newchangefx.com'.
@@ -54,6 +56,16 @@ export const cryptoEndpoint = new CryptoPriceEndpoint({
   aliases: DEFAULT_LWBA_ALIASES,
   transport,
   customInputValidation,
+  customOutputValidation: (output) => {
+    const data = output.data as LwbaResponseDataFields['Data']
+    const error = validateLwbaResponse(data.bid, data.mid, data.ask)
+
+    if (error) {
+      throw new AdapterLWBAError({ statusCode: 500, message: error })
+    }
+
+    return undefined
+  },
   inputParameters,
   requestTransforms: [
     (req) => {

--- a/packages/sources/ncfx/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/ncfx/test/integration/__snapshots__/adapter.test.ts.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`websocket crypto endpoint should return error (LWBA invariant violation) 1`] = `
+{
+  "error": {
+    "message": "Invariant violation. Mid price must be between bid and ask prices. Got: (bid: 3106.8495, mid: 3106.9885, ask: 3105.1275)",
+    "name": "AdapterLWBAError",
+  },
+  "status": "errored",
+  "statusCode": 500,
+}
+`;
+
 exports[`websocket crypto endpoint should return success 1`] = `
 {
   "data": {

--- a/packages/sources/ncfx/test/integration/adapter.test.ts
+++ b/packages/sources/ncfx/test/integration/adapter.test.ts
@@ -20,6 +20,10 @@ describe('websocket', () => {
     base: 'eth',
     quote: 'usd',
   }
+  const cryptoDataLwbaInvariantViolation = {
+    base: 'btc',
+    quote: 'usd',
+  }
   const forexData = {
     base: 'CAD',
     quote: 'USD',
@@ -50,8 +54,9 @@ describe('websocket', () => {
 
     // Send initial request to start background execute and wait for cache to be filled with results
     await testAdapter.request(cryptoData)
+    await testAdapter.request(cryptoDataLwbaInvariantViolation)
     await testAdapter.request(forexData)
-    await testAdapter.waitForCache(2)
+    await testAdapter.waitForCache(3)
   })
 
   afterAll(async () => {
@@ -81,6 +86,11 @@ describe('websocket', () => {
     it('should return error (empty quote)', async () => {
       const response = await testAdapter.request({ base: 'ETH' })
       expect(response.statusCode).toEqual(400)
+    })
+
+    it('should return error (LWBA invariant violation)', async () => {
+      const response = await testAdapter.request(cryptoDataLwbaInvariantViolation)
+      expect(response.json()).toMatchSnapshot()
     })
   })
 

--- a/packages/sources/ncfx/test/integration/fixtures.ts
+++ b/packages/sources/ncfx/test/integration/fixtures.ts
@@ -17,6 +17,13 @@ export const mockCryptoResponse = {
   offer: 3107.1275,
   mid: 3106.9885,
 }
+export const mockCryptoResponseLwbaInvariantViolation = {
+  timestamp: '2022-08-01T07:15:54.909',
+  currencyPair: 'BTC/USD',
+  bid: 3106.8495,
+  offer: 3105.1275,
+  mid: 3106.9885,
+}
 
 export const mockForexResponse = {
   USDAED: { price: 3.673, timestamp: '2022-08-01T07:14:54.909Z' },
@@ -118,6 +125,7 @@ export const mockCryptoWebSocketServer = (URL: string): MockWebsocketServer => {
     socket.on('message', () => {
       socket.send(JSON.stringify(subscribeResponse))
       socket.send(JSON.stringify(mockCryptoResponse))
+      socket.send(JSON.stringify(mockCryptoResponseLwbaInvariantViolation))
     })
   })
   return mockWsServer


### PR DESCRIPTION
## Closes #MERC-5642

## Description
Added LWBA invariant violation detection to LWBA EAs using CryptoPriceEndpoint
......

## Changes

- Add LWBA customOutputValidation to NCFX, GSR, Elwood. 
- Update integration tests with LWBA validation test

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

- run integration tests
- test manually with cryptolwba endpoint

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [x] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [x] This is related to a maximum of one Jira story or GitHub issue.
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
