### PR TITLE
Remove NCFX RON/USD Includes Config

### DIFF
--- a/.changeset/light-walls-look.md
+++ b/.changeset/light-walls-look.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/ncfx-adapter': minor
+---
+
+Remove NCFX RON/USD Includes Config

--- a/packages/sources/ncfx/src/config/includes.json
+++ b/packages/sources/ncfx/src/config/includes.json
@@ -385,17 +385,6 @@
     ]
   },
   {
-    "from": "RON",
-    "to": "USD",
-    "includes": [
-      {
-        "from": "USD",
-        "to": "RON",
-        "inverse": true
-      }
-    ]
-  },
-  {
     "from": "GHS",
     "to": "USD",
     "includes": [


### PR DESCRIPTION
Removes NCFX RON/USD Includes config, as we don't have that feed as a Forex feed (which it was originally added for), only a Crypto feed (which we don't need it for).

As it is effecting RON/USD on the crypto endpoint.

Discussion here:
https://chainlink-core.slack.com/archives/C02UT77UL6R/p1732641514765829