### PR TITLE
Implied-price: Support multiplying prices

### DIFF
--- a/.changeset/flat-bears-dance.md
+++ b/.changeset/flat-bears-dance.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/implied-price-adapter': minor
+---
+
+Support multiplying prices in addition to dividing

--- a/packages/composites/implied-price/README.md
+++ b/packages/composites/implied-price/README.md
@@ -1,6 +1,6 @@
 # Chainlink Implied-price Composite Adapter
 
-An adapter that fetches the median value from any two sets of underlying adapters, and divides the results from each set together.
+An adapter that fetches the median value from any two sets of underlying adapters, and divides or multiplied the results from each set together.
 
 ## Configuration
 
@@ -14,7 +14,78 @@ The adapter takes the following environment variables:
 
 See the [Composite Adapter README](../README.md) for more information on how to get started.
 
-### Input Params
+### computedPrice endpoint
+
+#### Input Params
+
+| Required? |         Name         |                                               Description                                               |         Options          | Defaults to |
+| :-------: | :------------------: | :-----------------------------------------------------------------------------------------------------: | :----------------------: | :---------: |
+|    ✅     |  `operand1Sources`   | An array (string[]) or comma delimited list (string) of source adapters to query for the operand1 value |                          |             |
+|           | `operand1MinAnswers` |                 The minimum number of answers needed to return a value for the operand1                 |                          |     `1`     |
+|    ✅     |   `operand1Input`    |                               The payload to send to the operand1 sources                               |                          |             |
+|    ✅     |  `operand2Sources`   | An array (string[]) or comma delimited list (string) of source adapters to query for the operand2 value |                          |             |
+|           | `operand2MinAnswers` |                 The minimum number of answers needed to return a value for the operand2                 |                          |     `1`     |
+|    ✅     |   `operand2Input`    |                               The payload to send to the operand2 sources                               |                          |             |
+|    ✅     |     `operation`      |                               The payload to send to the operand2 sources                               | `"divide"`, `"multiply"` |             |
+
+Each source in `sources` needs to have a defined `*_ADAPTER_URL` defined as an env var.
+
+_E.g. for a request with `"operand1Sources": ["coingecko", "coinpaprika"]`, you will need to have pre-set the following env vars:_
+
+```
+COINGECKO_ADAPTER_URL=https://coingecko_adapter_url/
+COINPAPRIKA_ADAPTER_URL=https://coinpaprika_adapter_url/
+```
+
+#### Sample Input
+
+```json
+{
+  "id": "1",
+  "data": {
+    "operand1Sources": ["coingecko"],
+    "operand2Sources": ["coingecko"],
+    "operand1Input": {
+      "from": "LINK",
+      "to": "USD",
+      "overrides": {
+        "coingecko": {
+          "LINK": "chainlink"
+        }
+      }
+    },
+    "operand2Input": {
+      "from": "ETH",
+      "to": "USD",
+      "overrides": {
+        "coingecko": {
+          "ETH": "ethereum"
+        }
+      }
+    },
+    "operation": "divide"
+  }
+}
+```
+
+#### Sample Output
+
+```json
+{
+  "jobRunID": "1",
+  "result": "0.005204390891874140333",
+  "statusCode": 200,
+  "data": {
+    "result": "0.005204390891874140333"
+  }
+}
+```
+
+### impliedPrice endpoint
+
+This legacy endpoint is the default endpoint for backward compatibility.
+
+#### Input Params
 
 | Required? |         Name         |                                               Description                                               | Options | Defaults to |
 | :-------: | :------------------: | :-----------------------------------------------------------------------------------------------------: | :-----: | :---------: |
@@ -34,7 +105,7 @@ COINGECKO_ADAPTER_URL=https://coingecko_adapter_url/
 COINPAPRIKA_ADAPTER_URL=https://coinpaprika_adapter_url/
 ```
 
-### Sample Input
+#### Sample Input
 
 ```json
 {
@@ -64,7 +135,7 @@ COINPAPRIKA_ADAPTER_URL=https://coinpaprika_adapter_url/
 }
 ```
 
-### Sample Output
+#### Sample Output
 
 ```json
 {

--- a/packages/composites/implied-price/src/endpoint/computedPrice.ts
+++ b/packages/composites/implied-price/src/endpoint/computedPrice.ts
@@ -1,0 +1,156 @@
+import { AdapterResponseInvalidError, Requester, util, Validator } from '@chainlink/ea-bootstrap'
+import type {
+  AdapterRequest,
+  ExecuteWithConfig,
+  Config,
+  InputParameters,
+  AxiosRequestConfig,
+} from '@chainlink/ea-bootstrap'
+import { AxiosResponse } from 'axios'
+import Decimal from 'decimal.js'
+
+export const supportedEndpoints = ['impliedPrice']
+
+export type SourceRequestOptions = { [source: string]: AxiosRequestConfig }
+
+export type TInputParameters = {
+  dividendSources: string | string[]
+  dividendMinAnswers?: number
+  dividendInput: AdapterRequest
+  divisorSources: string | string[]
+  divisorMinAnswers?: number
+  divisorInput: AdapterRequest
+}
+
+const inputParameters: InputParameters<TInputParameters> = {
+  dividendSources: {
+    required: true,
+    description:
+      'An array (string[]) or comma delimited list (string) of source adapters to query for the dividend value',
+  },
+  dividendMinAnswers: {
+    required: false,
+    type: 'number',
+    description: 'The minimum number of answers needed to return a value for the dividend',
+    default: 1,
+  },
+  dividendInput: {
+    required: true,
+    type: 'object',
+    description: 'The payload to send to the dividend sources',
+  },
+  divisorSources: {
+    required: true,
+    description:
+      'An array (string[]) or comma delimited list (string) of source adapters to query for the divisor value',
+  },
+  divisorMinAnswers: {
+    required: false,
+    type: 'number',
+    description: 'The minimum number of answers needed to return a value for the divisor',
+    default: 1,
+  },
+  divisorInput: {
+    required: true,
+    type: 'object',
+    description: 'The payload to send to the divisor sources',
+  },
+}
+
+export const execute: ExecuteWithConfig<Config> = async (input, _, config) => {
+  const validator = new Validator(input, inputParameters)
+
+  const jobRunID = validator.validated.id
+  const dividendSources = parseSources(validator.validated.data.dividendSources)
+  const divisorSources = parseSources(validator.validated.data.divisorSources)
+  const dividendMinAnswers = validator.validated.data.dividendMinAnswers as number
+  const divisorMinAnswers = validator.validated.data.divisorMinAnswers as number
+  const dividendInput = validator.validated.data.dividendInput
+  const divisorInput = validator.validated.data.divisorInput
+  // TODO: non-nullable default types
+
+  const dividendUrls = dividendSources.map((source) => util.getRequiredURL(source.toUpperCase()))
+  const dividendResult = await getExecuteMedian(
+    jobRunID,
+    dividendUrls,
+    dividendInput,
+    dividendMinAnswers,
+    config,
+  )
+  if (dividendResult.isZero()) {
+    throw new AdapterResponseInvalidError({ message: 'Dividend result is zero' })
+  }
+
+  const divisorUrls = divisorSources.map((source) => util.getRequiredURL(source.toUpperCase()))
+  const divisorResult = await getExecuteMedian(
+    jobRunID,
+    divisorUrls,
+    divisorInput,
+    divisorMinAnswers,
+    config,
+  )
+  if (divisorResult.isZero()) {
+    throw new AdapterResponseInvalidError({ message: 'Divisor result is zero' })
+  }
+
+  const result = dividendResult.div(divisorResult)
+
+  const data = {
+    dividendResult: dividendResult.toString(),
+    divisorResult: divisorResult.toString(),
+    result: result.toString(),
+  }
+
+  const response = { data, status: 200 }
+  return Requester.success(jobRunID, response)
+}
+
+export const parseSources = (sources: string | string[]): string[] => {
+  if (Array.isArray(sources)) {
+    return sources
+  }
+  return sources.split(',')
+}
+
+const getExecuteMedian = async (
+  jobRunID: string,
+  urls: string[],
+  request: AdapterRequest,
+  minAnswers: number,
+  config: Config,
+): Promise<Decimal> => {
+  const responses = await Promise.allSettled(
+    urls.map(
+      async (url) =>
+        await Requester.request({
+          ...config.api,
+          method: 'post',
+          url,
+          data: {
+            id: jobRunID,
+            data: request,
+          },
+        }),
+    ),
+  )
+  const values = responses
+    .filter((result) => result.status === 'fulfilled' && 'value' in result)
+    .map(
+      (result) =>
+        (result as PromiseFulfilledResult<AxiosResponse<Record<string, number>>>).value.data.result,
+    )
+  if (values.length < minAnswers)
+    throw new AdapterResponseInvalidError({
+      jobRunID,
+      message: `Not returning median: got ${values.length} answers, requiring min. ${minAnswers} answers`,
+    })
+  return median(values)
+}
+
+export const median = (values: number[]): Decimal => {
+  if (values.length === 0) return new Decimal(0)
+  values.sort((a, b) => a - b)
+  const half = Math.floor(values.length / 2)
+  if (values.length % 2) return new Decimal(values[half])
+  return new Decimal(values[half - 1] + values[half]).div(2)
+}

--- a/packages/composites/implied-price/src/endpoint/impliedPrice.ts
+++ b/packages/composites/implied-price/src/endpoint/impliedPrice.ts
@@ -1,4 +1,4 @@
-import { AdapterResponseInvalidError, Requester, util, Validator } from '@chainlink/ea-bootstrap'
+import { Validator } from '@chainlink/ea-bootstrap'
 import type {
   AdapterRequest,
   ExecuteWithConfig,
@@ -6,8 +6,7 @@ import type {
   InputParameters,
   AxiosRequestConfig,
 } from '@chainlink/ea-bootstrap'
-import { AxiosResponse } from 'axios'
-import Decimal from 'decimal.js'
+import { executeComputedPrice } from './computedPrice'
 
 export const supportedEndpoints = ['impliedPrice']
 
@@ -60,97 +59,24 @@ const inputParameters: InputParameters<TInputParameters> = {
 export const execute: ExecuteWithConfig<Config> = async (input, _, config) => {
   const validator = new Validator(input, inputParameters)
 
-  const jobRunID = validator.validated.id
-  const dividendSources = parseSources(validator.validated.data.dividendSources)
-  const divisorSources = parseSources(validator.validated.data.divisorSources)
-  const dividendMinAnswers = validator.validated.data.dividendMinAnswers as number
-  const divisorMinAnswers = validator.validated.data.divisorMinAnswers as number
-  const dividendInput = validator.validated.data.dividendInput
-  const divisorInput = validator.validated.data.divisorInput
-  // TODO: non-nullable default types
-
-  const dividendUrls = dividendSources.map((source) => util.getRequiredURL(source.toUpperCase()))
-  const dividendResult = await getExecuteMedian(
-    jobRunID,
-    dividendUrls,
-    dividendInput,
+  const {
+    dividendSources,
     dividendMinAnswers,
-    config,
-  )
-  if (dividendResult.isZero()) {
-    throw new AdapterResponseInvalidError({ message: 'Dividend result is zero' })
-  }
-
-  const divisorUrls = divisorSources.map((source) => util.getRequiredURL(source.toUpperCase()))
-  const divisorResult = await getExecuteMedian(
-    jobRunID,
-    divisorUrls,
-    divisorInput,
+    dividendInput,
+    divisorSources,
     divisorMinAnswers,
-    config,
-  )
-  if (divisorResult.isZero()) {
-    throw new AdapterResponseInvalidError({ message: 'Divisor result is zero' })
+    divisorInput,
+  } = validator.validated.data
+
+  const validatedData = {
+    operand1Sources: dividendSources,
+    operand1MinAnswers: dividendMinAnswers,
+    operand1Input: dividendInput,
+    operand2Sources: divisorSources,
+    operand2MinAnswers: divisorMinAnswers,
+    operand2Input: divisorInput,
+    operation: 'divide',
   }
 
-  const result = dividendResult.div(divisorResult)
-
-  const data = {
-    dividendResult: dividendResult.toString(),
-    divisorResult: divisorResult.toString(),
-    result: result.toString(),
-  }
-
-  const response = { data, status: 200 }
-  return Requester.success(jobRunID, response)
-}
-
-export const parseSources = (sources: string | string[]): string[] => {
-  if (Array.isArray(sources)) {
-    return sources
-  }
-  return sources.split(',')
-}
-
-const getExecuteMedian = async (
-  jobRunID: string,
-  urls: string[],
-  request: AdapterRequest,
-  minAnswers: number,
-  config: Config,
-): Promise<Decimal> => {
-  const responses = await Promise.allSettled(
-    urls.map(
-      async (url) =>
-        await Requester.request({
-          ...config.api,
-          method: 'post',
-          url,
-          data: {
-            id: jobRunID,
-            data: request,
-          },
-        }),
-    ),
-  )
-  const values = responses
-    .filter((result) => result.status === 'fulfilled' && 'value' in result)
-    .map(
-      (result) =>
-        (result as PromiseFulfilledResult<AxiosResponse<Record<string, number>>>).value.data.result,
-    )
-  if (values.length < minAnswers)
-    throw new AdapterResponseInvalidError({
-      jobRunID,
-      message: `Not returning median: got ${values.length} answers, requiring min. ${minAnswers} answers`,
-    })
-  return median(values)
-}
-
-export const median = (values: number[]): Decimal => {
-  if (values.length === 0) return new Decimal(0)
-  values.sort((a, b) => a - b)
-  const half = Math.floor(values.length / 2)
-  if (values.length % 2) return new Decimal(values[half])
-  return new Decimal(values[half - 1] + values[half]).div(2)
+  return executeComputedPrice(validator.validated.id, validatedData, config)
 }

--- a/packages/composites/implied-price/src/endpoint/index.ts
+++ b/packages/composites/implied-price/src/endpoint/index.ts
@@ -3,3 +3,4 @@ import * as impliedPrice from './impliedPrice'
 export type TInputParameters = impliedPrice.TInputParameters
 
 export * as impliedPrice from './impliedPrice'
+export * as computedPrice from './computedPrice'

--- a/packages/composites/implied-price/test-payload.json
+++ b/packages/composites/implied-price/test-payload.json
@@ -1,5 +1,29 @@
 {
  "requests": [{
+  "endpoint": "computedPrice",
+  "operand1Sources": ["coingecko"],
+  "operand2Sources": ["coingecko"],
+  "operand1Input": {
+   "from": "LINK",
+   "to": "USD",
+   "overrides": {
+    "coingecko": {
+     "LINK": "chainlink"
+    }
+   }
+  },
+  "operand2Input": {
+   "from": "ETH",
+   "to": "USD",
+   "overrides": {
+    "coingecko": {
+     "ETH": "ethereum"
+    }
+   }
+  },
+  "operation": "divide"
+ },
+ {
   "dividendSources": ["coingecko"],
   "divisorSources": ["coingecko"],
   "dividendInput": {

--- a/packages/composites/implied-price/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/composites/implied-price/test/integration/__snapshots__/adapter.test.ts.snap
@@ -1,35 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`impliedPrice erroring calls returns error if dividend has zero price 1`] = `
+exports[`impliedPrice with endpoint computedPrice erroring calls returns error if not reaching minAnswers 1`] = `
 {
   "error": {
-    "feedID": "{"data":{"dividendSources":["coingecko","coinpaprika"],"divisorSources":["coingecko","coinpaprika"],"dividendInput":{"from":"DEAD","to":"USD"},"divisorInput":{"from":"ETH","to":"USD"}}}",
-    "message": "Dividend result is zero",
-    "name": "AdapterError",
-  },
-  "jobRunID": "1",
-  "status": "errored",
-  "statusCode": 500,
-}
-`;
-
-exports[`impliedPrice erroring calls returns error if divisor has zero price 1`] = `
-{
-  "error": {
-    "feedID": "{"data":{"dividendSources":["coingecko","coinpaprika"],"divisorSources":["coingecko","coinpaprika"],"dividendInput":{"from":"LINK","to":"USD"},"divisorInput":{"from":"DEAD","to":"USD"}}}",
-    "message": "Divisor result is zero",
-    "name": "AdapterError",
-  },
-  "jobRunID": "1",
-  "status": "errored",
-  "statusCode": 500,
-}
-`;
-
-exports[`impliedPrice erroring calls returns error if not reaching minAnswers 1`] = `
-{
-  "error": {
-    "feedID": "{"data":{"dividendSources":["coingecko"],"dividendMinAnswers":2,"divisorSources":["coingecko"],"dividendInput":{"from":"LINK","to":"USD"},"divisorInput":{"from":"ETH","to":"USD"}}}",
+    "feedID": "{"data":{"endpoint":"computedPrice","operand1Sources":["coingecko"],"operand1MinAnswers":2,"operand2Sources":["coingecko"],"operand1Input":{"from":"LINK","to":"USD"},"operand2Input":{"from":"ETH","to":"USD"},"operation":"divide"}}",
     "message": "Not returning median: got 1 answers, requiring min. 2 answers",
     "name": "AdapterError",
   },
@@ -39,34 +13,72 @@ exports[`impliedPrice erroring calls returns error if not reaching minAnswers 1`
 }
 `;
 
-exports[`impliedPrice successful calls return success without comma separated sources 1`] = `
-{
-  "data": {
-    "result": "0.0038975944001909025829",
-  },
-  "jobRunID": "1",
-  "providerStatusCode": 200,
-  "result": "0.0038975944001909025829",
-  "statusCode": 200,
-}
-`;
-
-exports[`impliedPrice successful calls returns success with comma separated sources 1`] = `
-{
-  "data": {
-    "result": "0.0038975944001909025829",
-  },
-  "jobRunID": "1",
-  "providerStatusCode": 200,
-  "result": "0.0038975944001909025829",
-  "statusCode": 200,
-}
-`;
-
-exports[`impliedPrice validation error returns a validation error if the request contains unsupported sources 1`] = `
+exports[`impliedPrice with endpoint computedPrice erroring calls returns error if operand1 has zero price 1`] = `
 {
   "error": {
-    "feedID": "{"data":{"dividendSources":["NOT_REAL"],"divisorSources":["coingecko"],"dividendInput":{"from":"LINK","to":"USD"},"divisorInput":{"from":"ETH","to":"USD"}}}",
+    "feedID": "{"data":{"endpoint":"computedPrice","operand1Sources":["coingecko","coinpaprika"],"operand2Sources":["coingecko","coinpaprika"],"operand1Input":{"from":"DEAD","to":"USD"},"operand2Input":{"from":"ETH","to":"USD"},"operation":"divide"}}",
+    "message": "Operand 1 result is zero",
+    "name": "AdapterError",
+  },
+  "jobRunID": "1",
+  "status": "errored",
+  "statusCode": 500,
+}
+`;
+
+exports[`impliedPrice with endpoint computedPrice erroring calls returns error if operand2 has zero price 1`] = `
+{
+  "error": {
+    "feedID": "{"data":{"endpoint":"computedPrice","operand1Sources":["coingecko","coinpaprika"],"operand2Sources":["coingecko","coinpaprika"],"operand1Input":{"from":"LINK","to":"USD"},"operand2Input":{"from":"DEAD","to":"USD"},"operation":"divide"}}",
+    "message": "Operand 2 result is zero",
+    "name": "AdapterError",
+  },
+  "jobRunID": "1",
+  "status": "errored",
+  "statusCode": 500,
+}
+`;
+
+exports[`impliedPrice with endpoint computedPrice successful calls can multiply operands 1`] = `
+{
+  "data": {
+    "result": "75462.5725",
+  },
+  "jobRunID": "1",
+  "providerStatusCode": 200,
+  "result": "75462.5725",
+  "statusCode": 200,
+}
+`;
+
+exports[`impliedPrice with endpoint computedPrice successful calls return success without comma separated sources 1`] = `
+{
+  "data": {
+    "result": "0.0038975944001909025829",
+  },
+  "jobRunID": "1",
+  "providerStatusCode": 200,
+  "result": "0.0038975944001909025829",
+  "statusCode": 200,
+}
+`;
+
+exports[`impliedPrice with endpoint computedPrice successful calls returns success with comma separated sources 1`] = `
+{
+  "data": {
+    "result": "0.0038975944001909025829",
+  },
+  "jobRunID": "1",
+  "providerStatusCode": 200,
+  "result": "0.0038975944001909025829",
+  "statusCode": 200,
+}
+`;
+
+exports[`impliedPrice with endpoint computedPrice validation error returns a validation error if the request contains unsupported sources 1`] = `
+{
+  "error": {
+    "feedID": "{"data":{"endpoint":"computedPrice","operand1Sources":["NOT_REAL"],"operand2Sources":["coingecko"],"operand1Input":{"from":"LINK","to":"USD"},"operand2Input":{"from":"ETH","to":"USD"},"operation":"divide"}}",
     "message": "Please set the required env NOT_REAL_ADAPTER_URL.",
     "name": "RequiredEnvError",
   },
@@ -76,7 +88,135 @@ exports[`impliedPrice validation error returns a validation error if the request
 }
 `;
 
-exports[`impliedPrice validation error returns a validation error if the request data is empty 1`] = `
+exports[`impliedPrice with endpoint computedPrice validation error returns a validation error if the request data is empty 1`] = `
+{
+  "error": {
+    "feedID": "{"data":{"endpoint":"computedPrice"}}",
+    "message": "Required parameter operand1Sources must be non-null and non-empty",
+    "name": "AdapterError",
+  },
+  "jobRunID": "1",
+  "status": "errored",
+  "statusCode": 400,
+}
+`;
+
+exports[`impliedPrice with endpoint computedPrice validation error returns a validation error if the request is missing operand1 input 1`] = `
+{
+  "error": {
+    "feedID": "{"data":{"endpoint":"computedPrice","operand1Sources":["coingecko"],"operand2Sources":["coingecko"],"operand2Input":{"from":"ETH","to":"USD"},"operation":"divide"}}",
+    "message": "Required parameter operand1Input must be non-null and non-empty",
+    "name": "AdapterError",
+  },
+  "jobRunID": "1",
+  "status": "errored",
+  "statusCode": 400,
+}
+`;
+
+exports[`impliedPrice with endpoint computedPrice validation error returns a validation error if the request is missing operand2 input 1`] = `
+{
+  "error": {
+    "feedID": "{"data":{"endpoint":"computedPrice","operand1Sources":["coingecko"],"operand2Sources":["coingecko"],"operand1Input":{"from":"LINK","to":"USD"},"operation":"divide"}}",
+    "message": "Required parameter operand2Input must be non-null and non-empty",
+    "name": "AdapterError",
+  },
+  "jobRunID": "1",
+  "status": "errored",
+  "statusCode": 400,
+}
+`;
+
+exports[`impliedPrice with endpoint computedPrice validation error returns a validation error if the request is missing operation 1`] = `
+{
+  "error": {
+    "feedID": "{"data":{"endpoint":"computedPrice","operand1Sources":["coingecko"],"operand2Sources":["coingecko"],"operand1Input":{"from":"LINK","to":"USD"},"operand2Input":{"from":"ETH","to":"USD"}}}",
+    "message": "Required parameter operation must be non-null and non-empty",
+    "name": "AdapterError",
+  },
+  "jobRunID": "1",
+  "status": "errored",
+  "statusCode": 400,
+}
+`;
+
+exports[`impliedPrice with endpoint impliedPrice erroring calls returns error if dividend has zero price 1`] = `
+{
+  "error": {
+    "feedID": "{"data":{"endpoint":"impliedPrice","dividendSources":["coingecko","coinpaprika"],"divisorSources":["coingecko","coinpaprika"],"dividendInput":{"from":"DEAD","to":"USD"},"divisorInput":{"from":"ETH","to":"USD"}}}",
+    "message": "Operand 1 result is zero",
+    "name": "AdapterError",
+  },
+  "jobRunID": "1",
+  "status": "errored",
+  "statusCode": 500,
+}
+`;
+
+exports[`impliedPrice with endpoint impliedPrice erroring calls returns error if divisor has zero price 1`] = `
+{
+  "error": {
+    "feedID": "{"data":{"endpoint":"impliedPrice","dividendSources":["coingecko","coinpaprika"],"divisorSources":["coingecko","coinpaprika"],"dividendInput":{"from":"LINK","to":"USD"},"divisorInput":{"from":"DEAD","to":"USD"}}}",
+    "message": "Operand 2 result is zero",
+    "name": "AdapterError",
+  },
+  "jobRunID": "1",
+  "status": "errored",
+  "statusCode": 500,
+}
+`;
+
+exports[`impliedPrice with endpoint impliedPrice erroring calls returns error if not reaching minAnswers 1`] = `
+{
+  "error": {
+    "feedID": "{"data":{"endpoint":"impliedPrice","dividendSources":["coingecko"],"dividendMinAnswers":2,"divisorSources":["coingecko"],"dividendInput":{"from":"LINK","to":"USD"},"divisorInput":{"from":"ETH","to":"USD"}}}",
+    "message": "Not returning median: got 1 answers, requiring min. 2 answers",
+    "name": "AdapterError",
+  },
+  "jobRunID": "1",
+  "status": "errored",
+  "statusCode": 500,
+}
+`;
+
+exports[`impliedPrice with endpoint impliedPrice successful calls return success without comma separated sources 1`] = `
+{
+  "data": {
+    "result": "0.0038975944001909025829",
+  },
+  "jobRunID": "1",
+  "providerStatusCode": 200,
+  "result": "0.0038975944001909025829",
+  "statusCode": 200,
+}
+`;
+
+exports[`impliedPrice with endpoint impliedPrice successful calls returns success with comma separated sources 1`] = `
+{
+  "data": {
+    "result": "0.0038975944001909025829",
+  },
+  "jobRunID": "1",
+  "providerStatusCode": 200,
+  "result": "0.0038975944001909025829",
+  "statusCode": 200,
+}
+`;
+
+exports[`impliedPrice with endpoint impliedPrice validation error returns a validation error if the request contains unsupported sources 1`] = `
+{
+  "error": {
+    "feedID": "{"data":{"endpoint":"impliedPrice","dividendSources":["NOT_REAL"],"divisorSources":["coingecko"],"dividendInput":{"from":"LINK","to":"USD"},"divisorInput":{"from":"ETH","to":"USD"}}}",
+    "message": "Please set the required env NOT_REAL_ADAPTER_URL.",
+    "name": "RequiredEnvError",
+  },
+  "jobRunID": "1",
+  "status": "errored",
+  "statusCode": 500,
+}
+`;
+
+exports[`impliedPrice with endpoint impliedPrice validation error returns a validation error if the request data is empty 1`] = `
 {
   "error": {
     "feedID": "{"data":{}}",
@@ -89,10 +229,10 @@ exports[`impliedPrice validation error returns a validation error if the request
 }
 `;
 
-exports[`impliedPrice validation error returns a validation error if the request is missing dividend input 1`] = `
+exports[`impliedPrice with endpoint impliedPrice validation error returns a validation error if the request is missing dividend input 1`] = `
 {
   "error": {
-    "feedID": "{"data":{"dividendSources":["coingecko"],"divisorSources":["coingecko"],"divisorInput":{"from":"ETH","to":"USD"}}}",
+    "feedID": "{"data":{"endpoint":"impliedPrice","dividendSources":["coingecko"],"divisorSources":["coingecko"],"divisorInput":{"from":"ETH","to":"USD"}}}",
     "message": "Required parameter dividendInput must be non-null and non-empty",
     "name": "AdapterError",
   },
@@ -102,10 +242,10 @@ exports[`impliedPrice validation error returns a validation error if the request
 }
 `;
 
-exports[`impliedPrice validation error returns a validation error if the request is missing divisor input 1`] = `
+exports[`impliedPrice with endpoint impliedPrice validation error returns a validation error if the request is missing divisor input 1`] = `
 {
   "error": {
-    "feedID": "{"data":{"dividendSources":["coingecko"],"divisorSources":["coingecko"],"dividendInput":{"from":"LINK","to":"USD"}}}",
+    "feedID": "{"data":{"endpoint":"impliedPrice","dividendSources":["coingecko"],"divisorSources":["coingecko"],"dividendInput":{"from":"LINK","to":"USD"}}}",
     "message": "Required parameter divisorInput must be non-null and non-empty",
     "name": "AdapterError",
   },

--- a/packages/composites/implied-price/test/integration/adapter.test.ts
+++ b/packages/composites/implied-price/test/integration/adapter.test.ts
@@ -21,243 +21,574 @@ describe('impliedPrice', () => {
   }
   const envVariables = setupEnvironment(['coingecko', 'coinpaprika', 'failing'])
   setupExternalAdapterTest(envVariables, context)
-  describe('successful calls', () => {
-    const jobID = '1'
+  describe('with endpoint computedPrice', () => {
+    const endpoint = 'computedPrice'
 
-    it('return success without comma separated sources', async () => {
-      mockSuccessfulResponseCoingecko()
-      mockSuccessfulResponseCoinpaprika()
-      const data: AdapterRequest = {
-        id: jobID,
-        data: {
-          dividendSources: ['coingecko', 'coinpaprika'],
-          divisorSources: ['coingecko', 'coinpaprika'],
-          dividendInput: {
-            from: 'LINK',
-            to: 'USD',
-          },
-          divisorInput: {
-            from: 'ETH',
-            to: 'USD',
-          },
-        },
-      }
+    describe('successful calls', () => {
+      const jobID = '1'
 
-      const response = await (context.req as SuperTest<Test>)
-        .post('/')
-        .send(data)
-        .set('Accept', '*/*')
-        .set('Content-Type', 'application/json')
-        .expect('Content-Type', /json/)
-        .expect(200)
-      expect(response.body).toMatchSnapshot()
+      it('return success without comma separated sources', async () => {
+        mockSuccessfulResponseCoingecko()
+        mockSuccessfulResponseCoinpaprika()
+        const data: AdapterRequest = {
+          id: jobID,
+          data: {
+            endpoint,
+            operand1Sources: ['coingecko', 'coinpaprika'],
+            operand2Sources: ['coingecko', 'coinpaprika'],
+            operand1Input: {
+              from: 'LINK',
+              to: 'USD',
+            },
+            operand2Input: {
+              from: 'ETH',
+              to: 'USD',
+            },
+            operation: 'divide',
+          },
+        }
+
+        const response = await (context.req as SuperTest<Test>)
+          .post('/')
+          .send(data)
+          .set('Accept', '*/*')
+          .set('Content-Type', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(200)
+        expect(response.body).toMatchSnapshot()
+      })
+
+      it('returns success with comma separated sources', async () => {
+        mockSuccessfulResponseCoingecko()
+        mockSuccessfulResponseCoinpaprika()
+        const data: AdapterRequest = {
+          id: jobID,
+          data: {
+            endpoint,
+            operand1Sources: 'coingecko,coinpaprika',
+            operand2Sources: 'coingecko,coinpaprika',
+            operand1Input: {
+              from: 'LINK',
+              to: 'USD',
+            },
+            operand2Input: {
+              from: 'ETH',
+              to: 'USD',
+            },
+            operation: 'divide',
+          },
+        }
+
+        const response = await (context.req as SuperTest<Test>)
+          .post('/')
+          .send(data)
+          .set('Accept', '*/*')
+          .set('Content-Type', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(200)
+        expect(response.body).toMatchSnapshot()
+      })
+
+      it('can multiply operands', async () => {
+        mockSuccessfulResponseCoingecko()
+        mockSuccessfulResponseCoinpaprika()
+        const data: AdapterRequest = {
+          id: jobID,
+          data: {
+            endpoint,
+            operand1Sources: ['coingecko', 'coinpaprika'],
+            operand2Sources: ['coingecko', 'coinpaprika'],
+            operand1Input: {
+              from: 'LINK',
+              to: 'USD',
+            },
+            operand2Input: {
+              from: 'ETH',
+              to: 'USD',
+            },
+            operation: 'multiply',
+          },
+        }
+
+        const response = await (context.req as SuperTest<Test>)
+          .post('/')
+          .send(data)
+          .set('Accept', '*/*')
+          .set('Content-Type', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(200)
+        expect(response.body).toMatchSnapshot()
+      })
     })
 
-    it('returns success with comma separated sources', async () => {
-      mockSuccessfulResponseCoingecko()
-      mockSuccessfulResponseCoinpaprika()
-      const data: AdapterRequest = {
-        id: jobID,
-        data: {
-          dividendSources: 'coingecko,coinpaprika',
-          divisorSources: 'coingecko,coinpaprika',
-          dividendInput: {
-            from: 'LINK',
-            to: 'USD',
-          },
-          divisorInput: {
-            from: 'ETH',
-            to: 'USD',
-          },
-        },
-      }
+    describe('erroring calls', () => {
+      const jobID = '1'
 
-      const response = await (context.req as SuperTest<Test>)
-        .post('/')
-        .send(data)
-        .set('Accept', '*/*')
-        .set('Content-Type', 'application/json')
-        .expect('Content-Type', /json/)
-        .expect(200)
-      expect(response.body).toMatchSnapshot()
+      it('returns error if not reaching minAnswers', async () => {
+        mockSuccessfulResponseCoingecko()
+        const data: AdapterRequest = {
+          id: jobID,
+          data: {
+            endpoint,
+            operand1Sources: ['coingecko'],
+            operand1MinAnswers: 2,
+            operand2Sources: ['coingecko'],
+            operand1Input: {
+              from: 'LINK',
+              to: 'USD',
+            },
+            operand2Input: {
+              from: 'ETH',
+              to: 'USD',
+            },
+            operation: 'divide',
+          },
+        }
+        const response = await (context.req as SuperTest<Test>)
+          .post('/')
+          .send(data)
+          .set('Accept', '*/*')
+          .set('Content-Type', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(500)
+        expect(response.body).toMatchSnapshot()
+      })
+
+      it('returns error if operand1 has zero price', async () => {
+        mockSuccessfulResponseCoingecko()
+        mockSuccessfulResponseCoinpaprika()
+        const data: AdapterRequest = {
+          id: jobID,
+          data: {
+            endpoint,
+            operand1Sources: ['coingecko', 'coinpaprika'],
+            operand2Sources: ['coingecko', 'coinpaprika'],
+            operand1Input: {
+              from: 'DEAD',
+              to: 'USD',
+            },
+            operand2Input: {
+              from: 'ETH',
+              to: 'USD',
+            },
+            operation: 'divide',
+          },
+        }
+        const response = await (context.req as SuperTest<Test>)
+          .post('/')
+          .send(data)
+          .set('Accept', '*/*')
+          .set('Content-Type', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(500)
+        expect(response.body).toMatchSnapshot()
+      })
+
+      it('returns error if operand2 has zero price', async () => {
+        mockSuccessfulResponseCoingecko()
+        mockSuccessfulResponseCoinpaprika()
+        const data: AdapterRequest = {
+          id: jobID,
+          data: {
+            endpoint,
+            operand1Sources: ['coingecko', 'coinpaprika'],
+            operand2Sources: ['coingecko', 'coinpaprika'],
+            operand1Input: {
+              from: 'LINK',
+              to: 'USD',
+            },
+            operand2Input: {
+              from: 'DEAD',
+              to: 'USD',
+            },
+            operation: 'divide',
+          },
+        }
+        const response = await (context.req as SuperTest<Test>)
+          .post('/')
+          .send(data)
+          .set('Accept', '*/*')
+          .set('Content-Type', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(500)
+        expect(response.body).toMatchSnapshot()
+      })
+    })
+
+    describe('validation error', () => {
+      const jobID = '1'
+
+      it('returns a validation error if the request data is empty', async () => {
+        const data: AdapterRequest = { id: jobID, data: { endpoint } }
+
+        const response = await (context.req as SuperTest<Test>)
+          .post('/')
+          .send(data)
+          .set('Accept', '*/*')
+          .set('Content-Type', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(400)
+        expect(response.body).toMatchSnapshot()
+      })
+
+      it('returns a validation error if the request is missing operand1 input', async () => {
+        const data: AdapterRequest = {
+          id: jobID,
+          data: {
+            endpoint,
+            operand1Sources: ['coingecko'],
+            operand2Sources: ['coingecko'],
+            operand2Input: {
+              from: 'ETH',
+              to: 'USD',
+            },
+            operation: 'divide',
+          },
+        }
+
+        const response = await (context.req as SuperTest<Test>)
+          .post('/')
+          .send(data)
+          .set('Accept', '*/*')
+          .set('Content-Type', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(400)
+        expect(response.body).toMatchSnapshot()
+      })
+
+      it('returns a validation error if the request is missing operand2 input', async () => {
+        const data: AdapterRequest = {
+          id: jobID,
+          data: {
+            endpoint,
+            operand1Sources: ['coingecko'],
+            operand2Sources: ['coingecko'],
+            operand1Input: {
+              from: 'LINK',
+              to: 'USD',
+            },
+            operation: 'divide',
+          },
+        }
+
+        const response = await (context.req as SuperTest<Test>)
+          .post('/')
+          .send(data)
+          .set('Accept', '*/*')
+          .set('Content-Type', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(400)
+        expect(response.body).toMatchSnapshot()
+      })
+
+      it('returns a validation error if the request is missing operation', async () => {
+        const data: AdapterRequest = {
+          id: jobID,
+          data: {
+            endpoint,
+            operand1Sources: ['coingecko'],
+            operand2Sources: ['coingecko'],
+            operand1Input: {
+              from: 'LINK',
+              to: 'USD',
+            },
+            operand2Input: {
+              from: 'ETH',
+              to: 'USD',
+            },
+          },
+        }
+
+        const response = await (context.req as SuperTest<Test>)
+          .post('/')
+          .send(data)
+          .set('Accept', '*/*')
+          .set('Content-Type', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(400)
+        expect(response.body).toMatchSnapshot()
+      })
+
+      it('returns a validation error if the request contains unsupported sources', async () => {
+        const data: AdapterRequest = {
+          id: jobID,
+          data: {
+            endpoint,
+            operand1Sources: ['NOT_REAL'],
+            operand2Sources: ['coingecko'],
+            operand1Input: {
+              from: 'LINK',
+              to: 'USD',
+            },
+            operand2Input: {
+              from: 'ETH',
+              to: 'USD',
+            },
+            operation: 'divide',
+          },
+        }
+
+        const response = await (context.req as SuperTest<Test>)
+          .post('/')
+          .send(data)
+          .set('Accept', '*/*')
+          .set('Content-Type', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(500)
+        expect(response.body).toMatchSnapshot()
+      })
     })
   })
 
-  describe('erroring calls', () => {
-    const jobID = '1'
+  describe('with endpoint impliedPrice', () => {
+    const endpoint = 'impliedPrice'
 
-    it('returns error if not reaching minAnswers', async () => {
-      mockSuccessfulResponseCoingecko()
-      const data: AdapterRequest = {
-        id: jobID,
-        data: {
-          dividendSources: ['coingecko'],
-          dividendMinAnswers: 2,
-          divisorSources: ['coingecko'],
-          dividendInput: {
-            from: 'LINK',
-            to: 'USD',
+    describe('successful calls', () => {
+      const jobID = '1'
+
+      it('return success without comma separated sources', async () => {
+        mockSuccessfulResponseCoingecko()
+        mockSuccessfulResponseCoinpaprika()
+        const data: AdapterRequest = {
+          id: jobID,
+          data: {
+            endpoint,
+            dividendSources: ['coingecko', 'coinpaprika'],
+            divisorSources: ['coingecko', 'coinpaprika'],
+            dividendInput: {
+              from: 'LINK',
+              to: 'USD',
+            },
+            divisorInput: {
+              from: 'ETH',
+              to: 'USD',
+            },
           },
-          divisorInput: {
-            from: 'ETH',
-            to: 'USD',
+        }
+
+        const response = await (context.req as SuperTest<Test>)
+          .post('/')
+          .send(data)
+          .set('Accept', '*/*')
+          .set('Content-Type', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(200)
+        expect(response.body).toMatchSnapshot()
+      })
+
+      it('returns success with comma separated sources', async () => {
+        mockSuccessfulResponseCoingecko()
+        mockSuccessfulResponseCoinpaprika()
+        const data: AdapterRequest = {
+          id: jobID,
+          data: {
+            endpoint,
+            dividendSources: 'coingecko,coinpaprika',
+            divisorSources: 'coingecko,coinpaprika',
+            dividendInput: {
+              from: 'LINK',
+              to: 'USD',
+            },
+            divisorInput: {
+              from: 'ETH',
+              to: 'USD',
+            },
           },
-        },
-      }
-      const response = await (context.req as SuperTest<Test>)
-        .post('/')
-        .send(data)
-        .set('Accept', '*/*')
-        .set('Content-Type', 'application/json')
-        .expect('Content-Type', /json/)
-        .expect(500)
-      expect(response.body).toMatchSnapshot()
+        }
+
+        const response = await (context.req as SuperTest<Test>)
+          .post('/')
+          .send(data)
+          .set('Accept', '*/*')
+          .set('Content-Type', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(200)
+        expect(response.body).toMatchSnapshot()
+      })
     })
 
-    it('returns error if dividend has zero price', async () => {
-      mockSuccessfulResponseCoingecko()
-      mockSuccessfulResponseCoinpaprika()
-      const data: AdapterRequest = {
-        id: jobID,
-        data: {
-          dividendSources: ['coingecko', 'coinpaprika'],
-          divisorSources: ['coingecko', 'coinpaprika'],
-          dividendInput: {
-            from: 'DEAD',
-            to: 'USD',
+    describe('erroring calls', () => {
+      const jobID = '1'
+
+      it('returns error if not reaching minAnswers', async () => {
+        mockSuccessfulResponseCoingecko()
+        const data: AdapterRequest = {
+          id: jobID,
+          data: {
+            endpoint,
+            dividendSources: ['coingecko'],
+            dividendMinAnswers: 2,
+            divisorSources: ['coingecko'],
+            dividendInput: {
+              from: 'LINK',
+              to: 'USD',
+            },
+            divisorInput: {
+              from: 'ETH',
+              to: 'USD',
+            },
           },
-          divisorInput: {
-            from: 'ETH',
-            to: 'USD',
+        }
+        const response = await (context.req as SuperTest<Test>)
+          .post('/')
+          .send(data)
+          .set('Accept', '*/*')
+          .set('Content-Type', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(500)
+        expect(response.body).toMatchSnapshot()
+      })
+
+      it('returns error if dividend has zero price', async () => {
+        mockSuccessfulResponseCoingecko()
+        mockSuccessfulResponseCoinpaprika()
+        const data: AdapterRequest = {
+          id: jobID,
+          data: {
+            endpoint,
+            dividendSources: ['coingecko', 'coinpaprika'],
+            divisorSources: ['coingecko', 'coinpaprika'],
+            dividendInput: {
+              from: 'DEAD',
+              to: 'USD',
+            },
+            divisorInput: {
+              from: 'ETH',
+              to: 'USD',
+            },
           },
-        },
-      }
-      const response = await (context.req as SuperTest<Test>)
-        .post('/')
-        .send(data)
-        .set('Accept', '*/*')
-        .set('Content-Type', 'application/json')
-        .expect('Content-Type', /json/)
-        .expect(500)
-      expect(response.body).toMatchSnapshot()
+        }
+        const response = await (context.req as SuperTest<Test>)
+          .post('/')
+          .send(data)
+          .set('Accept', '*/*')
+          .set('Content-Type', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(500)
+        expect(response.body).toMatchSnapshot()
+      })
+
+      it('returns error if divisor has zero price', async () => {
+        mockSuccessfulResponseCoingecko()
+        mockSuccessfulResponseCoinpaprika()
+        const data: AdapterRequest = {
+          id: jobID,
+          data: {
+            endpoint,
+            dividendSources: ['coingecko', 'coinpaprika'],
+            divisorSources: ['coingecko', 'coinpaprika'],
+            dividendInput: {
+              from: 'LINK',
+              to: 'USD',
+            },
+            divisorInput: {
+              from: 'DEAD',
+              to: 'USD',
+            },
+          },
+        }
+        const response = await (context.req as SuperTest<Test>)
+          .post('/')
+          .send(data)
+          .set('Accept', '*/*')
+          .set('Content-Type', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(500)
+        expect(response.body).toMatchSnapshot()
+      })
     })
 
-    it('returns error if divisor has zero price', async () => {
-      mockSuccessfulResponseCoingecko()
-      mockSuccessfulResponseCoinpaprika()
-      const data: AdapterRequest = {
-        id: jobID,
-        data: {
-          dividendSources: ['coingecko', 'coinpaprika'],
-          divisorSources: ['coingecko', 'coinpaprika'],
-          dividendInput: {
-            from: 'LINK',
-            to: 'USD',
+    describe('validation error', () => {
+      const jobID = '1'
+
+      it('returns a validation error if the request data is empty', async () => {
+        const data: AdapterRequest = { id: jobID, data: {} }
+
+        const response = await (context.req as SuperTest<Test>)
+          .post('/')
+          .send(data)
+          .set('Accept', '*/*')
+          .set('Content-Type', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(400)
+        expect(response.body).toMatchSnapshot()
+      })
+
+      it('returns a validation error if the request is missing dividend input', async () => {
+        const data: AdapterRequest = {
+          id: jobID,
+          data: {
+            endpoint,
+            dividendSources: ['coingecko'],
+            divisorSources: ['coingecko'],
+            divisorInput: {
+              from: 'ETH',
+              to: 'USD',
+            },
           },
-          divisorInput: {
-            from: 'DEAD',
-            to: 'USD',
+        }
+
+        const response = await (context.req as SuperTest<Test>)
+          .post('/')
+          .send(data)
+          .set('Accept', '*/*')
+          .set('Content-Type', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(400)
+        expect(response.body).toMatchSnapshot()
+      })
+
+      it('returns a validation error if the request is missing divisor input', async () => {
+        const data: AdapterRequest = {
+          id: jobID,
+          data: {
+            endpoint,
+            dividendSources: ['coingecko'],
+            divisorSources: ['coingecko'],
+            dividendInput: {
+              from: 'LINK',
+              to: 'USD',
+            },
           },
-        },
-      }
-      const response = await (context.req as SuperTest<Test>)
-        .post('/')
-        .send(data)
-        .set('Accept', '*/*')
-        .set('Content-Type', 'application/json')
-        .expect('Content-Type', /json/)
-        .expect(500)
-      expect(response.body).toMatchSnapshot()
-    })
-  })
+        }
 
-  describe('validation error', () => {
-    const jobID = '1'
+        const response = await (context.req as SuperTest<Test>)
+          .post('/')
+          .send(data)
+          .set('Accept', '*/*')
+          .set('Content-Type', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(400)
+        expect(response.body).toMatchSnapshot()
+      })
 
-    it('returns a validation error if the request data is empty', async () => {
-      const data: AdapterRequest = { id: jobID, data: {} }
-
-      const response = await (context.req as SuperTest<Test>)
-        .post('/')
-        .send(data)
-        .set('Accept', '*/*')
-        .set('Content-Type', 'application/json')
-        .expect('Content-Type', /json/)
-        .expect(400)
-      expect(response.body).toMatchSnapshot()
-    })
-
-    it('returns a validation error if the request is missing dividend input', async () => {
-      const data: AdapterRequest = {
-        id: jobID,
-        data: {
-          dividendSources: ['coingecko'],
-          divisorSources: ['coingecko'],
-          divisorInput: {
-            from: 'ETH',
-            to: 'USD',
+      it('returns a validation error if the request contains unsupported sources', async () => {
+        const data: AdapterRequest = {
+          id: jobID,
+          data: {
+            endpoint,
+            dividendSources: ['NOT_REAL'],
+            divisorSources: ['coingecko'],
+            dividendInput: {
+              from: 'LINK',
+              to: 'USD',
+            },
+            divisorInput: {
+              from: 'ETH',
+              to: 'USD',
+            },
           },
-        },
-      }
+        }
 
-      const response = await (context.req as SuperTest<Test>)
-        .post('/')
-        .send(data)
-        .set('Accept', '*/*')
-        .set('Content-Type', 'application/json')
-        .expect('Content-Type', /json/)
-        .expect(400)
-      expect(response.body).toMatchSnapshot()
-    })
-
-    it('returns a validation error if the request is missing divisor input', async () => {
-      const data: AdapterRequest = {
-        id: jobID,
-        data: {
-          dividendSources: ['coingecko'],
-          divisorSources: ['coingecko'],
-          dividendInput: {
-            from: 'LINK',
-            to: 'USD',
-          },
-        },
-      }
-
-      const response = await (context.req as SuperTest<Test>)
-        .post('/')
-        .send(data)
-        .set('Accept', '*/*')
-        .set('Content-Type', 'application/json')
-        .expect('Content-Type', /json/)
-        .expect(400)
-      expect(response.body).toMatchSnapshot()
-    })
-
-    it('returns a validation error if the request contains unsupported sources', async () => {
-      const data: AdapterRequest = {
-        id: jobID,
-        data: {
-          dividendSources: ['NOT_REAL'],
-          divisorSources: ['coingecko'],
-          dividendInput: {
-            from: 'LINK',
-            to: 'USD',
-          },
-          divisorInput: {
-            from: 'ETH',
-            to: 'USD',
-          },
-        },
-      }
-
-      const response = await (context.req as SuperTest<Test>)
-        .post('/')
-        .send(data)
-        .set('Accept', '*/*')
-        .set('Content-Type', 'application/json')
-        .expect('Content-Type', /json/)
-        .expect(500)
-      expect(response.body).toMatchSnapshot()
+        const response = await (context.req as SuperTest<Test>)
+          .post('/')
+          .send(data)
+          .set('Accept', '*/*')
+          .set('Content-Type', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(500)
+        expect(response.body).toMatchSnapshot()
+      })
     })
   })
 })

--- a/packages/composites/implied-price/test/unit/adapter.test.ts
+++ b/packages/composites/implied-price/test/unit/adapter.test.ts
@@ -1,4 +1,4 @@
-import { median, parseSources } from '../../src/endpoint/impliedPrice'
+import { median, parseSources } from '../../src/endpoint/computedPrice'
 
 describe('parseSources', () => {
   it('parses an array of sources', () => {


### PR DESCRIPTION
[DF-21193](https://smartcontract-it.atlassian.net/browse/DF-21193)

## Description

The `implied-price` EA can divide 2 prices from other EA(s).
We now want to be able to multiply 2 prices as well.

The current parameters (dividend* and divisor*) refer specifically to the division operation.
So we add a new endpoint (`computedPrice`) with parameters prefixed with `operand1` and `operand2` to be operation agnostic, and an additional `operation` parameter to indicate whether to divide or multiply.
The old endpoint remains the default endpoint for backwards compatibility.

Note for reviewers:
1. A separate commit copies `impliedPrice.ts` to `computedPrice.ts` without making any changes. This should make it easier to see what changes were made in the following commit.
2. I recommend enabling "Hide whitespace", especially when reviewing `adapter.test.ts` because the additional `describe` block adds indentation to a large block of code.

## Changes

1. Copied `impliedPrice.ts` to `computedPrice.ts`.
2. Renamed `dividend` to `operand1` and `divisor` to `operand2`.
3. Added `operation` parameter to determine the applied operation.
4. Changed `impliedPrice.ts` to reuse the logic from `computedPrices.ts` with `operation` hard coded to `"divide"`.
5. Added to `test-payload.json`.
6. Duplicated integration tests for the new endpoint and added extra tests for multiplication and absence of the `operation` parameter.

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. Run `aleno` EA (any should work but this is the one I used because I'm familiar with it)
2. Run `implied-price` EA
```
$ curl -X POST http://localhost:8082 -H "Content-Type: application/json" -d '{
  "id": "1",
  "data": {
    "dividendSources": ["aleno"],
    "divisorSources": ["aleno"],
    "dividendInput": {
      "from": "FRAX",
      "to": "USD"
    },
    "divisorInput": {
      "from": "LBTC",
      "to": "USD"
    }
  }
}
'

{"jobRunID":"1","result":"0.00001137192088438718021","providerStatusCode":200,"statusCode":200,"data":{"result":"0.00001137192088438718021"},"meta":{"adapterName":"IMPLIED_PRICE"},"metricsMeta":{"feedId":"{\"data\":{\"dividendSources\":[\"aleno\"],\"divisorSources\":[\"aleno\"],\"dividendInput\":{\"from\":\"FRAX\",\"to\":\"USD\"},\"divisorInput\":{\"from\":\"LBTC\",\"to\":\"USD\"}}}"}}

$ curl -X POST http://localhost:8082 -H "Content-Type: application/json" -d '{
  "id": "1",
  "data": {
    "endpoint": "computedPrice",
    "operand1Sources": ["aleno"],
    "operand2Sources": ["aleno"],
    "operand1Input": {
      "from": "FRAX",
      "to": "USD"
    },
    "operand2Input": {
      "from": "LBTC",
      "to": "USD"
    },                      
    "operation": "multiply"
  }
}
'
{"jobRunID":"1","result":"87221.66960739051242","providerStatusCode":200,"statusCode":200,"data":{"result":"87221.66960739051242"},"meta":{"adapterName":"IMPLIED_PRICE"},"metricsMeta":{"feedId":"{\"data\":{\"endpoint\":\"computedPrice\",\"operand1Sources\":[\"aleno\"],\"operand2Sources\":[\"aleno\"],\"operand1Input\":{\"from\":\"FRAX\",\"to\":\"USD\"},\"operand2Input\":{\"from\":\"LBTC\",\"to\":\"USD\"},\"operation\":\"multiply\"}}"}}
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [x] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [x] This is related to a maximum of one Jira story or GitHub issue.
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[DF-21193]: https://smartcontract-it.atlassian.net/browse/DF-21193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ