### PR TITLE
Feat/STRUCT-2627 tiingo iex update

### DIFF
--- a/.changeset/light-maps-scream.md
+++ b/.changeset/light-maps-scream.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/tiingo-adapter': minor
+---
+
+Update IEX endpoint with new payload

--- a/packages/sources/tiingo/test/integration/__snapshots__/adapter-ws.test.ts.snap
+++ b/packages/sources/tiingo/test/integration/__snapshots__/adapter-ws.test.ts.snap
@@ -92,32 +92,17 @@ exports[`websocket forex endpoint should return success 1`] = `
 }
 `;
 
-exports[`websocket iex endpoint Q request should return success 1`] = `
+exports[`websocket iex endpoint iex A request should return success 1`] = `
 {
   "data": {
-    "result": 170.285,
+    "result": 232.66,
   },
-  "result": 170.285,
+  "result": 232.66,
   "statusCode": 200,
   "timestamps": {
     "providerDataReceivedUnixMs": 3038,
     "providerDataStreamEstablishedUnixMs": 3030,
-    "providerIndicatedTimeUnixMs": 1645032916595,
-  },
-}
-`;
-
-exports[`websocket iex endpoint T request should return success 1`] = `
-{
-  "data": {
-    "result": 106.21,
-  },
-  "result": 106.21,
-  "statusCode": 200,
-  "timestamps": {
-    "providerDataReceivedUnixMs": 3038,
-    "providerDataStreamEstablishedUnixMs": 3030,
-    "providerIndicatedTimeUnixMs": 1645032916595,
+    "providerIndicatedTimeUnixMs": 1736885388216,
   },
 }
 `;
@@ -125,14 +110,14 @@ exports[`websocket iex endpoint T request should return success 1`] = `
 exports[`websocket iex endpoint should update the ttl after heartbeat is received 1`] = `
 {
   "data": {
-    "result": 170.285,
+    "result": 232.66,
   },
-  "result": 170.285,
+  "result": 232.66,
   "statusCode": 200,
   "timestamps": {
     "providerDataReceivedUnixMs": 3038,
     "providerDataStreamEstablishedUnixMs": 3030,
-    "providerIndicatedTimeUnixMs": 1645032916595,
+    "providerIndicatedTimeUnixMs": 1736885388216,
   },
 }
 `;

--- a/packages/sources/tiingo/test/integration/adapter-ws.test.ts
+++ b/packages/sources/tiingo/test/integration/adapter-ws.test.ts
@@ -14,7 +14,6 @@ import {
 import { WebSocketClassProvider } from '@chainlink/external-adapter-framework/transports'
 import FakeTimers from '@sinonjs/fake-timers'
 import * as lwbaTransport from '../../src/transport/crypto-lwba'
-import * as lwbaEndpoint from '../../src/endpoint/crypto-lwba'
 
 describe('websocket', () => {
   let mockWsServerCrypto: MockWebsocketServer | undefined
@@ -37,11 +36,6 @@ describe('websocket', () => {
   const priceDataAapl = {
     endpoint: 'iex',
     base: 'aapl',
-    transport: 'ws',
-  }
-  const priceDataAmzn = {
-    endpoint: 'iex',
-    base: 'amzn',
     transport: 'ws',
   }
   const priceDataForex = {
@@ -75,9 +69,8 @@ describe('websocket', () => {
     await testAdapter.request(priceData)
     await testAdapter.request(spreadData)
     await testAdapter.request(priceDataAapl)
-    await testAdapter.request(priceDataAmzn)
     await testAdapter.request(priceDataForex)
-    await testAdapter.waitForCache(5)
+    await testAdapter.waitForCache(4)
   })
 
   afterAll(async () => {
@@ -137,12 +130,8 @@ describe('websocket', () => {
   })
 
   describe('iex endpoint', () => {
-    it('Q request should return success', async () => {
+    it('iex A request should return success', async () => {
       const response = await testAdapter.request(priceDataAapl)
-      expect(response.json()).toMatchSnapshot()
-    })
-    it('T request should return success', async () => {
-      const response = await testAdapter.request(priceDataAmzn)
       expect(response.json()).toMatchSnapshot()
     })
 

--- a/packages/sources/tiingo/test/integration/fixtures.ts
+++ b/packages/sources/tiingo/test/integration/fixtures.ts
@@ -413,49 +413,10 @@ export const mockCryptoLwbaWebSocketServer = (URL: string): MockWebsocketServer 
 }
 
 export const mockIexWebSocketServer = (URL: string): MockWebsocketServer => {
-  const wsResponseQ = {
+  const wsResponseIexA = {
     messageType: 'A',
     service: 'iex',
-    data: [
-      'Q',
-      '2022-02-16T12:35:16.595244526-05:00',
-      1645032916595244500,
-      'aapl',
-      399,
-      170.28,
-      170.285,
-      170.29,
-      100,
-      null,
-      null,
-      0,
-      0,
-      null,
-      null,
-      null,
-    ],
-  }
-  const wsResponseT = {
-    messageType: 'A',
-    service: 'iex',
-    data: [
-      'T',
-      '2022-02-16T12:35:16.595244526-05:00',
-      1645032916595244500,
-      'amzn',
-      null,
-      null,
-      null,
-      null,
-      null,
-      106.21,
-      null,
-      null,
-      0,
-      0,
-      0,
-      0,
-    ],
+    data: ['2025-01-14T15:09:48.216010528-05:00', 'aapl', 232.66],
   }
   const wsResponseHeartbeat = {
     response: { code: 200, message: 'HeartBeat' },
@@ -466,8 +427,7 @@ export const mockIexWebSocketServer = (URL: string): MockWebsocketServer => {
     let counter = 0
     socket.on('message', () => {
       if (counter++ === 0) {
-        socket.send(JSON.stringify(wsResponseQ))
-        socket.send(JSON.stringify(wsResponseT))
+        socket.send(JSON.stringify(wsResponseIexA))
         setTimeout(() => {
           socket.send(JSON.stringify(wsResponseHeartbeat))
         }, 10000)


### PR DESCRIPTION
## Closes #[STRUCT-2627](https://smartcontract-it.atlassian.net/browse/STRUCT-2627)

## Description
Tiingo IEX endpoint is changing by Feb 1, updating to reflect new DP response payload

## Changes
- update IEX endpoint
- associated test

Note: https://www.tiingo.com/documentation/websockets/iex
> As of February 1st, 2025 IEX Exchange has changed their market data policies. To receive the FULL TOPS Feed, you must now have a market data agreement signed with the IEX Exchange. Upon signing, you will then be able to receive the full TOPS feed in real-time. If you want a thresholdLevel of 0 or 5 as described below, you will need this agreement.
For customers who do not want to sign a license agreement, you may use our derived data that calculates a reference price for each asset in real-time. While this is not a subsitute for the TOPS Feed, we do believe it will fulfill the needs of 95% of our customer base. There is no additional cost to the IEX Exchange if using our derived data. If you want this compliant-friendly reference price, you may use a thresholdLevel of 6 as described below.

Ask is to switch to threshold level 6 to keep our current subscription level and only receive the reference price

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test
1. yarn test tiingo
2. sanity test iex endpoint

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[STRUCT-2627]: https://smartcontract-it.atlassian.net/browse/STRUCT-2627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ