### PR TITLE
Fix/DF-20791 legacy

### DIFF
--- a/.changeset/light-swans-camp.md
+++ b/.changeset/light-swans-camp.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/eth-balance-adapter': minor
+---
+
+use default provider for legacy chainIds

--- a/packages/sources/eth-balance/src/endpoint/balance.ts
+++ b/packages/sources/eth-balance/src/endpoint/balance.ts
@@ -75,7 +75,7 @@ export const execute: ExecuteWithConfig<Config> = async (request, _, config) => 
   const addressProviders = []
   for (const address of addresses) {
     let provider
-    if (address.chainId) {
+    if (address.chainId && !isNaN(Number(address.chainId))) {
       provider = config.chainIdToProviderMap.get(address.chainId)
     } else {
       provider = config.provider

--- a/packages/sources/eth-balance/test/integration/__snapshots__/balance.test.ts.snap
+++ b/packages/sources/eth-balance/test/integration/__snapshots__/balance.test.ts.snap
@@ -30,6 +30,28 @@ exports[`execute with address.chainId should return success 1`] = `
 }
 `;
 
+exports[`execute with address.chainId should use default provider when string chainId (legacy) 1`] = `
+{
+  "data": {
+    "result": [
+      {
+        "address": "0x6a1544F72A2A275715e8d5924e6D8A017F0e41ed",
+        "balance": "1604497408893139674",
+      },
+    ],
+  },
+  "jobRunID": "1",
+  "providerStatusCode": 200,
+  "result": [
+    {
+      "address": "0x6a1544F72A2A275715e8d5924e6D8A017F0e41ed",
+      "balance": "1604497408893139674",
+    },
+  ],
+  "statusCode": 200,
+}
+`;
+
 exports[`execute with explicit minConfirmations should return success 1`] = `
 {
   "data": {

--- a/packages/sources/eth-balance/test/integration/balance.test.ts
+++ b/packages/sources/eth-balance/test/integration/balance.test.ts
@@ -136,6 +136,19 @@ describe('execute', () => {
       },
     }
 
+    const legacyChainId: AdapterRequest = {
+      id,
+      data: {
+        result: [
+          {
+            address: '0x6a1544F72A2A275715e8d5924e6D8A017F0e41ed',
+            chainId: 'test',
+            network: 'ethereum',
+          },
+        ],
+      },
+    }
+
     it('should fail 400 when only some have chainId', async () => {
       await (context.req as SuperTest<Test>)
         .post('/')
@@ -154,6 +167,19 @@ describe('execute', () => {
         .set('Content-Type', 'application/json')
         .expect('Content-Type', /json/)
         .expect(400)
+    })
+
+    it('should use default provider when string chainId (legacy)', async () => {
+      mockETHBalanceAtBlockResponseSuccess()
+
+      const response = await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(legacyChainId)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+      expect(response.body).toMatchSnapshot()
     })
 
     it('should return success', async () => {


### PR DESCRIPTION
## Closes #[DF-20791](https://smartcontract-it.atlassian.net/browse/DF-20791)

## Description
Fixing eth-balance update to allow proper ethers provider selection for `"chainId": "mainnet"` as used in several other feeds

## Changes
- fixed provider selection logic

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test
1. yarn test eth-balance
2. sanity check existing calls with chainId: "string" use configured default RPC provider

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[DF-20791]: https://smartcontract-it.atlassian.net/browse/DF-20791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ