### PR TITLE
Fix off-by-one in por-address-list batch size

### DIFF
--- a/.changeset/five-tomatoes-warn.md
+++ b/.changeset/five-tomatoes-warn.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/por-address-list-adapter': minor
+---
+
+Fix off-by-one bug in batch size of address fetching.

--- a/packages/sources/por-address-list/src/transport/addressManager.ts
+++ b/packages/sources/por-address-list/src/transport/addressManager.ts
@@ -29,7 +29,7 @@ export abstract class AddressManager<T> {
     let batchRequests: Promise<T>[] = []
 
     while (totalRequestedAddressesCount < numAddresses.toNumber()) {
-      const nextEndIdx = startIdx.add(batchSize)
+      const nextEndIdx = startIdx.add(batchSize - 1)
       const endIdx = nextEndIdx.gte(numAddresses) ? numAddresses.sub(1) : nextEndIdx
       const batchCall = this.getPoRAddressListCall(startIdx, endIdx, blockTag)
       batchRequests.push(batchCall)

--- a/packages/sources/por-address-list/test/integration/fixtures-api.ts
+++ b/packages/sources/por-address-list/test/integration/fixtures-api.ts
@@ -221,7 +221,6 @@ export const mockBaseContractCallResponseSuccess = (): nock.Scope =>
         request.params[0].to === '0xdd50c053c096cb04a3e3362e2b622529ec5f2e8a' &&
         request.params[0].data === '0xc5f24068' // getWithdrawalQueueLength()
       ) {
-        console.log('getWithdrawalQueueLength')
         return {
           jsonrpc: '2.0',
           id: request.id,
@@ -233,7 +232,6 @@ export const mockBaseContractCallResponseSuccess = (): nock.Scope =>
         request.params[0].data ===
           '0xf3d4902a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006' // getPoRAddressList()
       ) {
-        console.log('getPoRAddressList')
         return {
           jsonrpc: '2.0',
           id: request.id,

--- a/packages/sources/por-address-list/test/unit/utils.test.ts
+++ b/packages/sources/por-address-list/test/unit/utils.test.ts
@@ -132,21 +132,28 @@ describe('address endpoint', () => {
 
       verifyAddressListMatches(result, DEFAULT_EXPECTED_ADDRESSES)
 
+      expect(addressManager.contract.getPoRAddressList).toBeCalledTimes(4)
       expect(addressManager.contract.getPoRAddressList).toHaveBeenNthCalledWith(
         1,
         ethers.BigNumber.from(0),
-        ethers.BigNumber.from(3),
+        ethers.BigNumber.from(2),
         { blockTag: LATEST_BLOCK_NUM - confirmations },
       )
       expect(addressManager.contract.getPoRAddressList).toHaveBeenNthCalledWith(
         2,
-        ethers.BigNumber.from(4),
-        ethers.BigNumber.from(7),
+        ethers.BigNumber.from(3),
+        ethers.BigNumber.from(5),
         { blockTag: LATEST_BLOCK_NUM - confirmations },
       )
       expect(addressManager.contract.getPoRAddressList).toHaveBeenNthCalledWith(
         3,
+        ethers.BigNumber.from(6),
         ethers.BigNumber.from(8),
+        { blockTag: LATEST_BLOCK_NUM - confirmations },
+      )
+      expect(addressManager.contract.getPoRAddressList).toHaveBeenNthCalledWith(
+        4,
+        ethers.BigNumber.from(9),
         ethers.BigNumber.from(DEFAULT_EXPECTED_ADDRESSES.length - 1),
         { blockTag: LATEST_BLOCK_NUM - confirmations },
       )


### PR DESCRIPTION
## Description

The `endIndex` of a `getPoRAddressList` call on the `PoRAddressList` [contract interface](https://smartcontract-it.atlassian.net/wiki/spaces/DEPLOY/pages/590545195/PoR+address+list+interface+proposal) is considered to be **inclusive**.
So when we need to fetch a batch of `batchSize`, we need `endIndex = startIndex + batchSize - 1`.

But the current code in por-address-list external adapter is missing that `- 1`.
And this is also visible in the unit test.

## Changes

1. Add missing `- 1`.
2. Update unit test.
3. Drive-by cleanup: remove accidental debug `console.log` calls added in https://github.com/smartcontractkit/external-adapters-js/pull/3732

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

```
yarn test packages/sources/por-address-list/
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
