### PR TITLE
Support multiplying in implied-price EA

### DIFF
--- a/.changeset/cuddly-gifts-chew.md
+++ b/.changeset/cuddly-gifts-chew.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/implied-price-adapter': minor
+---
+
+Support multiplying prices in addition to dividing

--- a/packages/composites/implied-price/README.md
+++ b/packages/composites/implied-price/README.md
@@ -1,6 +1,6 @@
 # Chainlink Implied-price Composite Adapter
 
-An adapter that fetches the median value from any two sets of underlying adapters, and divides the results from each set together.
+An adapter that fetches the median value from any two sets of underlying adapters, and multiplies or divides the results from each set together.
 
 ## Configuration
 
@@ -16,14 +16,28 @@ See the [Composite Adapter README](../README.md) for more information on how to 
 
 ### Input Params
 
+When using `operand` paramters:
+
+| Required? |         Name         |                                               Description                                               |       Options        | Defaults to |
+| :-------: | :------------------: | :-----------------------------------------------------------------------------------------------------: | :------------------: | :---------: |
+|    ✅     |  `operand1Sources`   | An array (string[]) or comma delimited list (string) of source adapters to query for the operand1 value |                      |             |
+|           | `operand1MinAnswers` |                 The minimum number of answers needed to return a value for the operand1                 |                      |     `1`     |
+|    ✅     |   `operand1Input`    |                               The payload to send to the operand1 sources                               |                      |             |
+|    ✅     |  `operand2Sources`   | An array (string[]) or comma delimited list (string) of source adapters to query for the operand2 value |                      |             |
+|           | `operand2MinAnswers` |                 The minimum number of answers needed to return a value for the operand2                 |                      |     `1`     |
+|    ✅     |   `operand2Input`    |                               The payload to send to the operand2 sources                               |                      |             |
+|    ✅     |     `operation`      |                                 The operation to peform on the operands                                 | `divide`, `multiply` |             |
+
+When using legacy dividend/divisor parameters:
+
 | Required? |         Name         |                                               Description                                               | Options | Defaults to |
 | :-------: | :------------------: | :-----------------------------------------------------------------------------------------------------: | :-----: | :---------: |
 |    ✅     |  `dividendSources`   | An array (string[]) or comma delimited list (string) of source adapters to query for the dividend value |         |             |
 |           | `dividendMinAnswers` |                 The minimum number of answers needed to return a value for the dividend                 |         |     `1`     |
-|           |   `dividendInput`    |                               The payload to send to the dividend sources                               |         |    `{}`     |
+|    ✅     |   `dividendInput`    |                               The payload to send to the dividend sources                               |         |             |
 |    ✅     |   `divisorSources`   | An array (string[]) or comma delimited list (string) of source adapters to query for the divisor value  |         |             |
 |           | `divisorMinAnswers`  |                 The minimum number of answers needed to return a value for the divisor                  |         |     `1`     |
-|           |    `divisorInput`    |                               The payload to send to the divisor sources                                |         |    `{}`     |
+|    ✅     |    `divisorInput`    |                               The payload to send to the divisor sources                                |         |             |
 
 Each source in `sources` needs to have a defined `*_ADAPTER_URL` defined as an env var.
 
@@ -35,6 +49,35 @@ COINPAPRIKA_ADAPTER_URL=https://coinpaprika_adapter_url/
 ```
 
 ### Sample Input
+
+```json
+{
+  "id": "1",
+  "data": {
+    "operand1Sources": ["coingecko"],
+    "operand2Sources": ["coingecko"],
+    "operand1Input": {
+      "from": "LINK",
+      "to": "USD",
+      "overrides": {
+        "coingecko": {
+          "LINK": "chainlink"
+        }
+      }
+    },
+    "operand2Input": {
+      "from": "ETH",
+      "to": "USD",
+      "overrides": {
+        "coingecko": {
+          "ETH": "ethereum"
+        }
+      }
+    },
+    "operation": "divide"
+  }
+}
+```
 
 ```json
 {

--- a/packages/composites/implied-price/test-payload.json
+++ b/packages/composites/implied-price/test-payload.json
@@ -1,5 +1,28 @@
 {
  "requests": [{
+  "operand1Sources": ["coingecko"],
+  "operand2Sources": ["coingecko"],
+  "operand1Input": {
+   "from": "LINK",
+   "to": "USD",
+   "overrides": {
+    "coingecko": {
+     "LINK": "chainlink"
+    }
+   }
+  },
+  "operand2Input": {
+   "from": "ETH",
+   "to": "USD",
+   "overrides": {
+    "coingecko": {
+     "ETH": "ethereum"
+    }
+   }
+  },
+  "operation": "divide"
+ },
+ {
   "dividendSources": ["coingecko"],
   "divisorSources": ["coingecko"],
   "dividendInput": {

--- a/packages/composites/implied-price/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/composites/implied-price/test/integration/__snapshots__/adapter.test.ts.snap
@@ -13,7 +13,7 @@ exports[`impliedPrice erroring calls returns error if not reaching minAnswers 1`
 }
 `;
 
-exports[`impliedPrice successful calls return success without comma separated sources 1`] = `
+exports[`impliedPrice successful calls with dividend and divisor parameters return success without comma separated sources 1`] = `
 {
   "data": {
     "result": "0.0038975944001909025829",
@@ -25,7 +25,7 @@ exports[`impliedPrice successful calls return success without comma separated so
 }
 `;
 
-exports[`impliedPrice successful calls returns success with comma separated sources 1`] = `
+exports[`impliedPrice successful calls with dividend and divisor parameters returns success with comma separated sources 1`] = `
 {
   "data": {
     "result": "0.0038975944001909025829",
@@ -34,6 +34,211 @@ exports[`impliedPrice successful calls returns success with comma separated sour
   "providerStatusCode": 200,
   "result": "0.0038975944001909025829",
   "statusCode": 200,
+}
+`;
+
+exports[`impliedPrice successful calls with operand1 and operand2 parameters can multiply operands 1`] = `
+{
+  "data": {
+    "result": "75462.5725",
+  },
+  "jobRunID": "1",
+  "providerStatusCode": 200,
+  "result": "75462.5725",
+  "statusCode": 200,
+}
+`;
+
+exports[`impliedPrice successful calls with operand1 and operand2 parameters return success without comma separated sources 1`] = `
+{
+  "data": {
+    "result": "0.0038975944001909025829",
+  },
+  "jobRunID": "1",
+  "providerStatusCode": 200,
+  "result": "0.0038975944001909025829",
+  "statusCode": 200,
+}
+`;
+
+exports[`impliedPrice successful calls with operand1 and operand2 parameters returns success with comma separated sources 1`] = `
+{
+  "data": {
+    "result": "0.0038975944001909025829",
+  },
+  "jobRunID": "1",
+  "providerStatusCode": 200,
+  "result": "0.0038975944001909025829",
+  "statusCode": 200,
+}
+`;
+
+exports[`impliedPrice validation error returns a validation error if additional dividend parameters are given 1`] = `
+{
+  "error": {
+    "feedID": "{"data":{"operand1Sources":["coingecko","coinpaprika"],"dividendSources":["coingecko","coinpaprika"],"operand2Sources":["coingecko","coinpaprika"],"operand1Input":{"from":"LINK","to":"USD"},"operand2Input":{"from":"ETH","to":"USD"},"operation":"divide"}}",
+    "message": "Must use only dividend/divisor parameters or only operand1/operand2 parameters",
+    "name": "AdapterError",
+  },
+  "jobRunID": "1",
+  "status": "errored",
+  "statusCode": 400,
+}
+`;
+
+exports[`impliedPrice validation error returns a validation error if additional operand parameters are given 1`] = `
+{
+  "error": {
+    "feedID": "{"data":{"dividendSources":["coingecko","coinpaprika"],"divisorSources":["coingecko","coinpaprika"],"operand1Sources":["coingecko","coinpaprika"],"dividendInput":{"from":"LINK","to":"USD"},"divisorInput":{"from":"ETH","to":"USD"}}}",
+    "message": "Must use only dividend/divisor parameters or only operand1/operand2 parameters",
+    "name": "AdapterError",
+  },
+  "jobRunID": "1",
+  "status": "errored",
+  "statusCode": 400,
+}
+`;
+
+exports[`impliedPrice validation error returns a validation error if dividendInput is missing 1`] = `
+{
+  "error": {
+    "feedID": "{"data":{"dividendSources":["coingecko","coinpaprika"],"divisorSources":["coingecko","coinpaprika"],"divisorInput":{"from":"ETH","to":"USD"}}}",
+    "message": "Must specify all required dividend/divisor parameters: dividendSources, dividendInput, divisorSources, divisorInput",
+    "name": "AdapterError",
+  },
+  "jobRunID": "1",
+  "status": "errored",
+  "statusCode": 400,
+}
+`;
+
+exports[`impliedPrice validation error returns a validation error if dividendSources are missing 1`] = `
+{
+  "error": {
+    "feedID": "{"data":{"divisorSources":["coingecko","coinpaprika"],"dividendInput":{"from":"LINK","to":"USD"},"divisorInput":{"from":"ETH","to":"USD"}}}",
+    "message": "Must specify all required dividend/divisor parameters: dividendSources, dividendInput, divisorSources, divisorInput",
+    "name": "AdapterError",
+  },
+  "jobRunID": "1",
+  "status": "errored",
+  "statusCode": 400,
+}
+`;
+
+exports[`impliedPrice validation error returns a validation error if divisorInput is missing 1`] = `
+{
+  "error": {
+    "feedID": "{"data":{"dividendSources":["coingecko","coinpaprika"],"divisorSources":["coingecko","coinpaprika"],"dividendInput":{"from":"LINK","to":"USD"}}}",
+    "message": "Must specify all required dividend/divisor parameters: dividendSources, dividendInput, divisorSources, divisorInput",
+    "name": "AdapterError",
+  },
+  "jobRunID": "1",
+  "status": "errored",
+  "statusCode": 400,
+}
+`;
+
+exports[`impliedPrice validation error returns a validation error if divisorSources are missing 1`] = `
+{
+  "error": {
+    "feedID": "{"data":{"dividendSources":["coingecko","coinpaprika"],"dividendInput":{"from":"LINK","to":"USD"},"divisorInput":{"from":"ETH","to":"USD"}}}",
+    "message": "Must specify all required dividend/divisor parameters: dividendSources, dividendInput, divisorSources, divisorInput",
+    "name": "AdapterError",
+  },
+  "jobRunID": "1",
+  "status": "errored",
+  "statusCode": 400,
+}
+`;
+
+exports[`impliedPrice validation error returns a validation error if operand1Input is missing 1`] = `
+{
+  "error": {
+    "feedID": "{"data":{"operand1Sources":["coingecko","coinpaprika"],"operand2Sources":["coingecko","coinpaprika"],"operand2Input":{"from":"ETH","to":"USD"},"operation":"divide"}}",
+    "message": "Must specify all required operand1/operand2 parameters: operand1Sources, operand1Input, operand2Sources, operand2Input, operation",
+    "name": "AdapterError",
+  },
+  "jobRunID": "1",
+  "status": "errored",
+  "statusCode": 400,
+}
+`;
+
+exports[`impliedPrice validation error returns a validation error if operand1Sources are missing 1`] = `
+{
+  "error": {
+    "feedID": "{"data":{"operand2Sources":["coingecko","coinpaprika"],"operand1Input":{"from":"LINK","to":"USD"},"operand2Input":{"from":"ETH","to":"USD"},"operation":"divide"}}",
+    "message": "Must specify all required operand1/operand2 parameters: operand1Sources, operand1Input, operand2Sources, operand2Input, operation",
+    "name": "AdapterError",
+  },
+  "jobRunID": "1",
+  "status": "errored",
+  "statusCode": 400,
+}
+`;
+
+exports[`impliedPrice validation error returns a validation error if operand2Input is missing 1`] = `
+{
+  "error": {
+    "feedID": "{"data":{"operand1Sources":["coingecko","coinpaprika"],"operand2Sources":["coingecko","coinpaprika"],"operand1Input":{"from":"LINK","to":"USD"},"operation":"divide"}}",
+    "message": "Must specify all required operand1/operand2 parameters: operand1Sources, operand1Input, operand2Sources, operand2Input, operation",
+    "name": "AdapterError",
+  },
+  "jobRunID": "1",
+  "status": "errored",
+  "statusCode": 400,
+}
+`;
+
+exports[`impliedPrice validation error returns a validation error if operand2Sources are missing 1`] = `
+{
+  "error": {
+    "feedID": "{"data":{"operand1Sources":["coingecko","coinpaprika"],"operand1Input":{"from":"LINK","to":"USD"},"operand2Input":{"from":"ETH","to":"USD"},"operation":"divide"}}",
+    "message": "Must specify all required operand1/operand2 parameters: operand1Sources, operand1Input, operand2Sources, operand2Input, operation",
+    "name": "AdapterError",
+  },
+  "jobRunID": "1",
+  "status": "errored",
+  "statusCode": 400,
+}
+`;
+
+exports[`impliedPrice validation error returns a validation error if operation is missing 1`] = `
+{
+  "error": {
+    "feedID": "{"data":{"operand1Sources":["coingecko","coinpaprika"],"operand2Sources":["coingecko","coinpaprika"],"operand1Input":{"from":"LINK","to":"USD"},"operand2Input":{"from":"ETH","to":"USD"}}}",
+    "message": "Must specify all required operand1/operand2 parameters: operand1Sources, operand1Input, operand2Sources, operand2Input, operation",
+    "name": "AdapterError",
+  },
+  "jobRunID": "1",
+  "status": "errored",
+  "statusCode": 400,
+}
+`;
+
+exports[`impliedPrice validation error returns a validation error if operation is used with dividend and divisor 1`] = `
+{
+  "error": {
+    "feedID": "{"data":{"dividendSources":["coingecko","coinpaprika"],"divisorSources":["coingecko","coinpaprika"],"dividendInput":{"from":"LINK","to":"USD"},"divisorInput":{"from":"ETH","to":"USD"},"operation":"divide"}}",
+    "message": "Must use only dividend/divisor parameters or only operand1/operand2 parameters",
+    "name": "AdapterError",
+  },
+  "jobRunID": "1",
+  "status": "errored",
+  "statusCode": 400,
+}
+`;
+
+exports[`impliedPrice validation error returns a validation error if parameters are mixed 1`] = `
+{
+  "error": {
+    "feedID": "{"data":{"dividendSources":["coingecko","coinpaprika"],"operand2Sources":["coingecko","coinpaprika"],"dividendInput":{"from":"LINK","to":"USD"},"operand2Input":{"from":"ETH","to":"USD"}}}",
+    "message": "Must use only dividend/divisor parameters or only operand1/operand2 parameters",
+    "name": "AdapterError",
+  },
+  "jobRunID": "1",
+  "status": "errored",
+  "statusCode": 400,
 }
 `;
 
@@ -54,7 +259,7 @@ exports[`impliedPrice validation error returns a validation error if the request
 {
   "error": {
     "feedID": "{"data":{}}",
-    "message": "Required parameter dividendSources must be non-null and non-empty",
+    "message": "Must specify required dividend/divisor or required operand1/operand2 parameters",
     "name": "AdapterError",
   },
   "jobRunID": "1",

--- a/packages/composites/implied-price/test/integration/adapter.test.ts
+++ b/packages/composites/implied-price/test/integration/adapter.test.ts
@@ -24,62 +24,156 @@ describe('impliedPrice', () => {
   describe('successful calls', () => {
     const jobID = '1'
 
-    it('return success without comma separated sources', async () => {
-      mockSuccessfulResponseCoingecko()
-      mockSuccessfulResponseCoinpaprika()
-      const data: AdapterRequest = {
-        id: jobID,
-        data: {
-          dividendSources: ['coingecko', 'coinpaprika'],
-          divisorSources: ['coingecko', 'coinpaprika'],
-          dividendInput: {
-            from: 'LINK',
-            to: 'USD',
+    describe('with operand1 and operand2 parameters', () => {
+      it('return success without comma separated sources', async () => {
+        mockSuccessfulResponseCoingecko()
+        mockSuccessfulResponseCoinpaprika()
+        const data: AdapterRequest = {
+          id: jobID,
+          data: {
+            operand1Sources: ['coingecko', 'coinpaprika'],
+            operand2Sources: ['coingecko', 'coinpaprika'],
+            operand1Input: {
+              from: 'LINK',
+              to: 'USD',
+            },
+            operand2Input: {
+              from: 'ETH',
+              to: 'USD',
+            },
+            operation: 'divide',
           },
-          divisorInput: {
-            from: 'ETH',
-            to: 'USD',
-          },
-        },
-      }
+        }
 
-      const response = await (context.req as SuperTest<Test>)
-        .post('/')
-        .send(data)
-        .set('Accept', '*/*')
-        .set('Content-Type', 'application/json')
-        .expect('Content-Type', /json/)
-        .expect(200)
-      expect(response.body).toMatchSnapshot()
+        const response = await (context.req as SuperTest<Test>)
+          .post('/')
+          .send(data)
+          .set('Accept', '*/*')
+          .set('Content-Type', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(200)
+        expect(response.body).toMatchSnapshot()
+      })
+
+      it('returns success with comma separated sources', async () => {
+        mockSuccessfulResponseCoingecko()
+        mockSuccessfulResponseCoinpaprika()
+        const data: AdapterRequest = {
+          id: jobID,
+          data: {
+            operand1Sources: 'coingecko,coinpaprika',
+            operand2Sources: 'coingecko,coinpaprika',
+            operand1Input: {
+              from: 'LINK',
+              to: 'USD',
+            },
+            operand2Input: {
+              from: 'ETH',
+              to: 'USD',
+            },
+            operation: 'divide',
+          },
+        }
+
+        const response = await (context.req as SuperTest<Test>)
+          .post('/')
+          .send(data)
+          .set('Accept', '*/*')
+          .set('Content-Type', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(200)
+        expect(response.body).toMatchSnapshot()
+      })
+
+      it('can multiply operands', async () => {
+        mockSuccessfulResponseCoingecko()
+        mockSuccessfulResponseCoinpaprika()
+        const data: AdapterRequest = {
+          id: jobID,
+          data: {
+            operand1Sources: ['coingecko', 'coinpaprika'],
+            operand2Sources: ['coingecko', 'coinpaprika'],
+            operand1Input: {
+              from: 'LINK',
+              to: 'USD',
+            },
+            operand2Input: {
+              from: 'ETH',
+              to: 'USD',
+            },
+            operation: 'multiply',
+          },
+        }
+
+        const response = await (context.req as SuperTest<Test>)
+          .post('/')
+          .send(data)
+          .set('Accept', '*/*')
+          .set('Content-Type', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(200)
+        expect(response.body).toMatchSnapshot()
+      })
     })
 
-    it('returns success with comma separated sources', async () => {
-      mockSuccessfulResponseCoingecko()
-      mockSuccessfulResponseCoinpaprika()
-      const data: AdapterRequest = {
-        id: jobID,
-        data: {
-          dividendSources: 'coingecko,coinpaprika',
-          divisorSources: 'coingecko,coinpaprika',
-          dividendInput: {
-            from: 'LINK',
-            to: 'USD',
+    describe('with dividend and divisor parameters', () => {
+      it('return success without comma separated sources', async () => {
+        mockSuccessfulResponseCoingecko()
+        mockSuccessfulResponseCoinpaprika()
+        const data: AdapterRequest = {
+          id: jobID,
+          data: {
+            dividendSources: ['coingecko', 'coinpaprika'],
+            divisorSources: ['coingecko', 'coinpaprika'],
+            dividendInput: {
+              from: 'LINK',
+              to: 'USD',
+            },
+            divisorInput: {
+              from: 'ETH',
+              to: 'USD',
+            },
           },
-          divisorInput: {
-            from: 'ETH',
-            to: 'USD',
-          },
-        },
-      }
+        }
 
-      const response = await (context.req as SuperTest<Test>)
-        .post('/')
-        .send(data)
-        .set('Accept', '*/*')
-        .set('Content-Type', 'application/json')
-        .expect('Content-Type', /json/)
-        .expect(200)
-      expect(response.body).toMatchSnapshot()
+        const response = await (context.req as SuperTest<Test>)
+          .post('/')
+          .send(data)
+          .set('Accept', '*/*')
+          .set('Content-Type', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(200)
+        expect(response.body).toMatchSnapshot()
+      })
+
+      it('returns success with comma separated sources', async () => {
+        mockSuccessfulResponseCoingecko()
+        mockSuccessfulResponseCoinpaprika()
+        const data: AdapterRequest = {
+          id: jobID,
+          data: {
+            dividendSources: 'coingecko,coinpaprika',
+            divisorSources: 'coingecko,coinpaprika',
+            dividendInput: {
+              from: 'LINK',
+              to: 'USD',
+            },
+            divisorInput: {
+              from: 'ETH',
+              to: 'USD',
+            },
+          },
+        }
+
+        const response = await (context.req as SuperTest<Test>)
+          .post('/')
+          .send(data)
+          .set('Accept', '*/*')
+          .set('Content-Type', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(200)
+        expect(response.body).toMatchSnapshot()
+      })
     })
   })
 
@@ -155,6 +249,344 @@ describe('impliedPrice', () => {
         .set('Content-Type', 'application/json')
         .expect('Content-Type', /json/)
         .expect(500)
+      expect(response.body).toMatchSnapshot()
+    })
+
+    it('returns a validation error if dividendSources are missing', async () => {
+      const data: AdapterRequest = {
+        id: jobID,
+        data: {
+          divisorSources: ['coingecko', 'coinpaprika'],
+          dividendInput: {
+            from: 'LINK',
+            to: 'USD',
+          },
+          divisorInput: {
+            from: 'ETH',
+            to: 'USD',
+          },
+        },
+      }
+
+      const response = await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(400)
+      expect(response.body).toMatchSnapshot()
+    })
+
+    it('returns a validation error if divisorSources are missing', async () => {
+      const data: AdapterRequest = {
+        id: jobID,
+        data: {
+          dividendSources: ['coingecko', 'coinpaprika'],
+          dividendInput: {
+            from: 'LINK',
+            to: 'USD',
+          },
+          divisorInput: {
+            from: 'ETH',
+            to: 'USD',
+          },
+        },
+      }
+      const response = await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(400)
+      expect(response.body).toMatchSnapshot()
+    })
+
+    it('returns a validation error if dividendInput is missing', async () => {
+      const data: AdapterRequest = {
+        id: jobID,
+        data: {
+          dividendSources: ['coingecko', 'coinpaprika'],
+          divisorSources: ['coingecko', 'coinpaprika'],
+          divisorInput: {
+            from: 'ETH',
+            to: 'USD',
+          },
+        },
+      }
+
+      const response = await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(400)
+      expect(response.body).toMatchSnapshot()
+    })
+
+    it('returns a validation error if divisorInput is missing', async () => {
+      const data: AdapterRequest = {
+        id: jobID,
+        data: {
+          dividendSources: ['coingecko', 'coinpaprika'],
+          divisorSources: ['coingecko', 'coinpaprika'],
+          dividendInput: {
+            from: 'LINK',
+            to: 'USD',
+          },
+        },
+      }
+
+      const response = await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(400)
+      expect(response.body).toMatchSnapshot()
+    })
+
+    it('returns a validation error if operand1Sources are missing', async () => {
+      const data: AdapterRequest = {
+        id: jobID,
+        data: {
+          operand2Sources: ['coingecko', 'coinpaprika'],
+          operand1Input: {
+            from: 'LINK',
+            to: 'USD',
+          },
+          operand2Input: {
+            from: 'ETH',
+            to: 'USD',
+          },
+          operation: 'divide',
+        },
+      }
+
+      const response = await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(400)
+      expect(response.body).toMatchSnapshot()
+    })
+
+    it('returns a validation error if operand2Sources are missing', async () => {
+      const data: AdapterRequest = {
+        id: jobID,
+        data: {
+          operand1Sources: ['coingecko', 'coinpaprika'],
+          operand1Input: {
+            from: 'LINK',
+            to: 'USD',
+          },
+          operand2Input: {
+            from: 'ETH',
+            to: 'USD',
+          },
+          operation: 'divide',
+        },
+      }
+
+      const response = await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(400)
+      expect(response.body).toMatchSnapshot()
+    })
+
+    it('returns a validation error if operand1Input is missing', async () => {
+      const data: AdapterRequest = {
+        id: jobID,
+        data: {
+          operand1Sources: ['coingecko', 'coinpaprika'],
+          operand2Sources: ['coingecko', 'coinpaprika'],
+          operand2Input: {
+            from: 'ETH',
+            to: 'USD',
+          },
+          operation: 'divide',
+        },
+      }
+
+      const response = await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(400)
+      expect(response.body).toMatchSnapshot()
+    })
+
+    it('returns a validation error if operand2Input is missing', async () => {
+      const data: AdapterRequest = {
+        id: jobID,
+        data: {
+          operand1Sources: ['coingecko', 'coinpaprika'],
+          operand2Sources: ['coingecko', 'coinpaprika'],
+          operand1Input: {
+            from: 'LINK',
+            to: 'USD',
+          },
+          operation: 'divide',
+        },
+      }
+
+      const response = await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(400)
+      expect(response.body).toMatchSnapshot()
+    })
+
+    it('returns a validation error if operation is missing', async () => {
+      const data: AdapterRequest = {
+        id: jobID,
+        data: {
+          operand1Sources: ['coingecko', 'coinpaprika'],
+          operand2Sources: ['coingecko', 'coinpaprika'],
+          operand1Input: {
+            from: 'LINK',
+            to: 'USD',
+          },
+          operand2Input: {
+            from: 'ETH',
+            to: 'USD',
+          },
+        },
+      }
+
+      const response = await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(400)
+      expect(response.body).toMatchSnapshot()
+    })
+
+    it('returns a validation error if operation is used with dividend and divisor', async () => {
+      const data: AdapterRequest = {
+        id: jobID,
+        data: {
+          dividendSources: ['coingecko', 'coinpaprika'],
+          divisorSources: ['coingecko', 'coinpaprika'],
+          dividendInput: {
+            from: 'LINK',
+            to: 'USD',
+          },
+          divisorInput: {
+            from: 'ETH',
+            to: 'USD',
+          },
+          operation: 'divide',
+        },
+      }
+
+      const response = await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(400)
+      expect(response.body).toMatchSnapshot()
+    })
+
+    it('returns a validation error if additional operand parameters are given', async () => {
+      const data: AdapterRequest = {
+        id: jobID,
+        data: {
+          dividendSources: ['coingecko', 'coinpaprika'],
+          divisorSources: ['coingecko', 'coinpaprika'],
+          operand1Sources: ['coingecko', 'coinpaprika'],
+          dividendInput: {
+            from: 'LINK',
+            to: 'USD',
+          },
+          divisorInput: {
+            from: 'ETH',
+            to: 'USD',
+          },
+        },
+      }
+
+      const response = await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(400)
+      expect(response.body).toMatchSnapshot()
+    })
+
+    it('returns a validation error if additional dividend parameters are given', async () => {
+      const data: AdapterRequest = {
+        id: jobID,
+        data: {
+          operand1Sources: ['coingecko', 'coinpaprika'],
+          dividendSources: ['coingecko', 'coinpaprika'],
+          operand2Sources: ['coingecko', 'coinpaprika'],
+          operand1Input: {
+            from: 'LINK',
+            to: 'USD',
+          },
+          operand2Input: {
+            from: 'ETH',
+            to: 'USD',
+          },
+          operation: 'divide',
+        },
+      }
+
+      const response = await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(400)
+      expect(response.body).toMatchSnapshot()
+    })
+
+    it('returns a validation error if parameters are mixed', async () => {
+      const data: AdapterRequest = {
+        id: jobID,
+        data: {
+          dividendSources: ['coingecko', 'coinpaprika'],
+          operand2Sources: ['coingecko', 'coinpaprika'],
+          dividendInput: {
+            from: 'LINK',
+            to: 'USD',
+          },
+          operand2Input: {
+            from: 'ETH',
+            to: 'USD',
+          },
+        },
+      }
+
+      const response = await (context.req as SuperTest<Test>)
+        .post('/')
+        .send(data)
+        .set('Accept', '*/*')
+        .set('Content-Type', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(400)
       expect(response.body).toMatchSnapshot()
     })
   })


### PR DESCRIPTION
[DF-21193](https://smartcontract-it.atlassian.net/browse/DF-21193)

## Description

The `implied-price` EA can divide 2 prices from other EA(s).
We now want to be able to multiply 2 prices as well.

The current parameters (dividend* and divisor*) refer specifically to the division operation.
So we rename them to operand1* and operand2* while continuing to support the old parameters as well.

Note that while `dividendInput` and `divisorInput` were marked as optional parameters, their default values were not valid values so in practice those parameters were always required.

Now all parameters are marked as optional because you can choose which set of parameters to use. But without each set of parameters, the source and input parameters are effectively required.

One additional `operation` parameter determines whether to divide or multiply. This allows the new set of parameters to be used for all (including future) functionality of the EA.

## Changes

1. Mark all parameters as optional.
2. Remove default values from `*Input` parameters.
3. Add "legacy" description to old parameters.
4. Add custom validation to determine if parameter sets are not mixed and required parameters of the chosen set are present.
5. Transform the request data to always have the new parameters.
6. Change the code to use the new parameters.
7. Use `operation` to determine whether to divide or multiply.
8. Add additional payload to `test-payload.json`.
9. Add integration tests for using new parameters, multiplying and mixing parameters.
10. Update README.

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. Run `aleno` EA (any should work but this is the one I used because I'm familiar with it)
2. Run `implied-price` EA
```
$ curl -X POST http://localhost:8082 -H "Content-Type: application/json" -d '{
  "id": "1",
  "data": {
    "dividendSources": ["aleno"],
    "divisorSources": ["aleno"],
    "dividendInput": {
      "from": "FRAX",
      "to": "USD"
    },
    "divisorInput": {
      "from": "LBTC",
      "to": "USD"
    }
  }
}
'

{"jobRunID":"1","result":"0.00001137192088438718021","providerStatusCode":200,"statusCode":200,"data":{"result":"0.00001137192088438718021"},"meta":{"adapterName":"IMPLIED_PRICE"},"metricsMeta":{"feedId":"{\"data\":{\"dividendSources\":[\"aleno\"],\"divisorSources\":[\"aleno\"],\"dividendInput\":{\"from\":\"FRAX\",\"to\":\"USD\"},\"divisorInput\":{\"from\":\"LBTC\",\"to\":\"USD\"}}}"}}

$ curl -X POST http://localhost:8082 -H "Content-Type: application/json" -d '{
  "id": "1",
  "data": {
    "operand1Sources": ["aleno"],
    "operand2Sources": ["aleno"],
    "operand1Input": {
      "from": "FRAX",
      "to": "USD"
    },
    "operand2Input": {
      "from": "LBTC",
      "to": "USD"
    },                      
    "operation": "MULTIPLY"
  }
}
'
{"jobRunID":"1","result":"87745.994466934539848","providerStatusCode":200,"statusCode":200,"data":{"result":"87745.994466934539848"},"meta":{"adapterName":"IMPLIED_PRICE"},"metricsMeta":{"feedId":"{\"data\":{\"operand1Sources\":[\"aleno\"],\"operand2Sources\":[\"aleno\"],\"operand1Input\":{\"from\":\"FRAX\",\"to\":\"USD\"},\"operand2Input\":{\"from\":\"LBTC\",\"to\":\"USD\"},\"operation\":\"MULTIPLY\"}}"}}
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [x] This is related to a maximum of one Jira story or GitHub issue.
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[DF-21193]: https://smartcontract-it.atlassian.net/browse/DF-21193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ