### PR TITLE
Use 'yarn test' in checks.yml

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Run unit tests
         env:
           CHANGED_PACKAGES: ${{ needs.install-packages.outputs.changed-packages }}
-        run: METRICS_ENABLED=false yarn jest --passWithNoTests $(echo $CHANGED_PACKAGES | jq '.[].location + "/test/unit"' -r | tr '\n' ' ')
+        run: yarn test --passWithNoTests $(echo $CHANGED_PACKAGES | jq '.[].location + "/test/unit"' -r | tr '\n' ' ')
 
   # Run integration tests
   integration-tests:
@@ -87,7 +87,7 @@ jobs:
       - name: Run integration tests
         env:
           CHANGED_PACKAGES: ${{ needs.install-packages.outputs.changed-packages }}
-        run: EA_PORT=0 METRICS_ENABLED=false yarn jest --passWithNoTests $(echo $CHANGED_PACKAGES | jq '.[].location + "/test/integration"' -r | tr '\n' ' ')
+        run: yarn test --passWithNoTests $(echo $CHANGED_PACKAGES | jq '.[].location + "/test/integration"' -r | tr '\n' ' ')
 
   # Run linters
   linters:


### PR DESCRIPTION
## Description

I was trying to find where we run tests on CI and couldn't find `yarn test`.
Then I realized we call `yarn jest` directly after setting `EA_PORT=0 METRICS_ENABLED=false`, but this is exactly what `yarn test` does.

So why not call `yarn test`?
For unit test we didn't set `EA_PORT=0` and with `yarn test` now we will, but I doubt this hurts anything.

## Changes

In `.github/workflows/checks.yml` call `yarn test` instead of `yarn jest` and remove unnecessary environment setup.

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

N/A

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
