### PR TITLE
Add Solana endpoint to token-balance EA

### DIFF
--- a/.changeset/eleven-terms-thank.md
+++ b/.changeset/eleven-terms-thank.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/token-balance-adapter': patch
+---
+
+Add Solana endpoint

--- a/.changeset/tall-monkeys-behave.md
+++ b/.changeset/tall-monkeys-behave.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/por-address-list-adapter': patch
+---
+
+Add Solana to Solv

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -9093,6 +9093,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@chainlink/token-balance-adapter", "workspace:packages/sources/token-balance"],\
           ["@chainlink/external-adapter-framework", "npm:1.7.7"],\
+          ["@solana/web3.js", "npm:1.95.8"],\
           ["@types/jest", "npm:27.5.2"],\
           ["@types/node", "npm:16.18.115"],\
           ["ethers", "npm:6.13.4"],\

--- a/packages/sources/por-address-list/src/config/SolvSolanaMultiAddressList.json
+++ b/packages/sources/por-address-list/src/config/SolvSolanaMultiAddressList.json
@@ -1,0 +1,32 @@
+[
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "startIndex_", "type": "uint256" },
+      { "internalType": "uint256", "name": "endIndex_", "type": "uint256" }
+    ],
+    "name": "getPoRAddressList",
+    "outputs": [
+      {
+        "components": [
+          { "internalType": "string", "name": "tokenSymbol", "type": "string" },
+          { "internalType": "string", "name": "chain", "type": "string" },
+          { "internalType": "uint64", "name": "chainId", "type": "uint64" },
+          { "internalType": "string", "name": "tokenAddress", "type": "string" },
+          { "internalType": "string", "name": "vaultAddress", "type": "string" }
+        ],
+        "internalType": "struct IPoRAddressListMulti.TokenVaultInfo[]",
+        "name": "tokenVaultInfos_",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getPoRAddressListLength",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/packages/sources/por-address-list/src/endpoint/multichainAddress.ts
+++ b/packages/sources/por-address-list/src/endpoint/multichainAddress.ts
@@ -20,7 +20,12 @@ export const inputParameters = new InputParameters(
     abiName: {
       description: 'Used to select the ABI by name',
       type: 'string',
-      options: ['MultiEVMPoRAddressList', 'PoRAddressListMulti', 'SolvMultiAddressList'],
+      options: [
+        'MultiEVMPoRAddressList',
+        'PoRAddressListMulti',
+        'SolvMultiAddressList',
+        'SolvSolanaMultiAddressList',
+      ],
       required: true,
     },
     type: {

--- a/packages/sources/por-address-list/src/transport/multichainAddress.ts
+++ b/packages/sources/por-address-list/src/transport/multichainAddress.ts
@@ -4,6 +4,7 @@ import { TransportDependencies } from '@chainlink/external-adapter-framework/tra
 import { AdapterResponse, sleep } from '@chainlink/external-adapter-framework/util'
 import PoRAddressListMultiABI from '../config/PoRAddressListMulti.json'
 import SolvMultiAddressListABI from '../config/SolvMultiAddressList.json'
+import SolvSolanaMultiAddressListABI from '../config/SolvSolanaMultiAddressList.json'
 import MultiEVMPoRAddressListABI from '../config/MultiEVMPoRAddressList.json'
 import { BaseEndpointTypes, inputParameters } from '../endpoint/multichainAddress'
 import { ethers } from 'ethers'
@@ -115,6 +116,8 @@ export class AddressTransport extends SubscriptionTransport<AddressTransportType
         return PoRAddressListMultiABI
       case 'SolvMultiAddressList':
         return SolvMultiAddressListABI
+      case 'SolvSolanaMultiAddressList':
+        return SolvSolanaMultiAddressListABI
       default:
         throw new AdapterInputError({
           errorResponse: 'abiName not found',
@@ -152,6 +155,7 @@ const buildTokenResponse = (addressList: ResponseSchema[][], vaultPlaceHolder?: 
         k,
         {
           chainId: v[0].chainId.toString(),
+          network: v[0].chain,
           contractAddress: v[0].tokenAddress,
           wallets: v.map((v) => v.vaultAddress),
         },

--- a/packages/sources/por-address-list/test/integration/__snapshots__/adapter-multichain.test.ts.snap
+++ b/packages/sources/por-address-list/test/integration/__snapshots__/adapter-multichain.test.ts.snap
@@ -27,6 +27,7 @@ exports[`execute multichainAddress endpoint should return success 1`] = `
       {
         "chainId": "56",
         "contractAddress": "token1",
+        "network": "bnb",
         "wallets": [
           "vault1",
           "vault2",
@@ -35,6 +36,7 @@ exports[`execute multichainAddress endpoint should return success 1`] = `
       {
         "chainId": "223",
         "contractAddress": "token3",
+        "network": "b2",
         "wallets": [
           "vault3",
         ],

--- a/packages/sources/token-balance/package.json
+++ b/packages/sources/token-balance/package.json
@@ -28,6 +28,7 @@
     "start": "yarn server:dist"
   },
   "devDependencies": {
+    "@solana/web3.js": "^1.95.8",
     "@types/jest": "27.5.2",
     "@types/node": "16.18.115",
     "nock": "13.5.4",

--- a/packages/sources/token-balance/src/config/index.ts
+++ b/packages/sources/token-balance/src/config/index.ts
@@ -1,6 +1,16 @@
 import { AdapterConfig } from '@chainlink/external-adapter-framework/config'
 
 export const config = new AdapterConfig({
+  SOLANA_RPC_URL: {
+    description: 'Solana Rpc Url',
+    type: 'string',
+    default: 'https://TODO',
+  },
+  SOLANA_COMMITMENT: {
+    description: 'Solana transaction commitment level',
+    type: 'string',
+    default: 'finalized',
+  },
   BACKGROUND_EXECUTE_MS: {
     description:
       'The amount of time the background execute should sleep before performing the next request',

--- a/packages/sources/token-balance/src/endpoint/index.ts
+++ b/packages/sources/token-balance/src/endpoint/index.ts
@@ -1,1 +1,2 @@
 export { endpoint as evm } from './evm'
+export { endpoint as solana } from './solana'

--- a/packages/sources/token-balance/src/endpoint/solana.ts
+++ b/packages/sources/token-balance/src/endpoint/solana.ts
@@ -1,0 +1,68 @@
+import { AdapterEndpoint } from '@chainlink/external-adapter-framework/adapter'
+import { InputParameters } from '@chainlink/external-adapter-framework/validation'
+import { config } from '../config'
+import { solanaBalanceTransport } from '../transport/solana'
+
+export const inputParameters = new InputParameters(
+  {
+    addresses: {
+      required: true,
+      type: {
+        network: {
+          aliases: ['chain'],
+          required: false,
+          type: 'string',
+          description: 'Network of the contract, only solana will be processed',
+        },
+        contractAddress: {
+          required: true,
+          type: 'string',
+          description: 'Address of token contract',
+        },
+        wallets: {
+          required: true,
+          type: 'string',
+          array: true,
+          description: 'Array of wallets to sum balances',
+        },
+      },
+      array: true,
+      description: 'List of addresses to read',
+    },
+  },
+  [
+    {
+      addresses: [
+        {
+          network: 'solana',
+          contractAddress: '27G8MtK7VtTcCHkpASjSDdkWWYfoqT6ggEuKidVJidD4',
+          wallets: ['9P9MwtNknCNZkWLqgkuofM2b8FEDE8jNJxhnuSkHnhrf'],
+        },
+      ],
+    },
+  ],
+)
+
+export type BaseEndpointTypes = {
+  Parameters: typeof inputParameters.definition
+  Response: {
+    Result: string
+    Data: {
+      result: string
+      decimals: number
+      wallets: {
+        token: string
+        wallet: string
+        value: string
+        decimals: number
+      }[]
+    }
+  }
+  Settings: typeof config.settings
+}
+
+export const endpoint = new AdapterEndpoint({
+  name: 'solana',
+  transport: solanaBalanceTransport,
+  inputParameters,
+})

--- a/packages/sources/token-balance/src/index.ts
+++ b/packages/sources/token-balance/src/index.ts
@@ -1,13 +1,13 @@
 import { expose, ServerInstance } from '@chainlink/external-adapter-framework'
 import { Adapter } from '@chainlink/external-adapter-framework/adapter'
 import { config } from './config'
-import { evm } from './endpoint'
+import { evm, solana } from './endpoint'
 
 export const adapter = new Adapter({
   defaultEndpoint: evm.name,
   name: 'TOKEN_BALANCE',
   config,
-  endpoints: [evm],
+  endpoints: [evm, solana],
 })
 
 export const server = (): Promise<ServerInstance | undefined> => expose(adapter)

--- a/packages/sources/token-balance/src/transport/evm.ts
+++ b/packages/sources/token-balance/src/transport/evm.ts
@@ -99,7 +99,7 @@ export class ERC20TokenBalanceTransport extends SubscriptionTransport<BaseEndpoi
   async _handleRequest(
     param: RequestParams,
   ): Promise<AdapterResponse<BaseEndpointTypes['Response']>> {
-    const { addresses } = param
+    const addresses = param.addresses.filter((a) => a.chainId != '0')
 
     // verify providers exist for this request
     const normalizedAddresses = this.verifyProviders(addresses)

--- a/packages/sources/token-balance/src/transport/solana.ts
+++ b/packages/sources/token-balance/src/transport/solana.ts
@@ -1,0 +1,139 @@
+import { TransportDependencies } from '@chainlink/external-adapter-framework/transports'
+import { AdapterResponse, makeLogger, sleep } from '@chainlink/external-adapter-framework/util'
+import { SubscriptionTransport } from '@chainlink/external-adapter-framework/transports/abstract/subscription'
+import { EndpointContext } from '@chainlink/external-adapter-framework/adapter'
+import { AdapterInputError } from '@chainlink/external-adapter-framework/validation/error'
+import { BaseEndpointTypes, inputParameters } from '../endpoint/solana'
+import * as solanaWeb3 from '@solana/web3.js'
+
+const logger = makeLogger('Token Balances - Solana')
+
+type RequestParams = typeof inputParameters.validated
+
+const RESULT_DECIMALS = 18
+
+export class SolanaBalanceTransport extends SubscriptionTransport<BaseEndpointTypes> {
+  connection!: solanaWeb3.Connection
+
+  async initialize(
+    dependencies: TransportDependencies<BaseEndpointTypes>,
+    adapterSettings: BaseEndpointTypes['Settings'],
+    endpointName: string,
+    transportName: string,
+  ): Promise<void> {
+    if (!adapterSettings.SOLANA_RPC_URL || adapterSettings.SOLANA_RPC_URL == 'https://TODO') {
+      logger.error('SOLANA_RPC_URL is missing')
+    } else {
+      this.connection = new solanaWeb3.Connection(
+        adapterSettings.SOLANA_RPC_URL,
+        adapterSettings.SOLANA_COMMITMENT as solanaWeb3.Commitment,
+      )
+    }
+
+    await super.initialize(dependencies, adapterSettings, endpointName, transportName)
+  }
+
+  async backgroundHandler(context: EndpointContext<BaseEndpointTypes>, entries: RequestParams[]) {
+    await Promise.all(entries.map(async (param) => this.handleRequest(param)))
+    await sleep(context.adapterSettings.BACKGROUND_EXECUTE_MS)
+  }
+
+  async handleRequest(param: RequestParams) {
+    let response: AdapterResponse<BaseEndpointTypes['Response']>
+    try {
+      response = await this._handleRequest(param)
+    } catch (e: unknown) {
+      const errorMessage = e instanceof Error ? e.message : 'Unknown error occurred'
+      logger.error(e, errorMessage)
+      response = {
+        statusCode: (e as AdapterInputError)?.statusCode || 502,
+        errorMessage,
+        timestamps: {
+          providerDataRequestedUnixMs: 0,
+          providerDataReceivedUnixMs: 0,
+          providerIndicatedTimeUnixMs: undefined,
+        },
+      }
+    }
+    await this.responseCache.write(this.name, [{ params: param, response }])
+  }
+
+  async _handleRequest(
+    param: RequestParams,
+  ): Promise<AdapterResponse<BaseEndpointTypes['Response']>> {
+    if (!this.connection) {
+      throw new AdapterInputError({
+        statusCode: 400,
+        message: 'SOLANA_RPC_URL is missing',
+      })
+    }
+
+    const providerDataRequestedUnixMs = Date.now()
+
+    const response = await Promise.all(
+      param.addresses
+        .filter((a) => a.network?.toLowerCase() == 'solana')
+        .flatMap((a) =>
+          a.wallets.map((wallet) => ({
+            token: new solanaWeb3.PublicKey(a.contractAddress),
+            wallet: new solanaWeb3.PublicKey(wallet),
+          })),
+        )
+        .map(async (a) =>
+          this.connection.getParsedTokenAccountsByOwner(a.wallet, {
+            mint: a.token,
+          }),
+        ),
+    )
+
+    const result = response
+      .flatMap((r) => r.value)
+      .map((v) => ({
+        value: BigInt(v.account.data.parsed.info.tokenAmount.amount),
+        decimals: Number(v.account.data.parsed.info.tokenAmount.decimals),
+      }))
+      .reduce((accumulator, current) => {
+        if (current.decimals <= RESULT_DECIMALS) {
+          return (
+            accumulator +
+            BigInt(current.value) * BigInt(Math.pow(10, RESULT_DECIMALS - current.decimals))
+          )
+        } else {
+          return (
+            accumulator +
+            BigInt(current.value) / BigInt(Math.pow(10, current.decimals - RESULT_DECIMALS))
+          )
+        }
+      }, BigInt(0))
+
+    const formattedResponse = response
+      .flatMap((r) => r.value)
+      .map((r) => ({
+        token: r.account.data.parsed.info.mint,
+        wallet: r.account.data.parsed.info.owner,
+        value: r.account.data.parsed.info.tokenAmount.amount,
+        decimals: r.account.data.parsed.info.tokenAmount.decimals,
+      }))
+
+    return {
+      data: {
+        result: String(result),
+        decimals: RESULT_DECIMALS,
+        wallets: formattedResponse,
+      },
+      statusCode: 200,
+      result: String(result),
+      timestamps: {
+        providerDataRequestedUnixMs,
+        providerDataReceivedUnixMs: Date.now(),
+        providerIndicatedTimeUnixMs: undefined,
+      },
+    }
+  }
+
+  getSubscriptionTtlFromConfig(adapterSettings: BaseEndpointTypes['Settings']): number {
+    return adapterSettings.WARMUP_SUBSCRIPTION_TTL
+  }
+}
+
+export const solanaBalanceTransport = new SolanaBalanceTransport()

--- a/yarn.lock
+++ b/yarn.lock
@@ -5749,6 +5749,7 @@ __metadata:
   resolution: "@chainlink/token-balance-adapter@workspace:packages/sources/token-balance"
   dependencies:
     "@chainlink/external-adapter-framework": "npm:1.7.7"
+    "@solana/web3.js": "npm:^1.95.8"
     "@types/jest": "npm:27.5.2"
     "@types/node": "npm:16.18.115"
     ethers: "npm:^6.13.2"


### PR DESCRIPTION
## Closes #DF-20965

## Description
 - Add Solana address for Solv
 - Support calculating token-balance for Solana


## Changes

## Steps to Test

```
{
    "data": {
        "result": "17341563263297000000000000",
        "decimals": 18,
        "wallets": [
            {
                "token": "27G8MtK7VtTcCHkpASjSDdkWWYfoqT6ggEuKidVJidD4",
                "wallet": "9P9MwtNknCNZkWLqgkuofM2b8FEDE8jNJxhnuSkHnhrf",
                "value": "14171266747702",
                "decimals": 6
            },
            {
                "token": "27G8MtK7VtTcCHkpASjSDdkWWYfoqT6ggEuKidVJidD4",
                "wallet": "CmxF3yQgwEXNkgXgCapB6HXmGMGsUyNQsZdAkyKg6CWR",
                "value": "3170296515595",
                "decimals": 6
            }
        ]
    },
    "statusCode": 200,
    "result": "17341563263297000000000000",
    "timestamps": {
        "providerDataRequestedUnixMs": 1736784798973,
        "providerDataReceivedUnixMs": 1736784809784
    },
    "meta": {
        "adapterName": "TOKEN_BALANCE",
        "metrics": {
            "feedId": "9KGiFkP9bkQWmLNGKCEMwfuk1Ak="
        }
    }
}
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
