### PR TITLE
MERC-6221 Enable full symbol overrides for TP EA

### DIFF
--- a/.changeset/wicked-carrots-bow.md
+++ b/.changeset/wicked-carrots-bow.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/tp-adapter': minor
+---
+
+Enable full symbol override

--- a/packages/sources/tp/README.md
+++ b/packages/sources/tp/README.md
@@ -46,13 +46,13 @@ There are no rate limits for this adapter.
 
 ## Input Parameters
 
-| Required? |   Name   |     Description     |  Type  |                      Options                       | Default |
-| :-------: | :------: | :-----------------: | :----: | :------------------------------------------------: | :-----: |
-|           | endpoint | The endpoint to use | string | [forex](#price-endpoint), [price](#price-endpoint) | `price` |
+| Required? |   Name   |     Description     |  Type  |                                      Options                                       | Default |
+| :-------: | :------: | :-----------------: | :----: | :--------------------------------------------------------------------------------: | :-----: |
+|           | endpoint | The endpoint to use | string | [commodities](#price-endpoint), [forex](#price-endpoint), [price](#price-endpoint) | `price` |
 
 ## Price Endpoint
 
-Supported names for this endpoint are: `forex`, `price`.
+Supported names for this endpoint are: `commodities`, `forex`, `price`.
 
 ### Input Params
 

--- a/packages/sources/tp/src/endpoint/price.ts
+++ b/packages/sources/tp/src/endpoint/price.ts
@@ -1,5 +1,5 @@
 import {
-  ForexPriceEndpoint,
+  PriceEndpoint,
   priceEndpointInputParametersDefinition,
   PriceEndpointInputParametersDefinition,
 } from '@chainlink/external-adapter-framework/adapter'
@@ -20,6 +20,7 @@ export type GeneratePriceOptions = {
   streamName: 'TP' | 'IC'
   sourceOptions?: string[]
 }
+
 export const generateInputParams = (
   generatePriceOptions: GeneratePriceOptions,
 ): InputParameters<PriceEndpointInputParametersDefinition> =>
@@ -47,14 +48,14 @@ export const generateInputParams = (
 const tpOptions: GeneratePriceOptions = {
   sourceName: 'tpSource',
   streamName: 'TP',
-}
+} as const
 
 const inputParameters = generateInputParams(tpOptions)
 const wsTransport = generateTransport(tpOptions)
 
-export const priceEndpoint = new ForexPriceEndpoint({
+export const priceEndpoint = new PriceEndpoint({
   name: 'price',
-  aliases: ['forex'],
+  aliases: ['commodities', 'forex'],
   transport: wsTransport,
   inputParameters,
 })

--- a/packages/sources/tp/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/tp/test/integration/__snapshots__/adapter.test.ts.snap
@@ -83,6 +83,48 @@ exports[`Price Endpoint should return price for inverse pair 1`] = `
 }
 `;
 
+exports[`Price Endpoint should return price for mapped symbol 1`] = `
+{
+  "data": {
+    "result": 200,
+  },
+  "result": 200,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 1018,
+    "providerDataStreamEstablishedUnixMs": 1010,
+  },
+}
+`;
+
+exports[`Price Endpoint should return price for overridden mapped symbol 1`] = `
+{
+  "data": {
+    "result": 200,
+  },
+  "result": 200,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 1018,
+    "providerDataStreamEstablishedUnixMs": 1010,
+  },
+}
+`;
+
+exports[`Price Endpoint should return price for overridden symbol 1`] = `
+{
+  "data": {
+    "result": 1.0539,
+  },
+  "result": 1.0539,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 1018,
+    "providerDataStreamEstablishedUnixMs": 1010,
+  },
+}
+`;
+
 exports[`Price Endpoint should return price for specific source 1`] = `
 {
   "data": {

--- a/packages/sources/tp/test/integration/adapter.test.ts
+++ b/packages/sources/tp/test/integration/adapter.test.ts
@@ -63,6 +63,30 @@ describe('Price Endpoint', () => {
     expect(response.json()).toMatchSnapshot()
   })
 
+  it('should return price for overridden symbol', async () => {
+    const response = await testAdapter.request({
+      base: 'ZZZ',
+      quote: 'USD',
+      overrides: { tp: { ZZZ: 'FXSPTEURUSDSPT:GBL.BIL.QTE.RTM!TP' } },
+    })
+    expect(response.json()).toMatchSnapshot()
+  })
+
+  it('should return price for mapped symbol', async () => {
+    const response = await testAdapter.request({ base: 'WTI', quote: 'USD', tpSource: 'LDN' })
+    expect(response.json()).toMatchSnapshot()
+  })
+
+  it('should return price for overridden mapped symbol', async () => {
+    const response = await testAdapter.request({
+      base: 'ZZZ',
+      quote: 'USD',
+      tpSource: 'LDN',
+      overrides: { tp: { ZZZ: 'CEOILOTRWTSBOM:LDN.BIL.QTE.RTM!TP' } },
+    })
+    expect(response.json()).toMatchSnapshot()
+  })
+
   it('should return error when queried for IC price', async () => {
     const response = await testAdapter.request({ base: 'ABC', quote: 'USD' })
     expect(response.json()).toMatchSnapshot()
@@ -87,6 +111,7 @@ describe('Price Endpoint', () => {
     const response = await testAdapter.request({ base: 'EUR' })
     expect(response.json()).toMatchSnapshot()
   })
+
   it('should update the ttl after heartbeat is received', async () => {
     // The cache tll is 90 seconds. Mocked heartbeat message is sent after 10s after connection which should
     // update the ttl and therefore after 91 seconds (from the initial message) we can access the asset

--- a/packages/sources/tp/test/integration/fixtures.ts
+++ b/packages/sources/tp/test/integration/fixtures.ts
@@ -99,6 +99,19 @@ export const mockStalePriceResponse = {
   },
 }
 
+export const mockWTIPriceResponse = {
+  msg: 'sub',
+  pro: 'OMM',
+  rec: 'CEOILOTRWTSBOM:LDN.BIL.QTE.RTM!TP',
+  sta: 1,
+  img: 1,
+  fvs: {
+    ASK: 100,
+    BID: 300,
+    MID_PRICE: 200,
+  },
+}
+
 export const mockHeartbeatResponse = {
   msg: 'sub',
   pro: 'OMM',
@@ -128,6 +141,7 @@ export const mockPriceWebSocketServer = (URL: string): MockWebsocketServer => {
       socket.send(JSON.stringify(mockInversePriceResponse))
       socket.send(JSON.stringify(mockICPriceResponse))
       socket.send(JSON.stringify(mockSeparateSourcePriceResponse))
+      socket.send(JSON.stringify(mockWTIPriceResponse))
       setTimeout(() => {
         socket.send(JSON.stringify(mockHeartbeatResponse))
       }, 10000)

--- a/packages/sources/tp/test/unit/price.test.ts
+++ b/packages/sources/tp/test/unit/price.test.ts
@@ -1,0 +1,50 @@
+import { parseRec } from '../../src'
+
+describe('parseRec', () => {
+  it('invalid symbols return null', () => {
+    expect(parseRec('')).toEqual(null)
+    expect(parseRec('FXSPTUSDAEDSPT:GBL.BIL.QTE.RTM')).toEqual(null)
+    expect(parseRec('FXSPTUSDAEDSPT!IC')).toEqual(null)
+    expect(parseRec('FXSPTUSDAEDSPT')).toEqual(null)
+  })
+
+  it('parses a forex spot symbol', () => {
+    expect(parseRec('FXSPTUSDAEDSPT:GBL.BIL.QTE.RTM!IC')).toEqual({
+      market: 'FXSPT',
+      base: 'USD',
+      quote: 'AED',
+      source: 'GBL',
+      stream: 'IC',
+    })
+  })
+
+  it('parses a metals spot symbol', () => {
+    expect(parseRec('CESPTUSDXPTSPT:GBL.BIL.QTE.RTM!TP')).toEqual({
+      market: 'CESPT',
+      base: 'USD',
+      quote: 'XPT',
+      source: 'GBL',
+      stream: 'TP',
+    })
+  })
+
+  it('parses a metals forward symbol', () => {
+    expect(parseRec('CEFWDXAUUSDSPT06M:LDN.BIL.QTE.RTM!TP')).toEqual({
+      market: 'CEFWD',
+      base: 'XAU',
+      quote: 'USD',
+      source: 'LDN',
+      stream: 'TP',
+    })
+  })
+
+  it('parses an overridden symbol', () => {
+    expect(parseRec('CEOILOTRWTSBOM:LDN.BIL.QTE.RTM!TP')).toEqual({
+      market: 'CEOIL',
+      base: 'WTI',
+      quote: 'USD',
+      source: 'LDN',
+      stream: 'TP',
+    })
+  })
+})


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/MERC-6221

Enable full symbol overrides for the TP EA. For example, sending the request `{"data":{"endpoint":"forex","from":"EGP","to":"JPY","overrides":{"tp":{"EGP":"FXSPTEGPJPYSPT:GBL.BIL.QTE.RTM!TP"}}}}` would return the exact price for the symbol `FXSPTEGPJPYSPT:GBL.BIL.QTE.RTM!TP` rather than any other prices cached for the base `EPG`. This is relevant in cases where there are multiple instruments (e.g. different expiring forwards) for the same base/quote pair.

This is simply implemented by returning two provider results, the default one with the parsed base and an additional one where the base is the full symbol. Note that I refactored the parsing to use string splitting because forward symbols (e.g. `CEFWDXAUUSDSPT06M:LDN.BIL.QTE.RTM!TP`) can have more characters than spot symbols (e.g. `FXSPTUSDAEDSPT:GBL.BIL.QTE.RTM!TP`)

Also added a `commodities` endpoint that's an alias of the existing `prices` / `forex` endpoint.

