### PR TITLE
Error Handling Coinmetrics

### DIFF
--- a/.changeset/witty-melons-thank.md
+++ b/.changeset/witty-melons-thank.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/coinmetrics-adapter': minor
+---
+
+Error Handling

--- a/packages/sources/coinmetrics/src/transport/error-handling.ts
+++ b/packages/sources/coinmetrics/src/transport/error-handling.ts
@@ -1,0 +1,21 @@
+import { makeLogger } from '@chainlink/external-adapter-framework/util'
+import { ResponseError } from './types'
+
+const logger = makeLogger('CoinMetrics Crypto error handling')
+
+export const logPossibleSolutionForKnownErrors = (error: ResponseError) => {
+  if (error['type'] === 'wrong_credentials') {
+    logger.error(`There is something wrong with your credentials.
+      Possible Solution:
+      1. Doublecheck your supplied credentials.
+      2. Contact Data Provider to ensure your subscription is active
+      3. If credentials are supplied under the node licensing agreement with Chainlink Labs, please make contact with us and we will look into it.`)
+  }
+
+  if (error['type'] === 'bad_parameter') {
+    logger.error(`This error indicates that the supplied asset or metric parameter is incorrect.
+      Possible Solution:
+      1. Confirm you are using the same symbol found in the job spec with the correct case.
+      2. There maybe an issue with the job spec or the Data Provider may have delisted the asset. Reach out to Chainlink Labs.`)
+  }
+}

--- a/packages/sources/coinmetrics/src/transport/lwba.ts
+++ b/packages/sources/coinmetrics/src/transport/lwba.ts
@@ -8,6 +8,8 @@ import {
 import { TypeFromDefinition } from '@chainlink/external-adapter-framework/validation/input-params'
 import { EndpointContext } from '@chainlink/external-adapter-framework/adapter'
 import { WebSocketTransport } from '@chainlink/external-adapter-framework/transports/websocket'
+import { logPossibleSolutionForKnownErrors } from './error-handling'
+import { ResponseError } from './types'
 
 const logger = makeLogger('CoinMetrics Crypto LWBA WS')
 
@@ -28,10 +30,7 @@ export type WsCryptoLwbaSuccessResponse = {
   cm_sequence_id: string
 }
 export type WsCryptoLwbaErrorResponse = {
-  error: {
-    type: string
-    message: string
-  }
+  error: ResponseError
 }
 export type WsCryptoLwbaWarningResponse = {
   warning: {
@@ -80,6 +79,7 @@ export const handleCryptoLwbaMessage = (
 ): MultiVarResult<WsTransportTypes>[] | undefined => {
   if ('error' in message) {
     logger.error(message, `Error response from websocket`)
+    logPossibleSolutionForKnownErrors(message.error)
   } else if ('warning' in message) {
     logger.warn(message, `Warning response from websocket`)
   } else if ('type' in message && message.type === 'reorg') {

--- a/packages/sources/coinmetrics/src/transport/price-ws.ts
+++ b/packages/sources/coinmetrics/src/transport/price-ws.ts
@@ -3,6 +3,8 @@ import { WebSocketTransport } from '@chainlink/external-adapter-framework/transp
 import { makeLogger, ProviderResult } from '@chainlink/external-adapter-framework/util'
 import { VALID_QUOTES } from '../config'
 import { assetMetricsInputParameters, BaseEndpointTypes } from '../endpoint/price'
+import { logPossibleSolutionForKnownErrors } from './error-handling'
+import { ResponseError } from './types'
 
 const logger = makeLogger('CoinMetrics WS')
 
@@ -25,10 +27,7 @@ export type WsAssetMetricsSuccessResponse = {
   ReferenceRateBTC?: string
 }
 export type WsAssetMetricsErrorResponse = {
-  error: {
-    type: string
-    message: string
-  }
+  error: ResponseError
 }
 export type WsAssetMetricsWarningResponse = {
   warning: {
@@ -89,6 +88,7 @@ export const handleAssetMetricsMessage = (
   if ('error' in message) {
     // Is WsAssetMetricsErrorResponse
     logger.error(message, `Error response from websocket`)
+    logPossibleSolutionForKnownErrors(message.error)
 
     const findBaseCurrenciesRegex = new RegExp(/'([^']+)'/g)
     if (message['error']['type'] === 'bad_parameter') {

--- a/packages/sources/coinmetrics/src/transport/types.ts
+++ b/packages/sources/coinmetrics/src/transport/types.ts
@@ -1,0 +1,4 @@
+export type ResponseError = {
+  type: string
+  message: string
+}


### PR DESCRIPTION
## Description

https://smartcontract-it.atlassian.net/browse/DF-20101

## Changes

1. Extract duplicate `ResponseError` type into separate file to reuse.
2. Add `error-handling.ts` with `logPossibleSolutionForKnownErrors` common across `price-ws` and `lwba` transports.
3. Call `logPossibleSolutionForKnownErrors` from `price-ws` and `lwba` transports.