### PR TITLE
Elwood Optimize /subscriptions call

### DIFF
--- a/.changeset/sharp-jobs-draw.md
+++ b/.changeset/sharp-jobs-draw.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/elwood-adapter': patch
+---
+
+Reduce the frequency of /subscriptions api calls to check active subscriptions to only when we desire to subscribe to a stream.

--- a/packages/sources/elwood/src/transport/crypto.ts
+++ b/packages/sources/elwood/src/transport/crypto.ts
@@ -102,6 +102,13 @@ export const transport: WebSocketTransport<WsTransportTypes> =
       // are multiple EAs that share the same key then we should only subscribe to new symbols. For
       // the same reason, it is not safe to unsubscribe otherwise another EA expecting the symbol
       // may unexpectedly stop receiving data for it without knowing.
+
+      // `subscribes` will be populated if there are new subscriptions to be made. This can happen
+      // if we request a new pair to be subscribed to, or if the subscription set TTL has expired
+      if (!subscribes || subscribes.length === 0) return
+
+      logger.info(`Subscription requests: ${JSON.stringify(subscribes)}`)
+
       const subscriptions = await getSubscriptions(
         context.adapterSettings.API_ENDPOINT,
         context.adapterSettings.API_KEY,

--- a/packages/sources/elwood/src/transport/lwba.ts
+++ b/packages/sources/elwood/src/transport/lwba.ts
@@ -104,6 +104,13 @@ export const transport: WebSocketTransport<WsTransportTypes> =
       // are multiple EAs that share the same key then we should only subscribe to new symbols. For
       // the same reason, it is not safe to unsubscribe otherwise another EA expecting the symbol
       // may unexpectedly stop receiving data for it without knowing.
+
+      // `subscribes` will be populated if there are new subscriptions to be made. This can happen
+      // if we request a new pair to be subscribed to, or if the subscription set TTL has expired
+      if (!subscribes || subscribes.length === 0) return
+
+      logger.info(`Subscription requests: ${JSON.stringify(subscribes)}`)
+
       const subscriptions = await getSubscriptions(
         context.adapterSettings.API_ENDPOINT,
         context.adapterSettings.API_KEY,

--- a/packages/sources/elwood/test/integration/adapter.test.ts
+++ b/packages/sources/elwood/test/integration/adapter.test.ts
@@ -75,11 +75,12 @@ describe('websocket', () => {
 
     it('should skip subscribing if already subscribed', async () => {
       const symbol = `${dataAlreadySubscribed.base}-${dataAlreadySubscribed.quote}`
-      mockSubscriptionsResponse(apiKey, [symbol])
+      const subscriptionScope = mockSubscriptionsResponse(apiKey, [symbol])
       const scope = mockSubscribeResponse(apiKey, symbol)
       const response = await testAdapter.request(data)
       expect(response.json()).toMatchSnapshot()
       expect(scope.isDone()).toEqual(false)
+      expect(subscriptionScope.isDone()).toEqual(false)
     })
 
     it('should return success (LWBA)', async () => {


### PR DESCRIPTION
## Description
Reduce the amount of subscription check API calls to when the EA receives new subscription requests that are not in the subscription set. This can happen in these cases:
- subscription item expires
- new subscription
- Provider WS connection is reset ([here](https://github.com/smartcontractkit/ea-framework-js/blob/945c7bb9786db2507af0c7a54d741041a5ed69f1/src/transports/websocket.ts#L379))

In the current scenario we are unnecessarily calling /subscriptions endpoint on every background loop execute [here](https://github.com/smartcontractkit/ea-framework-js/blob/945c7bb9786db2507af0c7a54d741041a5ed69f1/src/transports/websocket.ts#L397)


## Steps to Test
Unit tests via `yarn test`

E2E test Locally:
- Start the EA 
- Make a request for some pair
- - observe that the call to /subscriptions will only happen if you make an EA request with a pair that is not already in the subscription set


## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
