### PR TITLE
DF-20626 add bitgo-reserves EA

### DIFF
--- a/.changeset/spicy-bears-burn.md
+++ b/.changeset/spicy-bears-burn.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/bitgo-reserves-adapter': major
+---
+
+bitgo-reserves EA initial release

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -263,6 +263,10 @@ const RAW_RUNTIME_STATE =
       "reference": "workspace:packages/sources/bitgo"\
     },\
     {\
+      "name": "@chainlink/bitgo-reserves-adapter",\
+      "reference": "workspace:packages/sources/bitgo-reserves"\
+    },\
+    {\
       "name": "@chainlink/bitso-adapter",\
       "reference": "workspace:packages/sources/bitso"\
     },\
@@ -937,6 +941,7 @@ const RAW_RUNTIME_STATE =
     ["@chainlink/bitcoin-json-rpc-adapter", ["workspace:packages/composites/bitcoin-json-rpc"]],\
     ["@chainlink/bitex-adapter", ["workspace:packages/sources/bitex"]],\
     ["@chainlink/bitgo-adapter", ["workspace:packages/sources/bitgo"]],\
+    ["@chainlink/bitgo-reserves-adapter", ["workspace:packages/sources/bitgo-reserves"]],\
     ["@chainlink/bitso-adapter", ["workspace:packages/sources/bitso"]],\
     ["@chainlink/blockchain.com-adapter", ["workspace:packages/sources/blockchain.com"]],\
     ["@chainlink/blockchair-adapter", ["workspace:packages/sources/blockchair"]],\
@@ -5994,6 +5999,21 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./packages/sources/bitgo/",\
         "packageDependencies": [\
           ["@chainlink/bitgo-adapter", "workspace:packages/sources/bitgo"],\
+          ["@chainlink/external-adapter-framework", "npm:1.5.0"],\
+          ["@types/jest", "npm:27.5.2"],\
+          ["@types/node", "npm:16.11.68"],\
+          ["nock", "npm:13.5.4"],\
+          ["tslib", "npm:2.4.1"],\
+          ["typescript", "patch:typescript@npm%3A5.0.4#optional!builtin<compat/typescript>::version=5.0.4&hash=b5f058"]\
+        ],\
+        "linkType": "SOFT"\
+      }]\
+    ]],\
+    ["@chainlink/bitgo-reserves-adapter", [\
+      ["workspace:packages/sources/bitgo-reserves", {\
+        "packageLocation": "./packages/sources/bitgo-reserves/",\
+        "packageDependencies": [\
+          ["@chainlink/bitgo-reserves-adapter", "workspace:packages/sources/bitgo-reserves"],\
           ["@chainlink/external-adapter-framework", "npm:1.5.0"],\
           ["@types/jest", "npm:27.5.2"],\
           ["@types/node", "npm:16.11.68"],\

--- a/packages/sources/bitgo-reserves/README.md
+++ b/packages/sources/bitgo-reserves/README.md
@@ -6,9 +6,9 @@ This document was generated automatically. Please see [README Generator](../../s
 
 ## Environment Variables
 
-| Required? |     Name     |            Description            |  Type  | Options |                 Default                 |
-| :-------: | :----------: | :-------------------------------: | :----: | :-----: | :-------------------------------------: |
-|           | API_ENDPOINT | An API endpoint for Data Provider | string |         | `https://d2nz84bmzl209r.cloudfront.net` |
+| Required? |     Name     |            Description            |  Type  | Options |              Default              |
+| :-------: | :----------: | :-------------------------------: | :----: | :-----: | :-------------------------------: |
+|           | API_ENDPOINT | An API endpoint for Data Provider | string |         | `http://por.usdstandard-test.com` |
 
 ---
 

--- a/packages/sources/bitgo-reserves/README.md
+++ b/packages/sources/bitgo-reserves/README.md
@@ -1,0 +1,3 @@
+# Chainlink External Adapter for bitgo-reserves
+
+This README will be generated automatically when code is merged to `main`. If you would like to generate a preview of the README, please run `yarn generate:readme bitgo-reserves`.

--- a/packages/sources/bitgo-reserves/README.md
+++ b/packages/sources/bitgo-reserves/README.md
@@ -1,3 +1,51 @@
-# Chainlink External Adapter for bitgo-reserves
+# BITGO_RESERVES
 
-This README will be generated automatically when code is merged to `main`. If you would like to generate a preview of the README, please run `yarn generate:readme bitgo-reserves`.
+![0.0.0](https://img.shields.io/github/package-json/v/smartcontractkit/external-adapters-js?filename=packages/sources/bitgo-reserves/package.json) ![v3](https://img.shields.io/badge/framework%20version-v3-blueviolet)
+
+This document was generated automatically. Please see [README Generator](../../scripts#readme-generator) for more info.
+
+## Environment Variables
+
+| Required? |     Name     |            Description            |  Type  | Options |                 Default                 |
+| :-------: | :----------: | :-------------------------------: | :----: | :-----: | :-------------------------------------: |
+|           | API_ENDPOINT | An API endpoint for Data Provider | string |         | `https://d2nz84bmzl209r.cloudfront.net` |
+
+---
+
+## Data Provider Rate Limits
+
+|  Name   | Requests/credits per second | Requests/credits per minute | Requests/credits per hour | Note |
+| :-----: | :-------------------------: | :-------------------------: | :-----------------------: | :--: |
+| default |                             |             10              |                           |      |
+
+---
+
+## Input Parameters
+
+| Required? |   Name   |     Description     |  Type  |            Options             |  Default   |
+| :-------: | :------: | :-----------------: | :----: | :----------------------------: | :--------: |
+|           | endpoint | The endpoint to use | string | [reserves](#reserves-endpoint) | `reserves` |
+
+## Reserves Endpoint
+
+`reserves` is the only supported name for this endpoint.
+
+### Input Params
+
+There are no input parameters for this endpoint.
+
+### Example
+
+Request:
+
+```json
+{
+  "data": {
+    "endpoint": "reserves"
+  }
+}
+```
+
+---
+
+MIT License

--- a/packages/sources/bitgo-reserves/package.json
+++ b/packages/sources/bitgo-reserves/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@chainlink/bitgo-reserves-adapter",
+  "version": "0.0.0",
+  "description": "Chainlink bitgo-reserves adapter.",
+  "keywords": [
+    "Chainlink",
+    "LINK",
+    "blockchain",
+    "oracle",
+    "bitgo-reserves"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "url": "https://github.com/smartcontractkit/external-adapters-js",
+    "type": "git"
+  },
+  "license": "MIT",
+  "scripts": {
+    "clean": "rm -rf dist && rm -f tsconfig.tsbuildinfo",
+    "prepack": "yarn build",
+    "build": "tsc -b",
+    "server": "node -e 'require(\"./index.js\").server()'",
+    "server:dist": "node -e 'require(\"./dist/index.js\").server()'",
+    "start": "yarn server:dist"
+  },
+  "devDependencies": {
+    "@types/jest": "27.5.2",
+    "@types/node": "16.11.68",
+    "nock": "13.5.4",
+    "typescript": "5.0.4"
+  },
+  "dependencies": {
+    "@chainlink/external-adapter-framework": "1.5.0",
+    "tslib": "2.4.1"
+  }
+}

--- a/packages/sources/bitgo-reserves/src/config/index.ts
+++ b/packages/sources/bitgo-reserves/src/config/index.ts
@@ -1,0 +1,9 @@
+import { AdapterConfig } from '@chainlink/external-adapter-framework/config'
+
+export const config = new AdapterConfig({
+  API_ENDPOINT: {
+    description: 'An API endpoint for Data Provider',
+    type: 'string',
+    default: 'https://d2nz84bmzl209r.cloudfront.net',
+  },
+})

--- a/packages/sources/bitgo-reserves/src/config/index.ts
+++ b/packages/sources/bitgo-reserves/src/config/index.ts
@@ -4,6 +4,6 @@ export const config = new AdapterConfig({
   API_ENDPOINT: {
     description: 'An API endpoint for Data Provider',
     type: 'string',
-    default: 'https://d2nz84bmzl209r.cloudfront.net',
+    default: 'http://por.usdstandard-test.com',
   },
 })

--- a/packages/sources/bitgo-reserves/src/endpoint/index.ts
+++ b/packages/sources/bitgo-reserves/src/endpoint/index.ts
@@ -1,0 +1,1 @@
+export { endpoint as reserves } from './reserves'

--- a/packages/sources/bitgo-reserves/src/endpoint/reserves.ts
+++ b/packages/sources/bitgo-reserves/src/endpoint/reserves.ts
@@ -1,0 +1,19 @@
+import { AdapterEndpoint } from '@chainlink/external-adapter-framework/adapter'
+import { InputParameters } from '@chainlink/external-adapter-framework/validation'
+import { SingleNumberResultResponse } from '@chainlink/external-adapter-framework/util'
+import { config } from '../config'
+import { httpTransport } from '../transport/reserves'
+
+export const inputParameters = new InputParameters({})
+
+export type BaseEndpointTypes = {
+  Parameters: typeof inputParameters.definition
+  Response: SingleNumberResultResponse
+  Settings: typeof config.settings
+}
+
+export const endpoint = new AdapterEndpoint({
+  name: 'reserves',
+  transport: httpTransport,
+  inputParameters,
+})

--- a/packages/sources/bitgo-reserves/src/index.ts
+++ b/packages/sources/bitgo-reserves/src/index.ts
@@ -1,0 +1,20 @@
+import { expose, ServerInstance } from '@chainlink/external-adapter-framework'
+import { Adapter } from '@chainlink/external-adapter-framework/adapter'
+import { config } from './config'
+import { reserves } from './endpoint'
+
+export const adapter = new Adapter({
+  defaultEndpoint: reserves.name,
+  name: 'BITGO_RESERVES',
+  config,
+  endpoints: [reserves],
+  rateLimiting: {
+    tiers: {
+      default: {
+        rateLimit1m: 10, // setting a rate limit so we don't blast the server as fast as possible
+      },
+    },
+  },
+})
+
+export const server = (): Promise<ServerInstance | undefined> => expose(adapter)

--- a/packages/sources/bitgo-reserves/src/transport/reserves.ts
+++ b/packages/sources/bitgo-reserves/src/transport/reserves.ts
@@ -1,0 +1,57 @@
+import { HttpTransport } from '@chainlink/external-adapter-framework/transports'
+import { BaseEndpointTypes } from '../endpoint/reserves'
+
+export interface ResponseSchema {
+  totalReserve: number
+  lastUpdated: Date
+  cashReserve: number
+  investedReserve: number
+}
+
+export type HttpTransportTypes = BaseEndpointTypes & {
+  Provider: {
+    RequestBody: never
+    ResponseBody: ResponseSchema
+  }
+}
+
+// returns reserves info for USDS
+export const httpTransport = new HttpTransport<HttpTransportTypes>({
+  prepareRequests: (params, config) => {
+    return params.map((param) => {
+      return {
+        params: [param],
+        request: {
+          baseURL: config.API_ENDPOINT,
+          url: '/reserves.json',
+        },
+      }
+    })
+  },
+  parseResponse: (params, response) => {
+    if (!response.data) {
+      return params.map((param) => {
+        return {
+          params: param,
+          response: {
+            errorMessage: `The data provider didn't return any value`,
+            statusCode: 502,
+          },
+        }
+      })
+    }
+
+    return params.map((param) => {
+      const result = response.data.totalReserve
+      return {
+        params: param,
+        response: {
+          result,
+          data: {
+            result,
+          },
+        },
+      }
+    })
+  },
+})

--- a/packages/sources/bitgo-reserves/src/transport/reserves.ts
+++ b/packages/sources/bitgo-reserves/src/transport/reserves.ts
@@ -3,7 +3,7 @@ import { BaseEndpointTypes } from '../endpoint/reserves'
 
 export interface ResponseSchema {
   totalReserve: number
-  lastUpdated: Date
+  lastUpdated: string
   cashReserve: number
   investedReserve: number
 }
@@ -29,6 +29,10 @@ export const httpTransport = new HttpTransport<HttpTransportTypes>({
     })
   },
   parseResponse: (params, response) => {
+    const timestamps = {
+      providerIndicatedTimeUnixMs: new Date(response.data.lastUpdated).getTime(),
+    }
+
     if (!response.data) {
       return params.map((param) => {
         return {
@@ -36,6 +40,7 @@ export const httpTransport = new HttpTransport<HttpTransportTypes>({
           response: {
             errorMessage: `The data provider didn't return any value`,
             statusCode: 502,
+            timestamps,
           },
         }
       })
@@ -50,6 +55,7 @@ export const httpTransport = new HttpTransport<HttpTransportTypes>({
           data: {
             result,
           },
+          timestamps,
         },
       }
     })

--- a/packages/sources/bitgo-reserves/test-payload.json
+++ b/packages/sources/bitgo-reserves/test-payload.json
@@ -1,0 +1,6 @@
+{
+ "requests": [{
+  "from": "BTC",
+  "to": "USD"
+ }]
+}

--- a/packages/sources/bitgo-reserves/test-payload.json
+++ b/packages/sources/bitgo-reserves/test-payload.json
@@ -1,6 +1,3 @@
 {
- "requests": [{
-  "from": "BTC",
-  "to": "USD"
- }]
+ "requests": [{}]
 }

--- a/packages/sources/bitgo-reserves/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/bitgo-reserves/test/integration/__snapshots__/adapter.test.ts.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`execute reserves endpoint should return success 1`] = `
+{
+  "data": {
+    "result": 1234567.89,
+  },
+  "result": 1234567.89,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 978347471111,
+    "providerDataRequestedUnixMs": 978347471111,
+  },
+}
+`;

--- a/packages/sources/bitgo-reserves/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/bitgo-reserves/test/integration/__snapshots__/adapter.test.ts.snap
@@ -10,6 +10,7 @@ exports[`execute reserves endpoint should return success 1`] = `
   "timestamps": {
     "providerDataReceivedUnixMs": 978347471111,
     "providerDataRequestedUnixMs": 978347471111,
+    "providerIndicatedTimeUnixMs": 1727745825000,
   },
 }
 `;

--- a/packages/sources/bitgo-reserves/test/integration/adapter.test.ts
+++ b/packages/sources/bitgo-reserves/test/integration/adapter.test.ts
@@ -1,0 +1,46 @@
+import {
+  TestAdapter,
+  setEnvVariables,
+} from '@chainlink/external-adapter-framework/util/testing-utils'
+import * as nock from 'nock'
+import { mockResponseSuccess } from './fixtures'
+
+describe('execute', () => {
+  let spy: jest.SpyInstance
+  let testAdapter: TestAdapter
+  let oldEnv: NodeJS.ProcessEnv
+
+  beforeAll(async () => {
+    oldEnv = JSON.parse(JSON.stringify(process.env))
+    process.env.API_ENDPOINT = 'http://test-endpoint.com'
+
+    const mockDate = new Date('2001-01-01T11:11:11.111Z')
+    spy = jest.spyOn(Date, 'now').mockReturnValue(mockDate.getTime())
+
+    const adapter = (await import('./../../src')).adapter
+    adapter.rateLimiting = undefined
+    testAdapter = await TestAdapter.startWithMockedCache(adapter, {
+      testAdapter: {} as TestAdapter<never>,
+    })
+  })
+
+  afterAll(async () => {
+    setEnvVariables(oldEnv)
+    await testAdapter.api.close()
+    nock.restore()
+    nock.cleanAll()
+    spy.mockRestore()
+  })
+
+  describe('reserves endpoint', () => {
+    it('should return success', async () => {
+      const data = {
+        endpoint: 'reserves',
+      }
+      mockResponseSuccess()
+      const response = await testAdapter.request(data)
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toMatchSnapshot()
+    })
+  })
+})

--- a/packages/sources/bitgo-reserves/test/integration/fixtures.ts
+++ b/packages/sources/bitgo-reserves/test/integration/fixtures.ts
@@ -1,0 +1,25 @@
+import nock from 'nock'
+
+export const mockResponseSuccess = (): nock.Scope =>
+  nock('http://test-endpoint.com', {
+    encodedQueryParams: true,
+  })
+    .get('/reserves.json')
+    .reply(
+      200,
+      () => ({
+        totalReserve: 1234567.89,
+        lastUpdated: '2024-10-01T01:23:45Z',
+      }),
+      [
+        'Content-Type',
+        'application/json',
+        'Connection',
+        'close',
+        'Vary',
+        'Accept-Encoding',
+        'Vary',
+        'Origin',
+      ],
+    )
+    .persist()

--- a/packages/sources/bitgo-reserves/tsconfig.json
+++ b/packages/sources/bitgo-reserves/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*", "src/**/*.json"],
+  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]
+}

--- a/packages/sources/bitgo-reserves/tsconfig.test.json
+++ b/packages/sources/bitgo-reserves/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*", "**/test", "src/**/*.json"],
+  "compilerOptions": {
+    "noEmit": true
+  }
+}

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -177,6 +177,9 @@
       "path": "./sources/bitgo"
     },
     {
+      "path": "./sources/bitgo-reserves"
+    },
+    {
       "path": "./sources/bitso"
     },
     {

--- a/packages/tsconfig.test.json
+++ b/packages/tsconfig.test.json
@@ -177,6 +177,9 @@
       "path": "./sources/bitgo/tsconfig.test.json"
     },
     {
+      "path": "./sources/bitgo-reserves/tsconfig.test.json"
+    },
+    {
       "path": "./sources/bitso/tsconfig.test.json"
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3219,6 +3219,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@chainlink/bitgo-reserves-adapter@workspace:packages/sources/bitgo-reserves":
+  version: 0.0.0-use.local
+  resolution: "@chainlink/bitgo-reserves-adapter@workspace:packages/sources/bitgo-reserves"
+  dependencies:
+    "@chainlink/external-adapter-framework": "npm:1.5.0"
+    "@types/jest": "npm:27.5.2"
+    "@types/node": "npm:16.11.68"
+    nock: "npm:13.5.4"
+    tslib: "npm:2.4.1"
+    typescript: "npm:5.0.4"
+  languageName: unknown
+  linkType: soft
+
 "@chainlink/bitso-adapter@workspace:packages/sources/bitso":
   version: 0.0.0-use.local
   resolution: "@chainlink/bitso-adapter@workspace:packages/sources/bitso"


### PR DESCRIPTION
## Closes #[DF-20626](https://smartcontract-it.atlassian.net/browse/DF-20626)

## Description
Adding new EA for bitgo reserves
**NOTE** the default endpoint is a test endpoint and not meant to be used in production
**NOTE** no secrets

## Steps to Test
1. yarn test bitgo-reserves
2. sanity test reserves endpoint EA request

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[DF-20626]: https://smartcontract-it.atlassian.net/browse/DF-20626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ