### PR TITLE
Update bedrock address list

### DIFF
--- a/.changeset/fuzzy-trees-act.md
+++ b/.changeset/fuzzy-trees-act.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/por-address-list-adapter': patch
+---
+
+Update bedrock address list

--- a/packages/sources/por-address-list/src/config/index.ts
+++ b/packages/sources/por-address-list/src/config/index.ts
@@ -27,7 +27,7 @@ export const config = new AdapterConfig({
   BEDROCK_UNIBTC_API_ENDPOINT: {
     description: 'An API endpoint for Bedrock uniBTC native BTC wallet address',
     type: 'string',
-    default: 'https://bedrock-datacenter.rockx.com/uniBTC/reserve/address',
+    default: 'https://bedrock-datacenter.rockx.com/data/tvl/reserve_with_native.json',
   },
   SOLVBTC_API_ENDPOINT: {
     description: 'An API endpoint for SolvBTC native BTC wallet address',

--- a/packages/sources/por-address-list/src/endpoint/bedrockBTC.ts
+++ b/packages/sources/por-address-list/src/endpoint/bedrockBTC.ts
@@ -1,18 +1,39 @@
-import {
-  PoRAddressEndpoint,
-  PoRAddressResponse,
-} from '@chainlink/external-adapter-framework/adapter/por'
-import { EmptyInputParameters } from '@chainlink/external-adapter-framework/validation/input-params'
+import { PoRAddress, PoRTokenAddress } from '@chainlink/external-adapter-framework/adapter/por'
+import { AdapterEndpoint } from '@chainlink/external-adapter-framework/adapter'
+import { InputParameters } from '@chainlink/external-adapter-framework/validation'
 import { config } from '../config'
 import { bedrockHttpTransport } from '../transport/bedrockUniBTC'
 
+export const inputParameters = new InputParameters(
+  {
+    type: {
+      description:
+        'The type of addresses you are looking for. BTC is native BTC address. tokens is for token-balance EA. vault is for eth-balance EA.',
+      options: ['BTC', 'tokens', 'vault'],
+      type: 'string',
+      required: true,
+    },
+  },
+  [
+    {
+      type: 'BTC',
+    },
+  ],
+)
+
 export type BaseEndpointTypes = {
-  Parameters: EmptyInputParameters
-  Response: PoRAddressResponse
+  Parameters: typeof inputParameters.definition
+  Response: {
+    Result: null
+    Data: {
+      result: PoRAddress[] | PoRTokenAddress[]
+    }
+  }
   Settings: typeof config.settings
 }
 
-export const endpoint = new PoRAddressEndpoint({
+export const endpoint = new AdapterEndpoint({
   name: 'bedrockBtcAddress',
   transport: bedrockHttpTransport,
+  inputParameters,
 })

--- a/packages/sources/por-address-list/src/transport/bedrockUniBTC.ts
+++ b/packages/sources/por-address-list/src/transport/bedrockUniBTC.ts
@@ -1,12 +1,22 @@
 import { HttpTransport } from '@chainlink/external-adapter-framework/transports'
+import { TypeFromDefinition } from '@chainlink/external-adapter-framework/validation/input-params'
 import { BaseEndpointTypes } from '../endpoint/bedrockBTC'
 
 interface ResponseSchema {
-  btc: string[]
+  btc: {
+    type: string
+    addr: string
+  }[]
   evm: {
-    [key: string]: string
+    [key: string]: {
+      chain_id: number
+      vault: string
+      tokens: string[]
+    }
   }
 }
+
+const VAULT_PLACEHOLDER = '0x0000000000000000000000000000000000000000'
 
 export type HttpTransportTypes = BaseEndpointTypes & {
   Provider: {
@@ -26,25 +36,31 @@ export const bedrockHttpTransport = new HttpTransport<HttpTransportTypes>({
     })
   },
   parseResponse: (params, response) => {
-    if (!response.data || response.data.btc.length == 0) {
+    if (!response.data) {
       return [
         {
           params: params[0],
           response: {
-            errorMessage: `The data provider didn't return any address for solvBTC`,
+            errorMessage: `The data provider didn't return any data for bedrockBTC`,
             statusCode: 502,
           },
         },
       ]
     }
 
-    const addresses = response.data.btc
-      .map((adr) => ({
-        address: adr,
-        network: 'bitcoin',
-        chainId: 'mainnet',
-      }))
-      .sort()
+    const addresses = getAddresses(params[0].type, response.data)
+
+    if (addresses.length == 0) {
+      return [
+        {
+          params: params[0],
+          response: {
+            errorMessage: `The data provider didn't return any ${params[0].type} address for bedrockBTC`,
+            statusCode: 502,
+          },
+        },
+      ]
+    }
 
     return [
       {
@@ -59,3 +75,36 @@ export const bedrockHttpTransport = new HttpTransport<HttpTransportTypes>({
     ]
   },
 })
+
+const getAddresses = (
+  type: TypeFromDefinition<BaseEndpointTypes['Parameters']>['type'],
+  data: ResponseSchema,
+) => {
+  switch (type) {
+    case 'BTC':
+      return data.btc
+        .map((d) => ({
+          address: d.addr,
+          network: 'bitcoin',
+          chainId: 'mainnet',
+        }))
+        .sort()
+    case 'tokens':
+      return Object.entries(data.evm)
+        .map(([_, value]) => ({
+          chainId: value.chain_id.toString(),
+          contractAddress: value.vault,
+          wallets: value.tokens.filter((t) => t != VAULT_PLACEHOLDER).sort(),
+        }))
+        .sort()
+    case 'vault':
+      return Object.entries(data.evm)
+        .filter(([_, value]) => value.tokens.includes(VAULT_PLACEHOLDER))
+        .map(([key, value]) => ({
+          address: value.vault,
+          network: key,
+          chainId: value.chain_id.toString(),
+        }))
+        .sort()
+  }
+}

--- a/packages/sources/por-address-list/test-payload.json
+++ b/packages/sources/por-address-list/test-payload.json
@@ -11,7 +11,8 @@
     "network": "bitcoin",
     "batchSize": 100
  }, {
-    "endpoint": "bedrockBtcAddress"
+    "endpoint": "bedrockBtcAddress",
+    "type": "BTC"
  }, {
     "endpoint": "solvBtcAddress"
  }, {

--- a/packages/sources/por-address-list/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/por-address-list/test/integration/__snapshots__/adapter.test.ts.snap
@@ -65,7 +65,7 @@ exports[`execute address endpoint should return success 1`] = `
 }
 `;
 
-exports[`execute apiAddress endpoint bedrock should return success 1`] = `
+exports[`execute apiAddress endpoint bedrock BTC should return success 1`] = `
 {
   "data": {
     "result": [
@@ -78,6 +78,55 @@ exports[`execute apiAddress endpoint bedrock should return success 1`] = `
         "address": "btc_2",
         "chainId": "mainnet",
         "network": "bitcoin",
+      },
+    ],
+  },
+  "result": null,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 978347471111,
+    "providerDataRequestedUnixMs": 978347471111,
+  },
+}
+`;
+
+exports[`execute apiAddress endpoint bedrock tokens should return success 1`] = `
+{
+  "data": {
+    "result": [
+      {
+        "chainId": "1",
+        "contractAddress": "vault_1",
+        "wallets": [
+          "token_1",
+        ],
+      },
+      {
+        "chainId": "56",
+        "contractAddress": "vault_2",
+        "wallets": [
+          "token_2",
+        ],
+      },
+    ],
+  },
+  "result": null,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 978347471111,
+    "providerDataRequestedUnixMs": 978347471111,
+  },
+}
+`;
+
+exports[`execute apiAddress endpoint bedrock vault should return success 1`] = `
+{
+  "data": {
+    "result": [
+      {
+        "address": "vault_1",
+        "chainId": "1",
+        "network": "eth",
       },
     ],
   },

--- a/packages/sources/por-address-list/test/integration/adapter.test.ts
+++ b/packages/sources/por-address-list/test/integration/adapter.test.ts
@@ -90,9 +90,32 @@ describe('execute', () => {
   })
 
   describe('apiAddress endpoint', () => {
-    it('bedrock should return success', async () => {
+    it('bedrock BTC should return success', async () => {
       const data = {
         endpoint: 'bedrockBtcAddress',
+        type: 'BTC',
+      }
+      mockBedRockResponseSuccess()
+      const response = await testAdapter.request(data)
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toMatchSnapshot()
+    })
+
+    it('bedrock tokens should return success', async () => {
+      const data = {
+        endpoint: 'bedrockBtcAddress',
+        type: 'tokens',
+      }
+      mockBedRockResponseSuccess()
+      const response = await testAdapter.request(data)
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toMatchSnapshot()
+    })
+
+    it('bedrock vault should return success', async () => {
+      const data = {
+        endpoint: 'bedrockBtcAddress',
+        type: 'vault',
       }
       mockBedRockResponseSuccess()
       const response = await testAdapter.request(data)

--- a/packages/sources/por-address-list/test/integration/fixtures-api.ts
+++ b/packages/sources/por-address-list/test/integration/fixtures-api.ts
@@ -1,5 +1,19 @@
 import nock from 'nock'
 
+interface ResponseSchema {
+  btc: {
+    type: string
+    addr: string
+  }[]
+  evm: {
+    [key: string]: {
+      chain_id: number
+      vault: string
+      tokens: string[]
+    }
+  }
+}
+
 export const mockBedRockResponseSuccess = (): nock.Scope =>
   nock('http://bedrock', {
     encodedQueryParams: true,
@@ -8,10 +22,21 @@ export const mockBedRockResponseSuccess = (): nock.Scope =>
     .reply(
       200,
       () => ({
-        btc: ['btc_1', 'btc_2'],
+        btc: [
+          { type: 'addr', addr: 'btc_1' },
+          { type: 'addr', addr: 'btc_2' },
+        ],
         evm: {
-          '1': 'ABC',
-          '10': 'DEF',
+          eth: {
+            chain_id: 1,
+            vault: 'vault_1',
+            tokens: ['token_1', '0x0000000000000000000000000000000000000000'],
+          },
+          bsc: {
+            chain_id: 56,
+            vault: 'vault_2',
+            tokens: ['token_2'],
+          },
         },
       }),
       [


### PR DESCRIPTION
## Closes #DF-20749

## Description

There are 3 types of bedrock Por address:
 - bitcoin native
 - tokens - to be consumed by token-balance EA
 - vaults - to be consumed by eth-balance EA

## Changes

## Steps to Test

```
{
    "result": null,
    "data": {
        "result": [
            {
                "address": "1LaC3Xt8RZWYH1pjcvXxrWxLvXe7iR3ybe",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1patpjgd37q68kmt4zd5u3ajp7t95r785t5e0wkh4e20kwnducv5rqpvzat0",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1pjyxkkt2ufregr92cu0ccuje8efez68wzf347hlf5ym02ah8nqlhslg8lwz",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1ph5jl0sm97wcdp5k3ctpcrl7sy3hmt7e6gs2tr35qq8pnfpqn2ejqqhh6ur",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1p0tsy45wav45req0ltwlca56m2wss9dd26g3wpdjujwmhtk0q79dq7d8fhp",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1p7dafndyllnsqtthxhp76gzjwujzeelzc2qt8haua7ds8cmqgvhkqtr00ya",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1pmjcg79u2quppamjtekfns5pqmdlpd0gqlwvksq9tzrua0f3vq7hsdmfcs9",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1p4su5lzpaxz7rc9z6tv8u4pfstpxaw7hagdrlrq8p2z3uvd8p8thsddye9w",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "3FRaevESEjvvrE9q5GdmuAvjsGUy8sCfS4",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1qwmw0j0nwe2r8rl8cgecf9pqhgqkpzs0zcfcraz",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1phhfsdcts2lqkc44ver6v24460x5kx5dpg364elxd8jzfjpg5q4yqt8saty",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1paew2r3hqqnwhatttwx3qe3f837vvhwx7jhv228py9u3t7s22ltmqenjdym",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1qma2epmz00c7kutshs0h7m8rra8ceekht87amu7",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1p93qry6vdxutmtnqk0n48hs9au54xha6ywr9a8fryy2a3ctqcn0hqt5s0cv",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1qdrhewkdyy44xf80n79wmls3pyg07lrg3syhmze",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1phql7l5rrfqn9egmppjtlvyw0evav853q5uzlzcq8rdp5sp0dwjzq9x57pn",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1pc8t32hxvlnnv0lyuqhfqy9mfmaxtl66e495rqw4rmp7y4q60kkcs2wt2pq",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1pxfwnyqng7c622te5m5ayjsz6lrsxjl542wyw99h2p5e60zmeknqq49g0fm",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1p6mu8mrtnfz0frdfghfxr05tr8dq6j0q65rpzhhgg7998zelfp74qxxejh9",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1qkj4yxrlsear0hujkf3pq5zc4r8mnz3ep8udftj",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "3KKdHVw5TFrPLqM9q8znpjxCyYpzZhErFH",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1qj9w5ee2kf4akvtzrj59p77yc6x02nqqg9m0tcd",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "38fLZKJQuNMAEmFXTbbpkTo6fD5su2fD9P",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1p8jpunkzxpued6d4k4n8the7trn3m53vjphxwwaxls58kg3gyracqwetwzl",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "3Pg6HJJPhm3X7eWrdHbPFQeHU723a9GSJ7",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1qwgnhe6vn5zzu7csukavhfatzdasvmkavktqe4udzx96dk602ghsqaz8vt6",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1qf2lqvumkq2l2d3qej7u6w9u84djfnmy7kfcqdulfpcm7zqxl330smc0mkj",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1qyzsetzfrwzxs7zzqtsmyaz39mumhrh58mu04kyjcy8pynn9zhk5q2dc2r3",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1p8275ypqm7z4pyzhrvs6ashfgz5fuchtet8lqpl3xaecgyy07rrgq3jmvrx",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1pyfmtputwx7uvug972jp5r658da90m4dl4sgx506znnw3ezushuzqwz5u8a",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1pzlhnwcyytvmzl5kmp4usxwt9jhw7u2c2w4u5gej5ef4y0uznv5ps84c4vv",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1pyc5v468mmltf503uhhdumxmadq3s0ykj5q5cyhj8a54k8sq5ze2su4vdy4",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1pu4hcya6n2qrpr773qdxjrsz0wk8epyl0eyc98g97qdp2n0f0z7cqtq6hnk",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1pyax28jhft0lzzwz9fj5cm5mehxpffa6efmddexch04tup7d23arqpcqm2x",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1purqv24xky3l7yf2gf48lsd3et7yc2gw38fj3laflf4g0fdm8xelq4u95fh",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1pvkr32l23vr0e9uv0ylkwn8fkt8whkl2h620yeh08x25fd5msw7usdmdv4f",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1pwhy84kvvxzfyrlwkyyzapf2ztkwpfj7yv0y6al7pg9kwht7undhsj3ww9p",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1pjwjx9ygltd4ehp8rlwxlep803e0w9gtz8hxx6ekjpvetay3yytsqhfm7d4",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1psjmpuxzryfxh863xlhk8hxvfdrywj0v6uqfxd0w5xxaa9sx0hjhqkx8qff",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1pwtr406pv8l6ean6hu6rzhwknd86u2hwszum9zqtvn8cls8h59keqjua0m3",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1puacezgtudwq587zp9ffkgugxrw7a405yrf586s8nvg53x3hsg6zs67eafn",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1p94j8r24zm409k8wgqylh0z9p66mwuwgk5nkz9525mug7kda40hcqc0qdmc",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1p45penescv68n8aeh4z2gpktls7cvgttgstx96myws4rxx9xhgjxqzf6srh",
                "network": "bitcoin",
                "chainId": "mainnet"
            },
            {
                "address": "bc1p59yh7hz8v7rcrktd095xtt9kcjfgdalv54vxwmdpms057pesgntqqkfg67",
                "network": "bitcoin",
                "chainId": "mainnet"
            }
        ]
    },
    "timestamps": {
        "providerDataRequestedUnixMs": 1731968566364,
        "providerDataReceivedUnixMs": 1731968567693
    },
    "statusCode": 200,
    "meta": {
        "adapterName": "POR_ADDRESS_LIST",
        "metrics": {
            "feedId": "{\"type\":\"btc\"}"
        }
    }
}
```

```
{
    "result": null,
    "data": {
        "result": [
            {
                "chainId": "42161",
                "contractAddress": "0x84E5C854A7fF9F49c888d69DECa578D406C26800",
                "wallets": [
                    "0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f"
                ]
            },
            {
                "chainId": "200901",
                "contractAddress": "0xF9775085d726E782E83585033B58606f7731AB18",
                "wallets": [
                    "0xfF204e2681A6fA0e2C3FaDe68a1B28fb90E4Fc5F"
                ]
            },
            {
                "chainId": "60808",
                "contractAddress": "0x2ac98DB41Cbd3172CB7B8FD8A8Ab3b91cFe45dCf",
                "wallets": [
                    "0x03C7054BCB39f7b2e5B2c7AcB37583e32D70Cfa3",
                    "0xC96dE26018A54D51c097160568752c4E3BD6C364"
                ]
            },
            {
                "chainId": "56",
                "contractAddress": "0x84E5C854A7fF9F49c888d69DECa578D406C26800",
                "wallets": [
                    "0x7130d2A12B9BCbFAe4f2634d864A1Ee1Ce3Ead9c",
                    "0xC96dE26018A54D51c097160568752c4E3BD6C364"
                ]
            },
            {
                "chainId": "223",
                "contractAddress": "0xF9775085d726E782E83585033B58606f7731AB18",
                "wallets": [
                    "0x4200000000000000000000000000000000000006"
                ]
            },
            {
                "chainId": "1",
                "contractAddress": "0x047D41F2544B7F63A8e991aF2068a363d210d6Da",
                "wallets": [
                    "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
                    "0xC96dE26018A54D51c097160568752c4E3BD6C364",
                    "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf"
                ]
            },
            {
                "chainId": "5000",
                "contractAddress": "0xF9775085d726E782E83585033B58606f7731AB18",
                "wallets": [
                    "0xC96dE26018A54D51c097160568752c4E3BD6C364"
                ]
            },
            {
                "chainId": "4200",
                "contractAddress": "0xF9775085d726E782E83585033B58606f7731AB18",
                "wallets": [
                    "0xB880fd278198bd590252621d4CD071b1842E9Bcd",
                    "0xF6D226f9Dc15d9bB51182815b320D3fBE324e1bA"
                ]
            },
            {
                "chainId": "34443",
                "contractAddress": "0x84E5C854A7fF9F49c888d69DECa578D406C26800",
                "wallets": [
                    "0x59889b7021243dB5B1e065385F918316cD90D46c",
                    "0xcDd475325D6F564d27247D1DddBb0DAc6fA0a5CF"
                ]
            },
            {
                "chainId": "10",
                "contractAddress": "0xF9775085d726E782E83585033B58606f7731AB18",
                "wallets": [
                    "0x68f180fcCe6836688e9084f035309E29Bf0A2095"
                ]
            },
            {
                "chainId": "7000",
                "contractAddress": "0x84E5C854A7fF9F49c888d69DECa578D406C26800",
                "wallets": [
                    "0x13A0c5930C028511Dc02665E7285134B6d11A5f4"
                ]
            }
        ]
    },
    "timestamps": {
        "providerDataRequestedUnixMs": 1731968586802,
        "providerDataReceivedUnixMs": 1731968587925
    },
    "statusCode": 200,
    "meta": {
        "adapterName": "POR_ADDRESS_LIST",
        "metrics": {
            "feedId": "{\"type\":\"tokens\"}"
        }
    }
}
```

```
{
    "result": null,
    "data": {
        "result": [
            {
                "address": "0xF9775085d726E782E83585033B58606f7731AB18",
                "network": "bitlayer",
                "chainId": "200901"
            },
            {
                "address": "0xF9775085d726E782E83585033B58606f7731AB18",
                "network": "bsquared",
                "chainId": "223"
            },
            {
                "address": "0xF9775085d726E782E83585033B58606f7731AB18",
                "network": "merlin",
                "chainId": "4200"
            }
        ]
    },
    "timestamps": {
        "providerDataRequestedUnixMs": 1731968597667,
        "providerDataReceivedUnixMs": 1731968598755
    },
    "statusCode": 200,
    "meta": {
        "adapterName": "POR_ADDRESS_LIST",
        "metrics": {
            "feedId": "{\"type\":\"vault\"}"
        }
    }
}
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
