### PR TITLE
Feat/DF-20791 eth balance multichain

### DIFF
--- a/.changeset/wicked-crabs-punch.md
+++ b/.changeset/wicked-crabs-punch.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/eth-balance-adapter': minor
+---
+
+Add multichain functionality via address chainId selectors

--- a/packages/sources/eth-balance/src/config/index.ts
+++ b/packages/sources/eth-balance/src/config/index.ts
@@ -1,4 +1,4 @@
-import { Requester, util } from '@chainlink/ea-bootstrap'
+import { Logger, Requester, util } from '@chainlink/ea-bootstrap'
 import { Config as BaseConfig } from '@chainlink/ea-bootstrap'
 import { ethers } from 'ethers'
 
@@ -10,9 +10,46 @@ export const ENV_ETHEREUM_CHAIN_ID = 'ETHEREUM_CHAIN_ID'
 export const ENV_FALLBACK_CHAIN_ID = 'CHAIN_ID'
 export const DEFAULT_CHAIN_ID = '1'
 export const DEFAULT_ENDPOINT = 'balance'
+const _RPC_CHAIN_ID = '_RPC_CHAIN_ID'
 
 export type Config = BaseConfig & {
   provider: ethers.providers.Provider
+  chainIdToProviderMap: Map<string, ethers.providers.Provider>
+}
+
+// reverse mapping from chain ID to network to RPC url
+const constructChainIdProviderMap = (): Map<string, ethers.providers.Provider> => {
+  const chainIdToProviderMap = new Map<string, ethers.providers.Provider>()
+
+  for (const [key, value] of Object.entries(process.env)) {
+    if (!key.endsWith(_RPC_CHAIN_ID)) continue
+
+    const chainId = value
+
+    if (!chainId) {
+      Logger.warn(`env var ${key} is incorrect`)
+      continue
+    }
+    if (chainIdToProviderMap.has(chainId)) {
+      Logger.warn(`chain ID ${chainId} present multiple times`)
+      continue
+    }
+
+    // extract network name from XXX_RPC_CHAIN_ID & get RPC_URL
+    const networkName = key.split(_RPC_CHAIN_ID)[0]
+    const rpcEnvVar = `${networkName}_RPC_URL`
+    const rpcUrl = process.env[rpcEnvVar]
+
+    if (!rpcUrl) {
+      Logger.warn(`Missing RPC_URL for ${networkName}`)
+      continue
+    }
+
+    const provider = new ethers.providers.JsonRpcProvider(rpcUrl, Number(chainId))
+    chainIdToProviderMap.set(chainId, provider)
+    Logger.info(`created provider for network: ${networkName}, chain ID: ${chainId}`)
+  }
+  return chainIdToProviderMap
 }
 
 export const makeConfig = (prefix?: string): Config => {
@@ -26,9 +63,13 @@ export const makeConfig = (prefix?: string): Config => {
       util.getEnvWithFallback(ENV_ETHEREUM_CHAIN_ID, [ENV_FALLBACK_CHAIN_ID]) || DEFAULT_CHAIN_ID,
     ) || util.getEnvWithFallback(ENV_ETHEREUM_CHAIN_ID, [ENV_FALLBACK_CHAIN_ID])
 
+  const chainIdToProviderMap = constructChainIdProviderMap()
+
+  Logger.info('creating new Json RPC Provider')
   return {
     ...Requester.getDefaultConfig(prefix),
     defaultEndpoint: DEFAULT_ENDPOINT,
     provider: new ethers.providers.JsonRpcProvider(rpcURL, chainId),
+    chainIdToProviderMap,
   }
 }

--- a/packages/sources/eth-balance/src/endpoint/balance.ts
+++ b/packages/sources/eth-balance/src/endpoint/balance.ts
@@ -148,24 +148,3 @@ const getBalance = async (
   address,
   balance: (await provider.getBalance(address, targetBlockTag)).toString(),
 })
-
-// const getBalanceMultiChain = async (
-//   address: string,
-//   targetBlockTag: string | number,
-//   config: Config,
-//   chainId: string,
-//   jobRunID: string | undefined,
-// ): Promise<AddressWithBalance> => {
-//   const provider = config.chainIdToProviderMap.get(chainId)
-//   if (!provider) {
-//     throw new AdapterInputError({
-//       jobRunID,
-//       message: `Missing provider mapping for chainId ${chainId}.`,
-//       statusCode: 400,
-//     })
-//   }
-//   return {
-//     address,
-//     balance: (await provider.getBalance(address, targetBlockTag)).toString(),
-//   }
-// }

--- a/packages/sources/eth-balance/src/endpoint/balance.ts
+++ b/packages/sources/eth-balance/src/endpoint/balance.ts
@@ -7,6 +7,7 @@ import {
 } from '@chainlink/ea-bootstrap'
 import { ExecuteWithConfig, InputParameters, AxiosResponse } from '@chainlink/ea-bootstrap'
 import { Config } from '../config'
+import { ethers } from 'ethers'
 
 export const supportedEndpoints = ['balance']
 
@@ -20,7 +21,7 @@ export const inputParameters: InputParameters<TInputParameters> = {
     required: true,
     type: 'array',
     description:
-      'An array of addresses to get the balances of (as an object with string `address` as an attribute)',
+      'An array of addresses to get the balances of (as an object with string `address` as an attribute). Optionally includes a `chainId` attribute to select RPC provider by chain ID.',
   },
   minConfirmations: {
     required: false,
@@ -39,6 +40,7 @@ interface AddressWithBalance {
 
 type Address = {
   address: string
+  chainId?: string
 }
 
 interface ResponseWithResult extends Partial<AxiosResponse> {
@@ -60,6 +62,34 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
     })
   }
 
+  // verify chainId is present in all addresses or none
+  const chainIds = addresses.map((address) => address.chainId).filter(Boolean)
+  if (chainIds.length != addresses.length && chainIds.length != 0) {
+    throw new AdapterInputError({
+      jobRunID,
+      message: `'chainId' must be present or absent across all addresses.`,
+      statusCode: 400,
+    })
+  }
+
+  const addressProviders = []
+  for (const address of addresses) {
+    let provider
+    if (address.chainId) {
+      provider = config.chainIdToProviderMap.get(address.chainId)
+    } else {
+      provider = config.provider
+    }
+    if (!provider) {
+      throw new AdapterInputError({
+        jobRunID,
+        message: `Missing provider mapping for chainId ${address.chainId}.`,
+        statusCode: 400,
+      })
+    }
+    addressProviders.push({ address: address.address, provider })
+  }
+
   // The limitation of 64 is to make it work with both full and light/fast sync nodes
   if (!Number.isInteger(minConfirmations) || minConfirmations < 0 || minConfirmations > 64) {
     throw new AdapterInputError({
@@ -78,7 +108,9 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
   let balances
   try {
     balances = await Promise.all(
-      addresses.map((addr) => getBalance(addr.address, targetBlockTag, config)),
+      addressProviders.map((address) =>
+        getBalance(address.address, targetBlockTag, address.provider),
+      ),
     )
   } catch (e: any) {
     throw new AdapterDataProviderError({
@@ -111,8 +143,29 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
 const getBalance = async (
   address: string,
   targetBlockTag: string | number,
-  config: Config,
+  provider: ethers.providers.Provider,
 ): Promise<AddressWithBalance> => ({
   address,
-  balance: (await config.provider.getBalance(address, targetBlockTag)).toString(),
+  balance: (await provider.getBalance(address, targetBlockTag)).toString(),
 })
+
+// const getBalanceMultiChain = async (
+//   address: string,
+//   targetBlockTag: string | number,
+//   config: Config,
+//   chainId: string,
+//   jobRunID: string | undefined,
+// ): Promise<AddressWithBalance> => {
+//   const provider = config.chainIdToProviderMap.get(chainId)
+//   if (!provider) {
+//     throw new AdapterInputError({
+//       jobRunID,
+//       message: `Missing provider mapping for chainId ${chainId}.`,
+//       statusCode: 400,
+//     })
+//   }
+//   return {
+//     address,
+//     balance: (await provider.getBalance(address, targetBlockTag)).toString(),
+//   }
+// }

--- a/packages/sources/eth-balance/test/integration/__snapshots__/balance.test.ts.snap
+++ b/packages/sources/eth-balance/test/integration/__snapshots__/balance.test.ts.snap
@@ -1,5 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`execute with address.chainId should return success 1`] = `
+{
+  "data": {
+    "result": [
+      {
+        "address": "0xEF9FFcFbeCB6213E5903529c8457b6F61141140d",
+        "balance": "842796652117371",
+      },
+      {
+        "address": "0x6a1544F72A2A275715e8d5924e6D8A017F0e41ed",
+        "balance": "1604497408893139674",
+      },
+    ],
+  },
+  "jobRunID": "1",
+  "providerStatusCode": 200,
+  "result": [
+    {
+      "address": "0xEF9FFcFbeCB6213E5903529c8457b6F61141140d",
+      "balance": "842796652117371",
+    },
+    {
+      "address": "0x6a1544F72A2A275715e8d5924e6D8A017F0e41ed",
+      "balance": "1604497408893139674",
+    },
+  ],
+  "statusCode": 200,
+}
+`;
+
 exports[`execute with explicit minConfirmations should return success 1`] = `
 {
   "data": {

--- a/packages/sources/eth-balance/test/integration/balance.test.ts
+++ b/packages/sources/eth-balance/test/integration/balance.test.ts
@@ -16,6 +16,8 @@ describe('execute', () => {
   const envVariables = {
     CACHE_ENABLED: 'false',
     ETHEREUM_RPC_URL: process.env.ETHEREUM_RPC_URL || 'http://localhost:8545',
+    ETHEREUM_CHAIN_ID: process.env.ETHEREUM_CHAIN_ID || '1',
+    ETHEREUM_RPC_CHAIN_ID: process.env.ETHEREUM_RPC_CHAIN_ID || '1',
   }
 
   setupExternalAdapterTest(envVariables, context)
@@ -75,6 +77,84 @@ describe('execute', () => {
         minConfirmations: 20,
       },
     }
+
+    it('should return success', async () => {
+      mockETHBalanceAtBlockResponseSuccess()
+
+      const response = await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+      expect(response.body).toMatchSnapshot()
+    })
+  })
+
+  describe('with address.chainId', () => {
+    const data: AdapterRequest = {
+      id,
+      data: {
+        result: [
+          {
+            address: '0xEF9FFcFbeCB6213E5903529c8457b6F61141140d',
+            chainId: '1',
+          },
+          {
+            address: '0x6a1544F72A2A275715e8d5924e6D8A017F0e41ed',
+            chainId: '1',
+          },
+        ],
+      },
+    }
+
+    const singleChainId: AdapterRequest = {
+      id,
+      data: {
+        result: [
+          {
+            address: '0x6a1544F72A2A275715e8d5924e6D8A017F0e41ed',
+            chainId: '1',
+          },
+          {
+            address: '0x6a1544F72A2A275715e8d5924e6D8A017F0e41ec',
+          },
+        ],
+      },
+    }
+
+    const invalidChainId: AdapterRequest = {
+      id,
+      data: {
+        result: [
+          {
+            address: '0x6a1544F72A2A275715e8d5924e6D8A017F0e41ed',
+            chainId: '2',
+          },
+        ],
+      },
+    }
+
+    it('should fail 400 when only some have chainId', async () => {
+      await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(singleChainId)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(400)
+    })
+
+    it('should fail 400 when chainId has no mapping', async () => {
+      await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(invalidChainId)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(400)
+    })
 
     it('should return success', async () => {
       mockETHBalanceAtBlockResponseSuccess()


### PR DESCRIPTION
## Closes #[DF-20791](https://smartcontract-it.atlassian.net/browse/DF-20791)

## Description
Adding multichain functionality to the eth-balance EA to allow it to read from multiple chains selected via an `address.chainId` param. Standard `${CHAIN}_RPC_URL` and `${CHAIN}_RPC_CHAIN_ID` env vars

## Changes
- Updated balance endpoint

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. yarn test eth-balance
2. sanity test with test payload for regression
3. sanity test with test payload and adding chainId to the addresses

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[DF-20791]: https://smartcontract-it.atlassian.net/browse/DF-20791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ