### PR TITLE
Add token and vault param in multichainAddress

### DIFF
--- a/.changeset/honest-maps-mate.md
+++ b/.changeset/honest-maps-mate.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/por-address-list-adapter': patch
+---
+
+Add token and vault param

--- a/packages/sources/por-address-list/src/endpoint/multichainAddress.ts
+++ b/packages/sources/por-address-list/src/endpoint/multichainAddress.ts
@@ -1,7 +1,5 @@
-import {
-  PoRTokenAddressEndpoint,
-  PoRTokenAddressResponse,
-} from '@chainlink/external-adapter-framework/adapter/por'
+import { PoRAddress, PoRTokenAddress } from '@chainlink/external-adapter-framework/adapter/por'
+import { AdapterEndpoint } from '@chainlink/external-adapter-framework/adapter'
 import { InputParameters } from '@chainlink/external-adapter-framework/validation'
 import { config } from '../config'
 import { addressTransport } from '../transport/multichainAddress'
@@ -19,6 +17,17 @@ export const inputParameters = new InputParameters(
       type: 'string',
       required: true,
     },
+    type: {
+      description:
+        'The type of addresses you are looking for. tokens is for token-balance EA. vault is for eth-balance EA.',
+      options: ['tokens', 'vault'],
+      type: 'string',
+      default: 'tokens',
+    },
+    vaultPlaceHolder: {
+      description: 'The tokenAddress indicating which vaultAddress needs to be returned',
+      type: 'string',
+    },
     confirmations: {
       description: 'The number of confirmations to query data from',
       type: 'number',
@@ -34,21 +43,26 @@ export const inputParameters = new InputParameters(
     {
       contractAddress: '0xb7C0817Dd23DE89E4204502dd2C2EF7F57d3A3B8',
       contractAddressNetwork: 'BINANCE',
+      type: 'tokens',
+      vaultPlaceHolder: '0x0000000000000000000000000000000000000001',
       confirmations: 0,
       batchSize: 10,
     },
   ],
 )
 
-type ResponseSchema = PoRTokenAddressResponse
-
 export type BaseEndpointTypes = {
   Parameters: typeof inputParameters.definition
-  Response: ResponseSchema
+  Response: {
+    Result: null
+    Data: {
+      result: PoRAddress[] | PoRTokenAddress[]
+    }
+  }
   Settings: typeof config.settings
 }
 
-export const endpoint = new PoRTokenAddressEndpoint({
+export const endpoint = new AdapterEndpoint({
   name: 'multichainAddress',
   transport: addressTransport,
   inputParameters,

--- a/packages/sources/por-address-list/test/integration/__snapshots__/adapter-multichain.test.ts.snap
+++ b/packages/sources/por-address-list/test/integration/__snapshots__/adapter-multichain.test.ts.snap
@@ -1,5 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`execute multichainAddress endpoint should return success - vault 1`] = `
+{
+  "data": {
+    "result": [
+      {
+        "address": "vault4",
+        "chainId": "223",
+        "network": "b2",
+      },
+    ],
+  },
+  "result": null,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 978347471111,
+    "providerDataRequestedUnixMs": 978347471111,
+  },
+}
+`;
+
 exports[`execute multichainAddress endpoint should return success 1`] = `
 {
   "data": {

--- a/packages/sources/por-address-list/test/integration/adapter-multichain.test.ts
+++ b/packages/sources/por-address-list/test/integration/adapter-multichain.test.ts
@@ -27,6 +27,13 @@ const mockExpectedAddresses = [
     tokenAddress: 'token3',
     vaultAddress: 'vault3',
   },
+  {
+    tokenSymbol: 'B2 BTC',
+    chain: 'b2',
+    chainId: 223,
+    tokenAddress: 'PLACE_HOLDER',
+    vaultAddress: 'vault4',
+  },
 ]
 
 const mockAddressListLength = ethers.BigNumber.from(mockExpectedAddresses.length)
@@ -92,6 +99,20 @@ describe('execute', () => {
         endpoint: 'multichainAddress',
         contractAddress: 'mock-contract-address',
         contractAddressNetwork: 'BSC',
+        vaultPlaceHolder: 'PLACE_HOLDER',
+      }
+      const response = await testAdapter.request(data)
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toMatchSnapshot()
+    })
+
+    it('should return success - vault', async () => {
+      const data = {
+        endpoint: 'multichainAddress',
+        contractAddress: 'mock-contract-address',
+        contractAddressNetwork: 'BSC',
+        vaultPlaceHolder: 'PLACE_HOLDER',
+        type: 'vault',
       }
       const response = await testAdapter.request(data)
       expect(response.statusCode).toBe(200)


### PR DESCRIPTION
## Closes #ISSUE_NUMBER_GOES_HERE

## Description

We need to query native gas balance for Lorenzo as well

## Changes

Build it in por-address-list with additional params, no impact to existing functionality 

## Steps to Test

```
{
    "data": {
        "result": [
            {
                "chainId": "56",
                "contractAddress": "0x7130d2A12B9BCbFAe4f2634d864A1Ee1Ce3Ead9c",
                "wallets": [
                    "0xdE2BA910eBDCC53FC8a11dcD51aDe24E3eD5c3fC",
                    "0x70451b1AF665F490df5aC86c15F5162a383A594B"
                ]
            }
        ]
    },
    "statusCode": 200,
    "result": null,
    "timestamps": {
        "providerDataRequestedUnixMs": 1732288426190,
        "providerDataReceivedUnixMs": 1732288427405
    },
    "meta": {
        "adapterName": "POR_ADDRESS_LIST",
        "metrics": {
            "feedId": "{\"contractAddress\":\"0xb7c0817dd23de89e4204502dd2c2ef7f57d3a3b8\",\"contractAddressNetwork\":\"binance\",\"type\":\"tokens\",\"vaultPlaceHolder\":\"0x0000000000000000000000000000000000000001\",\"confirmations\":0,\"batchSize\":10}"
        }
    }
}
```

```
{
    "data": {
        "result": [
            {
                "address": "0xb8119F2ccfA504735c14D381cf888d1D267dbe43",
                "network": "b2",
                "chainId": "223"
            }
        ]
    },
    "statusCode": 200,
    "result": null,
    "timestamps": {
        "providerDataRequestedUnixMs": 1732288450036,
        "providerDataReceivedUnixMs": 1732288450884
    },
    "meta": {
        "adapterName": "POR_ADDRESS_LIST",
        "metrics": {
            "feedId": "{\"contractAddress\":\"0xb7c0817dd23de89e4204502dd2c2ef7f57d3a3b8\",\"contractAddressNetwork\":\"binance\",\"type\":\"vault\",\"vaultPlaceHolder\":\"0x0000000000000000000000000000000000000001\",\"confirmations\":0,\"batchSize\":10}"
        }
    }
}
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
