### PR TITLE
market-status: Use NCFX as primary for forex and metals markets

### DIFF
--- a/.changeset/fair-goats-carry.md
+++ b/.changeset/fair-goats-carry.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/market-status-adapter': minor
+---
+
+Use NCFX as primary for forex and metals markets

--- a/packages/composites/market-status/src/config/adapters.ts
+++ b/packages/composites/market-status/src/config/adapters.ts
@@ -3,9 +3,17 @@ export const adapterNames = ['NCFX', 'TRADINGHOURS'] as const
 export type AdapterName = (typeof adapterNames)[number]
 
 // Mapping from market to primary and secondary adapters.
-export const marketAdapters: Record<string, Record<'primary' | 'secondary', AdapterName>> = {
+export const marketAdapters: Record<string, { primary: AdapterName; secondary: AdapterName }> = {
   __default: {
     primary: 'TRADINGHOURS',
     secondary: 'NCFX',
+  },
+  forex: {
+    primary: 'NCFX',
+    secondary: 'TRADINGHOURS',
+  },
+  metals: {
+    primary: 'NCFX',
+    secondary: 'TRADINGHOURS',
   },
 }


### PR DESCRIPTION
Use NCFX as primary for forex and metals markets only. All other markets, including future ones, will continue to use TradingHours as primary.