### PR TITLE
Update bedrock API structure

### DIFF
--- a/.changeset/honest-suits-tell.md
+++ b/.changeset/honest-suits-tell.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/por-address-list-adapter': patch
+---
+
+Update bedrock BTC structure

--- a/packages/sources/por-address-list/src/transport/bedrockUniBTC.ts
+++ b/packages/sources/por-address-list/src/transport/bedrockUniBTC.ts
@@ -12,7 +12,7 @@ interface ResponseSchema {
     [key: string]: {
       chain_id: number
       vault: string
-      tokens: string[][]
+      tokens: [name: string, address: string, decimals: string, value: string][]
     }
   }
 }

--- a/packages/sources/por-address-list/src/transport/bedrockUniBTC.ts
+++ b/packages/sources/por-address-list/src/transport/bedrockUniBTC.ts
@@ -5,13 +5,14 @@ import { BaseEndpointTypes } from '../endpoint/bedrockBTC'
 interface ResponseSchema {
   btc: {
     type: string
+    bridge_source: string
     addr: string
   }[]
   evm: {
     [key: string]: {
       chain_id: number
       vault: string
-      tokens: string[]
+      tokens: string[][]
     }
   }
 }
@@ -94,7 +95,7 @@ const getAddresses = (
         .flatMap(([_, value]) =>
           value.tokens.map((token) => ({
             chainId: value.chain_id.toString(),
-            contractAddress: token,
+            contractAddress: token[1],
             wallet: value.vault,
           })),
         )
@@ -117,7 +118,7 @@ const getAddresses = (
     }
     case 'vault':
       return Object.entries(data.evm)
-        .filter(([_, value]) => value.tokens.includes(VAULT_PLACEHOLDER))
+        .filter(([_, value]) => value.tokens.map((token) => token[1]).includes(VAULT_PLACEHOLDER))
         .map(([key, value]) => ({
           address: value.vault,
           network: key,

--- a/packages/sources/por-address-list/test/integration/fixtures-api.ts
+++ b/packages/sources/por-address-list/test/integration/fixtures-api.ts
@@ -1,19 +1,5 @@
 import nock from 'nock'
 
-interface ResponseSchema {
-  btc: {
-    type: string
-    addr: string
-  }[]
-  evm: {
-    [key: string]: {
-      chain_id: number
-      vault: string
-      tokens: string[]
-    }
-  }
-}
-
 export const mockBedRockResponseSuccess = (): nock.Scope =>
   nock('http://bedrock', {
     encodedQueryParams: true,
@@ -23,19 +9,22 @@ export const mockBedRockResponseSuccess = (): nock.Scope =>
       200,
       () => ({
         btc: [
-          { type: 'addr', addr: 'btc_1' },
-          { type: 'addr', addr: 'btc_2' },
+          { type: 'addr', bridge_source: 'btc', addr: 'btc_1' },
+          { type: 'addr', bridge_source: 'btc', addr: 'btc_2' },
         ],
         evm: {
           eth: {
             chain_id: 1,
             vault: 'vault_1',
-            tokens: ['token_1', '0x0000000000000000000000000000000000000000'],
+            tokens: [
+              ['BTC', 'token_1', '18', '10'],
+              ['BTC', '0x0000000000000000000000000000000000000000', '18', '10'],
+            ],
           },
           bsc: {
             chain_id: 56,
             vault: 'vault_2',
-            tokens: ['token_2'],
+            tokens: [['BTC', 'token_2', '18', '10']],
           },
         },
       }),


### PR DESCRIPTION
## Description

API structure has changed

## Changes

## Steps to Test

```
{
    "result": null,
    "data": {
        "result": [
            {
                "address": "0xF9775085d726E782E83585033B58606f7731AB18",
                "network": "bitlayer",
                "chainId": "200901"
            },
            {
                "address": "0xF9775085d726E782E83585033B58606f7731AB18",
                "network": "bsquared",
                "chainId": "223"
            },
            {
                "address": "0xF9775085d726E782E83585033B58606f7731AB18",
                "network": "merlin",
                "chainId": "4200"
            }
        ]
    },
    "timestamps": {
        "providerDataRequestedUnixMs": 1732725039121,
        "providerDataReceivedUnixMs": 1732725040398
    },
    "statusCode": 200,
    "meta": {
        "adapterName": "POR_ADDRESS_LIST",
        "metrics": {
            "feedId": "{\"type\":\"vault\"}"
        }
    }
}
```

```
{
    "result": null,
    "data": {
        "result": [
            {
                "chainId": "42161",
                "contractAddress": "0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f",
                "wallets": [
                    "0x84E5C854A7fF9F49c888d69DECa578D406C26800"
                ]
            },
            {
                "chainId": "42161",
                "contractAddress": "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf",
                "wallets": [
                    "0x84E5C854A7fF9F49c888d69DECa578D406C26800"
                ]
            },
            {
                "chainId": "42161",
                "contractAddress": "0xC96dE26018A54D51c097160568752c4E3BD6C364",
                "wallets": [
                    "0x84E5C854A7fF9F49c888d69DECa578D406C26800"
                ]
            },
            {
                "chainId": "200901",
                "contractAddress": "0xfF204e2681A6fA0e2C3FaDe68a1B28fb90E4Fc5F",
                "wallets": [
                    "0xF9775085d726E782E83585033B58606f7731AB18"
                ]
            },
            {
                "chainId": "60808",
                "contractAddress": "0x03C7054BCB39f7b2e5B2c7AcB37583e32D70Cfa3",
                "wallets": [
                    "0x2ac98DB41Cbd3172CB7B8FD8A8Ab3b91cFe45dCf"
                ]
            },
            {
                "chainId": "60808",
                "contractAddress": "0xC96dE26018A54D51c097160568752c4E3BD6C364",
                "wallets": [
                    "0x2ac98DB41Cbd3172CB7B8FD8A8Ab3b91cFe45dCf"
                ]
            },
            {
                "chainId": "56",
                "contractAddress": "0x7130d2A12B9BCbFAe4f2634d864A1Ee1Ce3Ead9c",
                "wallets": [
                    "0x84E5C854A7fF9F49c888d69DECa578D406C26800"
                ]
            },
            {
                "chainId": "56",
                "contractAddress": "0xC96dE26018A54D51c097160568752c4E3BD6C364",
                "wallets": [
                    "0x84E5C854A7fF9F49c888d69DECa578D406C26800"
                ]
            },
            {
                "chainId": "223",
                "contractAddress": "0x4200000000000000000000000000000000000006",
                "wallets": [
                    "0xF9775085d726E782E83585033B58606f7731AB18"
                ]
            },
            {
                "chainId": "1",
                "contractAddress": "0xC96dE26018A54D51c097160568752c4E3BD6C364",
                "wallets": [
                    "0x047D41F2544B7F63A8e991aF2068a363d210d6Da"
                ]
            },
            {
                "chainId": "1",
                "contractAddress": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
                "wallets": [
                    "0x047D41F2544B7F63A8e991aF2068a363d210d6Da"
                ]
            },
            {
                "chainId": "1",
                "contractAddress": "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf",
                "wallets": [
                    "0x047D41F2544B7F63A8e991aF2068a363d210d6Da"
                ]
            },
            {
                "chainId": "5000",
                "contractAddress": "0xC96dE26018A54D51c097160568752c4E3BD6C364",
                "wallets": [
                    "0xF9775085d726E782E83585033B58606f7731AB18"
                ]
            },
            {
                "chainId": "4200",
                "contractAddress": "0xB880fd278198bd590252621d4CD071b1842E9Bcd",
                "wallets": [
                    "0xF9775085d726E782E83585033B58606f7731AB18"
                ]
            },
            {
                "chainId": "4200",
                "contractAddress": "0xF6D226f9Dc15d9bB51182815b320D3fBE324e1bA",
                "wallets": [
                    "0xF9775085d726E782E83585033B58606f7731AB18"
                ]
            },
            {
                "chainId": "34443",
                "contractAddress": "0x59889b7021243dB5B1e065385F918316cD90D46c",
                "wallets": [
                    "0x84E5C854A7fF9F49c888d69DECa578D406C26800"
                ]
            },
            {
                "chainId": "34443",
                "contractAddress": "0xcDd475325D6F564d27247D1DddBb0DAc6fA0a5CF",
                "wallets": [
                    "0x84E5C854A7fF9F49c888d69DECa578D406C26800"
                ]
            },
            {
                "chainId": "10",
                "contractAddress": "0x68f180fcCe6836688e9084f035309E29Bf0A2095",
                "wallets": [
                    "0xF9775085d726E782E83585033B58606f7731AB18"
                ]
            },
            {
                "chainId": "7000",
                "contractAddress": "0x13A0c5930C028511Dc02665E7285134B6d11A5f4",
                "wallets": [
                    "0x84E5C854A7fF9F49c888d69DECa578D406C26800"
                ]
            }
        ]
    },
    "timestamps": {
        "providerDataRequestedUnixMs": 1732725056427,
        "providerDataReceivedUnixMs": 1732725056761
    },
    "statusCode": 200,
    "meta": {
        "adapterName": "POR_ADDRESS_LIST",
        "metrics": {
            "feedId": "{\"type\":\"tokens\"}"
        }
    }
}
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
