### PR TITLE
Chore/DF-20691 update endpoint

### DIFF
--- a/.changeset/dirty-avocados-impress.md
+++ b/.changeset/dirty-avocados-impress.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/bitgo-reserves-adapter': minor
+---
+
+Update default endpoint

--- a/packages/sources/bitgo-reserves/src/config/index.ts
+++ b/packages/sources/bitgo-reserves/src/config/index.ts
@@ -4,6 +4,6 @@ export const config = new AdapterConfig({
   API_ENDPOINT: {
     description: 'An API endpoint for Data Provider',
     type: 'string',
-    default: 'http://por.usdstandard-test.com',
+    default: 'https://reserves.usdstandard-test.com/por.json',
   },
 })

--- a/packages/sources/bitgo-reserves/src/transport/reserves.ts
+++ b/packages/sources/bitgo-reserves/src/transport/reserves.ts
@@ -23,7 +23,6 @@ export const httpTransport = new HttpTransport<HttpTransportTypes>({
         params: [param],
         request: {
           baseURL: config.API_ENDPOINT,
-          url: '/reserves.json',
         },
       }
     })

--- a/packages/sources/bitgo-reserves/test/integration/fixtures.ts
+++ b/packages/sources/bitgo-reserves/test/integration/fixtures.ts
@@ -4,7 +4,7 @@ export const mockResponseSuccess = (): nock.Scope =>
   nock('http://test-endpoint.com', {
     encodedQueryParams: true,
   })
-    .get('/reserves.json')
+    .get('/')
     .reply(
       200,
       () => ({


### PR DESCRIPTION
## Closes #[DF-20691](https://smartcontract-it.atlassian.net/browse/DF-20691)

## Description
Updating default endpoint for bitgo-reserves and removing sub-URI

## Changes
- updated default endpoint to changed prod endpoint
- removed hardcoded `/reserves.json` in transport

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test
1. sanity test `"endpoint": "reserves"`
2. `yarn test bitgo-reserves` from root

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[DF-20691]: https://smartcontract-it.atlassian.net/browse/DF-20691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ