### PR TITLE
Synthetix: Downgrade noisy log from Warn to Debug

### DIFF
--- a/.changeset/silly-boxes-move.md
+++ b/.changeset/silly-boxes-move.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/synthetix-feeds-adapter': patch
+---
+
+Downgrade log from Warn to Debug

--- a/packages/sources/synthetix-feeds/src/transport/util.ts
+++ b/packages/sources/synthetix-feeds/src/transport/util.ts
@@ -44,7 +44,7 @@ const getUSDeToUSD = async (
   const resultDecimal = new Decimal(utils.formatUnits(result, decimals).toString())
 
   if (resultDecimal > new Decimal(1)) {
-    logger.warn(`USDe/USD price ${resultDecimal} is over $1, capping to $1`)
+    logger.debug(`USDe/USD price ${resultDecimal} is over $1, capping to $1`)
     return new Decimal(1)
   } else {
     return resultDecimal


### PR DESCRIPTION
- This log is expected to fire often, downgrading to Debug to avoid unnecessary noise. 