### PR TITLE
Update sock test

### DIFF
--- a/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts
+++ b/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts
@@ -85,4 +85,5 @@ export const SoakTestBlacklist: string[] = [
   'unibit',
   'vesper',
   'bank-frick', // Not in-use, no creds available for testing
+  'blockchain.com', // Does not support . in the name
 ]


### PR DESCRIPTION
```
	* Service "adapter-qa-ea-blockchain.com-3260" is invalid: metadata.name: Invalid value: "adapter-qa-ea-blockchain.com-3260": a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')
```

This EA was developed 3 years ago and does not appear in RDD, we can fix the naming later if this need to be in-use