### PR TITLE
Fix Tiingo AGEUR pair issue

### DIFF
--- a/.changeset/lazy-dogs-vanish.md
+++ b/.changeset/lazy-dogs-vanish.md
@@ -2,4 +2,4 @@
 '@chainlink/tiingo-adapter': minor
 ---
 
-Fix Tiingo ageur pair issue
+Fix Tiingo ageur pair issue, use baseCurrency/convertCurrency/consolidateBaseCurrency instead of tickers as input param

--- a/.changeset/lazy-dogs-vanish.md
+++ b/.changeset/lazy-dogs-vanish.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/tiingo-adapter': minor
+---
+
+Fix Tiingo ageur pair issue

--- a/packages/sources/tiingo/src/transport/crypto-http.ts
+++ b/packages/sources/tiingo/src/transport/crypto-http.ts
@@ -1,9 +1,9 @@
 import { HttpTransport } from '@chainlink/external-adapter-framework/transports'
-import { buildBatchedRequestBody, constructEntry, CryptoHttpTransportTypes } from './utils'
+import { buildBatchedRequestBodyForPrice, constructEntry, CryptoHttpTransportTypes } from './utils'
 
 export const httpTransport = new HttpTransport<CryptoHttpTransportTypes>({
   prepareRequests: (params, config) => {
-    return buildBatchedRequestBody(params, config, 'tiingo/crypto/prices')
+    return buildBatchedRequestBodyForPrice(params, config, 'tiingo/crypto/prices')
   },
   parseResponse: (params, res) => {
     return constructEntry(res.data, params, 'close')

--- a/packages/sources/tiingo/src/transport/crypto-ws.ts
+++ b/packages/sources/tiingo/src/transport/crypto-ws.ts
@@ -52,15 +52,24 @@ export const wsTransport: TiingoWebsocketTransport<WsTransportTypes> =
         return {
           eventName: 'subscribe',
           authorization: wsTransport.apiKey,
-          eventData: { thresholdLevel: 6, tickers: [`${params.base}/${params.quote}`] },
+          eventData: getEventData(params.base, params.quote),
         }
       },
       unsubscribeMessage: (params) => {
         return {
           eventName: 'unsubscribe',
           authorization: wsTransport.apiKey,
-          eventData: { thresholdLevel: 6, tickers: [`${params.base}/${params.quote}`] },
+          eventData: getEventData(params.base, params.quote),
         }
       },
     },
   })
+
+function getEventData(base: string, quote: string) {
+  return {
+    thresholdLevel: 6,
+    baseCurrency: base,
+    convertCurrency: quote,
+    consolidateBaseCurrency: true,
+  }
+}

--- a/packages/sources/tiingo/src/transport/utils.ts
+++ b/packages/sources/tiingo/src/transport/utils.ts
@@ -34,6 +34,7 @@ export type CryptoHttpTransportTypes = BaseCryptoEndpointTypes & {
     ResponseBody: ProviderResponseBody[]
   }
 }
+
 export const buildBatchedRequestBody = <T extends typeof inputParameters.validated>(
   params: T[],
   settings: typeof config.settings,
@@ -54,6 +55,29 @@ export const buildBatchedRequestBody = <T extends typeof inputParameters.validat
             ',',
           ),
           resampleFreq: url === 'tiingo/crypto/prices' ? '24hour' : undefined,
+        },
+      },
+    }
+  })
+}
+
+export const buildBatchedRequestBodyForPrice = <T extends typeof inputParameters.validated>(
+  params: T[],
+  settings: typeof config.settings,
+  url: string,
+) => {
+  return params.map((param) => {
+    return {
+      params: [{ base: param.base, quote: param.quote }],
+      request: {
+        baseURL: settings.API_ENDPOINT,
+        url: url,
+        params: {
+          token: settings.API_KEY,
+          baseCurrency: `${param.base.toLowerCase()}`,
+          convertCurrency: param.quote.toLowerCase(),
+          consolidateBaseCurrency: true,
+          resampleFreq: '24hour',
         },
       },
     }

--- a/packages/sources/tiingo/src/transport/utils.ts
+++ b/packages/sources/tiingo/src/transport/utils.ts
@@ -74,7 +74,7 @@ export const buildBatchedRequestBodyForPrice = <T extends typeof inputParameters
         url: url,
         params: {
           token: settings.API_KEY,
-          baseCurrency: `${param.base.toLowerCase()}`,
+          baseCurrency: param.base.toLowerCase(),
           convertCurrency: param.quote.toLowerCase(),
           consolidateBaseCurrency: true,
           resampleFreq: '24hour',

--- a/packages/sources/tiingo/src/transport/volume.ts
+++ b/packages/sources/tiingo/src/transport/volume.ts
@@ -1,8 +1,8 @@
 import { HttpTransport } from '@chainlink/external-adapter-framework/transports'
-import { buildBatchedRequestBody, constructEntry, CryptoHttpTransportTypes } from './utils'
+import { buildBatchedRequestBodyForPrice, constructEntry, CryptoHttpTransportTypes } from './utils'
 export const transport = new HttpTransport<CryptoHttpTransportTypes>({
   prepareRequests: (params, config) => {
-    return buildBatchedRequestBody(params, config, 'tiingo/crypto/prices')
+    return buildBatchedRequestBodyForPrice(params, config, 'tiingo/crypto/prices')
   },
   parseResponse: (params, res) => {
     return constructEntry(res.data, params, 'volumeNotional')

--- a/packages/sources/tiingo/test/integration/fixtures.ts
+++ b/packages/sources/tiingo/test/integration/fixtures.ts
@@ -114,7 +114,9 @@ export const mockResponseSuccess = (): nock.Scope =>
     .get('/tiingo/crypto/prices')
     .query({
       token: 'fake-api-key',
-      tickers: 'ethusd',
+      convertCurrency: 'usd',
+      baseCurrency: 'eth',
+      consolidateBaseCurrency: true,
       resampleFreq: '24hour',
     })
     .reply(


### PR DESCRIPTION


## Closes #[DF-20032](https://smartcontract-it.atlassian.net/browse/DF-20032)

## Description

## Changes

Use `convertCurrency, baseCurrency & consolidateBaseCurrency` instead of `tickers` for `crypto` and `volume` endpoints

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

- Verified that btc -> usd still works
- Verified that aegur -> used does not work before and works after fix

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [x] This is related to a maximum of one Jira story or GitHub issue.
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[DF-20032]: https://smartcontract-it.atlassian.net/browse/DF-20032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ