### PR TITLE
Fix/DF-20791 minconfirmations

### DIFF
--- a/.changeset/large-plums-obey.md
+++ b/.changeset/large-plums-obey.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/eth-balance-adapter': minor
+---
+
+Fix minConfirmations only using default provider

--- a/packages/sources/eth-balance/src/config/index.ts
+++ b/packages/sources/eth-balance/src/config/index.ts
@@ -47,7 +47,7 @@ const constructChainIdProviderMap = (): Map<string, ethers.providers.Provider> =
 
     const provider = new ethers.providers.JsonRpcProvider(rpcUrl, Number(chainId))
     chainIdToProviderMap.set(chainId, provider)
-    Logger.info(`created provider for network: ${networkName}, chain ID: ${chainId}`)
+    Logger.debug(`created provider for network: ${networkName}, chain ID: ${chainId}`)
   }
   return chainIdToProviderMap
 }
@@ -65,7 +65,7 @@ export const makeConfig = (prefix?: string): Config => {
 
   const chainIdToProviderMap = constructChainIdProviderMap()
 
-  Logger.info('creating new Json RPC Provider')
+  Logger.debug('creating new Json RPC Provider')
   return {
     ...Requester.getDefaultConfig(prefix),
     defaultEndpoint: DEFAULT_ENDPOINT,


### PR DESCRIPTION
## Closes #[DF-20791](https://smartcontract-it.atlassian.net/browse/DF-20791)

## Description
Update minConfirmations to allow for multiple providers, some logic to fetch only once per provider to avoid overwhelming RPC unnecessarily

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test
1. yarn test eth-balance
2. test with multiple chainIds

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[DF-20791]: https://smartcontract-it.atlassian.net/browse/DF-20791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ