### PR TITLE
Proof of Reserves Aggregator

### DIFF
--- a/.changeset/few-vans-rule.md
+++ b/.changeset/few-vans-rule.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/proof-of-reserves-adapter': minor
+---
+
+Add multiReserves endpoint

--- a/.changeset/large-ghosts-build.md
+++ b/.changeset/large-ghosts-build.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/por-address-list-adapter': patch
+---
+
+Fix input convension

--- a/packages/composites/proof-of-reserves/src/endpoint/index.ts
+++ b/packages/composites/proof-of-reserves/src/endpoint/index.ts
@@ -1,5 +1,7 @@
-import * as reserves from './reserves'
+import type { TInputParameters as SingleTInputParameters } from './reserves'
+import type { TInputParameters as MultiTInputParameters } from './multiReserves'
 
-export type TInputParameters = reserves.TInputParameters
+export type TInputParameters = SingleTInputParameters | MultiTInputParameters
 
 export * as reserves from './reserves'
+export * as multiReserves from './multiReserves'

--- a/packages/composites/proof-of-reserves/src/endpoint/multiReserves.ts
+++ b/packages/composites/proof-of-reserves/src/endpoint/multiReserves.ts
@@ -20,6 +20,8 @@ const inputParameters: InputParameters<TInputParameters> = {
 }
 
 export const execute: ExecuteWithConfig<Config> = async (input, context, config) => {
+  const providerDataRequestedUnixMs = Date.now()
+
   const validator = new Validator(input, inputParameters)
   const jobRunID = validator.validated.id
 
@@ -57,6 +59,10 @@ export const execute: ExecuteWithConfig<Config> = async (input, context, config)
       result: result,
       statusCode: 200,
       decimals: 18,
+      timestamps: {
+        providerDataRequestedUnixMs,
+        providerDataReceivedUnixMs: Date.now(),
+      },
     },
   }
 }

--- a/packages/composites/proof-of-reserves/src/endpoint/multiReserves.ts
+++ b/packages/composites/proof-of-reserves/src/endpoint/multiReserves.ts
@@ -1,0 +1,71 @@
+import type { ExecuteWithConfig, InputParameters } from '@chainlink/ea-bootstrap'
+import type { TInputParameters as SingleTInputParameters } from './reserves'
+import { execute as singleExecute } from './reserves'
+import { Validator } from '@chainlink/ea-bootstrap'
+import { Config } from '../config'
+import { AdapterError } from '@chainlink/ea-bootstrap'
+
+export const supportedEndpoints = ['multiReserves']
+
+export type TInputParameters = {
+  input: SingleTInputParameters[]
+}
+
+const inputParameters: InputParameters<TInputParameters> = {
+  input: {
+    required: true,
+    type: 'array',
+    description: 'An array of PoR request, each request is a request to the reserves endpoint',
+  },
+}
+
+export const execute: ExecuteWithConfig<Config> = async (input, context, config) => {
+  const validator = new Validator(input, inputParameters)
+  const jobRunID = validator.validated.id
+
+  const results = await Promise.all(
+    validator.validated.data.input.map((input) =>
+      singleExecute(
+        {
+          id: jobRunID,
+          data: input,
+        },
+        context,
+        config,
+      ),
+    ),
+  )
+
+  const result = results
+    .map((result) => {
+      if (result.statusCode != 200 || !result.result) {
+        throw new AdapterError({
+          ...result,
+        })
+      } else {
+        return scale(BigInt(result.result.toString()), result.data.decimals?.toString())
+      }
+    })
+    .reduce((s, e) => s + e)
+    .toString()
+
+  return {
+    jobRunID,
+    result: result,
+    statusCode: 200,
+    data: {
+      result: result,
+      statusCode: 200,
+      decimals: 18,
+    },
+  }
+}
+
+const scale = (value: bigint, decimal?: string) => {
+  if (decimal) {
+    // Scale to 18 decimals
+    return value * 10n ** (18n - BigInt(decimal))
+  } else {
+    return value
+  }
+}

--- a/packages/composites/proof-of-reserves/src/utils/reduce.ts
+++ b/packages/composites/proof-of-reserves/src/utils/reduce.ts
@@ -16,6 +16,7 @@ const returnParsedUnits = (jobRunID: string, result: string, units: number) => {
     data: {
       result: convertedResult,
       statusCode: 200,
+      decimals: units,
     },
   }
 }

--- a/packages/composites/proof-of-reserves/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/composites/proof-of-reserves/test/integration/__snapshots__/adapter.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`execute Bitcoin list protocol should return success 1`] = `
 {
   "data": {
+    "decimals": 8,
     "result": "75100045155",
     "statusCode": 200,
   },
@@ -27,6 +28,7 @@ exports[`execute Ethereum list protocol should return success 1`] = `
 exports[`execute Filecoin Gemini protocol should return success 1`] = `
 {
   "data": {
+    "decimals": 0,
     "result": "127530375584000000000000",
     "statusCode": 200,
   },
@@ -38,10 +40,24 @@ exports[`execute Filecoin Gemini protocol should return success 1`] = `
 exports[`execute Filecoin list protocol w/ miner format address should return success 1`] = `
 {
   "data": {
+    "decimals": 0,
     "result": "127530375584000000000000",
     "statusCode": 200,
   },
   "result": "127530375584000000000000",
+  "statusCode": 200,
+}
+`;
+
+exports[`execute multiReserves endpoint should return success 1`] = `
+{
+  "data": {
+    "decimals": 18,
+    "result": "751221097708354962165",
+    "statusCode": 200,
+  },
+  "jobRunID": "1",
+  "result": "751221097708354962165",
   "statusCode": 200,
 }
 `;

--- a/packages/composites/proof-of-reserves/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/composites/proof-of-reserves/test/integration/__snapshots__/adapter.test.ts.snap
@@ -55,6 +55,10 @@ exports[`execute multiReserves endpoint should return success 1`] = `
     "decimals": 18,
     "result": "751221097708354962165",
     "statusCode": 200,
+    "timestamps": {
+      "providerDataReceivedUnixMs": 1641035471111,
+      "providerDataRequestedUnixMs": 1641035471111,
+    },
   },
   "jobRunID": "1",
   "result": "751221097708354962165",

--- a/packages/composites/proof-of-reserves/test/integration/adapter.test.ts
+++ b/packages/composites/proof-of-reserves/test/integration/adapter.test.ts
@@ -26,6 +26,17 @@ describe('execute', () => {
 
   setupExternalAdapterTest(envVariables, context)
 
+  let spy: jest.SpyInstance
+  beforeAll(async () => {
+    const mockDate = new Date('2022-01-01T11:11:11.111Z')
+    spy = jest.spyOn(Date, 'now').mockReturnValue(mockDate.getTime())
+  })
+
+  afterAll((done) => {
+    spy.mockRestore()
+    done()
+  })
+
   describe('Bitcoin list protocol', () => {
     const data: AdapterRequest = {
       id: '1',

--- a/packages/composites/proof-of-reserves/test/integration/adapter.test.ts
+++ b/packages/composites/proof-of-reserves/test/integration/adapter.test.ts
@@ -101,7 +101,7 @@ describe('execute', () => {
         .set('Accept', '*/*')
         .set('Content-Type', 'application/json')
         .expect('Content-Type', /json/)
-      // .expect(200)
+        .expect(200)
       expect(response.body).toMatchSnapshot()
     })
   })
@@ -119,14 +119,63 @@ describe('execute', () => {
     }
 
     it('should return success', async () => {
-      //mockLotusSuccess()
+      mockLotusSuccess()
       const response = await (context.req as SuperTest<Test>)
         .post('/')
         .send(data)
         .set('Accept', '*/*')
         .set('Content-Type', 'application/json')
         .expect('Content-Type', /json/)
-      // .expect(200)
+        .expect(200)
+      expect(response.body).toMatchSnapshot()
+    })
+  })
+
+  describe('multiReserves endpoint', () => {
+    it('should return success', async () => {
+      const data: AdapterRequest = {
+        id: '1',
+        data: {
+          endpoint: 'multiReserves',
+          input: [
+            {
+              protocol: 'list',
+              indexer: 'por_indexer',
+              addresses: [
+                {
+                  address: '39e7mxbeNmRRnjfy1qkphv1TiMcztZ8VuE',
+                  chainId: 'mainnet',
+                  network: 'bitcoin',
+                },
+                {
+                  address: '35ULMyVnFoYaPaMxwHTRmaGdABpAThM4QR',
+                  chainId: 'mainnet',
+                  network: 'bitcoin',
+                },
+              ],
+            },
+            {
+              indexer: 'eth_balance',
+              protocol: 'list',
+              addresses: [
+                '0x8288C280F35FB8809305906C79BD075962079DD8',
+                '0x81910675DbaF69deE0fD77570BFD07f8E436386A',
+              ],
+              confirmations: 5,
+            },
+          ],
+        },
+      }
+      mockPoRindexerSuccess()
+      mockEthBalanceSuccess()
+
+      const response = await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
       expect(response.body).toMatchSnapshot()
     })
   })

--- a/packages/sources/por-address-list/src/transport/multichainAddress.ts
+++ b/packages/sources/por-address-list/src/transport/multichainAddress.ts
@@ -71,7 +71,7 @@ export class AddressTransport extends SubscriptionTransport<AddressTransportType
 
     const addressManager = new ethers.Contract(
       contractAddress,
-      contractAddressNetwork == 'POLYGON' ? PolygonABI : ABI,
+      contractAddressNetwork.toUpperCase() == 'POLYGON' ? PolygonABI : ABI,
       provider,
     )
     const latestBlockNum = await provider.getBlockNumber()


### PR DESCRIPTION
## Closes #DF-20744

## Description

We need a way to sum up multiple PoR results for a given feed.

## Changes

Here we introduce a new endpoint which simply takes in a list of PoR requests, execute them and then sum up the result.
We also introduce decimals into the aggregation process

## Steps to Test

```
{
    "data": {
        "endpoint": "multiReserves",
        "input": [
            {
                "chainId": "mainnet",
                "contractAddress": "0x9480f77911634a7dba7082b1422df058d23ba6c1",
                "contractAddressNetwork": "binance",
                "indexer": "por_indexer",
                "network": "bitcoin",
                "protocol": "por_address_list"
            },
            {
                "chainId": "mainnet",
                "contractAddress": "0x9480f77911634a7dba7082b1422df058d23ba6c1",
                "contractAddressNetwork": "binance",
                "indexer": "por_indexer",
                "network": "bitcoin",
                "protocol": "por_address_list"
            }
        ]
    }
}
```

```
{
    "jobRunID": "1",
    "result": "13500310240000000000",
    "statusCode": 200,
    "data": {
        "result": "13500310240000000000",
        "statusCode": 200,
        "decimals": 18
    },
    "meta": {
        "adapterName": "PROOF_OF_RESERVES"
    },
    "metricsMeta": {
        "feedId": "99bc8adffe392f8e961c945c202950a2"
    }
}
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
