### PR TITLE
Disable WS by default for cryptocompare (revert prev. commit)

### DIFF
--- a/.changeset/four-taxis-sit.md
+++ b/.changeset/four-taxis-sit.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/cryptocompare-adapter': minor
+---
+
+Disable WS by default

--- a/packages/sources/cryptocompare/src/config/index.ts
+++ b/packages/sources/cryptocompare/src/config/index.ts
@@ -26,6 +26,6 @@ export const config = new AdapterConfig({
   WS_ENABLED: {
     description: 'Whether data should be returned from websocket or not',
     type: 'boolean',
-    default: true,
+    default: false,
   },
 })

--- a/packages/sources/cryptocompare/test/integration/adapter.test.ts
+++ b/packages/sources/cryptocompare/test/integration/adapter.test.ts
@@ -13,7 +13,6 @@ describe('execute', () => {
   beforeAll(async () => {
     oldEnv = JSON.parse(JSON.stringify(process.env))
     process.env['API_KEY'] = 'API_KEY'
-    process.env['WS_ENABLED'] = 'false'
     const mockDate = new Date('2022-01-01T11:11:11.111Z')
     spy = jest.spyOn(Date, 'now').mockReturnValue(mockDate.getTime())
 


### PR DESCRIPTION
## Description
- Revert a previous change setting `WS_ENABLED` to `true` by default for the cryptocompare EA

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

`yarn && yarn setup`

`yarn test packages/sources/cryptocompare/test/integration/*

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [x] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [x] This is related to a maximum of one Jira story or GitHub issue.
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
