### PR TITLE
Allow override on cfbenchmarks2

### DIFF
--- a/.changeset/four-rocks-deliver.md
+++ b/.changeset/four-rocks-deliver.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/cfbenchmarks-adapter': minor
+---
+
+Seperate cfb with cfb2

--- a/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts
+++ b/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts
@@ -88,4 +88,6 @@ export const SoakTestBlacklist: string[] = [
   'blockchain.com', // Does not support . in the name
   'cache.gold',
   'ion.au',
+  'galaxy', // Not deployed internally
+  'stader-balance', // Not deployed internally
 ]

--- a/packages/sources/cfbenchmarks/src/endpoint/crypto.ts
+++ b/packages/sources/cfbenchmarks/src/endpoint/crypto.ts
@@ -30,6 +30,11 @@ export const inputParameters = new InputParameters(
       description: 'The symbol of the currency to convert to',
       required: false,
     },
+    adapterNameOverride: {
+      type: 'string',
+      description: 'Alternate adapter name to use for override and metrics',
+      required: false,
+    },
   },
   [
     {

--- a/packages/sources/cfbenchmarks/src/endpoint/crypto.ts
+++ b/packages/sources/cfbenchmarks/src/endpoint/crypto.ts
@@ -32,7 +32,7 @@ export const inputParameters = new InputParameters(
     },
     adapterNameOverride: {
       type: 'string',
-      description: 'Alternate adapter name to use for override and metrics',
+      description: 'Used internally for override and metrics, do not set this field',
       required: false,
     },
   },

--- a/packages/sources/cfbenchmarks/src/endpoint/utils.ts
+++ b/packages/sources/cfbenchmarks/src/endpoint/utils.ts
@@ -18,7 +18,12 @@ const overridenBaseQuoteFromId: BaseQuoteToIdLookup = {
 
 export function customInputValidation(
   req: AdapterRequest<typeof inputParameters.validated>,
+  adapterSettings: BaseEndpointTypes['Settings'],
 ): AdapterError | undefined {
+  if (adapterSettings.API_SECONDARY) {
+    req.requestContext.data.adapterNameOverride = 'cfbenchmarks2'
+  }
+
   const { base, quote, index } = req.requestContext.data
   // Base and quote must be provided OR index must be provided
   if (!(index || (base && quote))) {

--- a/packages/sources/cfbenchmarks/src/transport/crypto-ws.ts
+++ b/packages/sources/cfbenchmarks/src/transport/crypto-ws.ts
@@ -48,7 +48,12 @@ export const makeWsTransport = (
           const value = Number(message.value)
           return [
             {
-              params: { index, base: undefined, quote: undefined },
+              params: {
+                index,
+                base: undefined,
+                quote: undefined,
+                ...(type != 'primary' && { adapterNameOverride: 'cfbenchmarks2' }),
+              },
               response: {
                 result: value,
                 data: {


### PR DESCRIPTION
When SECONDARY_API is true, override adapter name to be cfb2.

This allows
 - metrics to show adapter as cfb2
 - Override will try to match cfb2 first, then cfb