### PR TITLE
Update aleno routes

### DIFF
--- a/.changeset/short-paws-type.md
+++ b/.changeset/short-paws-type.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/aleno-adapter': minor
+---
+
+Update route to use standard ws

--- a/packages/sources/aleno/src/endpoint/price.ts
+++ b/packages/sources/aleno/src/endpoint/price.ts
@@ -26,7 +26,7 @@ export const endpoint = new AdapterEndpoint({
   aliases: ['crypto', 'state'],
   transportRoutes: new TransportRoutes<BaseEndpointTypes>()
     .register('rest', httpTransport)
-    .register('socketio', socketioTransport),
+    .register('ws', socketioTransport),
   inputParameters,
-  defaultTransport: 'socketio',
+  defaultTransport: 'ws',
 })


### PR DESCRIPTION
Example payload
```
{"cid":"3717","endpoint":"crypto","from":"WBTC","to":"USD","transport":"ws"}
```

I looked in rdd and looks like we are not using `socketio` endpoint so safe to update