### PR TITLE
Update Github Runner Size

### DIFF
--- a/.github/workflows/soak-test-start.yml
+++ b/.github/workflows/soak-test-start.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   run-soak-tests:
     name: Run Soak Tests Against Changed Adapters
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4cores-16GB
     environment: QA
     permissions:
       id-token: write


### PR DESCRIPTION
This is failing because default runner only has 14GB disk, upgrade to one with 150GB