### PR TITLE
Update blocksize-capital provider indicated timestamp

### DIFF
--- a/.changeset/yellow-planes-explode.md
+++ b/.changeset/yellow-planes-explode.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/blocksize-capital-adapter': patch
+---
+
+Patch Blocksize Capital to use correct unit for provider indicated time ms

--- a/packages/sources/blocksize-capital/src/transport/crypto-lwba.ts
+++ b/packages/sources/blocksize-capital/src/transport/crypto-lwba.ts
@@ -67,7 +67,7 @@ export const transport: WebsocketReverseMappingTransport<WsTransportTypes, strin
                   mid: Number(update.agg_mid_price),
                 },
                 timestamps: {
-                  providerIndicatedTimeUnixMs: Number(update.ts),
+                  providerIndicatedTimeUnixMs: Math.floor(Number(update.ts) / 1000),
                 },
               },
             })

--- a/packages/sources/blocksize-capital/test/integration/fixtures.ts
+++ b/packages/sources/blocksize-capital/test/integration/fixtures.ts
@@ -32,7 +32,7 @@ export const mockLwbaResponse = {
         agg_ask_price: '27206.54222704013',
         agg_ask_size: '6.76037062',
         agg_mid_price: '27204.76629652509',
-        ts: 1693425803031,
+        ts: 1693425803031000,
       },
       {
         ticker: 'ETHUSD',
@@ -41,7 +41,7 @@ export const mockLwbaResponse = {
         agg_ask_price: '1702.223427255888',
         agg_ask_size: '11.44083383',
         agg_mid_price: '1702.034150611851',
-        ts: 1693425803028,
+        ts: 1693425803028000,
       },
       {
         ticker: 'LINKUSD',
@@ -50,7 +50,7 @@ export const mockLwbaResponse = {
         agg_ask_price: '123.124',
         agg_ask_size: '11.44083383',
         agg_mid_price: '123.125',
-        ts: 1693425803029,
+        ts: 1693425803029000,
       },
     ],
   },


### PR DESCRIPTION
## Closes [DF-20302](https://smartcontract-it.atlassian.net/browse/DF-20302)

## Description

Patch Blocksize Capital adapter to ensure it sends correct units for `providerIndicatedTimestampMs` for the `cryptolwba` endpoint. Note that this is the only endpoint that returns microseconds whereas the others return milliseconds.

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

`yarn && yarn setup && yarn test packages/sources/blocksize-capital/test/integration/*`

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [x] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [x] This is related to a maximum of one Jira story or GitHub issue.
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[DF-20302]: https://smartcontract-it.atlassian.net/browse/DF-20302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ