### PR TITLE
Chore/DF-20681 XPD includes in TP

### DIFF
--- a/.changeset/tame-walls-provide.md
+++ b/.changeset/tame-walls-provide.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/tp-adapter': patch
+---
+
+Add XPD to includes file

--- a/packages/sources/tp/src/config/includes.json
+++ b/packages/sources/tp/src/config/includes.json
@@ -1408,17 +1408,6 @@
     ]
   },
   {
-    "from": "XPF",
-    "to": "USD",
-    "includes": [
-      {
-        "from": "USD",
-        "to": "XPF",
-        "inverse": true
-      }
-    ]
-  },
-  {
     "from": "XPD",
     "to": "USD",
     "includes": [
@@ -1426,6 +1415,17 @@
         "from": "USD",
         "to": "XPD",
         "inverse": false
+      }
+    ]
+  },
+  {
+    "from": "XPF",
+    "to": "USD",
+    "includes": [
+      {
+        "from": "USD",
+        "to": "XPF",
+        "inverse": true
       }
     ]
   },

--- a/packages/sources/tp/src/config/includes.json
+++ b/packages/sources/tp/src/config/includes.json
@@ -1419,6 +1419,17 @@
     ]
   },
   {
+    "from": "XPD",
+    "to": "USD",
+    "includes": [
+      {
+        "from": "USD",
+        "to": "XPD",
+        "inverse": false
+      }
+    ]
+  },
+  {
     "from": "XPT",
     "to": "USD",
     "includes": [


### PR DESCRIPTION
## Closes #[DF-20681](https://smartcontract-it.atlassian.net/browse/DF-20681)

## Description
Add XPD/USD pair to TP includes file because the pair is returned wrong by the DP (similar to all other metals, XAU, XAG, XPT)

## Changes
- Add XPD/USD to TP includes file

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test
1. Sanity test request with `"base": "XPD", "quote": "USD"`

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[DF-20681]: https://smartcontract-it.atlassian.net/browse/DF-20681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ