### PR TITLE
Aleno: Change ResponseSchema from Record to Array

### DIFF
--- a/.changeset/purple-turtles-help.md
+++ b/.changeset/purple-turtles-help.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/aleno-adapter': patch
+---
+
+Change type definition of ResponseSchema to match API

--- a/packages/sources/aleno/src/transport/price-http.ts
+++ b/packages/sources/aleno/src/transport/price-http.ts
@@ -1,23 +1,23 @@
 import { HttpTransport } from '@chainlink/external-adapter-framework/transports'
 import { BaseEndpointTypes } from '../endpoint/price'
 
-export interface ResponseSchema {
-  [index: number]: {
-    id: string
-    baseSymbol: string
-    quoteSymbol: string
-    processTimestamp: number
-    processBlockChainId: string
-    processBlockNumber: number
-    processBlockTimestamp: number
-    aggregatedLast7DaysBaseVolume: number
-    price: number
-    aggregatedMarketDepthMinusOnePercentUsdAmount: number
-    aggregatedMarketDepthPlusOnePercentUsdAmount: number
-    aggregatedMarketDepthUsdAmount: number
-    aggregatedLast7DaysUsdVolume: number
-  }
+interface ResponseItem {
+  id: string
+  baseSymbol: string
+  quoteSymbol: string
+  processTimestamp: number
+  processBlockChainId: string
+  processBlockNumber: number
+  processBlockTimestamp: number
+  aggregatedLast7DaysBaseVolume: number
+  price: number
+  aggregatedMarketDepthMinusOnePercentUsdAmount: number
+  aggregatedMarketDepthPlusOnePercentUsdAmount: number
+  aggregatedMarketDepthUsdAmount: number
+  aggregatedLast7DaysUsdVolume: number
 }
+
+export type ResponseSchema = ResponseItem[]
 
 export type HttpTransportTypes = BaseEndpointTypes & {
   Provider: {
@@ -59,7 +59,7 @@ export const httpTransport = new HttpTransport<HttpTransportTypes>({
       let result
       let processTimestamp
 
-      Object.values(response.data).forEach((row) => {
+      response.data.forEach((row) => {
         if (row.baseSymbol === param.base && row.quoteSymbol === param.quote) {
           result = Number(row.price)
           processTimestamp = row.processTimestamp

--- a/packages/sources/aleno/src/transport/price-socketio.ts
+++ b/packages/sources/aleno/src/transport/price-socketio.ts
@@ -48,7 +48,7 @@ export class SocketIOTransport extends StreamingTransport<SocketIOTransportTypes
     providerDataStreamEstablishedTime: number,
     data: ResponseSchema,
   ): Promise<void> {
-    Object.values(data).forEach((row) => {
+    data.forEach((row) => {
       this.responseCache.write(this.name, [
         {
           params: {

--- a/packages/sources/aleno/test/integration/adapter-socket.test.ts
+++ b/packages/sources/aleno/test/integration/adapter-socket.test.ts
@@ -29,8 +29,8 @@ describe('execute', () => {
       testAdapter: {} as TestAdapter<never>,
     })
 
-    socket.clientMock.emit('initial_token_states', {
-      0: {
+    socket.clientMock.emit('initial_token_states', [
+      {
         id: 'FRAX/USD',
         baseSymbol: 'FRAX',
         quoteSymbol: 'USD',
@@ -45,7 +45,7 @@ describe('execute', () => {
         aggregatedMarketDepthUsdAmount: 41057587.41750349,
         aggregatedLast7DaysUsdVolume: 92915562.18873177,
       },
-    })
+    ])
   })
 
   afterAll(async () => {


### PR DESCRIPTION
## Description

The Aleno EA defines the `ResponseSchema` type as a record with number keys. But the actual `response.data` looks like this:
```
[
  {
    sentTimestampMs: 1741938791107,
    id: 'FRXUSD/USD',
    baseSymbol: 'FRXUSD',
    quoteSymbol: 'USD',
    processTimestamp: 1741938766,
    processBlockChainId: 'solana',
    processBlockNumber: 304919216,
    processBlockTimestamp: 1741938765,
    aggregatedLast7DaysBaseVolume: 6068293.355485149,
    price: 0.9977322090150218,
    aggregatedMarketDepthMinusOnePercentUsdAmount: 1387627.0370493107,
    aggregatedMarketDepthPlusOnePercentUsdAmount: 2686966.5138585414,
    aggregatedMarketDepthUsdAmount: 4074593.550907852,
    aggregatedLast7DaysUsdVolume: 12105411.019176643
  },
  ...
]
```
So it has the structure of a plain array.

While treating an array as if it's a record with number keys does work, it's not the most accurate and complicates things unnecessarily.

So in this PR we change the type `ResponseSchema` from a record with number keys to an array.

## Changes

1. Introduce private type `ResponseItem` to represent one element in the `ResponseSchema` array, to make the type definition of `ResponseSchema` more obviously an array.
2. Change the type definition of `ResponseSchema` to be an array of `ResponseItem`.
3. Stop using `Object.values` on arrays as it just returns the array itself.
4. Change the data emitted in the test to be an array.

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. `cd packages/sources/aleno/`
2. `yarn build && yarn start --env-file=~/env/aleno`
3. In another shell:
```
$ curl -X POST http://localhost:8080 -H "Content-Type: application/json" -d '{ "data": { "endpoint": "price", "base": "FRAX", "quote": "USD" } }'
{"data":{"result":0.9980603729067486},"result":0.9980603729067486,"timestamps":{"providerDataStreamEstablishedUnixMs":1741941338936,"providerDataReceivedUnixMs":1741941339186,"providerIndicatedTimeUnixMs":1741941312000},"statusCode":200,"meta":{"adapterName":"ALENO","metrics":{"feedId":"{\"base\":\"frax\",\"quote\":\"usd\"}"}}}
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [x] This is related to a maximum of one Jira story or GitHub issue.
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
