### PR TITLE
view function Aptos

### DIFF
--- a/.changeset/chatty-sheep-swim.md
+++ b/.changeset/chatty-sheep-swim.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/view-function-multi-chain-adapter': minor
+---
+
+Aptos

--- a/packages/scripts/src/schema-flatten/lib.ts
+++ b/packages/scripts/src/schema-flatten/lib.ts
@@ -124,7 +124,7 @@ function createChainlinkLabsResolver() {
 
   const resolver: $RefParser.ResolverOptions = {
     order: 1,
-    canRead: /^https:\/\/external-adapters\.chainlinklabs\.com$/i,
+    canRead: /^https:\/\/external-adapters\.chainlinklabs\.com\//i,
     read: (file, callback) => {
       if (!callback) {
         console.error('[resolver] No callback found')

--- a/packages/sources/view-function-multi-chain/src/config/index.ts
+++ b/packages/sources/view-function-multi-chain/src/config/index.ts
@@ -1,6 +1,13 @@
 import { AdapterConfig } from '@chainlink/external-adapter-framework/config'
 
 export const config = new AdapterConfig({
+  APTOS_URL: {
+    description: 'Aptos rest api url',
+    type: 'string',
+    required: false,
+    default: '',
+  },
+
   BACKGROUND_EXECUTE_MS: {
     description:
       'The amount of time the background execute should sleep before performing the next request',

--- a/packages/sources/view-function-multi-chain/src/endpoint/aptos.ts
+++ b/packages/sources/view-function-multi-chain/src/endpoint/aptos.ts
@@ -1,0 +1,55 @@
+import { AdapterEndpoint } from '@chainlink/external-adapter-framework/adapter'
+import { InputParameters } from '@chainlink/external-adapter-framework/validation'
+import { AdapterInputError } from '@chainlink/external-adapter-framework/validation/error'
+import { config } from '../config'
+import { aptosTransport } from '../transport/aptos'
+
+export const inputParameters = new InputParameters({
+  signature: {
+    type: 'string',
+    aliases: ['function'],
+    required: true,
+    description: 'Function signature. Format: {address}::{module name}::{function name}',
+  },
+  arguments: {
+    array: true,
+    description: 'Arguments of the function',
+    type: 'string',
+  },
+  type: {
+    array: true,
+    description: 'Type arguments of the function',
+    type: 'string',
+  },
+  index: {
+    description: 'Which item in the function output array to return',
+    type: 'number',
+    default: 0,
+  },
+})
+
+export type BaseEndpointTypes = {
+  Parameters: typeof inputParameters.definition
+  Response: {
+    Data: {
+      result: string
+    }
+    Result: string
+  }
+  Settings: typeof config.settings
+}
+
+export const endpoint = new AdapterEndpoint({
+  name: 'aptos',
+  transport: aptosTransport,
+  inputParameters,
+  customInputValidation: (_, adapterSettings): AdapterInputError | undefined => {
+    if (!adapterSettings['APTOS_URL']) {
+      throw new AdapterInputError({
+        statusCode: 400,
+        message: `Error: missing environment variable APTOS_URL`,
+      })
+    }
+    return
+  },
+})

--- a/packages/sources/view-function-multi-chain/src/endpoint/index.ts
+++ b/packages/sources/view-function-multi-chain/src/endpoint/index.ts
@@ -1,1 +1,2 @@
 export { endpoint as functionEndpoint } from './function'
+export { endpoint as aptosEndpoint } from './aptos'

--- a/packages/sources/view-function-multi-chain/src/index.ts
+++ b/packages/sources/view-function-multi-chain/src/index.ts
@@ -1,13 +1,21 @@
 import { expose, ServerInstance } from '@chainlink/external-adapter-framework'
 import { Adapter } from '@chainlink/external-adapter-framework/adapter'
 import { config } from './config'
-import { functionEndpoint } from './endpoint'
+import { functionEndpoint, aptosEndpoint } from './endpoint'
 
 export const adapter = new Adapter({
   defaultEndpoint: functionEndpoint.name,
   name: 'VIEW_FUNCTION_MULTI_CHAIN',
   config,
-  endpoints: [functionEndpoint],
+  endpoints: [functionEndpoint, aptosEndpoint],
+  rateLimiting: {
+    tiers: {
+      default: {
+        rateLimit1s: 1,
+        note: 'Reasonable limits',
+      },
+    },
+  },
 })
 
 export const server = (): Promise<ServerInstance | undefined> => expose(adapter)

--- a/packages/sources/view-function-multi-chain/src/transport/aptos.ts
+++ b/packages/sources/view-function-multi-chain/src/transport/aptos.ts
@@ -1,0 +1,76 @@
+import { HttpTransport } from '@chainlink/external-adapter-framework/transports'
+import { BaseEndpointTypes } from '../endpoint/aptos'
+
+export type HttpTransportTypes = BaseEndpointTypes & {
+  Provider: {
+    RequestBody: { function: string; type_arguments: string[]; arguments: string[] }
+    ResponseBody:
+      | any[]
+      | {
+          message: string
+          error_code: string
+          vm_error_code: number
+        }
+  }
+}
+export const aptosTransport = new HttpTransport<HttpTransportTypes>({
+  prepareRequests: (params, config) => {
+    return params.map((param) => {
+      return {
+        params: [param],
+        request: {
+          baseURL: config.APTOS_URL,
+          url: '/view',
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          data: {
+            function: param.signature,
+            type_arguments: param.type,
+            arguments: param.arguments,
+          },
+        },
+      }
+    })
+  },
+  parseResponse: (params, response) => {
+    if (response.data instanceof Array) {
+      if (params[0].index >= response.data.length) {
+        return [
+          {
+            params: params[0],
+            response: {
+              errorMessage: `index ${
+                params[0].index
+              } is more than result array length ${JSON.stringify(response.data)}`,
+              statusCode: 502,
+            },
+          },
+        ]
+      }
+      return response.data.map((elem, i) => ({
+        params: {
+          ...params[0],
+          index: i,
+        },
+        response: {
+          result: elem,
+          data: {
+            result: elem,
+          },
+        },
+      }))
+    } else {
+      return [
+        {
+          params: params[0],
+          response: {
+            errorMessage: JSON.stringify(response.data),
+            statusCode: 502,
+          },
+        },
+      ]
+    }
+  },
+})

--- a/packages/sources/view-function-multi-chain/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/view-function-multi-chain/test/integration/__snapshots__/adapter.test.ts.snap
@@ -1,8 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`execute aptos endpoint should return success 1`] = `
+{
+  "data": {
+    "result": 1,
+  },
+  "result": 1,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 978347471111,
+    "providerDataRequestedUnixMs": 978347471111,
+  },
+}
+`;
+
 exports[`execute function endpoint should return error for invalid input 1`] = `
 {
-  "errorMessage": "no matching function (argument="key", value="symbol() view returns (string)", code=INVALID_ARGUMENT, version=6.13.4)",
+  "errorMessage": "no matching function (argument="key", value="symbol() view returns (string)", code=INVALID_ARGUMENT, version=6.13.5)",
   "statusCode": 502,
   "timestamps": {
     "providerDataReceivedUnixMs": 0,

--- a/packages/sources/view-function-multi-chain/test/integration/fixtures.ts
+++ b/packages/sources/view-function-multi-chain/test/integration/fixtures.ts
@@ -118,3 +118,21 @@ export const mockETHGoerliContractCallResponseSuccess = (): nock.Scope =>
       ],
     )
     .persist()
+
+export const mockAptosSuccess = (): nock.Scope =>
+  nock('http://fake-aptos', {
+    encodedQueryParams: true,
+  })
+    .persist()
+    .post('/view')
+    .reply(200, () => [1], [
+      'Content-Type',
+      'application/json',
+      'Connection',
+      'close',
+      'Vary',
+      'Accept-Encoding',
+      'Vary',
+      'Origin',
+    ])
+    .persist()


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/DF-21081

## Description

Using this API: https://aptos.dev/en/build/apis/fullnode-rest-api-reference#tag/view/POST/view


## Steps to Test

```
{
    "data": {
        "endpoint": "aptos",
        "signature": "0x6f8ca77dd0a4c65362f475adb1c26ae921b1d75aa6b70e53d0e340efd7d8bc80::staker::share_price",
        "index": 1
    }
}
```

```
{
    "result": "9924571501801560000",
    "data": {
        "result": "9924571501801560000"
    },
    "timestamps": {
        "providerDataRequestedUnixMs": 1740670690713,
        "providerDataReceivedUnixMs": 1740670690874
    },
    "statusCode": 200,
    "meta": {
        "adapterName": "VIEW_FUNCTION_MULTI_CHAIN",
        "metrics": {
            "feedId": "{\"signature\":\"0x6f8ca77dd0a4c65362f475adb1c26ae921b1d75aa6b70e53d0e340efd7d8bc80::staker::share_price\",\"arguments\":[],\"type\":[],\"index\":1}"
        }
    }
}
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
