### PR TITLE
fix: Prototype-polluting assignment

### DIFF
--- a/packages/core/bootstrap/src/lib/modules/overrider.ts
+++ b/packages/core/bootstrap/src/lib/modules/overrider.ts
@@ -114,11 +114,11 @@ export class Overrider {
     internalOverrides: AdapterOverrides,
     inputOverrides: AdapterOverrides,
   ): AdapterOverrides => {
-    const combinedOverrides = internalOverrides || {}
-    for (const symbol of Object.keys(inputOverrides)) {
-      combinedOverrides[symbol] = inputOverrides[symbol]
+    const combinedOverrides = new Map(Object.entries(internalOverrides || {}))
+    for (const [symbol, value] of Object.entries(inputOverrides)) {
+      combinedOverrides.set(symbol, value)
     }
-    return combinedOverrides
+    return Object.fromEntries(combinedOverrides)
   }
 }
 


### PR DESCRIPTION
## Ticket 🎟️#3705

To fix the prototype pollution vulnerability, we should ensure that the keys used in the `combineOverrides` method cannot be used to modify the `Object.prototype`. One effective way to achieve this is by using a `Map` object instead of a plain object for `combinedOverrides`. This will prevent any prototype pollution since `Map` does not have the same prototype properties as plain objects.


## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
