### PR TITLE
Updated balancer EA READMEs with descriptions for MAX_PAYLOAD_SIZE_LIMIT

### DIFF
--- a/packages/sources/amberdata/README.md
+++ b/packages/sources/amberdata/README.md
@@ -6,6 +6,12 @@ Base URL wss://ws.web3api.io
 
 This document was generated automatically. Please see [README Generator](../../scripts#readme-generator) for more info.
 
+## Known Issues
+
+### MAX_PAYLOAD_SIZE_LIMIT configuration
+
+The `MAX_PAYLOAD_SIZE_LIMIT` environment variable is used for controlling the maximum size of the incoming request body that the EA can handle. If you decide to customize this value it's essential to ensure that any reverse proxy or web server in front of the EA, such as Nginx, is also configured with a corresponding limit. This alignment prevents scenarios where Nginx rejects a request for exceeding its payload size limit before it reaches the EA.
+
 ## Environment Variables
 
 | Required? |      Name       |  Description   |  Type  | Options |        Default        |

--- a/packages/sources/amberdata/docs/known-issues.md
+++ b/packages/sources/amberdata/docs/known-issues.md
@@ -1,9 +1,5 @@
 ## Known Issues
 
-### ETH Beacon API version
-
-Starting from version 3.0.0, the eth-beacon EA is compatible with the ETH Beacon API(`ETH_CONSENSUS_RPC_URL`) version 2.5.0 or later. If you are using an older version of the ETH Beacon API, you will need to upgrade it to 2.5.0 or later to use the eth-beacon EA.
-
 ### MAX_PAYLOAD_SIZE_LIMIT configuration
 
 The `MAX_PAYLOAD_SIZE_LIMIT` environment variable is used for controlling the maximum size of the incoming request body that the EA can handle. If you decide to customize this value it's essential to ensure that any reverse proxy or web server in front of the EA, such as Nginx, is also configured with a corresponding limit. This alignment prevents scenarios where Nginx rejects a request for exceeding its payload size limit before it reaches the EA.

--- a/packages/sources/avalanche-platform/README.md
+++ b/packages/sources/avalanche-platform/README.md
@@ -4,6 +4,12 @@
 
 This document was generated automatically. Please see [README Generator](../../scripts#readme-generator) for more info.
 
+## Known Issues
+
+### MAX_PAYLOAD_SIZE_LIMIT configuration
+
+The `MAX_PAYLOAD_SIZE_LIMIT` environment variable is used for controlling the maximum size of the incoming request body that the EA can handle. If you decide to customize this value it's essential to ensure that any reverse proxy or web server in front of the EA, such as Nginx, is also configured with a corresponding limit. This alignment prevents scenarios where Nginx rejects a request for exceeding its payload size limit before it reaches the EA.
+
 ## Environment Variables
 
 | Required? |      Name       |                                      Description                                       |  Type  | Options | Default |

--- a/packages/sources/avalanche-platform/docs/known-issues.md
+++ b/packages/sources/avalanche-platform/docs/known-issues.md
@@ -1,9 +1,5 @@
 ## Known Issues
 
-### ETH Beacon API version
-
-Starting from version 3.0.0, the eth-beacon EA is compatible with the ETH Beacon API(`ETH_CONSENSUS_RPC_URL`) version 2.5.0 or later. If you are using an older version of the ETH Beacon API, you will need to upgrade it to 2.5.0 or later to use the eth-beacon EA.
-
 ### MAX_PAYLOAD_SIZE_LIMIT configuration
 
 The `MAX_PAYLOAD_SIZE_LIMIT` environment variable is used for controlling the maximum size of the incoming request body that the EA can handle. If you decide to customize this value it's essential to ensure that any reverse proxy or web server in front of the EA, such as Nginx, is also configured with a corresponding limit. This alignment prevents scenarios where Nginx rejects a request for exceeding its payload size limit before it reaches the EA.

--- a/packages/sources/blockcypher/README.md
+++ b/packages/sources/blockcypher/README.md
@@ -6,6 +6,12 @@ Queries BTC address balance from blockcypher.com
 
 This document was generated automatically. Please see [README Generator](../../scripts#readme-generator) for more info.
 
+## Known Issues
+
+### MAX_PAYLOAD_SIZE_LIMIT configuration
+
+The `MAX_PAYLOAD_SIZE_LIMIT` environment variable is used for controlling the maximum size of the incoming request body that the EA can handle. If you decide to customize this value it's essential to ensure that any reverse proxy or web server in front of the EA, such as Nginx, is also configured with a corresponding limit. This alignment prevents scenarios where Nginx rejects a request for exceeding its payload size limit before it reaches the EA.
+
 ## Environment Variables
 
 | Required? |  Name   |          Description           |  Type  | Options | Default |

--- a/packages/sources/blockcypher/docs/known-issues.md
+++ b/packages/sources/blockcypher/docs/known-issues.md
@@ -1,9 +1,5 @@
 ## Known Issues
 
-### ETH Beacon API version
-
-Starting from version 3.0.0, the eth-beacon EA is compatible with the ETH Beacon API(`ETH_CONSENSUS_RPC_URL`) version 2.5.0 or later. If you are using an older version of the ETH Beacon API, you will need to upgrade it to 2.5.0 or later to use the eth-beacon EA.
-
 ### MAX_PAYLOAD_SIZE_LIMIT configuration
 
 The `MAX_PAYLOAD_SIZE_LIMIT` environment variable is used for controlling the maximum size of the incoming request body that the EA can handle. If you decide to customize this value it's essential to ensure that any reverse proxy or web server in front of the EA, such as Nginx, is also configured with a corresponding limit. This alignment prevents scenarios where Nginx rejects a request for exceeding its payload size limit before it reaches the EA.

--- a/packages/sources/btc.com/README.md
+++ b/packages/sources/btc.com/README.md
@@ -6,6 +6,12 @@ Base URL https://chain.api.btc.com
 
 This document was generated automatically. Please see [README Generator](../../scripts#readme-generator) for more info.
 
+## Known Issues
+
+### MAX_PAYLOAD_SIZE_LIMIT configuration
+
+The `MAX_PAYLOAD_SIZE_LIMIT` environment variable is used for controlling the maximum size of the incoming request body that the EA can handle. If you decide to customize this value it's essential to ensure that any reverse proxy or web server in front of the EA, such as Nginx, is also configured with a corresponding limit. This alignment prevents scenarios where Nginx rejects a request for exceeding its payload size limit before it reaches the EA.
+
 ## Environment Variables
 
 | Required? |     Name     | Description |  Type  | Options |           Default           |

--- a/packages/sources/btc.com/docs/known-issues.md
+++ b/packages/sources/btc.com/docs/known-issues.md
@@ -1,9 +1,5 @@
 ## Known Issues
 
-### ETH Beacon API version
-
-Starting from version 3.0.0, the eth-beacon EA is compatible with the ETH Beacon API(`ETH_CONSENSUS_RPC_URL`) version 2.5.0 or later. If you are using an older version of the ETH Beacon API, you will need to upgrade it to 2.5.0 or later to use the eth-beacon EA.
-
 ### MAX_PAYLOAD_SIZE_LIMIT configuration
 
 The `MAX_PAYLOAD_SIZE_LIMIT` environment variable is used for controlling the maximum size of the incoming request body that the EA can handle. If you decide to customize this value it's essential to ensure that any reverse proxy or web server in front of the EA, such as Nginx, is also configured with a corresponding limit. This alignment prevents scenarios where Nginx rejects a request for exceeding its payload size limit before it reaches the EA.

--- a/packages/sources/cryptoapis/README.md
+++ b/packages/sources/cryptoapis/README.md
@@ -4,6 +4,12 @@
 
 This document was generated automatically. Please see [README Generator](../../scripts#readme-generator) for more info.
 
+## Known Issues
+
+### MAX_PAYLOAD_SIZE_LIMIT configuration
+
+The `MAX_PAYLOAD_SIZE_LIMIT` environment variable is used for controlling the maximum size of the incoming request body that the EA can handle. If you decide to customize this value it's essential to ensure that any reverse proxy or web server in front of the EA, such as Nginx, is also configured with a corresponding limit. This alignment prevents scenarios where Nginx rejects a request for exceeding its payload size limit before it reaches the EA.
+
 ## Environment Variables
 
 | Required? |    Name     |                             Description                             |  Type  | Options | Default |

--- a/packages/sources/cryptoapis/docs/known-issues.md
+++ b/packages/sources/cryptoapis/docs/known-issues.md
@@ -1,9 +1,5 @@
 ## Known Issues
 
-### ETH Beacon API version
-
-Starting from version 3.0.0, the eth-beacon EA is compatible with the ETH Beacon API(`ETH_CONSENSUS_RPC_URL`) version 2.5.0 or later. If you are using an older version of the ETH Beacon API, you will need to upgrade it to 2.5.0 or later to use the eth-beacon EA.
-
 ### MAX_PAYLOAD_SIZE_LIMIT configuration
 
 The `MAX_PAYLOAD_SIZE_LIMIT` environment variable is used for controlling the maximum size of the incoming request body that the EA can handle. If you decide to customize this value it's essential to ensure that any reverse proxy or web server in front of the EA, such as Nginx, is also configured with a corresponding limit. This alignment prevents scenarios where Nginx rejects a request for exceeding its payload size limit before it reaches the EA.

--- a/packages/sources/eth-balance/README.md
+++ b/packages/sources/eth-balance/README.md
@@ -6,6 +6,12 @@ External adapter for fetching balances for ETH addresses
 
 This document was generated automatically. Please see [README Generator](../../scripts#readme-generator) for more info.
 
+## Known Issues
+
+### MAX_PAYLOAD_SIZE_LIMIT configuration
+
+The `MAX_PAYLOAD_SIZE_LIMIT` environment variable is used for controlling the maximum size of the incoming request body that the EA can handle. If you decide to customize this value it's essential to ensure that any reverse proxy or web server in front of the EA, such as Nginx, is also configured with a corresponding limit. This alignment prevents scenarios where Nginx rejects a request for exceeding its payload size limit before it reaches the EA.
+
 ## Environment Variables
 
 | Required? |       Name        |         Description         |  Type  | Options | Default |

--- a/packages/sources/eth-balance/docs/known-issues.md
+++ b/packages/sources/eth-balance/docs/known-issues.md
@@ -1,9 +1,5 @@
 ## Known Issues
 
-### ETH Beacon API version
-
-Starting from version 3.0.0, the eth-beacon EA is compatible with the ETH Beacon API(`ETH_CONSENSUS_RPC_URL`) version 2.5.0 or later. If you are using an older version of the ETH Beacon API, you will need to upgrade it to 2.5.0 or later to use the eth-beacon EA.
-
 ### MAX_PAYLOAD_SIZE_LIMIT configuration
 
 The `MAX_PAYLOAD_SIZE_LIMIT` environment variable is used for controlling the maximum size of the incoming request body that the EA can handle. If you decide to customize this value it's essential to ensure that any reverse proxy or web server in front of the EA, such as Nginx, is also configured with a corresponding limit. This alignment prevents scenarios where Nginx rejects a request for exceeding its payload size limit before it reaches the EA.

--- a/packages/sources/eth-beacon/README.md
+++ b/packages/sources/eth-beacon/README.md
@@ -10,6 +10,10 @@ This document was generated automatically. Please see [README Generator](../../s
 
 Starting from version 3.0.0, the eth-beacon EA is compatible with the ETH Beacon API(`ETH_CONSENSUS_RPC_URL`) version 2.5.0 or later. If you are using an older version of the ETH Beacon API, you will need to upgrade it to 2.5.0 or later to use the eth-beacon EA.
 
+### MAX_PAYLOAD_SIZE_LIMIT configuration
+
+The `MAX_PAYLOAD_SIZE_LIMIT` environment variable is used for controlling the maximum size of the incoming request body that the EA can handle. If you decide to customize this value it's essential to ensure that any reverse proxy or web server in front of the EA, such as Nginx, is also configured with a corresponding limit. This alignment prevents scenarios where Nginx rejects a request for exceeding its payload size limit before it reaches the EA.
+
 ## Environment Variables
 
 | Required? |         Name          |                                                                                                                    Description                                                                                                                    |  Type  | Options | Default |

--- a/packages/sources/lotus/README.md
+++ b/packages/sources/lotus/README.md
@@ -4,6 +4,12 @@
 
 This document was generated automatically. Please see [README Generator](../../scripts#readme-generator) for more info.
 
+## Known Issues
+
+### MAX_PAYLOAD_SIZE_LIMIT configuration
+
+The `MAX_PAYLOAD_SIZE_LIMIT` environment variable is used for controlling the maximum size of the incoming request body that the EA can handle. If you decide to customize this value it's essential to ensure that any reverse proxy or web server in front of the EA, such as Nginx, is also configured with a corresponding limit. This alignment prevents scenarios where Nginx rejects a request for exceeding its payload size limit before it reaches the EA.
+
 ## Environment Variables
 
 | Required? |         Name          |                                            Description                                             |  Type  | Options | Default |

--- a/packages/sources/lotus/docs/known-issues.md
+++ b/packages/sources/lotus/docs/known-issues.md
@@ -1,9 +1,5 @@
 ## Known Issues
 
-### ETH Beacon API version
-
-Starting from version 3.0.0, the eth-beacon EA is compatible with the ETH Beacon API(`ETH_CONSENSUS_RPC_URL`) version 2.5.0 or later. If you are using an older version of the ETH Beacon API, you will need to upgrade it to 2.5.0 or later to use the eth-beacon EA.
-
 ### MAX_PAYLOAD_SIZE_LIMIT configuration
 
 The `MAX_PAYLOAD_SIZE_LIMIT` environment variable is used for controlling the maximum size of the incoming request body that the EA can handle. If you decide to customize this value it's essential to ensure that any reverse proxy or web server in front of the EA, such as Nginx, is also configured with a corresponding limit. This alignment prevents scenarios where Nginx rejects a request for exceeding its payload size limit before it reaches the EA.

--- a/packages/sources/polkadot-balance/README.md
+++ b/packages/sources/polkadot-balance/README.md
@@ -4,6 +4,12 @@
 
 This document was generated automatically. Please see [README Generator](../../scripts#readme-generator) for more info.
 
+## Known Issues
+
+### MAX_PAYLOAD_SIZE_LIMIT configuration
+
+The `MAX_PAYLOAD_SIZE_LIMIT` environment variable is used for controlling the maximum size of the incoming request body that the EA can handle. If you decide to customize this value it's essential to ensure that any reverse proxy or web server in front of the EA, such as Nginx, is also configured with a corresponding limit. This alignment prevents scenarios where Nginx rejects a request for exceeding its payload size limit before it reaches the EA.
+
 ## Environment Variables
 
 | Required? |         Name          |                                           Description                                           |  Type  | Options | Default |

--- a/packages/sources/polkadot-balance/docs/known-issues.md
+++ b/packages/sources/polkadot-balance/docs/known-issues.md
@@ -1,9 +1,5 @@
 ## Known Issues
 
-### ETH Beacon API version
-
-Starting from version 3.0.0, the eth-beacon EA is compatible with the ETH Beacon API(`ETH_CONSENSUS_RPC_URL`) version 2.5.0 or later. If you are using an older version of the ETH Beacon API, you will need to upgrade it to 2.5.0 or later to use the eth-beacon EA.
-
 ### MAX_PAYLOAD_SIZE_LIMIT configuration
 
 The `MAX_PAYLOAD_SIZE_LIMIT` environment variable is used for controlling the maximum size of the incoming request body that the EA can handle. If you decide to customize this value it's essential to ensure that any reverse proxy or web server in front of the EA, such as Nginx, is also configured with a corresponding limit. This alignment prevents scenarios where Nginx rejects a request for exceeding its payload size limit before it reaches the EA.

--- a/packages/sources/por-indexer/README.md
+++ b/packages/sources/por-indexer/README.md
@@ -4,6 +4,12 @@
 
 This document was generated automatically. Please see [README Generator](../../scripts#readme-generator) for more info.
 
+## Known Issues
+
+### MAX_PAYLOAD_SIZE_LIMIT configuration
+
+The `MAX_PAYLOAD_SIZE_LIMIT` environment variable is used for controlling the maximum size of the incoming request body that the EA can handle. If you decide to customize this value it's essential to ensure that any reverse proxy or web server in front of the EA, such as Nginx, is also configured with a corresponding limit. This alignment prevents scenarios where Nginx rejects a request for exceeding its payload size limit before it reaches the EA.
+
 ## Environment Variables
 
 | Required? |               Name               |                                        Description                                        |  Type  | Options | Default |

--- a/packages/sources/por-indexer/docs/known-issues.md
+++ b/packages/sources/por-indexer/docs/known-issues.md
@@ -1,9 +1,5 @@
 ## Known Issues
 
-### ETH Beacon API version
-
-Starting from version 3.0.0, the eth-beacon EA is compatible with the ETH Beacon API(`ETH_CONSENSUS_RPC_URL`) version 2.5.0 or later. If you are using an older version of the ETH Beacon API, you will need to upgrade it to 2.5.0 or later to use the eth-beacon EA.
-
 ### MAX_PAYLOAD_SIZE_LIMIT configuration
 
 The `MAX_PAYLOAD_SIZE_LIMIT` environment variable is used for controlling the maximum size of the incoming request body that the EA can handle. If you decide to customize this value it's essential to ensure that any reverse proxy or web server in front of the EA, such as Nginx, is also configured with a corresponding limit. This alignment prevents scenarios where Nginx rejects a request for exceeding its payload size limit before it reaches the EA.

--- a/packages/sources/sochain/README.md
+++ b/packages/sources/sochain/README.md
@@ -6,6 +6,12 @@ Base URL https://sochain.com
 
 This document was generated automatically. Please see [README Generator](../../scripts#readme-generator) for more info.
 
+## Known Issues
+
+### MAX_PAYLOAD_SIZE_LIMIT configuration
+
+The `MAX_PAYLOAD_SIZE_LIMIT` environment variable is used for controlling the maximum size of the incoming request body that the EA can handle. If you decide to customize this value it's essential to ensure that any reverse proxy or web server in front of the EA, such as Nginx, is also configured with a corresponding limit. This alignment prevents scenarios where Nginx rejects a request for exceeding its payload size limit before it reaches the EA.
+
 ## Environment Variables
 
 | Required? |     Name     | Description |  Type  | Options |        Default        |

--- a/packages/sources/sochain/docs/known-issues.md
+++ b/packages/sources/sochain/docs/known-issues.md
@@ -1,9 +1,5 @@
 ## Known Issues
 
-### ETH Beacon API version
-
-Starting from version 3.0.0, the eth-beacon EA is compatible with the ETH Beacon API(`ETH_CONSENSUS_RPC_URL`) version 2.5.0 or later. If you are using an older version of the ETH Beacon API, you will need to upgrade it to 2.5.0 or later to use the eth-beacon EA.
-
 ### MAX_PAYLOAD_SIZE_LIMIT configuration
 
 The `MAX_PAYLOAD_SIZE_LIMIT` environment variable is used for controlling the maximum size of the incoming request body that the EA can handle. If you decide to customize this value it's essential to ensure that any reverse proxy or web server in front of the EA, such as Nginx, is also configured with a corresponding limit. This alignment prevents scenarios where Nginx rejects a request for exceeding its payload size limit before it reaches the EA.

--- a/packages/sources/stader-balance/README.md
+++ b/packages/sources/stader-balance/README.md
@@ -4,6 +4,12 @@
 
 This document was generated automatically. Please see [README Generator](../../scripts#readme-generator) for more info.
 
+## Known Issues
+
+### MAX_PAYLOAD_SIZE_LIMIT configuration
+
+The `MAX_PAYLOAD_SIZE_LIMIT` environment variable is used for controlling the maximum size of the incoming request body that the EA can handle. If you decide to customize this value it's essential to ensure that any reverse proxy or web server in front of the EA, such as Nginx, is also configured with a corresponding limit. This alignment prevents scenarios where Nginx rejects a request for exceeding its payload size limit before it reaches the EA.
+
 ## Environment Variables
 
 | Required? |         Name          |                                                                          Description                                                                          |  Type  | Options | Default |

--- a/packages/sources/stader-balance/docs/known-issues.md
+++ b/packages/sources/stader-balance/docs/known-issues.md
@@ -1,9 +1,5 @@
 ## Known Issues
 
-### ETH Beacon API version
-
-Starting from version 3.0.0, the eth-beacon EA is compatible with the ETH Beacon API(`ETH_CONSENSUS_RPC_URL`) version 2.5.0 or later. If you are using an older version of the ETH Beacon API, you will need to upgrade it to 2.5.0 or later to use the eth-beacon EA.
-
 ### MAX_PAYLOAD_SIZE_LIMIT configuration
 
 The `MAX_PAYLOAD_SIZE_LIMIT` environment variable is used for controlling the maximum size of the incoming request body that the EA can handle. If you decide to customize this value it's essential to ensure that any reverse proxy or web server in front of the EA, such as Nginx, is also configured with a corresponding limit. This alignment prevents scenarios where Nginx rejects a request for exceeding its payload size limit before it reaches the EA.


### PR DESCRIPTION
[DF-20246](https://smartcontract-it.atlassian.net/browse/DF-20246)

Added `known issues` section in README files for balancer EAs that explains the connection between `MAX_PAYLOAD_SIZE_LIMIT` env var the EA supports and Nginx config. 

Note for reviewer. 
Ideally this should apply to all EAs, although is currently relevant to balancer EAs as they accept an array of any size as an input parameter. I'm open to include this description in the [ea-framework](https://github.com/smartcontractkit/ea-framework-js/blob/main/src/config/index.ts#L165) itself, but since the ea-framework configs are not linked to EA READMEs, I'm also ok having those explicitly in balancer EAs READMEs for now


[DF-20246]: https://smartcontract-it.atlassian.net/browse/DF-20246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ