### PR TITLE
Adds L2EP zkSync integration

### DIFF
--- a/.changeset/poor-pumpkins-bow.md
+++ b/.changeset/poor-pumpkins-bow.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/layer2-sequencer-health-adapter': minor
+---
+
+Adds L2EP support for zkSync chain

--- a/packages/sources/layer2-sequencer-health/README.md
+++ b/packages/sources/layer2-sequencer-health/README.md
@@ -31,6 +31,10 @@ Adapter that checks the Layer 2 Sequencer status
 |           | `STARKWARE_DUMMY_ACCOUNT_ADDRESS` |             The dummy address to use to send dummy transactions to Starkware              |         | 0x00000000000000000000000000000000000000000000000000000000000001 |
 |           |         `STARKWARE_DELTA`         | Maximum time in milliseconds from last seen block to consider Starkware sequencer healthy |         |                          120000 (2 min)                          |
 |           | `STARKWARE_DUMMY_ACCOUNT_ADDRESS` |             The dummy address to use to send dummy transactions to Starkware              |         | 0x00000000000000000000000000000000000000000000000000000000000001 |
+|           |       `ZKSYNC_RPC_ENDPOINT`       |                                    zkSync RPC Endpoint                                    |         |                  https://mainnet.era.zksync.io                   |
+|           |     `ZKSYNC_HEALTH_ENDPOINT`      |                                  zkSync Health Endpoint                                   |         |                                                                  |
+|           |         `ZKSYNC_CHAIN_ID`         |                             The chain id to connect to zkSync                             |         |                               324                                |
+|           |          `ZKSYNC_DELTA`           |  Maximum time in milliseconds from last seen block to consider zkSync sequencer healthy   |         |                          120000 (2 min)                          |
 
 For the adapter to be useful on the desired network, at least one endpoint (RPC or HEALTH) needs to provided
 
@@ -38,9 +42,9 @@ For the adapter to be useful on the desired network, at least one endpoint (RPC 
 
 ### Input Parameters
 
-| Required? |  Name   |       Description        |                            Options                             | Defaults to |
-| :-------: | :-----: | :----------------------: | :------------------------------------------------------------: | :---------: |
-|    ✅     | network | Layer 2 Network to check | `arbitrum`, `optimism`, `base`, `metis`, `scroll`, `starkware` |             |
+| Required? |  Name   |       Description        |                                 Options                                  | Defaults to |
+| :-------: | :-----: | :----------------------: | :----------------------------------------------------------------------: | :---------: |
+|    ✅     | network | Layer 2 Network to check | `arbitrum`, `optimism`, `base`, `metis`, `scroll`, `starkware`, `zksync` |             |
 
 ---
 

--- a/packages/sources/layer2-sequencer-health/schemas/env.json
+++ b/packages/sources/layer2-sequencer-health/schemas/env.json
@@ -28,6 +28,10 @@
       "type": "number",
       "default": 120000
     },
+    "ZKSYNC_DELTA": {
+      "type": "number",
+      "default": 120000
+    },
     "ARBITRUM_RPC_ENDPOINT": {
       "type": "string",
       "default": "https://arb1.arbitrum.io/rpc"
@@ -113,6 +117,20 @@
     "STARKWARE_DUMMY_ACCOUNT_ADDRESS": {
       "type": "string",
       "default": "0x00000000000000000000000000000000000000000000000000000000000001"
+    },
+    "ZKSYNC_RPC_ENDPOINT": {
+      "type": "string",
+      "default": "https://mainnet.era.zksync.io"
+    },
+    "ZKSYNC_HEALTH_ENDPOINT": {
+      "type": "string",
+      "default": ""
+    },
+    "ZKSYNC_CHAIN_ID": {
+      "required": false,
+      "description": "The blockchain id to connect to",
+      "type": "string",
+      "default": "324"
     }
   },
   "allOf": [

--- a/packages/sources/layer2-sequencer-health/src/config/index.ts
+++ b/packages/sources/layer2-sequencer-health/src/config/index.ts
@@ -29,18 +29,21 @@ export const ENV_OPTIMISM_RPC_ENDPOINT = 'OPTIMISM_RPC_ENDPOINT'
 export const ENV_BASE_RPC_ENDPOINT = 'BASE_RPC_ENDPOINT'
 export const ENV_METIS_RPC_ENDPOINT = 'METIS_RPC_ENDPOINT'
 export const ENV_SCROLL_RPC_ENDPOINT = 'SCROLL_RPC_ENDPOINT'
+export const ENV_ZKSYNC_RPC_ENDPOINT = 'ZKSYNC_RPC_ENDPOINT'
 
 export const ENV_ARBITRUM_CHAIN_ID = 'ARBITRUM_CHAIN_ID'
 export const ENV_OPTIMISM_CHAIN_ID = 'OPTIMISM_CHAIN_ID'
 export const ENV_BASE_CHAIN_ID = 'BASE_CHAIN_ID'
 export const ENV_METIS_CHAIN_ID = 'METIS_CHAIN_ID'
 export const ENV_SCROLL_CHAIN_ID = 'SCROLL_CHAIN_ID'
+export const ENV_ZKSYNC_CHAIN_ID = 'ZKSYNC_CHAIN_ID'
 
 export const DEFAULT_ARBITRUM_CHAIN_ID = '42161'
 export const DEFAULT_OPTIMISM_CHAIN_ID = '10'
 export const DEFAULT_BASE_CHAIN_ID = '8453'
 export const DEFAULT_METIS_CHAIN_ID = '1088'
 export const DEFAULT_SCROLL_CHAIN_ID = '534352'
+export const DEFAULT_ZKSYNC_CHAIN_ID = '324'
 
 export enum Networks {
   Arbitrum = 'arbitrum',
@@ -49,6 +52,7 @@ export enum Networks {
   Metis = 'metis',
   Scroll = 'scroll',
   Starkware = 'starkware',
+  zkSync = 'zksync',
 }
 
 export type EVMNetworks = Exclude<Networks, Networks.Starkware>
@@ -58,6 +62,7 @@ const DEFAULT_OPTIMISM_RPC_ENDPOINT = 'https://mainnet.optimism.io'
 const DEFAULT_BASE_RPC_ENDPOINT = 'https://mainnet.base.org'
 const DEFAULT_METIS_RPC_ENDPOINT = 'https://andromeda.metis.io/?owner=1088'
 const DEFAULT_SCROLL_RPC_ENDPOINT = 'https://rpc.scroll.io'
+const DEFAULT_ZKSYNC_RPC_ENDPOINT = 'https://mainnet.era.zksync.io'
 
 export const RPC_ENDPOINTS: Record<EVMNetworks, string | undefined> = {
   [Networks.Arbitrum]: util.getEnv(ENV_ARBITRUM_RPC_ENDPOINT) || DEFAULT_ARBITRUM_RPC_ENDPOINT,
@@ -65,6 +70,7 @@ export const RPC_ENDPOINTS: Record<EVMNetworks, string | undefined> = {
   [Networks.Base]: util.getEnv(ENV_BASE_RPC_ENDPOINT) || DEFAULT_BASE_RPC_ENDPOINT,
   [Networks.Metis]: util.getEnv(ENV_METIS_RPC_ENDPOINT) || DEFAULT_METIS_RPC_ENDPOINT,
   [Networks.Scroll]: util.getEnv(ENV_SCROLL_RPC_ENDPOINT) || DEFAULT_SCROLL_RPC_ENDPOINT,
+  [Networks.zkSync]: util.getEnv(ENV_ZKSYNC_RPC_ENDPOINT) || DEFAULT_ZKSYNC_RPC_ENDPOINT,
 }
 
 export const CHAIN_IDS: Record<EVMNetworks, number | undefined | string> = {
@@ -83,6 +89,9 @@ export const CHAIN_IDS: Record<EVMNetworks, number | undefined | string> = {
   [Networks.Scroll]:
     parseInt(util.getEnv(ENV_SCROLL_CHAIN_ID) || DEFAULT_SCROLL_CHAIN_ID) ||
     util.getEnv(ENV_SCROLL_CHAIN_ID),
+  [Networks.zkSync]:
+    parseInt(util.getEnv(ENV_ZKSYNC_CHAIN_ID) || DEFAULT_ZKSYNC_CHAIN_ID) ||
+    util.getEnv(ENV_ZKSYNC_CHAIN_ID),
 }
 
 export const CHAIN_DELTA: Record<Networks, number> = {
@@ -92,6 +101,7 @@ export const CHAIN_DELTA: Record<Networks, number> = {
   [Networks.Metis]: Number(util.getEnv('METIS_DELTA')) || DEFAULT_DELTA_TIME_METIS,
   [Networks.Scroll]: Number(util.getEnv('SCROLL_DELTA')) || DEFAULT_DELTA_TIME,
   [Networks.Starkware]: Number(util.getEnv('STARKWARE_DELTA')) || DEFAULT_DELTA_TIME,
+  [Networks.zkSync]: Number(util.getEnv('ZKSYNC_DELTA')) || DEFAULT_DELTA_TIME,
 }
 
 const DEFAULT_METIS_HEALTH_ENDPOINT = 'https://andromeda-healthy.metisdevops.link/health'
@@ -134,6 +144,11 @@ export const HEALTH_ENDPOINTS: HeathEndpoints = {
   },
   [Networks.Starkware]: {
     endpoint: util.getEnv('STARKWARE_HEALTH_ENDPOINT'),
+    responsePath: [],
+    processResponse: () => undefined,
+  },
+  [Networks.zkSync]: {
+    endpoint: util.getEnv('ZKSYNC_HEALTH_ENDPOINT'),
     responsePath: [],
     processResponse: () => undefined,
   },

--- a/packages/sources/layer2-sequencer-health/src/endpoint/health.ts
+++ b/packages/sources/layer2-sequencer-health/src/endpoint/health.ts
@@ -23,6 +23,7 @@ const defaultRequireTxFailure = {
   [Networks.Optimism]: false,
   [Networks.Scroll]: false,
   [Networks.Starkware]: true,
+  [Networks.zkSync]: false,
 }
 
 export type TInputParameters = {
@@ -39,6 +40,7 @@ export const inputParameters: InputParameters<TInputParameters> = {
       Networks.Optimism,
       Networks.Scroll,
       Networks.Starkware,
+      Networks.zkSync,
     ],
   },
   requireTxFailure: {

--- a/packages/sources/layer2-sequencer-health/src/evm.ts
+++ b/packages/sources/layer2-sequencer-health/src/evm.ts
@@ -57,6 +57,12 @@ export const sendEVMDummyTransaction = async (
       gasPrice: 0,
       to: wallet.address,
     },
+    [Networks.zkSync]: {
+      value: 0,
+      gasLimit: 0,
+      gasPrice: 0,
+      to: wallet.address,
+    },
   }
   await race<ethers.providers.TransactionResponse>({
     timeout,
@@ -83,6 +89,10 @@ const lastSeenBlock: Record<EVMNetworks, { block: number; timestamp: number }> =
     timestamp: 0,
   },
   [Networks.Scroll]: {
+    block: 0,
+    timestamp: 0,
+  },
+  [Networks.zkSync]: {
     block: 0,
     timestamp: 0,
   },

--- a/packages/sources/layer2-sequencer-health/src/network.ts
+++ b/packages/sources/layer2-sequencer-health/src/network.ts
@@ -26,6 +26,7 @@ const sequencerOnlineErrors: Record<Networks, string[]> = {
   // has not been deployed to the network. The OutOfRangeFee error is thrown when
   // the network detects a transaction sent with 0 gas.
   [Networks.Starkware]: ['Contract not found', 'Known(OutOfRangeFee)'],
+  [Networks.zkSync]: ['max fee per gas less than block base fee'],
 }
 
 export interface NetworkHealthCheck {
@@ -90,6 +91,7 @@ const isExpectedErrorMessage = (network: Networks, error: Error) => {
       [Networks.Metis]: ['error', 'message'],
       [Networks.Scroll]: ['error', 'error', 'message'],
       [Networks.Starkware]: ['message'],
+      [Networks.zkSync]: ['error', 'message'],
     }
     return (Requester.getResult(error, paths[network]) as string) || ''
   }

--- a/packages/sources/layer2-sequencer-health/test/integration/__snapshots__/onchainFailKnown.test.ts.snap
+++ b/packages/sources/layer2-sequencer-health/test/integration/__snapshots__/onchainFailKnown.test.ts.snap
@@ -109,3 +109,25 @@ exports[`execute scroll network should return success when transaction submissio
   "statusCode": 200,
 }
 `;
+
+exports[`execute zksync network should return failure if tx not required 1`] = `
+{
+  "data": {
+    "result": 1,
+  },
+  "jobRunID": "1",
+  "result": 1,
+  "statusCode": 200,
+}
+`;
+
+exports[`execute zksync network should return success when transaction submission is known 1`] = `
+{
+  "data": {
+    "result": 0,
+  },
+  "jobRunID": "1",
+  "result": 0,
+  "statusCode": 200,
+}
+`;

--- a/packages/sources/layer2-sequencer-health/test/integration/__snapshots__/onchainSuccess.test.ts.snap
+++ b/packages/sources/layer2-sequencer-health/test/integration/__snapshots__/onchainSuccess.test.ts.snap
@@ -164,3 +164,36 @@ exports[`execute scroll network should return transaction submission is successf
   "statusCode": 200,
 }
 `;
+
+exports[`execute zksync network should return failure if tx not required even if it would be successful 1`] = `
+{
+  "data": {
+    "result": 1,
+  },
+  "jobRunID": "1",
+  "result": 1,
+  "statusCode": 200,
+}
+`;
+
+exports[`execute zksync network should return success when all methods succeed 1`] = `
+{
+  "data": {
+    "result": 0,
+  },
+  "jobRunID": "1",
+  "result": 0,
+  "statusCode": 200,
+}
+`;
+
+exports[`execute zksync network should return transaction submission is successful 1`] = `
+{
+  "data": {
+    "result": 0,
+  },
+  "jobRunID": "1",
+  "result": 0,
+  "statusCode": 200,
+}
+`;

--- a/packages/sources/layer2-sequencer-health/test/integration/fixtures.ts
+++ b/packages/sources/layer2-sequencer-health/test/integration/fixtures.ts
@@ -98,6 +98,19 @@ export const mockResponseSuccessBlock = (): void => {
       'Vary',
       'Origin',
     ])
+
+  nock('https://mainnet.era.zksync.io')
+    .post('/', { jsonrpc: '2.0', method: 'eth_blockNumber', params: [], id: /^\d+$/ })
+    .reply(200, () => ({ jsonrpc: '2.0', id: 1, result: '0x42d293' }), [
+      'Content-Type',
+      'application/json',
+      'Connection',
+      'close',
+      'Vary',
+      'Accept-Encoding',
+      'Vary',
+      'Origin',
+    ])
 }
 
 export const mockResponseSuccessRollup = (): void => {
@@ -192,6 +205,19 @@ export const mockResponseFailureBlock = (): void => {
     ])
 
   nock('https://rpc.scroll.io')
+    .post('/', { jsonrpc: '2.0', method: 'eth_blockNumber', params: [], id: /^\d+$/ })
+    .reply(200, () => ({ jsonrpc: '2.0', id: 1, result: '0x00' }), [
+      'Content-Type',
+      'application/json',
+      'Connection',
+      'close',
+      'Vary',
+      'Accept-Encoding',
+      'Vary',
+      'Origin',
+    ])
+
+  nock('https://mainnet.era.zksync.io')
     .post('/', { jsonrpc: '2.0', method: 'eth_blockNumber', params: [], id: /^\d+$/ })
     .reply(200, () => ({ jsonrpc: '2.0', id: 1, result: '0x00' }), [
       'Content-Type',

--- a/packages/sources/layer2-sequencer-health/test/integration/onchainFailKnown.test.ts
+++ b/packages/sources/layer2-sequencer-health/test/integration/onchainFailKnown.test.ts
@@ -13,6 +13,7 @@ const mockMessages = {
   'https://andromeda.metis.io/?owner=1088': 'cannot accept 0 gas price transaction',
   'https://rpc.scroll.io':
     'invalid transaction: insufficient funds for l1fee + gas * price + value',
+  'https://mainnet.era.zksync.io': 'max fee per gas less than block base fee',
 }
 
 jest.mock('ethers', () => {
@@ -210,6 +211,35 @@ describe('execute', () => {
         id,
         data: {
           network: 'scroll',
+        },
+      }
+
+      await sendRequestAndExpectStatus(data, 1)
+    })
+  })
+
+  describe('zksync network', () => {
+    it('should return success when transaction submission is known', async () => {
+      mockResponseFailureBlock()
+
+      const data: AdapterRequest = {
+        id,
+        data: {
+          network: 'zksync',
+          requireTxFailure: true,
+        },
+      }
+
+      await sendRequestAndExpectStatus(data, 0)
+    })
+
+    it('should return failure if tx not required', async () => {
+      mockResponseFailureBlock()
+
+      const data: AdapterRequest = {
+        id,
+        data: {
+          network: 'zksync',
         },
       }
 

--- a/packages/sources/layer2-sequencer-health/test/integration/onchainSuccess.test.ts
+++ b/packages/sources/layer2-sequencer-health/test/integration/onchainSuccess.test.ts
@@ -246,6 +246,51 @@ describe('execute', () => {
     })
   })
 
+  describe('zksync network', () => {
+    it('should return success when all methods succeed', async () => {
+      mockResponseSuccessBlock()
+      mockResponseSuccessHealth()
+
+      const data: AdapterRequest = {
+        id,
+        data: {
+          network: 'zksync',
+        },
+      }
+
+      await sendRequestAndExpectStatus(data, 0)
+    })
+
+    it('should return transaction submission is successful', async () => {
+      mockResponseFailureBlock()
+      mockResponseSuccessHealth()
+
+      const data: AdapterRequest = {
+        id,
+        data: {
+          network: 'zksync',
+          requireTxFailure: true,
+        },
+      }
+
+      await sendRequestAndExpectStatus(data, 0)
+    })
+
+    it('should return failure if tx not required even if it would be successful', async () => {
+      mockResponseFailureBlock()
+      mockResponseFailureHealth()
+
+      const data: AdapterRequest = {
+        id,
+        data: {
+          network: 'zksync',
+          requireTxFailure: false,
+        },
+      }
+
+      await sendRequestAndExpectStatus(data, 1)
+    })
+  })
   describe('base network', () => {
     it('should return success when all methods succeed', async () => {
       mockResponseSuccessHealth()


### PR DESCRIPTION
## Description
This PR adds the layer 2 sequencer health external adapter logic for zkSync. 

## Changes

-  Adds zkSync layer 2 sequencer health adapter


## Motivation
[SHIP-3010](https://smartcontract-it.atlassian.net/browse/SHIP-3010)

## Steps to Test

1. Unit tests
2. Ran the adapter locally and ran the request to check zkSync sequencer health.

```
export adapter=layer2-sequencer-health 
yarn test $adapter/test/integration
```

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- https://github.com/smartcontractkit/infra-k8s/pull/TBD
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [x] This is related to a maximum of one Jira story or GitHub issue.
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
