### PR TITLE
Fix get-release-notes test

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -110,7 +110,7 @@ jobs:
         run: |
           # TODO: Reduce the ignored patterns to only /dist/, /test/unit/ and
           # /test/integration/ by making the other tests actually pass.
-          yarn test --passWithNoTests $(echo $CHANGED_PACKAGES | jq '.[].location' -r | tr '\n' ' ') --testPathIgnorePatterns="$(echo $CHANGED_PACKAGES | jq --raw-output 'map(.location | . + "/dist/|" + . + "/test/unit/|" + . + "/test/integration") | join("|")')|/test/e2e/|/test/transports/|packages/scripts/src/get-release-notes/|packages/scripts/src/ephemeral-adapters/|packages/scripts/src/gha/|packages/scripts/src/docker-build/|packages/scripts/src/schema-flatten/|packages/scripts/src/generate-image-name/|packages/scripts/src/flux-emulator/|packages/k6/src/"
+          yarn test --passWithNoTests $(echo $CHANGED_PACKAGES | jq '.[].location' -r | tr '\n' ' ') --testPathIgnorePatterns="$(echo $CHANGED_PACKAGES | jq --raw-output 'map(.location | . + "/dist/|" + . + "/test/unit/|" + . + "/test/integration") | join("|")')|/test/e2e/|/test/transports/|packages/scripts/src/ephemeral-adapters/|packages/scripts/src/gha/|packages/scripts/src/docker-build/|packages/scripts/src/schema-flatten/|packages/scripts/src/generate-image-name/|packages/scripts/src/flux-emulator/|packages/k6/src/"
 
   # Run linters
   linters:

--- a/packages/scripts/src/get-release-notes/test/lib.test.ts
+++ b/packages/scripts/src/get-release-notes/test/lib.test.ts
@@ -4,7 +4,7 @@ import { mockReaddirSyncResponse, mockFileContentsMap } from '../fixtures/fs'
 
 jest.mock('../../workspace', () => {
   return {
-    getWorkspacePackages: () => {
+    getWorkspaceAdapters: () => {
       return mockGetWorkspacePackagesResponse
     },
   }


### PR DESCRIPTION
## Description

`packages/scripts/src/get-release-notes/test/lib.test.ts` currently doesn't run on CI and then it's run it fails.

https://github.com/smartcontractkit/external-adapters-js/commit/73d039d2d4161ffc3e26e3edc35dcdc6134edd75 made a change where `packages/scripts/src/get-release-notes/lib.ts` calls `getWorkspaceAdapters` instead of `getWorkspacePackages` but the test still mocks `getWorkspacePackages` and not ```.

## Changes

In `packages/scripts/src/get-release-notes/test/lib.test.ts`, mock `getWorkspaceAdapters` instead of `getWorkspacePackages`.

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test


## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
