### PR TITLE
Fix/DF-20612 por address list solv

### DIFF
--- a/.changeset/smooth-wasps-shop.md
+++ b/.changeset/smooth-wasps-shop.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/por-address-list-adapter': minor
+---
+
+Fix solv issues in multichain address list endpoint

--- a/packages/sources/por-address-list/src/config/SolvMultiAddressList.json
+++ b/packages/sources/por-address-list/src/config/SolvMultiAddressList.json
@@ -1,0 +1,32 @@
+[
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "startIndex_", "type": "uint256" },
+      { "internalType": "uint256", "name": "endIndex_", "type": "uint256" }
+    ],
+    "name": "getPoRAddressList",
+    "outputs": [
+      {
+        "components": [
+          { "internalType": "string", "name": "tokenSymbol", "type": "string" },
+          { "internalType": "string", "name": "chain", "type": "string" },
+          { "internalType": "uint64", "name": "chainId", "type": "uint64" },
+          { "internalType": "address", "name": "tokenAddress", "type": "address" },
+          { "internalType": "address", "name": "vaultAddress", "type": "address" }
+        ],
+        "internalType": "struct IPoRAddressListMulti.TokenVaultInfo[]",
+        "name": "tokenVaultInfos_",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getPoRAddressListLength",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/packages/sources/por-address-list/src/endpoint/multichainAddress.ts
+++ b/packages/sources/por-address-list/src/endpoint/multichainAddress.ts
@@ -17,6 +17,12 @@ export const inputParameters = new InputParameters(
       type: 'string',
       required: true,
     },
+    abiName: {
+      description: 'Used to select the ABI by name',
+      type: 'string',
+      options: ['MultiEVMPoRAddressList', 'PoRAddressListMulti', 'SolvMultiAddressList'],
+      required: true,
+    },
     type: {
       description:
         'The type of addresses you are looking for. tokens is for token-balance EA. vault is for eth-balance EA.',
@@ -43,6 +49,7 @@ export const inputParameters = new InputParameters(
     {
       contractAddress: '0xb7C0817Dd23DE89E4204502dd2C2EF7F57d3A3B8',
       contractAddressNetwork: 'BINANCE',
+      abiName: 'MultiEVMPoRAddressList',
       type: 'tokens',
       vaultPlaceHolder: '0x0000000000000000000000000000000000000001',
       confirmations: 0,

--- a/packages/sources/por-address-list/src/index.ts
+++ b/packages/sources/por-address-list/src/index.ts
@@ -8,6 +8,13 @@ export const adapter = new PoRAdapter({
   name: 'POR_ADDRESS_LIST',
   config,
   endpoints: [address, solvBTC, bedrockBTC, multichainAddress],
+  rateLimiting: {
+    tiers: {
+      default: {
+        rateLimit1s: 5,
+      },
+    },
+  },
 })
 
 export const server = (): Promise<ServerInstance | undefined> => expose(adapter)

--- a/packages/sources/por-address-list/src/index.ts
+++ b/packages/sources/por-address-list/src/index.ts
@@ -11,7 +11,7 @@ export const adapter = new PoRAdapter({
   rateLimiting: {
     tiers: {
       default: {
-        rateLimit1s: 5,
+        rateLimit1s: 1,
       },
     },
   },

--- a/packages/sources/por-address-list/src/transport/utils.ts
+++ b/packages/sources/por-address-list/src/transport/utils.ts
@@ -77,7 +77,7 @@ export const getProvider = (
     } else {
       throw new AdapterInputError({
         statusCode: 400,
-        message: `Missing ${networkName}_RPC_URL or ${networkName}_RPC_URL environment variables`,
+        message: `Missing ${networkName}_RPC_URL or ${networkName}_RPC_CHAIN_ID environment variables`,
       })
     }
   } else {

--- a/packages/sources/por-address-list/test-payload.json
+++ b/packages/sources/por-address-list/test-payload.json
@@ -18,6 +18,7 @@
  }, {
     "endpoint": "multichainAddress",
     "contractAddress": "0xb7C0817Dd23DE89E4204502dd2C2EF7F57d3A3B8",
-    "contractAddressNetwork": "BINANCE"
+    "contractAddressNetwork": "BINANCE",
+    "abiName": "PoRAddressListMulti"
  }]
 }

--- a/packages/sources/por-address-list/test/integration/adapter-multichain.test.ts
+++ b/packages/sources/por-address-list/test/integration/adapter-multichain.test.ts
@@ -99,6 +99,7 @@ describe('execute', () => {
         endpoint: 'multichainAddress',
         contractAddress: 'mock-contract-address',
         contractAddressNetwork: 'BSC',
+        abiName: 'PoRAddressListMulti',
         vaultPlaceHolder: 'PLACE_HOLDER',
       }
       const response = await testAdapter.request(data)
@@ -111,6 +112,7 @@ describe('execute', () => {
         endpoint: 'multichainAddress',
         contractAddress: 'mock-contract-address',
         contractAddressNetwork: 'BSC',
+        abiName: 'PoRAddressListMulti',
         vaultPlaceHolder: 'PLACE_HOLDER',
         type: 'vault',
       }

--- a/packages/sources/por-address-list/test/integration/adapter.test.ts
+++ b/packages/sources/por-address-list/test/integration/adapter.test.ts
@@ -59,6 +59,7 @@ describe('execute', () => {
     process.env.BEDROCK_UNIBTC_API_ENDPOINT = 'http://bedrock'
     process.env.SOLVBTC_API_ENDPOINT = 'http://solv'
     process.env.BACKGROUND_EXECUTE_MS = '0'
+    process.env.RATE_LIMIT_CAPACITY_SECOND = '500'
     const mockDate = new Date('2001-01-01T11:11:11.111Z')
     spy = jest.spyOn(Date, 'now').mockReturnValue(mockDate.getTime())
 


### PR DESCRIPTION
## Relates to #[DF-20612](https://smartcontract-it.atlassian.net/browse/DF-20612)

## Description
Fixing multichain address list endpoint for solv by adding separate ABI and abiName endpoint input param selector

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test
1. yarn test por-address-list
2. regression test other x-chain PoR requests still work after adding new required input param
3. test with solv payload

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[DF-20612]: https://smartcontract-it.atlassian.net/browse/DF-20612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ