### PR TITLE
DF-20045 - Separate LWBA & price endpoints

### DIFF
--- a/.changeset/curly-fireants-pay.md
+++ b/.changeset/curly-fireants-pay.md
@@ -1,0 +1,7 @@
+---
+'@chainlink/elwood-adapter': minor
+'@chainlink/ncfx-adapter': minor
+'@chainlink/gsr-adapter': minor
+---
+
+Separated price & LWBA endpoints

--- a/.changeset/curly-fireants-pay.md
+++ b/.changeset/curly-fireants-pay.md
@@ -1,6 +1,6 @@
 ---
-'@chainlink/elwood-adapter': minor
-'@chainlink/ncfx-adapter': minor
+'@chainlink/elwood-adapter': major
+'@chainlink/ncfx-adapter': major
 '@chainlink/gsr-adapter': minor
 ---
 

--- a/packages/sources/elwood/src/endpoint/crypto-lwba.ts
+++ b/packages/sources/elwood/src/endpoint/crypto-lwba.ts
@@ -1,0 +1,27 @@
+import {
+  LwbaEndpoint,
+  LwbaResponseDataFields,
+  lwbaEndpointInputParametersDefinition,
+} from '@chainlink/external-adapter-framework/adapter'
+import { InputParameters } from '@chainlink/external-adapter-framework/validation'
+import { config } from '../config'
+import { transport } from '../transport/lwba'
+
+export const inputParameters = new InputParameters(lwbaEndpointInputParametersDefinition, [
+  {
+    base: 'ETH',
+    quote: 'USD',
+  },
+])
+
+export type BaseEndpointTypesLwba = {
+  Parameters: typeof inputParameters.definition
+  Settings: typeof config.settings
+  Response: LwbaResponseDataFields
+}
+
+export const cryptoLwbaEndpoint = new LwbaEndpoint({
+  name: 'crypto-lwba',
+  transport,
+  inputParameters,
+})

--- a/packages/sources/elwood/src/endpoint/crypto.ts
+++ b/packages/sources/elwood/src/endpoint/crypto.ts
@@ -1,15 +1,11 @@
 import {
   CryptoPriceEndpoint,
-  DEFAULT_LWBA_ALIASES,
-  LwbaResponseDataFields,
   priceEndpointInputParametersDefinition,
-  validateLwbaResponse,
 } from '@chainlink/external-adapter-framework/adapter'
 import { SingleNumberResultResponse } from '@chainlink/external-adapter-framework/util'
 import { InputParameters } from '@chainlink/external-adapter-framework/validation'
 import { config } from '../config'
 import { transport } from '../transport/crypto'
-import { AdapterLWBAError } from '@chainlink/external-adapter-framework/validation/error'
 
 const inputParameters = new InputParameters(priceEndpointInputParametersDefinition, [
   {
@@ -18,27 +14,14 @@ const inputParameters = new InputParameters(priceEndpointInputParametersDefiniti
   },
 ])
 
-type OmitResultFromLwba = Omit<LwbaResponseDataFields, 'Result'>
-
 export type BaseEndpointTypes = {
   Parameters: typeof inputParameters.definition
   Settings: typeof config.settings
-  Response: OmitResultFromLwba & SingleNumberResultResponse
+  Response: SingleNumberResultResponse
 }
 
 export const cryptoEndpoint = new CryptoPriceEndpoint({
   name: 'price',
-  aliases: ['crypto', ...DEFAULT_LWBA_ALIASES],
   inputParameters,
   transport,
-  customOutputValidation: (output) => {
-    const data = output.data as LwbaResponseDataFields['Data']
-    const error = validateLwbaResponse(data.bid, data.mid, data.ask)
-
-    if (error) {
-      throw new AdapterLWBAError({ statusCode: 500, message: error })
-    }
-
-    return undefined
-  },
 })

--- a/packages/sources/elwood/src/endpoint/index.ts
+++ b/packages/sources/elwood/src/endpoint/index.ts
@@ -1,1 +1,2 @@
 export { cryptoEndpoint } from './crypto'
+export { cryptoLwbaEndpoint } from './crypto-lwba'

--- a/packages/sources/elwood/src/index.ts
+++ b/packages/sources/elwood/src/index.ts
@@ -1,13 +1,13 @@
 import { expose, ServerInstance } from '@chainlink/external-adapter-framework'
 import { PriceAdapter } from '@chainlink/external-adapter-framework/adapter'
-import { cryptoEndpoint } from './endpoint'
+import { cryptoEndpoint, cryptoLwbaEndpoint } from './endpoint'
 import { config } from './config'
 
 export const adapter = new PriceAdapter({
   name: 'ELWOOD',
   defaultEndpoint: cryptoEndpoint.name,
   config,
-  endpoints: [cryptoEndpoint],
+  endpoints: [cryptoEndpoint, cryptoLwbaEndpoint],
 })
 
 export const server = (): Promise<ServerInstance | undefined> => expose(adapter)

--- a/packages/sources/elwood/src/transport/lwba.ts
+++ b/packages/sources/elwood/src/transport/lwba.ts
@@ -1,0 +1,165 @@
+import { BaseEndpointTypesLwba } from '../endpoint/crypto-lwba'
+import { WebSocketTransport } from '@chainlink/external-adapter-framework/transports'
+import { makeLogger } from '@chainlink/external-adapter-framework/util'
+import { EndpointContext } from '@chainlink/external-adapter-framework/adapter'
+import axios from 'axios'
+
+const logger = makeLogger('ElwoodWsLwba')
+
+const DEFAULT_TRANSPORT_NAME = 'default_single_transport'
+
+export type SubscribeRequest = {
+  action: 'subscribe' | 'unsubscribe'
+  stream: 'index'
+  symbol: string
+  index_freq: number
+}
+
+export type PriceResponse = {
+  type: 'Index'
+  data: {
+    price: string
+    bid: string
+    ask: string
+    symbol: string
+    timestamp: string
+  }
+  sequence: number
+}
+
+export type HeartbeatResponse = {
+  type: 'heartbeat'
+  data: string
+  sequence: number
+}
+
+export type ErrorResponse = {
+  type: unknown
+  error: Record<string, unknown>
+}
+
+export type ResponseMessage = PriceResponse | HeartbeatResponse
+
+export type WsTransportTypes = BaseEndpointTypesLwba & {
+  Provider: {
+    WsMessage: ResponseMessage
+  }
+}
+
+export const transport: WebSocketTransport<WsTransportTypes> =
+  new (class extends WebSocketTransport<WsTransportTypes> {
+    constructor() {
+      super({
+        url: (context) =>
+          `${context.adapterSettings.WS_API_ENDPOINT}?apiKey=${context.adapterSettings.API_KEY}`,
+        handlers: {
+          message(message) {
+            if (message.type !== 'Index') {
+              return
+            }
+
+            if (!message.data) {
+              logger.warn(`Got no data in WS message of type Index`)
+              return
+            }
+
+            if (typeof message.data?.symbol !== 'string') {
+              logger.warn(
+                `Got non string symbol "${message.data?.symbol}" in WS message of type Index`,
+              )
+              return
+            }
+
+            const [base, quote] = message.data.symbol.split('-')
+            if (!base || !quote) {
+              logger.warn(
+                `Got invalid symbol "${message.data?.symbol}" in WS message of type Index`,
+              )
+              return
+            }
+
+            const result = Number(message.data.price)
+            if (result < 0) {
+              logger.warn(`Got invalid price "${message.data.price}" in WS message of type Index`)
+              return
+            }
+
+            return [
+              {
+                params: {
+                  base,
+                  quote,
+                },
+                response: {
+                  result: null,
+                  data: {
+                    bid: Number(message.data.bid),
+                    ask: Number(message.data.ask),
+                    mid: result,
+                  },
+                  timestamps: {
+                    providerIndicatedTimeUnixMs: new Date(message.data.timestamp).getTime(),
+                  },
+                },
+              },
+            ]
+          },
+        },
+        builders: {
+          subscribeMessage: (params): SubscribeRequest => ({
+            action: 'subscribe',
+            stream: 'index',
+            symbol: `${params.base}-${params.quote}`,
+            index_freq: 1_000, // Milliseconds
+          }),
+          unsubscribeMessage: (params): SubscribeRequest => ({
+            action: 'unsubscribe',
+            stream: 'index',
+            symbol: `${params.base}-${params.quote}`,
+            index_freq: 1_000, // Milliseconds
+          }),
+        },
+      })
+    }
+
+    override async sendMessages(
+      context: EndpointContext<WsTransportTypes>,
+      subscribes: SubscribeRequest[],
+      unsubscribes: SubscribeRequest[],
+    ): Promise<void> {
+      const messages = subscribes.concat(unsubscribes)
+      for (const message of messages) {
+        axios
+          .request({
+            url: `${context.adapterSettings.API_ENDPOINT}?apiKey=${context.adapterSettings.API_KEY}`,
+            method: 'post',
+            data: message,
+          })
+          .catch(async (error) => {
+            logger.debug(`Failed to ${message.action} the ${message.symbol} pair`)
+            const base = message.symbol.split('-')[0]
+            const quote = message.symbol.split('-')[1]
+            const defaultErrorMsg = `Failed to ${message.action} the ${message.symbol} pair`
+            if (error.response) {
+              await this.responseCache.write(DEFAULT_TRANSPORT_NAME, [
+                {
+                  params: {
+                    base,
+                    quote,
+                  },
+                  response: {
+                    statusCode: error.response.data['error']['code'] || 500,
+                    errorMessage: error.response.data['error']['message'] || defaultErrorMsg,
+                    timestamps: {
+                      providerDataReceivedUnixMs: Date.now(),
+                      providerIndicatedTimeUnixMs: undefined,
+                      providerDataStreamEstablishedUnixMs: this.providerDataStreamEstablished,
+                    },
+                  },
+                },
+              ])
+            }
+          })
+      }
+    }
+  })()

--- a/packages/sources/elwood/src/transport/lwba.ts
+++ b/packages/sources/elwood/src/transport/lwba.ts
@@ -1,12 +1,13 @@
 import { BaseEndpointTypesLwba } from '../endpoint/crypto-lwba'
 import { WebSocketTransport } from '@chainlink/external-adapter-framework/transports'
 import { makeLogger } from '@chainlink/external-adapter-framework/util'
-import { EndpointContext } from '@chainlink/external-adapter-framework/adapter'
-import axios from 'axios'
+import {
+  DEFAULT_TRANSPORT_NAME,
+  EndpointContext,
+} from '@chainlink/external-adapter-framework/adapter'
+import { buildWsMessage, buildWsUrl, sendMessage, validateWsMessage } from './util'
 
 const logger = makeLogger('ElwoodWsLwba')
-
-const DEFAULT_TRANSPORT_NAME = 'default_single_transport'
 
 export type SubscribeRequest = {
   action: 'subscribe' | 'unsubscribe'
@@ -51,38 +52,14 @@ export const transport: WebSocketTransport<WsTransportTypes> =
     constructor() {
       super({
         url: (context) =>
-          `${context.adapterSettings.WS_API_ENDPOINT}?apiKey=${context.adapterSettings.API_KEY}`,
+          buildWsUrl(context.adapterSettings.WS_API_ENDPOINT, context.adapterSettings.API_KEY),
         handlers: {
           message(message) {
-            if (message.type !== 'Index') {
+            const validatedWsMessage = validateWsMessage(logger, message)
+            if (!validatedWsMessage) {
               return
             }
-
-            if (!message.data) {
-              logger.warn(`Got no data in WS message of type Index`)
-              return
-            }
-
-            if (typeof message.data?.symbol !== 'string') {
-              logger.warn(
-                `Got non string symbol "${message.data?.symbol}" in WS message of type Index`,
-              )
-              return
-            }
-
-            const [base, quote] = message.data.symbol.split('-')
-            if (!base || !quote) {
-              logger.warn(
-                `Got invalid symbol "${message.data?.symbol}" in WS message of type Index`,
-              )
-              return
-            }
-
-            const result = Number(message.data.price)
-            if (result < 0) {
-              logger.warn(`Got invalid price "${message.data.price}" in WS message of type Index`)
-              return
-            }
+            const { base, quote, result, bid, ask, timestamp } = validatedWsMessage
 
             return [
               {
@@ -93,12 +70,12 @@ export const transport: WebSocketTransport<WsTransportTypes> =
                 response: {
                   result: null,
                   data: {
-                    bid: Number(message.data.bid),
-                    ask: Number(message.data.ask),
+                    bid: bid,
+                    ask: ask,
                     mid: result,
                   },
                   timestamps: {
-                    providerIndicatedTimeUnixMs: new Date(message.data.timestamp).getTime(),
+                    providerIndicatedTimeUnixMs: timestamp,
                   },
                 },
               },
@@ -106,18 +83,8 @@ export const transport: WebSocketTransport<WsTransportTypes> =
           },
         },
         builders: {
-          subscribeMessage: (params): SubscribeRequest => ({
-            action: 'subscribe',
-            stream: 'index',
-            symbol: `${params.base}-${params.quote}`,
-            index_freq: 1_000, // Milliseconds
-          }),
-          unsubscribeMessage: (params): SubscribeRequest => ({
-            action: 'unsubscribe',
-            stream: 'index',
-            symbol: `${params.base}-${params.quote}`,
-            index_freq: 1_000, // Milliseconds
-          }),
+          subscribeMessage: (params): SubscribeRequest => buildWsMessage('subscribe', params),
+          unsubscribeMessage: (params): SubscribeRequest => buildWsMessage('unsubscribe', params),
         },
       })
     }
@@ -129,37 +96,35 @@ export const transport: WebSocketTransport<WsTransportTypes> =
     ): Promise<void> {
       const messages = subscribes.concat(unsubscribes)
       for (const message of messages) {
-        axios
-          .request({
-            url: `${context.adapterSettings.API_ENDPOINT}?apiKey=${context.adapterSettings.API_KEY}`,
-            method: 'post',
-            data: message,
-          })
-          .catch(async (error) => {
-            logger.debug(`Failed to ${message.action} the ${message.symbol} pair`)
-            const base = message.symbol.split('-')[0]
-            const quote = message.symbol.split('-')[1]
-            const defaultErrorMsg = `Failed to ${message.action} the ${message.symbol} pair`
-            if (error.response) {
-              await this.responseCache.write(DEFAULT_TRANSPORT_NAME, [
-                {
-                  params: {
-                    base,
-                    quote,
-                  },
-                  response: {
-                    statusCode: error.response.data['error']['code'] || 500,
-                    errorMessage: error.response.data['error']['message'] || defaultErrorMsg,
-                    timestamps: {
-                      providerDataReceivedUnixMs: Date.now(),
-                      providerIndicatedTimeUnixMs: undefined,
-                      providerDataStreamEstablishedUnixMs: this.providerDataStreamEstablished,
-                    },
+        sendMessage(
+          context.adapterSettings.API_ENDPOINT,
+          context.adapterSettings.API_KEY,
+          message,
+        ).catch(async (error) => {
+          logger.debug(`Failed to ${message.action} the ${message.symbol} pair`)
+          const base = message.symbol.split('-')[0]
+          const quote = message.symbol.split('-')[1]
+          const defaultErrorMsg = `Failed to ${message.action} the ${message.symbol} pair`
+          if (error.response) {
+            await this.responseCache.write(DEFAULT_TRANSPORT_NAME, [
+              {
+                params: {
+                  base,
+                  quote,
+                },
+                response: {
+                  statusCode: error.response.data['error']['code'] || 500,
+                  errorMessage: error.response.data['error']['message'] || defaultErrorMsg,
+                  timestamps: {
+                    providerDataReceivedUnixMs: Date.now(),
+                    providerIndicatedTimeUnixMs: undefined,
+                    providerDataStreamEstablishedUnixMs: this.providerDataStreamEstablished,
                   },
                 },
-              ])
-            }
-          })
+              },
+            ])
+          }
+        })
       }
     }
   })()

--- a/packages/sources/elwood/src/transport/util.ts
+++ b/packages/sources/elwood/src/transport/util.ts
@@ -1,0 +1,104 @@
+import axios from 'axios'
+import { makeLogger } from '@chainlink/external-adapter-framework/util'
+
+export type SubscribeRequest = {
+  action: 'subscribe' | 'unsubscribe'
+  stream: 'index'
+  symbol: string
+  index_freq: number
+}
+
+export type PriceResponse = {
+  type: 'Index'
+  data: {
+    price: string
+    bid: string
+    ask: string
+    symbol: string
+    timestamp: string
+  }
+  sequence: number
+}
+
+export type HeartbeatResponse = {
+  type: 'heartbeat'
+  data: string
+  sequence: number
+}
+
+export type ErrorResponse = {
+  type: unknown
+  error: Record<string, unknown>
+}
+
+export type ResponseMessage = PriceResponse | HeartbeatResponse
+
+export type LoggerType = ReturnType<typeof makeLogger>
+
+export interface ValidatedWsMessage {
+  base: string
+  quote: string
+  result: number
+  bid: number
+  ask: number
+  timestamp: number
+}
+
+export const buildWsUrl = (endpoint: string, apiKey: string) => `${endpoint}?apiKey=${apiKey}`
+
+export const validateWsMessage = (
+  logger: LoggerType,
+  message: ResponseMessage,
+): ValidatedWsMessage | null => {
+  if (message.type !== 'Index') {
+    return null
+  }
+
+  if (!message.data) {
+    logger.warn(`Got no data in WS message of type Index`)
+    return null
+  }
+
+  if (typeof message.data?.symbol !== 'string') {
+    logger.warn(`Got non string symbol "${message.data?.symbol}" in WS message of type Index`)
+    return null
+  }
+
+  const [base, quote] = message.data.symbol.split('-')
+  if (!base || !quote) {
+    logger.warn(`Got invalid symbol "${message.data?.symbol}" in WS message of type Index`)
+    return null
+  }
+
+  const result = Number(message.data.price)
+  if (result < 0) {
+    logger.warn(`Got invalid price "${message.data.price}" in WS message of type Index`)
+    return null
+  }
+
+  return {
+    base,
+    quote,
+    result,
+    bid: Number(message.data.bid),
+    ask: Number(message.data.ask),
+    timestamp: new Date(message.data.timestamp).getTime(),
+  }
+}
+
+export const buildWsMessage = (
+  action: 'subscribe' | 'unsubscribe',
+  params: { base: string; quote: string },
+): SubscribeRequest => ({
+  action,
+  stream: 'index',
+  symbol: `${params.base}-${params.quote}`,
+  index_freq: 1_000, // Milliseconds
+})
+
+export const sendMessage = async (endpoint: string, apiKey: string, message: SubscribeRequest) =>
+  axios.request({
+    url: buildWsUrl(endpoint, apiKey),
+    method: 'post',
+    data: message,
+  })

--- a/packages/sources/elwood/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/elwood/test/integration/__snapshots__/adapter.test.ts.snap
@@ -22,12 +22,26 @@ exports[`websocket price endpoint should return error (LWBA invariant violation)
 }
 `;
 
+exports[`websocket price endpoint should return success (LWBA) 1`] = `
+{
+  "data": {
+    "ask": 32.18,
+    "bid": 32.16,
+    "mid": 32.17,
+  },
+  "result": null,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 2034,
+    "providerDataStreamEstablishedUnixMs": 2020,
+    "providerIndicatedTimeUnixMs": 1667881100736,
+  },
+}
+`;
+
 exports[`websocket price endpoint should return success 1`] = `
 {
   "data": {
-    "ask": 10002,
-    "bid": 10000,
-    "mid": 10001,
     "result": 10001,
   },
   "result": 10001,

--- a/packages/sources/elwood/test/integration/adapter.test.ts
+++ b/packages/sources/elwood/test/integration/adapter.test.ts
@@ -22,6 +22,11 @@ describe('websocket', () => {
     base: 'ETH',
     quote: 'USD',
   }
+  const dataLWBA = {
+    endpoint: 'crypto-lwba',
+    base: 'AVAX',
+    quote: 'USD',
+  }
   const dataLWBAInvariantViolation = {
     endpoint: 'crypto-lwba',
     base: 'BTC',
@@ -54,6 +59,13 @@ describe('websocket', () => {
       mockSubscribeResponse(apiKey, `${data.base}-${data.quote}`)
       mockUnsubscribeResponse(apiKey, `${data.base}-${data.quote}`)
       const response = await testAdapter.request(data)
+      expect(response.json()).toMatchSnapshot()
+    })
+
+    it('should return success (LWBA)', async () => {
+      mockSubscribeResponse(apiKey, `${dataLWBA.base}-${dataLWBA.quote}`)
+      mockUnsubscribeResponse(apiKey, `${dataLWBA.base}-${dataLWBA.quote}`)
+      const response = await testAdapter.request(dataLWBA)
       expect(response.json()).toMatchSnapshot()
     })
 

--- a/packages/sources/elwood/test/integration/adapter.test.ts
+++ b/packages/sources/elwood/test/integration/adapter.test.ts
@@ -23,6 +23,7 @@ describe('websocket', () => {
     quote: 'USD',
   }
   const dataLWBAInvariantViolation = {
+    endpoint: 'crypto-lwba',
     base: 'BTC',
     quote: 'USD',
   }

--- a/packages/sources/elwood/test/integration/fixtures.ts
+++ b/packages/sources/elwood/test/integration/fixtures.ts
@@ -85,6 +85,23 @@ export const mockWebSocketServer = (URL: string) => {
           ),
         10,
       )
+      setTimeout(
+        () =>
+          socket.send(
+            JSON.stringify({
+              type: 'Index',
+              data: {
+                bid: '32.16',
+                price: '32.17',
+                ask: '32.18',
+                symbol: 'AVAX-USD',
+                timestamp: '2022-11-08T04:18:20.736534617Z',
+              },
+              sequence: 123,
+            }),
+          ),
+        10,
+      )
     }
     parseMessage()
   })

--- a/packages/sources/gsr/src/adapter.ts
+++ b/packages/sources/gsr/src/adapter.ts
@@ -1,129 +1,14 @@
-import {
-  Adapter,
-  AdapterParams,
-  DEFAULT_LWBA_ALIASES,
-  IncludesFile,
-  PriceEndpoint,
-  PriceEndpointGenerics,
-  PriceEndpointInputParametersDefinition,
-} from '@chainlink/external-adapter-framework/adapter'
+import { DEFAULT_LWBA_ALIASES, PriceAdapter } from '@chainlink/external-adapter-framework/adapter'
 import { SettingsDefinitionMap } from '@chainlink/external-adapter-framework/config'
-import {
-  AdapterRequest,
-  AdapterRequestContext,
-  AdapterResponse,
-} from '@chainlink/external-adapter-framework/util'
+import { AdapterRequest, AdapterResponse } from '@chainlink/external-adapter-framework/util'
 import { AdapterError } from '@chainlink/external-adapter-framework/validation/error'
-import {
-  EmptyInputParameters,
-  TypeFromDefinition,
-} from '@chainlink/external-adapter-framework/validation/input-params'
-
-type IncludeDetails = {
-  from: string
-  to: string
-  inverse: boolean
-}
-type IncludesMap = Record<string, Record<string, IncludeDetails>>
-
-type PriceAdapterRequest<T> = AdapterRequest<T> & {
-  requestContext: AdapterRequestContext<T> & {
-    priceMeta: {
-      inverse: boolean
-    }
-  }
-}
-
-const buildIncludesMap = (includesFile: IncludesFile) => {
-  const includesMap: IncludesMap = {}
-
-  for (const { from, to, includes } of includesFile) {
-    if (!includesMap[from]) {
-      includesMap[from] = {}
-    }
-    includesMap[from][to] = includes[0]
-  }
-
-  return includesMap
-}
+import { EmptyInputParameters } from '@chainlink/external-adapter-framework/validation/input-params'
 
 export class GSRPriceAdapter<
   CustomSettingsDefinition extends SettingsDefinitionMap,
-> extends Adapter<CustomSettingsDefinition> {
-  includesMap?: IncludesMap
-
-  constructor(
-    params: AdapterParams<CustomSettingsDefinition> & {
-      includes?: IncludesFile
-    },
-  ) {
-    const priceEndpoints = params.endpoints.filter(
-      (e) => e instanceof PriceEndpoint,
-    ) as PriceEndpoint<PriceEndpointGenerics>[]
-    if (!priceEndpoints.length) {
-      throw new Error(
-        `This PriceAdapter's list of endpoints does not contain a valid PriceEndpoint`,
-      )
-    }
-
-    super(params)
-
-    if (params.includes) {
-      // Build includes map for constant lookups
-      this.includesMap = buildIncludesMap(params.includes)
-
-      const requestTransform = (req: AdapterRequest<EmptyInputParameters>) => {
-        const priceRequest = req as PriceAdapterRequest<
-          TypeFromDefinition<PriceEndpointInputParametersDefinition>
-        >
-
-        const requestData = priceRequest.requestContext.data
-        if (!requestData.base || !requestData.quote) {
-          return
-        }
-        const includesDetails = this.includesMap?.[requestData.base]?.[requestData.quote]
-
-        if (includesDetails) {
-          requestData.base = includesDetails.from || requestData.base
-          requestData.quote = includesDetails.to || requestData.quote
-        }
-
-        const inverse = includesDetails?.inverse || false
-        priceRequest.requestContext.priceMeta = {
-          inverse,
-        }
-      }
-
-      for (const endpoint of priceEndpoints) {
-        endpoint.requestTransforms?.push(requestTransform)
-      }
-    }
-  }
-
-  override async handleRequest(
-    req: PriceAdapterRequest<PriceEndpointInputParametersDefinition>,
-    replySent: Promise<unknown>,
-  ): Promise<AdapterResponse> {
-    const response = await super.handleRequest(req, replySent)
-
-    if (this.includesMap && req.requestContext.priceMeta?.inverse) {
-      // We need to search in the reverse order (quote -> base) because the request transform will have inverted the pair
-
-      // Deep clone the response, as it may contain objects which won't be cloned by simply destructuring
-      const cloneResponse = JSON.parse(JSON.stringify(response))
-
-      const inverseResult = 1 / (cloneResponse.result as number)
-      cloneResponse.result = inverseResult
-      // Check if response data has a result within it
-      const data = cloneResponse.data as { result: number } | null
-      if (data?.result) {
-        data.result = inverseResult
-      }
-      return cloneResponse
-    }
-
-    return response
-  }
+> extends PriceAdapter<CustomSettingsDefinition> {
+  // List of endpoints to apply validation to. Add any others we need to perform custom validation on here
+  endpointsToValidate = [...DEFAULT_LWBA_ALIASES]
 
   // Custom implementation of validateOutput to execute only for LWBA endpoints
   // This is because we need to use the same transport and cache keys for both price and LWBA endpoints due to the way GSR's API works
@@ -133,9 +18,9 @@ export class GSRPriceAdapter<
   ): AdapterError | undefined {
     const endpointObj = this.endpointsMap[req.requestContext.endpointName]
     const { endpoint = '' } = req.body.data
-    const isLwba = DEFAULT_LWBA_ALIASES.includes(endpoint.toLowerCase())
+    const shouldValidateOutput = this.endpointsToValidate.includes(endpoint.toLowerCase())
 
-    if (endpointObj.customOutputValidation && isLwba) {
+    if (endpointObj.customOutputValidation && shouldValidateOutput) {
       return endpointObj.customOutputValidation(output)
     }
     return undefined

--- a/packages/sources/gsr/src/adapter.ts
+++ b/packages/sources/gsr/src/adapter.ts
@@ -1,0 +1,143 @@
+import {
+  Adapter,
+  AdapterParams,
+  DEFAULT_LWBA_ALIASES,
+  IncludesFile,
+  PriceEndpoint,
+  PriceEndpointGenerics,
+  PriceEndpointInputParametersDefinition,
+} from '@chainlink/external-adapter-framework/adapter'
+import { SettingsDefinitionMap } from '@chainlink/external-adapter-framework/config'
+import {
+  AdapterRequest,
+  AdapterRequestContext,
+  AdapterResponse,
+} from '@chainlink/external-adapter-framework/util'
+import { AdapterError } from '@chainlink/external-adapter-framework/validation/error'
+import {
+  EmptyInputParameters,
+  TypeFromDefinition,
+} from '@chainlink/external-adapter-framework/validation/input-params'
+
+type IncludeDetails = {
+  from: string
+  to: string
+  inverse: boolean
+}
+type IncludesMap = Record<string, Record<string, IncludeDetails>>
+
+type PriceAdapterRequest<T> = AdapterRequest<T> & {
+  requestContext: AdapterRequestContext<T> & {
+    priceMeta: {
+      inverse: boolean
+    }
+  }
+}
+
+const buildIncludesMap = (includesFile: IncludesFile) => {
+  const includesMap: IncludesMap = {}
+
+  for (const { from, to, includes } of includesFile) {
+    if (!includesMap[from]) {
+      includesMap[from] = {}
+    }
+    includesMap[from][to] = includes[0]
+  }
+
+  return includesMap
+}
+
+export class GSRPriceAdapter<
+  CustomSettingsDefinition extends SettingsDefinitionMap,
+> extends Adapter<CustomSettingsDefinition> {
+  includesMap?: IncludesMap
+
+  constructor(
+    params: AdapterParams<CustomSettingsDefinition> & {
+      includes?: IncludesFile
+    },
+  ) {
+    const priceEndpoints = params.endpoints.filter(
+      (e) => e instanceof PriceEndpoint,
+    ) as PriceEndpoint<PriceEndpointGenerics>[]
+    if (!priceEndpoints.length) {
+      throw new Error(
+        `This PriceAdapter's list of endpoints does not contain a valid PriceEndpoint`,
+      )
+    }
+
+    super(params)
+
+    if (params.includes) {
+      // Build includes map for constant lookups
+      this.includesMap = buildIncludesMap(params.includes)
+
+      const requestTransform = (req: AdapterRequest<EmptyInputParameters>) => {
+        const priceRequest = req as PriceAdapterRequest<
+          TypeFromDefinition<PriceEndpointInputParametersDefinition>
+        >
+
+        const requestData = priceRequest.requestContext.data
+        if (!requestData.base || !requestData.quote) {
+          return
+        }
+        const includesDetails = this.includesMap?.[requestData.base]?.[requestData.quote]
+
+        if (includesDetails) {
+          requestData.base = includesDetails.from || requestData.base
+          requestData.quote = includesDetails.to || requestData.quote
+        }
+
+        const inverse = includesDetails?.inverse || false
+        priceRequest.requestContext.priceMeta = {
+          inverse,
+        }
+      }
+
+      for (const endpoint of priceEndpoints) {
+        endpoint.requestTransforms?.push(requestTransform)
+      }
+    }
+  }
+
+  override async handleRequest(
+    req: PriceAdapterRequest<PriceEndpointInputParametersDefinition>,
+    replySent: Promise<unknown>,
+  ): Promise<AdapterResponse> {
+    const response = await super.handleRequest(req, replySent)
+
+    if (this.includesMap && req.requestContext.priceMeta?.inverse) {
+      // We need to search in the reverse order (quote -> base) because the request transform will have inverted the pair
+
+      // Deep clone the response, as it may contain objects which won't be cloned by simply destructuring
+      const cloneResponse = JSON.parse(JSON.stringify(response))
+
+      const inverseResult = 1 / (cloneResponse.result as number)
+      cloneResponse.result = inverseResult
+      // Check if response data has a result within it
+      const data = cloneResponse.data as { result: number } | null
+      if (data?.result) {
+        data.result = inverseResult
+      }
+      return cloneResponse
+    }
+
+    return response
+  }
+
+  // Custom implementation of validateOutput to execute only for LWBA endpoints
+  // This is because we need to use the same transport and cache keys for both price and LWBA endpoints due to the way GSR's API works
+  override validateOutput(
+    req: AdapterRequest<EmptyInputParameters>,
+    output: Readonly<AdapterResponse>,
+  ): AdapterError | undefined {
+    const endpointObj = this.endpointsMap[req.requestContext.endpointName]
+    const { endpoint = '' } = req.body.data
+    const isLwba = DEFAULT_LWBA_ALIASES.includes(endpoint.toLowerCase())
+
+    if (endpointObj.customOutputValidation && isLwba) {
+      return endpointObj.customOutputValidation(output)
+    }
+    return undefined
+  }
+}

--- a/packages/sources/gsr/src/index.ts
+++ b/packages/sources/gsr/src/index.ts
@@ -1,9 +1,9 @@
 import { expose, ServerInstance } from '@chainlink/external-adapter-framework'
-import { PriceAdapter } from '@chainlink/external-adapter-framework/adapter'
 import { config } from './config'
 import { price } from './endpoint'
+import { GSRPriceAdapter } from './adapter'
 
-export const adapter = new PriceAdapter({
+export const adapter = new GSRPriceAdapter({
   defaultEndpoint: price.name,
   name: 'GSR',
   endpoints: [price],

--- a/packages/sources/ncfx/src/endpoint/crypto-lwba.ts
+++ b/packages/sources/ncfx/src/endpoint/crypto-lwba.ts
@@ -1,0 +1,29 @@
+import {
+  LwbaEndpoint,
+  LwbaResponseDataFields,
+  lwbaEndpointInputParametersDefinition,
+} from '@chainlink/external-adapter-framework/adapter'
+import { InputParameters } from '@chainlink/external-adapter-framework/validation'
+import { config } from '../config'
+import { transport } from '../transport/lwba'
+import { customInputValidation } from './crypto'
+
+export const inputParameters = new InputParameters(lwbaEndpointInputParametersDefinition, [
+  {
+    base: 'ETH',
+    quote: 'USD',
+  },
+])
+
+export type BaseEndpointTypesLwba = {
+  Parameters: typeof inputParameters.definition
+  Settings: typeof config.settings
+  Response: LwbaResponseDataFields
+}
+
+export const cryptoLwbaEndpoint = new LwbaEndpoint({
+  name: 'crypto-lwba',
+  customInputValidation,
+  transport,
+  inputParameters,
+})

--- a/packages/sources/ncfx/src/endpoint/crypto.ts
+++ b/packages/sources/ncfx/src/endpoint/crypto.ts
@@ -1,9 +1,6 @@
 import {
   CryptoPriceEndpoint,
-  LwbaResponseDataFields,
-  DEFAULT_LWBA_ALIASES,
   priceEndpointInputParametersDefinition,
-  validateLwbaResponse,
 } from '@chainlink/external-adapter-framework/adapter'
 import { config } from '../config'
 import { InputParameters } from '@chainlink/external-adapter-framework/validation'
@@ -15,7 +12,6 @@ import {
 import {
   AdapterError,
   AdapterInputError,
-  AdapterLWBAError,
 } from '@chainlink/external-adapter-framework/validation/error'
 
 // Note: this adapter is intended for the API with endpoint 'wss://cryptofeed.ws.newchangefx.com'.
@@ -30,11 +26,9 @@ export const inputParameters = new InputParameters(priceEndpointInputParametersD
   },
 ])
 
-type OmitResultFromLwba = Omit<LwbaResponseDataFields, 'Result'>
-
 export type BaseEndpointTypes = {
   Parameters: typeof inputParameters.definition
-  Response: OmitResultFromLwba & SingleNumberResultResponse
+  Response: SingleNumberResultResponse
   Settings: typeof config.settings
 }
 
@@ -53,19 +47,8 @@ export function customInputValidation(
 
 export const cryptoEndpoint = new CryptoPriceEndpoint({
   name: 'crypto',
-  aliases: DEFAULT_LWBA_ALIASES,
   transport,
   customInputValidation,
-  customOutputValidation: (output) => {
-    const data = output.data as LwbaResponseDataFields['Data']
-    const error = validateLwbaResponse(data.bid, data.mid, data.ask)
-
-    if (error) {
-      throw new AdapterLWBAError({ statusCode: 500, message: error })
-    }
-
-    return undefined
-  },
   inputParameters,
   requestTransforms: [
     (req) => {

--- a/packages/sources/ncfx/src/endpoint/index.ts
+++ b/packages/sources/ncfx/src/endpoint/index.ts
@@ -1,2 +1,3 @@
 export { cryptoEndpoint as crypto } from './crypto'
+export { cryptoLwbaEndpoint as lwba } from './crypto-lwba'
 export { forexEndpoint as forex } from './forex'

--- a/packages/sources/ncfx/src/index.ts
+++ b/packages/sources/ncfx/src/index.ts
@@ -2,11 +2,11 @@ import { expose, ServerInstance } from '@chainlink/external-adapter-framework'
 import { PriceAdapter } from '@chainlink/external-adapter-framework/adapter'
 import { config } from './config'
 import includes from './config/includes.json'
-import { crypto, forex } from './endpoint'
+import { crypto, forex, lwba } from './endpoint'
 
 export const adapter = new PriceAdapter({
   name: 'NCFX',
-  endpoints: [crypto, forex],
+  endpoints: [crypto, lwba, forex],
   defaultEndpoint: crypto.name,
   config,
   includes,

--- a/packages/sources/ncfx/src/transport/lwba.ts
+++ b/packages/sources/ncfx/src/transport/lwba.ts
@@ -1,8 +1,8 @@
 import { WebSocketTransport } from '@chainlink/external-adapter-framework/transports'
-import { BaseEndpointTypes } from '../endpoint/crypto'
 import { makeLogger } from '@chainlink/external-adapter-framework/util'
+import { BaseEndpointTypesLwba } from '../endpoint/crypto-lwba'
 
-const logger = makeLogger('NcfxCryptoEndpoint')
+const logger = makeLogger('NcfxLwbaEndpoint')
 
 type WsMessage = WsInfoMessage | WsPriceMessage
 
@@ -19,7 +19,7 @@ type WsPriceMessage = {
   mid?: number // e.g. 1595.5346
 }
 
-type WsTransportTypes = BaseEndpointTypes & {
+type WsTransportTypes = BaseEndpointTypesLwba & {
   Provider: {
     WsMessage: WsMessage
   }
@@ -74,9 +74,11 @@ export const transport = new WebSocketTransport<WsTransportTypes>({
         {
           params: { base, quote },
           response: {
-            result: message.mid || 0, // Already validated in the filter above
+            result: null,
             data: {
-              result: message.mid || 0, // Already validated in the filter above
+              bid: message.bid || 0,
+              mid: message.mid || 0,
+              ask: message.offer || 0,
             },
             timestamps: {
               providerIndicatedTimeUnixMs: new Date(providerTime).getTime(),

--- a/packages/sources/ncfx/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/ncfx/test/integration/__snapshots__/adapter.test.ts.snap
@@ -1,22 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`websocket crypto endpoint should return error (LWBA invariant violation) 1`] = `
-{
-  "error": {
-    "message": "Invariant violation. Mid price must be between bid and ask prices. Got: (bid: 3106.8495, mid: 3106.9885, ask: 3105.1275)",
-    "name": "AdapterLWBAError",
-  },
-  "status": "errored",
-  "statusCode": 500,
-}
-`;
-
 exports[`websocket crypto endpoint should return success 1`] = `
 {
   "data": {
-    "ask": 3107.1275,
-    "bid": 3106.8495,
-    "mid": 3106.9885,
     "result": 3106.9885,
   },
   "result": 3106.9885,
@@ -40,6 +26,34 @@ exports[`websocket forex endpoint should return success 1`] = `
     "providerDataReceivedUnixMs": 1018,
     "providerDataStreamEstablishedUnixMs": 1010,
     "providerIndicatedTimeUnixMs": 1659338092107,
+  },
+}
+`;
+
+exports[`websocket lwba endpoint should return error (LWBA invariant violation) 1`] = `
+{
+  "error": {
+    "message": "Invariant violation. Mid price must be between bid and ask prices. Got: (bid: 3106.8495, mid: 3106.9885, ask: 3105.1275)",
+    "name": "AdapterLWBAError",
+  },
+  "status": "errored",
+  "statusCode": 500,
+}
+`;
+
+exports[`websocket lwba endpoint should return success 1`] = `
+{
+  "data": {
+    "ask": 28.2,
+    "bid": 28.1,
+    "mid": 28.15,
+  },
+  "result": null,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 1018,
+    "providerDataStreamEstablishedUnixMs": 1010,
+    "providerIndicatedTimeUnixMs": 1659338154909,
   },
 }
 `;

--- a/packages/sources/ncfx/test/integration/adapter.test.ts
+++ b/packages/sources/ncfx/test/integration/adapter.test.ts
@@ -20,7 +20,13 @@ describe('websocket', () => {
     base: 'eth',
     quote: 'usd',
   }
+  const cryptoDataLwba = {
+    endpoint: 'crypto-lwba',
+    base: 'avax',
+    quote: 'usd',
+  }
   const cryptoDataLwbaInvariantViolation = {
+    endpoint: 'crypto-lwba',
     base: 'btc',
     quote: 'usd',
   }
@@ -54,9 +60,10 @@ describe('websocket', () => {
 
     // Send initial request to start background execute and wait for cache to be filled with results
     await testAdapter.request(cryptoData)
+    await testAdapter.request(cryptoDataLwba)
     await testAdapter.request(cryptoDataLwbaInvariantViolation)
     await testAdapter.request(forexData)
-    await testAdapter.waitForCache(3)
+    await testAdapter.waitForCache(7)
   })
 
   afterAll(async () => {
@@ -86,6 +93,13 @@ describe('websocket', () => {
     it('should return error (empty quote)', async () => {
       const response = await testAdapter.request({ base: 'ETH' })
       expect(response.statusCode).toEqual(400)
+    })
+  })
+
+  describe('lwba endpoint', () => {
+    it('should return success', async () => {
+      const response = await testAdapter.request(cryptoDataLwba)
+      expect(response.json()).toMatchSnapshot()
     })
 
     it('should return error (LWBA invariant violation)', async () => {

--- a/packages/sources/ncfx/test/integration/fixtures.ts
+++ b/packages/sources/ncfx/test/integration/fixtures.ts
@@ -17,6 +17,13 @@ export const mockCryptoResponse = {
   offer: 3107.1275,
   mid: 3106.9885,
 }
+export const mockCryptoResponseLwba = {
+  timestamp: '2022-08-01T07:15:54.909',
+  currencyPair: 'AVAX/USD',
+  bid: 28.1,
+  offer: 28.2,
+  mid: 28.15,
+}
 export const mockCryptoResponseLwbaInvariantViolation = {
   timestamp: '2022-08-01T07:15:54.909',
   currencyPair: 'BTC/USD',
@@ -125,6 +132,7 @@ export const mockCryptoWebSocketServer = (URL: string): MockWebsocketServer => {
     socket.on('message', () => {
       socket.send(JSON.stringify(subscribeResponse))
       socket.send(JSON.stringify(mockCryptoResponse))
+      socket.send(JSON.stringify(mockCryptoResponseLwba))
       socket.send(JSON.stringify(mockCryptoResponseLwbaInvariantViolation))
     })
   })


### PR DESCRIPTION
## Closes #DF-20045

## Description
A follow up to the LWBA validation changes. This PR separates LWBA & price endpoints in:
- Elwood
- NCFX

and updates GSR to use a custom Adapter implementation, allowing LWBA validation while using the same transport & cache keys for price & LWBA endpoints. This was necessary because GSR doesn't allow multiple WS connections and doesn't seem to handle multiple subscription requests from the same connection well.

......


## Steps to Test

- yarn test:unit
- yarn test:integration

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [x] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [x] This is related to a maximum of one Jira story or GitHub issue.
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
