### PR TITLE
Make implied-price inputs required

### DIFF
--- a/.changeset/tricky-tools-begin.md
+++ b/.changeset/tricky-tools-begin.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/implied-price-adapter': patch
+---
+
+Mark dividendInput and divisorInput input parameters as required since they effectively are already required.

--- a/packages/composites/implied-price/README.md
+++ b/packages/composites/implied-price/README.md
@@ -20,10 +20,10 @@ See the [Composite Adapter README](../README.md) for more information on how to 
 | :-------: | :------------------: | :-----------------------------------------------------------------------------------------------------: | :-----: | :---------: |
 |    ✅     |  `dividendSources`   | An array (string[]) or comma delimited list (string) of source adapters to query for the dividend value |         |             |
 |           | `dividendMinAnswers` |                 The minimum number of answers needed to return a value for the dividend                 |         |     `1`     |
-|           |   `dividendInput`    |                               The payload to send to the dividend sources                               |         |    `{}`     |
+|    ✅     |   `dividendInput`    |                               The payload to send to the dividend sources                               |         |             |
 |    ✅     |   `divisorSources`   | An array (string[]) or comma delimited list (string) of source adapters to query for the divisor value  |         |             |
 |           | `divisorMinAnswers`  |                 The minimum number of answers needed to return a value for the divisor                  |         |     `1`     |
-|           |    `divisorInput`    |                               The payload to send to the divisor sources                                |         |    `{}`     |
+|    ✅     |    `divisorInput`    |                               The payload to send to the divisor sources                                |         |             |
 
 Each source in `sources` needs to have a defined `*_ADAPTER_URL` defined as an env var.
 

--- a/packages/composites/implied-price/src/endpoint/impliedPrice.ts
+++ b/packages/composites/implied-price/src/endpoint/impliedPrice.ts
@@ -35,10 +35,9 @@ const inputParameters: InputParameters<TInputParameters> = {
     default: 1,
   },
   dividendInput: {
-    required: false,
+    required: true,
     type: 'object',
     description: 'The payload to send to the dividend sources',
-    default: {} as AdapterRequest,
   },
   divisorSources: {
     required: true,
@@ -52,10 +51,9 @@ const inputParameters: InputParameters<TInputParameters> = {
     default: 1,
   },
   divisorInput: {
-    required: false,
+    required: true,
     type: 'object',
     description: 'The payload to send to the divisor sources',
-    default: {} as AdapterRequest,
   },
 }
 

--- a/packages/composites/implied-price/src/endpoint/impliedPrice.ts
+++ b/packages/composites/implied-price/src/endpoint/impliedPrice.ts
@@ -16,10 +16,10 @@ export type SourceRequestOptions = { [source: string]: AxiosRequestConfig }
 export type TInputParameters = {
   dividendSources: string | string[]
   dividendMinAnswers?: number
-  dividendInput?: AdapterRequest
+  dividendInput: AdapterRequest
   divisorSources: string | string[]
   divisorMinAnswers?: number
-  divisorInput?: AdapterRequest
+  divisorInput: AdapterRequest
 }
 
 const inputParameters: InputParameters<TInputParameters> = {
@@ -65,8 +65,8 @@ export const execute: ExecuteWithConfig<Config> = async (input, _, config) => {
   const divisorSources = parseSources(validator.validated.data.divisorSources)
   const dividendMinAnswers = validator.validated.data.dividendMinAnswers as number
   const divisorMinAnswers = validator.validated.data.divisorMinAnswers as number
-  const dividendInput = validator.validated.data.dividendInput as AdapterRequest
-  const divisorInput = validator.validated.data.divisorInput as AdapterRequest
+  const dividendInput = validator.validated.data.dividendInput
+  const divisorInput = validator.validated.data.divisorInput
   // TODO: non-nullable default types
 
   const dividendUrls = dividendSources.map((source) => util.getRequiredURL(source.toUpperCase()))

--- a/packages/composites/implied-price/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/composites/implied-price/test/integration/__snapshots__/adapter.test.ts.snap
@@ -93,7 +93,7 @@ exports[`impliedPrice validation error returns a validation error if the request
 {
   "error": {
     "feedID": "{"data":{"dividendSources":["coingecko"],"divisorSources":["coingecko"],"divisorInput":{"from":"ETH","to":"USD"}}}",
-    "message": "dividendInput parameter must be an object with at least one property",
+    "message": "Required parameter dividendInput must be non-null and non-empty",
     "name": "AdapterError",
   },
   "jobRunID": "1",
@@ -106,7 +106,7 @@ exports[`impliedPrice validation error returns a validation error if the request
 {
   "error": {
     "feedID": "{"data":{"dividendSources":["coingecko"],"divisorSources":["coingecko"],"dividendInput":{"from":"LINK","to":"USD"}}}",
-    "message": "divisorInput parameter must be an object with at least one property",
+    "message": "Required parameter divisorInput must be non-null and non-empty",
     "name": "AdapterError",
   },
   "jobRunID": "1",


### PR DESCRIPTION
## Description

The `dividendInput` and `divisorInput` parameters in the `implied-price` EA are marked as optional, but their default value is not a valid value, so not specifying them still results in an error.

## Changes

1. Mark the effectively required inputs as actually required.
2. Remove the default values.
3. Update the test snapshots to the new (more accurate) error message.
4. Update `README.md`.

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

Run a price EA. I use Aleno because I'm familiar with it but any other should work.
```
cd packages/composites/implied-price
yarn build
yarn start --env-file=~/env/implied-price implied-price
```
In another shell:
```
$ curl -X POST http://localhost:8082 -H "Content-Type: application/json" -d '{
  "id": "1",
  "data": {
    "dividendSources": ["aleno"],
    "divisorSources": ["aleno"],
    "dividendInput": {
      "from": "LBTC",
      "to": "USD"
    },
    "divisorInput": {
      "from": "FRAX",
      "to": "USD"
    }
  }
}
'
{"jobRunID":"1","result":"88063.684095606124868","providerStatusCode":200,"statusCode":200,"data":{"result":"88063.684095606124868"},"meta":{"adapterName":"IMPLIED_PRICE"},"metricsMeta":{"feedId":"{\"data\":{\"dividendSources\":[\"aleno\"],\"divisorSources\":[\"aleno\"],\"dividendInput\":{\"from\":\"LBTC\",\"to\":\"USD\"},\"divisorInput\":{\"from\":\"FRAX\",\"to\":\"USD\"}}}"}}

$ curl -X POST http://localhost:8082 -H "Content-Type: application/json" -d '{
  "id": "1",
  "data": {
    "dividendSources": ["aleno"],
    "divisorSources": ["aleno"],
    "dividendInput": {
      "from": "LBTC",
      "to": "USD"
    } 
  }                  
}                  
'              
{"jobRunID":"1","status":"errored","statusCode":400,"error":{"name":"AdapterError","message":"Required parameter divisorInput must be non-null and non-empty","feedID":"{\"data\":{\"dividendSources\":[\"aleno\"],\"divisorSources\":[\"aleno\"],\"dividendInput\":{\"from\":\"LBTC\",\"to\":\"USD\"}}}"}}

$ curl -X POST http://localhost:8082 -H "Content-Type: application/json" -d '{
  "id": "1",
  "data": {
    "dividendSources": ["aleno"],
    "divisorSources": ["aleno"],
    "divisorInput": { 
      "from": "FRAX",
      "to": "USD"
    }            
  }            
}            
'            
{"jobRunID":"1","status":"errored","statusCode":400,"error":{"name":"AdapterError","message":"Required parameter dividendInput must be non-null and non-empty","feedID":"{\"data\":{\"dividendSources\":[\"aleno\"],\"divisorSources\":[\"aleno\"],\"divisorInput\":{\"from\":\"FRAX\",\"to\":\"USD\"}}}"}}
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [x] This is related to a maximum of one Jira story or GitHub issue.
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.