### PR TITLE
Fix/DF-20902 kaiko state crypto

### DIFF
--- a/.changeset/tidy-apples-flow.md
+++ b/.changeset/tidy-apples-flow.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/kaiko-state-adapter': patch
+---
+
+Add crypto alias to state endpoint

--- a/packages/sources/kaiko-state/src/endpoint/state.ts
+++ b/packages/sources/kaiko-state/src/endpoint/state.ts
@@ -35,7 +35,7 @@ export type BaseEndpointTypes = {
 
 export const endpoint = new AdapterEndpoint({
   name: 'state',
-  aliases: [],
+  aliases: ['crypto'],
   transport: kaikoStateTransport,
   inputParameters,
   requestTransforms: [


### PR DESCRIPTION
## Closes #[DF-20902](https://smartcontract-it.atlassian.net/browse/DF-20902)

## Description
Add crypto as an alias to state endpoint for kaiko state

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[DF-20902]: https://smartcontract-it.atlassian.net/browse/DF-20902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ