### PR TITLE
Chore/DF-20878 nav consulting default rate limit

### DIFF
--- a/.changeset/grumpy-tools-explain.md
+++ b/.changeset/grumpy-tools-explain.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/nav-consulting-adapter': minor
+---
+
+Add default rate limit

--- a/packages/sources/nav-consulting/src/index.ts
+++ b/packages/sources/nav-consulting/src/index.ts
@@ -8,6 +8,14 @@ export const adapter = new Adapter({
   name: 'NAV_CONSULTING',
   config,
   endpoints: [reserve],
+  rateLimiting: {
+    tiers: {
+      default: {
+        rateLimit1m: 20,
+        note: 'Nothing in docs, setting reasonable rate limit based on 2req/bg execute',
+      },
+    },
+  },
 })
 
 export const server = (): Promise<ServerInstance | undefined> => expose(adapter)


### PR DESCRIPTION
## Closes #[DF-20878](https://smartcontract-it.atlassian.net/browse/DF-20878)

## Description
default rate limits for nav-consulting

## Changes
- Added a 20/min default request limiter

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test
1. sanity test with existing payload
2. yarn test nav-consulting

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[DF-20878]: https://smartcontract-it.atlassian.net/browse/DF-20878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ