### PR TITLE
Feat/DF-20940 bitgo reserves multi

### DIFF
--- a/.changeset/afraid-drinks-rest.md
+++ b/.changeset/afraid-drinks-rest.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/bitgo-reserves-adapter': minor
+---
+
+Allow for multiple reserve provider endpoints

--- a/packages/sources/bitgo-reserves/src/config/index.ts
+++ b/packages/sources/bitgo-reserves/src/config/index.ts
@@ -1,15 +1,37 @@
 import { AdapterConfig } from '@chainlink/external-adapter-framework/config'
 
 export const config = new AdapterConfig({
-  API_ENDPOINT: {
-    description: 'An API endpoint for Data Provider',
+  PROD_API_ENDPOINT: {
+    description: 'Prod API endpoint for Data Provider',
     type: 'string',
-    default: 'https://reserves.usdstandard-test.com/por.json',
+    default: 'https://reserves.gousd.com/por.json',
   },
-  VERIFICATION_PUBKEY: {
+  STAGING_API_ENDPOINT: {
+    description: 'Staging API endpoint for Data Provider',
+    type: 'string',
+    default: 'https://reserves.gousd-staging.com/por.json',
+  },
+  TEST_API_ENDPOINT: {
+    description: 'Test API endpoint for Data Provider',
+    type: 'string',
+    default: 'https://reserves.gousd-test.com/por.json',
+  },
+  PROD_PUBKEY: {
     description:
       'Public RSA key used for verifying data signature. Expected to be formatted as a single line eg: "-----BEGIN PUBLIC KEY-----\\n...contents...\\n-----END PUBLIC KEY-----"',
     type: 'string',
     required: true,
+  },
+  STAGING_PUBKEY: {
+    description:
+      'Public RSA key used for verifying data signature. Expected to be formatted as a single line eg: "-----BEGIN PUBLIC KEY-----\\n...contents...\\n-----END PUBLIC KEY-----"',
+    type: 'string',
+    required: false,
+  },
+  TEST_PUBKEY: {
+    description:
+      'Public RSA key used for verifying data signature. Expected to be formatted as a single line eg: "-----BEGIN PUBLIC KEY-----\\n...contents...\\n-----END PUBLIC KEY-----"',
+    type: 'string',
+    required: false,
   },
 })

--- a/packages/sources/bitgo-reserves/src/endpoint/reserves.ts
+++ b/packages/sources/bitgo-reserves/src/endpoint/reserves.ts
@@ -4,7 +4,21 @@ import { SingleNumberResultResponse } from '@chainlink/external-adapter-framewor
 import { config } from '../config'
 import { httpTransport } from '../transport/reserves'
 
-export const inputParameters = new InputParameters({})
+export const inputParameters = new InputParameters(
+  {
+    providerEndpoint: {
+      description: 'Which environment endpoint to choose',
+      options: ['prod', 'staging', 'test'],
+      type: 'string',
+      required: true,
+    },
+  },
+  [
+    {
+      providerEndpoint: 'prod',
+    },
+  ],
+)
 
 export type BaseEndpointTypes = {
   Parameters: typeof inputParameters.definition

--- a/packages/sources/bitgo-reserves/test/integration/adapter.test.ts
+++ b/packages/sources/bitgo-reserves/test/integration/adapter.test.ts
@@ -12,8 +12,8 @@ describe('execute', () => {
 
   beforeAll(async () => {
     oldEnv = JSON.parse(JSON.stringify(process.env))
-    process.env.API_ENDPOINT = 'http://test-endpoint.com'
-    process.env.VERIFICATION_PUBKEY = 'test'
+    process.env.PROD_API_ENDPOINT = 'http://test-endpoint.com'
+    process.env.PROD_PUBKEY = 'test'
 
     const mockDate = new Date('2001-01-01T11:11:11.111Z')
     spy = jest.spyOn(Date, 'now').mockReturnValue(mockDate.getTime())
@@ -43,6 +43,7 @@ describe('execute', () => {
     it('should return success', async () => {
       const data = {
         endpoint: 'reserves',
+        providerEndpoint: 'prod',
       }
       mockResponseSuccess()
       const response = await testAdapter.request(data)


### PR DESCRIPTION
## Closes #[DF-20940](https://smartcontract-it.atlassian.net/browse/DF-20940)

## Description
Add providerEndpoint param allowing to connect to multiple provider endpoints

## Changes
- Added extra param to reserves endpoint
- Added env vars per env

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test
1. yarn test bitgo-reserves
2. sanity test reserves endpoint with additional param

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[DF-20940]: https://smartcontract-it.atlassian.net/browse/DF-20940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ