### PR TITLE
Fix ephemeral-adapters test

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -110,7 +110,7 @@ jobs:
         run: |
           # TODO: Reduce the ignored patterns to only /dist/, /test/unit/ and
           # /test/integration/ by making the other tests actually pass.
-          yarn test --passWithNoTests $(echo $CHANGED_PACKAGES | jq '.[].location' -r | tr '\n' ' ') --testPathIgnorePatterns="$(echo $CHANGED_PACKAGES | jq --raw-output 'map(.location | . + "/dist/|" + . + "/test/unit/|" + . + "/test/integration") | join("|")')|/test/e2e/|/test/transports/|packages/scripts/src/ephemeral-adapters/|packages/scripts/src/gha/|packages/scripts/src/docker-build/|packages/scripts/src/schema-flatten/|packages/scripts/src/generate-image-name/|packages/scripts/src/flux-emulator/|packages/k6/src/"
+          yarn test --passWithNoTests $(echo $CHANGED_PACKAGES | jq '.[].location' -r | tr '\n' ' ') --testPathIgnorePatterns="$(echo $CHANGED_PACKAGES | jq --raw-output 'map(.location | . + "/dist/|" + . + "/test/unit/|" + . + "/test/integration") | join("|")')|/test/e2e/|/test/transports/|packages/scripts/src/gha/|packages/scripts/src/docker-build/|packages/scripts/src/schema-flatten/|packages/scripts/src/generate-image-name/|packages/scripts/src/flux-emulator/|packages/k6/src/"
 
   # Run linters
   linters:

--- a/packages/scripts/src/ephemeral-adapters/__snapshots__/lib.test.ts.snap
+++ b/packages/scripts/src/ephemeral-adapters/__snapshots__/lib.test.ts.snap
@@ -1,10 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Ephemeral Adapters Testing starting and stopping ephemeral adapters should override any values passed in as arguments or environment variables 1`] = `
-Object {
+{
   "action": "start",
   "adapter": "adapter",
   "helmChartDir": "helm_chart_dir",
+  "helmSecrets": "",
   "helmValuesOverride": "-f helm_values",
   "imageRepository": "test_image_repo",
   "imageTag": "test_tag",
@@ -13,64 +14,68 @@ Object {
 }
 `;
 
-exports[`Ephemeral Adapters Testing starting and stopping ephemeral adapters should throw an error if a command is not installed 1`] = `"[31m[1mtest is not installed[22m[39m"`;
+exports[`Ephemeral Adapters Testing starting and stopping ephemeral adapters should throw an error if a command is not installed 1`] = `"test is not installed"`;
 
-exports[`Ephemeral Adapters Testing starting and stopping ephemeral adapters should throw an error if we are not on the sdlc cluster 1`] = `"[31m[1mWe only want to spin ephemeral environments up on the sdlc cluster. Please change your kubectx. [object Object][22m[39m"`;
+exports[`Ephemeral Adapters Testing starting and stopping ephemeral adapters should throw an error if we are not on the sdlc cluster 1`] = `"We only want to spin ephemeral environments up on the sdlc cluster. Please change your kubectx. [object Object]"`;
 
-exports[`Ephemeral Adapters Testing starting and stopping ephemeral adapters should throw an error if we can't deploy the helm chart 1`] = `"[31m[1mFailed to deploy the external adapter: [object Object][22m[39m"`;
+exports[`Ephemeral Adapters Testing starting and stopping ephemeral adapters should throw an error if we can't deploy the helm chart 1`] = `
+"Failed to deploy the external adapter: [object Object]. Please double check that test-payload.json
+ is correct as well as adapter-secrets repo contains the correct env variables"
+`;
 
-exports[`Ephemeral Adapters Testing starting and stopping ephemeral adapters should throw an error if we can't download the helm chart 1`] = `"[31m[1mFailed to pull the chainlink helm chart repository: [object Object][22m[39m"`;
+exports[`Ephemeral Adapters Testing starting and stopping ephemeral adapters should throw an error if we can't download the helm chart 1`] = `"Failed to pull the chainlink helm chart repository: [object Object]"`;
 
-exports[`Ephemeral Adapters Testing starting and stopping ephemeral adapters should throw an error if we can't remove the adapter 1`] = `"[31m[1mFailed to remove the external adapter: [object Object][22m[39m"`;
+exports[`Ephemeral Adapters Testing starting and stopping ephemeral adapters should throw an error if we can't remove the adapter 1`] = `"Failed to remove the external adapter: [object Object]"`;
 
 exports[`Ephemeral Adapters Testing starting and stopping ephemeral adapters should throw if args are less than 5 1`] = `
-"[31m[1m[22m[39m
-[31m[1mAt least 3 arguments are required and 1 optional.[22m[39m
-[31m[1m1: Options are \\"start\\" or \\"stop\\". In releation to whether you want to start or stop the adapter.[22m[39m
-[31m[1m2: The adapter name you wish to start. Must match an adapter we have built a docker image for.[22m[39m
-[31m[1m3: The unique release tag for this deployment. Use your name if you are running locally or the PR number for CI.[22m[39m
-[31m[1m4: Optional. The docker image tag you wish to deploy. Can also be a sha256 for the image. Defaults to develop-latest.[22m[39m
-[31m[1mThere are 3 other variables that can be changed via environment variables. These are:[22m[39m
-[31m[1mHELM_CHART_DIR - The path to the helm chart directory for the adapters. Defaults to the one in this project.[22m[39m
-[31m[1mHELM_VALUES - The path to a helm values file you wish to use to override any default values in the chart[22m[39m
-[31m[1mIMAGE_REPOSITORY - The docker image reposoitory where the image you want deployed lives. Defaults to the public chainlink ecr.[22m[39m"
+"
+At least 3 arguments are required and 1 optional.
+1: Options are "start" or "stop". In releation to whether you want to start or stop the adapter.
+2: The adapter name you wish to start. Must match an adapter we have built a docker image for.
+3: The unique release tag for this deployment. Use your name if you are running locally or the PR number for CI.
+4: Optional. The docker image tag you wish to deploy. Can also be a sha256 for the image. Defaults to develop-latest.
+There are 3 other variables that can be changed via environment variables. These are:
+HELM_CHART_DIR - The path to the helm chart directory for the adapters. Defaults to the one in this project.
+HELM_VALUES - The path to a helm values file you wish to use to override any default values in the chart
+IMAGE_REPOSITORY - The docker image reposoitory where the image you want deployed lives. Defaults to the public chainlink ecr."
 `;
 
 exports[`Ephemeral Adapters Testing starting and stopping ephemeral adapters should throw if we an empty string for the second argument 1`] = `
-"[31m[1mMissing second argument: adapter[22m[39m
-[31m[1m[22m[39m
-[31m[1mAt least 3 arguments are required and 1 optional.[22m[39m
-[31m[1m1: Options are \\"start\\" or \\"stop\\". In releation to whether you want to start or stop the adapter.[22m[39m
-[31m[1m2: The adapter name you wish to start. Must match an adapter we have built a docker image for.[22m[39m
-[31m[1m3: The unique release tag for this deployment. Use your name if you are running locally or the PR number for CI.[22m[39m
-[31m[1m4: Optional. The docker image tag you wish to deploy. Can also be a sha256 for the image. Defaults to develop-latest.[22m[39m
-[31m[1mThere are 3 other variables that can be changed via environment variables. These are:[22m[39m
-[31m[1mHELM_CHART_DIR - The path to the helm chart directory for the adapters. Defaults to the one in this project.[22m[39m
-[31m[1mHELM_VALUES - The path to a helm values file you wish to use to override any default values in the chart[22m[39m
-[31m[1mIMAGE_REPOSITORY - The docker image reposoitory where the image you want deployed lives. Defaults to the public chainlink ecr.[22m[39m"
+"Missing second argument: adapter
+
+At least 3 arguments are required and 1 optional.
+1: Options are "start" or "stop". In releation to whether you want to start or stop the adapter.
+2: The adapter name you wish to start. Must match an adapter we have built a docker image for.
+3: The unique release tag for this deployment. Use your name if you are running locally or the PR number for CI.
+4: Optional. The docker image tag you wish to deploy. Can also be a sha256 for the image. Defaults to develop-latest.
+There are 3 other variables that can be changed via environment variables. These are:
+HELM_CHART_DIR - The path to the helm chart directory for the adapters. Defaults to the one in this project.
+HELM_VALUES - The path to a helm values file you wish to use to override any default values in the chart
+IMAGE_REPOSITORY - The docker image reposoitory where the image you want deployed lives. Defaults to the public chainlink ecr."
 `;
 
 exports[`Ephemeral Adapters Testing starting and stopping ephemeral adapters should throw if we an empty string for the third argument 1`] = `
-"[31m[1mMissing third argument: release tag[22m[39m
-[31m[1m[22m[39m
-[31m[1mAt least 3 arguments are required and 1 optional.[22m[39m
-[31m[1m1: Options are \\"start\\" or \\"stop\\". In releation to whether you want to start or stop the adapter.[22m[39m
-[31m[1m2: The adapter name you wish to start. Must match an adapter we have built a docker image for.[22m[39m
-[31m[1m3: The unique release tag for this deployment. Use your name if you are running locally or the PR number for CI.[22m[39m
-[31m[1m4: Optional. The docker image tag you wish to deploy. Can also be a sha256 for the image. Defaults to develop-latest.[22m[39m
-[31m[1mThere are 3 other variables that can be changed via environment variables. These are:[22m[39m
-[31m[1mHELM_CHART_DIR - The path to the helm chart directory for the adapters. Defaults to the one in this project.[22m[39m
-[31m[1mHELM_VALUES - The path to a helm values file you wish to use to override any default values in the chart[22m[39m
-[31m[1mIMAGE_REPOSITORY - The docker image reposoitory where the image you want deployed lives. Defaults to the public chainlink ecr.[22m[39m"
+"Missing third argument: release tag
+
+At least 3 arguments are required and 1 optional.
+1: Options are "start" or "stop". In releation to whether you want to start or stop the adapter.
+2: The adapter name you wish to start. Must match an adapter we have built a docker image for.
+3: The unique release tag for this deployment. Use your name if you are running locally or the PR number for CI.
+4: Optional. The docker image tag you wish to deploy. Can also be a sha256 for the image. Defaults to develop-latest.
+There are 3 other variables that can be changed via environment variables. These are:
+HELM_CHART_DIR - The path to the helm chart directory for the adapters. Defaults to the one in this project.
+HELM_VALUES - The path to a helm values file you wish to use to override any default values in the chart
+IMAGE_REPOSITORY - The docker image reposoitory where the image you want deployed lives. Defaults to the public chainlink ecr."
 `;
 
-exports[`Ephemeral Adapters Testing starting and stopping ephemeral adapters should throw if we do not have a valid action as the first argument 1`] = `"[31m[1mThe first argument must be one of: start, stop[22m[39m"`;
+exports[`Ephemeral Adapters Testing starting and stopping ephemeral adapters should throw if we do not have a valid action as the first argument 1`] = `"The first argument must be one of: start, stop"`;
 
 exports[`Ephemeral Adapters Testing starting and stopping ephemeral adapters should use defaults if minimum viable arguments are passed 1`] = `
-Object {
+{
   "action": "start",
   "adapter": "adapter",
   "helmChartDir": "chainlink/cl-adapter",
+  "helmSecrets": "",
   "helmValuesOverride": "",
   "imageRepository": "795953128386.dkr.ecr.us-west-2.amazonaws.com/adapters/",
   "imageTag": "develop-latest",

--- a/packages/scripts/src/ephemeral-adapters/lib.test.ts
+++ b/packages/scripts/src/ephemeral-adapters/lib.test.ts
@@ -85,6 +85,10 @@ describe('Ephemeral Adapters Testing', () => {
     jest.clearAllMocks()
   })
 
+  afterAll(() => {
+    process.exitCode = 0
+  })
+
   describe('starting and stopping ephemeral adapters', () => {
     it('should generate an expected qa adapter name', async () => {
       const inputs: Inputs = {


### PR DESCRIPTION
## Description

`packages/scripts/src/ephemeral-adapters/lib.test.ts` currently doesn't run on CI and when it's run it fails.

## Changes


1. Set exit code to 0 to prevent the test command from failing when all tests pass.
2. Update snapshot with `FORCE_COLOR=0 yarn test packages/scripts/src/ephemeral-adapters/ -u`.
3. Remove `packages/scripts/src/ephemeral-adapters/` from tests skipped on CI.

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

`packages/scripts/src/ephemeral-adapters/lib.test.ts` now runs and passes on CI:
https://github.com/smartcontractkit/external-adapters-js/actions/runs/14201197279/job/39788850010

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
