### PR TITLE
Fix get-changed-adapters/lib.test.ts

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -108,21 +108,9 @@ jobs:
         env:
           CHANGED_PACKAGES: ${{ needs.install-packages.outputs.changed-packages }}
         run: |
-          yarn test packages/scripts/src/get-changed-adapters/lib.test.ts -u
-          git diff > dskloet-diff.txt
-          xxd dskloet-diff.txt > dskloet-diff.hex
-          cat dskloet-diff.txt
-          cat dskloet-diff.hex
           # TODO: Reduce the ignored patterns to only /dist/, /test/unit/ and
           # /test/integration/ by making the other tests actually pass.
           yarn test --passWithNoTests $(echo $CHANGED_PACKAGES | jq '.[].location' -r | tr '\n' ' ') --testPathIgnorePatterns="$(echo $CHANGED_PACKAGES | jq --raw-output 'map(.location | . + "/dist/|" + . + "/test/unit/|" + . + "/test/integration") | join("|")')|/test/e2e/|/test/transports/|packages/scripts/src/get-release-notes/|packages/scripts/src/ephemeral-adapters/|packages/scripts/src/gha/|packages/scripts/src/docker-build/|packages/scripts/src/schema-flatten/|packages/scripts/src/generate-image-name/|packages/scripts/src/flux-emulator/|packages/k6/src/"
-      - name: Upload diff.txt
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        with:
-          name: snapshot-diff-dskloet
-          path: |
-            dskloet-diff.txt
-            dskloet-diff.hex
 
   # Run linters
   linters:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -108,9 +108,21 @@ jobs:
         env:
           CHANGED_PACKAGES: ${{ needs.install-packages.outputs.changed-packages }}
         run: |
+          yarn test packages/scripts/src/get-changed-adapters/lib.test.ts -u
+          git diff > dskloet-diff.txt
+          xxd dskloet-diff.txt > dskloet-diff.hex
+          cat dskloet-diff.txt
+          cat dskloet-diff.hex
           # TODO: Reduce the ignored patterns to only /dist/, /test/unit/ and
           # /test/integration/ by making the other tests actually pass.
           yarn test --passWithNoTests $(echo $CHANGED_PACKAGES | jq '.[].location' -r | tr '\n' ' ') --testPathIgnorePatterns="$(echo $CHANGED_PACKAGES | jq --raw-output 'map(.location | . + "/dist/|" + . + "/test/unit/|" + . + "/test/integration") | join("|")')|/test/e2e/|/test/transports/|packages/scripts/src/get-release-notes/|packages/scripts/src/ephemeral-adapters/|packages/scripts/src/gha/|packages/scripts/src/docker-build/|packages/scripts/src/schema-flatten/|packages/scripts/src/generate-image-name/|packages/scripts/src/flux-emulator/|packages/k6/src/"
+      - name: Upload diff.txt
+        uses: actions/upload-artifact@v3
+        with:
+          name: snapshot-diff-dskloet
+          path: |
+            dskloet-diff.txt
+            dskloet-diff.hex
 
   # Run linters
   linters:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -107,7 +107,6 @@ jobs:
       - name: Run tests
         env:
           CHANGED_PACKAGES: ${{ needs.install-packages.outputs.changed-packages }}
-          FORCE_COLOR: 1
         run: |
           yarn test packages/scripts/src/get-changed-adapters/lib.test.ts -u
           git diff > dskloet-diff.txt

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -110,7 +110,7 @@ jobs:
         run: |
           # TODO: Reduce the ignored patterns to only /test/unit/ and
           # /test/integration/ by making the other tests actually pass.
-          yarn test --passWithNoTests $(echo $CHANGED_PACKAGES | jq '.[].location' -r | tr '\n' ' ') --testPathIgnorePatterns="$(echo $CHANGED_PACKAGES | jq --raw-output 'map(.location | . + "/test/unit/|" + . + "/test/integration") | join("|")')|/test/e2e/|/test/transports/|packages/scripts/src/get-release-notes/|packages/scripts/src/ephemeral-adapters/|packages/scripts/src/gha/|packages/scripts/src/docker-build/|packages/scripts/src/schema-flatten/|packages/scripts/src/generate-image-name/|packages/scripts/src/get-changed-adapters/|packages/scripts/src/flux-emulator/|packages/k6/src/"
+          yarn test --passWithNoTests $(echo $CHANGED_PACKAGES | jq '.[].location' -r | tr '\n' ' ') --testPathIgnorePatterns="$(echo $CHANGED_PACKAGES | jq --raw-output 'map(.location | . + "/test/unit/|" + . + "/test/integration") | join("|")')|/test/e2e/|/test/transports/|packages/scripts/src/get-release-notes/|packages/scripts/src/ephemeral-adapters/|packages/scripts/src/gha/|packages/scripts/src/docker-build/|packages/scripts/src/schema-flatten/|packages/scripts/src/generate-image-name/|packages/scripts/src/flux-emulator/|packages/k6/src/"
 
   # Run linters
   linters:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -108,9 +108,9 @@ jobs:
         env:
           CHANGED_PACKAGES: ${{ needs.install-packages.outputs.changed-packages }}
         run: |
-          # TODO: Reduce the ignored patterns to only /test/unit/ and
+          # TODO: Reduce the ignored patterns to only /dist/, /test/unit/ and
           # /test/integration/ by making the other tests actually pass.
-          yarn test --passWithNoTests $(echo $CHANGED_PACKAGES | jq '.[].location' -r | tr '\n' ' ') --testPathIgnorePatterns="$(echo $CHANGED_PACKAGES | jq --raw-output 'map(.location | . + "/test/unit/|" + . + "/test/integration") | join("|")')|/test/e2e/|/test/transports/|packages/scripts/src/get-release-notes/|packages/scripts/src/ephemeral-adapters/|packages/scripts/src/gha/|packages/scripts/src/docker-build/|packages/scripts/src/schema-flatten/|packages/scripts/src/generate-image-name/|packages/scripts/src/flux-emulator/|packages/k6/src/"
+          yarn test --passWithNoTests $(echo $CHANGED_PACKAGES | jq '.[].location' -r | tr '\n' ' ') --testPathIgnorePatterns="$(echo $CHANGED_PACKAGES | jq --raw-output 'map(.location | . + "/dist/|" . + "/test/unit/|" + . + "/test/integration") | join("|")')|/test/e2e/|/test/transports/|packages/scripts/src/get-release-notes/|packages/scripts/src/ephemeral-adapters/|packages/scripts/src/gha/|packages/scripts/src/docker-build/|packages/scripts/src/schema-flatten/|packages/scripts/src/generate-image-name/|packages/scripts/src/flux-emulator/|packages/k6/src/"
 
   # Run linters
   linters:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -117,7 +117,7 @@ jobs:
           # /test/integration/ by making the other tests actually pass.
           yarn test --passWithNoTests $(echo $CHANGED_PACKAGES | jq '.[].location' -r | tr '\n' ' ') --testPathIgnorePatterns="$(echo $CHANGED_PACKAGES | jq --raw-output 'map(.location | . + "/dist/|" + . + "/test/unit/|" + . + "/test/integration") | join("|")')|/test/e2e/|/test/transports/|packages/scripts/src/get-release-notes/|packages/scripts/src/ephemeral-adapters/|packages/scripts/src/gha/|packages/scripts/src/docker-build/|packages/scripts/src/schema-flatten/|packages/scripts/src/generate-image-name/|packages/scripts/src/flux-emulator/|packages/k6/src/"
       - name: Upload diff.txt
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: snapshot-diff-dskloet
           path: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -108,9 +108,21 @@ jobs:
         env:
           CHANGED_PACKAGES: ${{ needs.install-packages.outputs.changed-packages }}
         run: |
+          yarn test packages/scripts/src/get-changed-adapters/lib.test.ts -u
+          git diff > dskloet-diff.txt
+          xxd dskloet-diff.txt > dskloet-diff.hex
+          cat dskloet-diff.txt
+          cat dskloet-diff.hex
           # TODO: Reduce the ignored patterns to only /dist/, /test/unit/ and
           # /test/integration/ by making the other tests actually pass.
           yarn test --passWithNoTests $(echo $CHANGED_PACKAGES | jq '.[].location' -r | tr '\n' ' ') --testPathIgnorePatterns="$(echo $CHANGED_PACKAGES | jq --raw-output 'map(.location | . + "/dist/|" + . + "/test/unit/|" + . + "/test/integration") | join("|")')|/test/e2e/|/test/transports/|packages/scripts/src/get-release-notes/|packages/scripts/src/ephemeral-adapters/|packages/scripts/src/gha/|packages/scripts/src/docker-build/|packages/scripts/src/schema-flatten/|packages/scripts/src/generate-image-name/|packages/scripts/src/flux-emulator/|packages/k6/src/"
+      - name: Upload diff.txt
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: snapshot-diff-dskloet
+          path: |
+            dskloet-diff.txt
+            dskloet-diff.hex
 
   # Run linters
   linters:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -110,7 +110,7 @@ jobs:
         run: |
           # TODO: Reduce the ignored patterns to only /dist/, /test/unit/ and
           # /test/integration/ by making the other tests actually pass.
-          yarn test --passWithNoTests $(echo $CHANGED_PACKAGES | jq '.[].location' -r | tr '\n' ' ') --testPathIgnorePatterns="$(echo $CHANGED_PACKAGES | jq --raw-output 'map(.location | . + "/dist/|" . + "/test/unit/|" + . + "/test/integration") | join("|")')|/test/e2e/|/test/transports/|packages/scripts/src/get-release-notes/|packages/scripts/src/ephemeral-adapters/|packages/scripts/src/gha/|packages/scripts/src/docker-build/|packages/scripts/src/schema-flatten/|packages/scripts/src/generate-image-name/|packages/scripts/src/flux-emulator/|packages/k6/src/"
+          yarn test --passWithNoTests $(echo $CHANGED_PACKAGES | jq '.[].location' -r | tr '\n' ' ') --testPathIgnorePatterns="$(echo $CHANGED_PACKAGES | jq --raw-output 'map(.location | . + "/dist/|" + . + "/test/unit/|" + . + "/test/integration") | join("|")')|/test/e2e/|/test/transports/|packages/scripts/src/get-release-notes/|packages/scripts/src/ephemeral-adapters/|packages/scripts/src/gha/|packages/scripts/src/docker-build/|packages/scripts/src/schema-flatten/|packages/scripts/src/generate-image-name/|packages/scripts/src/flux-emulator/|packages/k6/src/"
 
   # Run linters
   linters:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -107,6 +107,7 @@ jobs:
       - name: Run tests
         env:
           CHANGED_PACKAGES: ${{ needs.install-packages.outputs.changed-packages }}
+          FORCE_COLOR: 1
         run: |
           yarn test packages/scripts/src/get-changed-adapters/lib.test.ts -u
           git diff > dskloet-diff.txt

--- a/packages/scripts/src/get-changed-adapters/__snapshots__/lib.test.ts.snap
+++ b/packages/scripts/src/get-changed-adapters/__snapshots__/lib.test.ts.snap
@@ -1,45 +1,41 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`get-changed-adapters cli check args should print the usage string if not enough args are provided 1`] = `
-"[31m[1m[22m[39m
-[31m[1mRequires 1 argument of the changed files file path.[22m[39m"
-`;
+exports[`get-changed-adapters cli check args should print the usage string if not enough args are provided 1`] = `"[31m[1mRequires 1 argument of the changed files file path.[22m[39m"`;
 
-exports[`get-changed-adapters cli check args should throw an error if the action argument is not a valid option 1`] = `
-"[31m[1m[22m[39m
-[31m[1mRequires 1 argument of the changed files file path.[22m[39m"
-`;
+exports[`get-changed-adapters cli check args should throw an error if the action argument is not a valid option 1`] = `"[31m[1mRequires 1 argument of the changed files file path.[22m[39m"`;
 
-exports[`get-changed-adapters cli createOutput should return the list of adapters when adapters exist in each type 1`] = `"coingecko coinpaprika"`;
+exports[`get-changed-adapters cli createOutput should return the list of adapters when adapters exist in each type 1`] = `"coingecko coinpaprika ghi coingecko coinmarketcap coinpaprika tiingo"`;
 
 exports[`get-changed-adapters cli generateFilteredAdaptersListByType should exclude non package and test files 1`] = `
-Object {
-  "composites": Array [
+{
+  "composites": [
     "bcd",
   ],
   "coreWasChanged": false,
-  "sources": Array [],
-  "targets": Array [],
+  "non-deployable": [],
+  "sources": [],
+  "targets": [],
 }
 `;
 
 exports[`get-changed-adapters cli generateFilteredAdaptersListByType should return the different types of adapters when multiple exist are changed and return that core was changed when core changes occur 1`] = `
-Object {
-  "composites": Array [
+{
+  "composites": [
     "bcd",
   ],
   "coreWasChanged": true,
-  "sources": Array [
+  "non-deployable": [],
+  "sources": [
     "abc",
   ],
-  "targets": Array [
+  "targets": [
     "gef",
   ],
 }
 `;
 
 exports[`get-changed-adapters cli loadChangedFileList should return an array of changed files 1`] = `
-Array [
+[
   "packages/sources/xbto/package.json",
   "packages/sources/coinpaprika/src/index.ts",
   "packages/sources/coingecko/test/integration/__snapshots__/adapter.test.ts.snap",

--- a/packages/scripts/src/get-changed-adapters/__snapshots__/lib.test.ts.snap
+++ b/packages/scripts/src/get-changed-adapters/__snapshots__/lib.test.ts.snap
@@ -1,41 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`get-changed-adapters cli check args should print the usage string if not enough args are provided 1`] = `"[31m[1mRequires 1 argument of the changed files file path.[22m[39m"`;
+exports[`get-changed-adapters cli check args should print the usage string if not enough args are provided 1`] = `
+"[31m[1m[22m[39m
+[31m[1mRequires 1 argument of the changed files file path.[22m[39m"
+`;
 
-exports[`get-changed-adapters cli check args should throw an error if the action argument is not a valid option 1`] = `"[31m[1mRequires 1 argument of the changed files file path.[22m[39m"`;
+exports[`get-changed-adapters cli check args should throw an error if the action argument is not a valid option 1`] = `
+"[31m[1m[22m[39m
+[31m[1mRequires 1 argument of the changed files file path.[22m[39m"
+`;
 
-exports[`get-changed-adapters cli createOutput should return the list of adapters when adapters exist in each type 1`] = `"coingecko coinpaprika ghi coingecko coinmarketcap coinpaprika tiingo"`;
+exports[`get-changed-adapters cli createOutput should return the list of adapters when adapters exist in each type 1`] = `"coingecko coinpaprika"`;
 
 exports[`get-changed-adapters cli generateFilteredAdaptersListByType should exclude non package and test files 1`] = `
-{
-  "composites": [
+Object {
+  "composites": Array [
     "bcd",
   ],
   "coreWasChanged": false,
-  "non-deployable": [],
-  "sources": [],
-  "targets": [],
+  "sources": Array [],
+  "targets": Array [],
 }
 `;
 
 exports[`get-changed-adapters cli generateFilteredAdaptersListByType should return the different types of adapters when multiple exist are changed and return that core was changed when core changes occur 1`] = `
-{
-  "composites": [
+Object {
+  "composites": Array [
     "bcd",
   ],
   "coreWasChanged": true,
-  "non-deployable": [],
-  "sources": [
+  "sources": Array [
     "abc",
   ],
-  "targets": [
+  "targets": Array [
     "gef",
   ],
 }
 `;
 
 exports[`get-changed-adapters cli loadChangedFileList should return an array of changed files 1`] = `
-[
+Array [
   "packages/sources/xbto/package.json",
   "packages/sources/coinpaprika/src/index.ts",
   "packages/sources/coingecko/test/integration/__snapshots__/adapter.test.ts.snap",

--- a/packages/scripts/src/get-changed-adapters/__snapshots__/lib.test.ts.snap
+++ b/packages/scripts/src/get-changed-adapters/__snapshots__/lib.test.ts.snap
@@ -1,45 +1,41 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`get-changed-adapters cli check args should print the usage string if not enough args are provided 1`] = `
-"[31m[1m[22m[39m
-[31m[1mRequires 1 argument of the changed files file path.[22m[39m"
-`;
+exports[`get-changed-adapters cli check args should print the usage string if not enough args are provided 1`] = `"Requires 1 argument of the changed files file path."`;
 
-exports[`get-changed-adapters cli check args should throw an error if the action argument is not a valid option 1`] = `
-"[31m[1m[22m[39m
-[31m[1mRequires 1 argument of the changed files file path.[22m[39m"
-`;
+exports[`get-changed-adapters cli check args should throw an error if the action argument is not a valid option 1`] = `"Requires 1 argument of the changed files file path."`;
 
-exports[`get-changed-adapters cli createOutput should return the list of adapters when adapters exist in each type 1`] = `"coingecko coinpaprika"`;
+exports[`get-changed-adapters cli createOutput should return the list of adapters when adapters exist in each type 1`] = `"coingecko coinpaprika ghi coingecko coinmarketcap coinpaprika tiingo"`;
 
 exports[`get-changed-adapters cli generateFilteredAdaptersListByType should exclude non package and test files 1`] = `
-Object {
-  "composites": Array [
+{
+  "composites": [
     "bcd",
   ],
   "coreWasChanged": false,
-  "sources": Array [],
-  "targets": Array [],
+  "non-deployable": [],
+  "sources": [],
+  "targets": [],
 }
 `;
 
 exports[`get-changed-adapters cli generateFilteredAdaptersListByType should return the different types of adapters when multiple exist are changed and return that core was changed when core changes occur 1`] = `
-Object {
-  "composites": Array [
+{
+  "composites": [
     "bcd",
   ],
   "coreWasChanged": true,
-  "sources": Array [
+  "non-deployable": [],
+  "sources": [
     "abc",
   ],
-  "targets": Array [
+  "targets": [
     "gef",
   ],
 }
 `;
 
 exports[`get-changed-adapters cli loadChangedFileList should return an array of changed files 1`] = `
-Array [
+[
   "packages/sources/xbto/package.json",
   "packages/sources/coinpaprika/src/index.ts",
   "packages/sources/coingecko/test/integration/__snapshots__/adapter.test.ts.snap",

--- a/packages/scripts/src/get-changed-adapters/lib.test.ts
+++ b/packages/scripts/src/get-changed-adapters/lib.test.ts
@@ -42,7 +42,6 @@ describe('get-changed-adapters cli', () => {
         checkArgs()
         expect('').toEqual('We should not make it to this expect statement')
       } catch (err) {
-        console.log('dskloetx', JSON.stringify(err))
         expect(err).toMatchSnapshot()
       }
     })

--- a/packages/scripts/src/get-changed-adapters/lib.test.ts
+++ b/packages/scripts/src/get-changed-adapters/lib.test.ts
@@ -42,6 +42,7 @@ describe('get-changed-adapters cli', () => {
         checkArgs()
         expect('').toEqual('We should not make it to this expect statement')
       } catch (err) {
+        console.log('dskloetx', JSON.stringify(err))
         expect(err).toMatchSnapshot()
       }
     })

--- a/packages/scripts/src/get-changed-adapters/lib.test.ts
+++ b/packages/scripts/src/get-changed-adapters/lib.test.ts
@@ -30,6 +30,11 @@ jest.mock('fs', () => {
 })
 
 describe('get-changed-adapters cli', () => {
+  afterAll(() => {
+    // Prevent yarn jest from exiting with a non-zero code even when tests pass.
+    process.exitCode = 0
+  })
+
   describe('check args', () => {
     it('should print the usage string if not enough args are provided', async () => {
       process.argv = ['', '']
@@ -126,7 +131,7 @@ describe('get-changed-adapters cli', () => {
 
       // verify the console output
       expect(console.log).toHaveBeenCalledTimes(1)
-      expect(console.log).toHaveBeenCalledWith('coinpaprika')
+      expect(console.log).toHaveBeenCalledWith('xbto coinpaprika')
     })
   })
 })


### PR DESCRIPTION
## Description

One of the failing tests currently not run on CI is `packages/scripts/src/generate-image-name/lib.test.ts`.

One failure is that `'should successfully run when a valid file is input'` expects `xbto` to be included in the output.
This used to be expected but was removed in https://github.com/smartcontractkit/external-adapters-js/commit/8f4983934f59aede38ad748f58a3265ca77ab9a1 although I can't tell from the commit description or other changes whether that was intentional.
I'm also not able to check if the test passed at the time because `yarn install` fails for me at that commit with
```
➤ YN0001: │ Error [ERR_STREAM_PREMATURE_CLOSE]: Premature close
    at PassThrough.onclose (node:internal/streams/end-of-stream:153:30)
    at PassThrough.emit (node:events:507:28)
    at emitCloseNT (node:internal/streams/destroy:148:10)
    at process.processTicksAndRejections (node:internal/process/task_queues:89:21)
```


## Changes

1. Updated expectation in `'should successfully run when a valid file is input'` to include `xbto` again.
2. Set `process.exitCode = 0` in `afterAll` to prevent `jest` from exiting with non-zero exit code.
3. Update snapshots with `FORCE_COLOR=0 yarn test packages/scripts/src/get-changed-adapters/lib.test.ts -u`.
4. Remove the test from the excluded patterns on CI.
5. Include `/dist/` in excluded patterns as it's just a compiled version of the same tests and results in testing test that should be excluded.

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

```
FORCE_COLOR=0 yarn test packages/scripts/src/get-changed-adapters/lib.test.ts && echo PASS
```


## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
