### PR TITLE
Fix GTAI

### DIFF
--- a/.github/workflows/soak-test-start.yml
+++ b/.github/workflows/soak-test-start.yml
@@ -100,7 +100,7 @@ jobs:
         if: steps.get-pr-info.outputs.TEST_ADAPTERS != ''
         env:
           GITHUB_TOKEN: ${{ steps.setup-github-token.outputs.access-token }}
-        run: git clone https://${GITHUB_TOKEN}@github.com/smartcontractkit/adapter-secrets.git
+        run: git clone https://oauth2:${GITHUB_TOKEN}@github.com/smartcontractkit/adapter-secrets.git
 
       - name: Build the k6 payloads and images
         if: steps.get-pr-info.outputs.TEST_ADAPTERS != ''


### PR DESCRIPTION
`Run git clone https://${GITHUB_TOKEN}@github.com/smartcontractkit/adapter-secrets.git
  git clone https://${GITHUB_TOKEN}@github.com/smartcontractkit/adapter-secrets.git
  shell: /usr/bin/bash -e {0}
  env:
    AWS_DEFAULT_REGION: ***
    AWS_REGION: ***
    AWS_ACCESS_KEY_ID: ***
    AWS_SECRET_ACCESS_KEY: ***
    AWS_SESSION_TOKEN: ***
    KUBECONFIG: /home/runner/work/_temp/kubeconfig_17229[52](https://github.com/smartcontractkit/external-adapters-js/actions/runs/10267786163/job/28409170062?pr=3372#step:16:52)012872
    GITHUB_TOKEN: ***
##[debug]/usr/bin/bash -e /home/runner/work/_temp/3318139c-a2c2-4ad2-affc-c4a60527b04e.sh
Cloning into 'adapter-secrets'...
fatal: could not read Password for 'https://***@github.com': No such device or address
Error: Process completed with exit code 128.
##[debug]Finishing: Clone adapter-secrets repo`

It appears to be caused by this: https://stackoverflow.com/questions/74532852/clone-github-repo-with-fine-grained-token

Confirmed this is the fix via: https://github.com/smartcontractkit/external-adapters-js/pull/3374