### PR TITLE
remove MNT/USD from includes.json

### DIFF
--- a/.changeset/tall-spoons-begin.md
+++ b/.changeset/tall-spoons-begin.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/ncfx-adapter': minor
+---
+
+modify includes.json

--- a/packages/sources/ncfx/src/config/includes.json
+++ b/packages/sources/ncfx/src/config/includes.json
@@ -341,17 +341,6 @@
     ]
   },
   {
-    "from": "MNT",
-    "to": "USD",
-    "includes": [
-      {
-        "from": "USD",
-        "to": "MNT",
-        "inverse": true
-      }
-    ]
-  },
-  {
     "from": "HKD",
     "to": "USD",
     "includes": [


### PR DESCRIPTION
## Closes #DF20946

## Description
Remove MNT/USd pair from includes.json
ncfx supports MNT/USD pair instead of earlier version of USD/MNT


## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [x] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
