### PR TITLE
Test request grouping in polkadot-balance

### DIFF
--- a/packages/sources/polkadot-balance/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/polkadot-balance/test/integration/__snapshots__/adapter.test.ts.snap
@@ -37,3 +37,38 @@ exports[`Balance Endpoint should return success 1`] = `
   },
 }
 `;
+
+exports[`Balance Endpoint should wait for the first group to finish before sending more requests 1`] = `
+{
+  "data": {
+    "result": [
+      {
+        "address": "100000000000000000000000000000000000000000000001",
+        "balance": "11039074987459742",
+      },
+      {
+        "address": "100000000000000000000000000000000000000000000002",
+        "balance": "11040093482701534",
+      },
+      {
+        "address": "100000000000000000000000000000000000000000000003",
+        "balance": "5514630890463855",
+      },
+      {
+        "address": "100000000000000000000000000000000000000000000004",
+        "balance": "11039074987459742",
+      },
+      {
+        "address": "100000000000000000000000000000000000000000000005",
+        "balance": "11040093482701534",
+      },
+    ],
+  },
+  "result": null,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 1659338094909,
+    "providerDataRequestedUnixMs": 1659338094909,
+  },
+}
+`;

--- a/packages/sources/polkadot-balance/test/integration/adapter.test.ts
+++ b/packages/sources/polkadot-balance/test/integration/adapter.test.ts
@@ -1,8 +1,93 @@
+import { sleep } from '@chainlink/external-adapter-framework/util'
 import {
   TestAdapter,
   setEnvVariables,
 } from '@chainlink/external-adapter-framework/util/testing-utils'
 import * as nock from 'nock'
+
+let delayResponse = false
+const resolvers: (() => void)[] = []
+
+const getBalance = async (address: string) => {
+  const mockPolkdotBalanceResponse1 = {
+    toJSON: () => {
+      return {
+        nonce: 0,
+        consumers: 2,
+        providers: 1,
+        sufficients: 0,
+        data: {
+          free: '0x0000000000000000002737faef46c49e',
+          reserved: 0,
+          miscFrozen: '0x0000000000000000002737faef46c49e',
+          feeFrozen: '0x0000000000000000002737faef46c49e',
+        },
+      }
+    },
+  }
+
+  const mockPolkdotBalanceResponse2 = {
+    toJSON: () => {
+      return {
+        nonce: 0,
+        consumers: 2,
+        providers: 1,
+        sufficients: 0,
+        data: {
+          free: '0x0000000000000000002738e81252d2de',
+          reserved: 0,
+          miscFrozen: '0x0000000000000000002738e81252d2de',
+          feeFrozen: '0x0000000000000000002738e81252d2de',
+        },
+      }
+    },
+  }
+
+  const mockPolkdotBalanceResponse3 = {
+    toJSON: () => {
+      return {
+        nonce: 0,
+        consumers: 2,
+        providers: 1,
+        sufficients: 0,
+        data: {
+          free: '0x0000000000000000001397870f4b226f',
+          reserved: 0,
+          miscFrozen: '0x000000000000000000135158a141e105',
+          feeFrozen: '0x000000000000000000135158a141e105',
+        },
+      }
+    },
+  }
+
+  const addressBalanceMap: Record<string, any> = {
+    '13nogjgyJcGQduHt8RtZiKKbt7Uy6py9hv1WMDZWueEcsHdh': mockPolkdotBalanceResponse1,
+    '126rjyDQEJm6V6YPDcN85hJDYraqB6hL9bFsvWLDnM8rLc3J': mockPolkdotBalanceResponse2,
+    '15vJFD1Y8nButjmgjbK5x6SYU2cQnbihM4GgkR5enkwyTVLq': mockPolkdotBalanceResponse3,
+  }
+
+  const delayedAddressBalanceMap: Record<string, any> = {
+    '100000000000000000000000000000000000000000000001': mockPolkdotBalanceResponse1,
+    '100000000000000000000000000000000000000000000002': mockPolkdotBalanceResponse2,
+    '100000000000000000000000000000000000000000000003': mockPolkdotBalanceResponse3,
+    '100000000000000000000000000000000000000000000004': mockPolkdotBalanceResponse1,
+    '100000000000000000000000000000000000000000000005': mockPolkdotBalanceResponse2,
+  }
+
+  if (address in delayedAddressBalanceMap) {
+    const response = delayedAddressBalanceMap[address]
+    if (delayResponse) {
+      return new Promise((resolve) => {
+        resolvers.push(() => {
+          resolve(response)
+        })
+      })
+    }
+    return response
+  }
+
+  return addressBalanceMap[address]
+}
 
 jest.mock('@polkadot/api', () => {
   return {
@@ -14,66 +99,7 @@ jest.mock('@polkadot/api', () => {
         return {
           query: {
             system: {
-              account: function (address: string) {
-                const mockPolkdotBalanceResponse1 = {
-                  toJSON: () => {
-                    return {
-                      nonce: 0,
-                      consumers: 2,
-                      providers: 1,
-                      sufficients: 0,
-                      data: {
-                        free: '0x0000000000000000002737faef46c49e',
-                        reserved: 0,
-                        miscFrozen: '0x0000000000000000002737faef46c49e',
-                        feeFrozen: '0x0000000000000000002737faef46c49e',
-                      },
-                    }
-                  },
-                }
-
-                const mockPolkdotBalanceResponse2 = {
-                  toJSON: () => {
-                    return {
-                      nonce: 0,
-                      consumers: 2,
-                      providers: 1,
-                      sufficients: 0,
-                      data: {
-                        free: '0x0000000000000000002738e81252d2de',
-                        reserved: 0,
-                        miscFrozen: '0x0000000000000000002738e81252d2de',
-                        feeFrozen: '0x0000000000000000002738e81252d2de',
-                      },
-                    }
-                  },
-                }
-                const mockPolkdotBalanceResponse3 = {
-                  toJSON: () => {
-                    return {
-                      nonce: 0,
-                      consumers: 2,
-                      providers: 1,
-                      sufficients: 0,
-                      data: {
-                        free: '0x0000000000000000001397870f4b226f',
-                        reserved: 0,
-                        miscFrozen: '0x000000000000000000135158a141e105',
-                        feeFrozen: '0x000000000000000000135158a141e105',
-                      },
-                    }
-                  },
-                }
-
-                const addressBalanceMap: Record<string, any> = {
-                  '13nogjgyJcGQduHt8RtZiKKbt7Uy6py9hv1WMDZWueEcsHdh': mockPolkdotBalanceResponse1,
-                  '126rjyDQEJm6V6YPDcN85hJDYraqB6hL9bFsvWLDnM8rLc3J': mockPolkdotBalanceResponse2,
-                  '15vJFD1Y8nButjmgjbK5x6SYU2cQnbihM4GgkR5enkwyTVLq': mockPolkdotBalanceResponse3,
-                }
-                return new Promise((resolve) => {
-                  resolve(addressBalanceMap[address])
-                })
-              },
+              account: getBalance,
             },
           },
         }
@@ -91,6 +117,7 @@ describe('Balance Endpoint', () => {
     oldEnv = JSON.parse(JSON.stringify(process.env))
     process.env['RPC_URL'] = 'http://localhost:9091'
     process.env['BACKGROUND_EXECUTE_MS'] = '0'
+    process.env['BATCH_SIZE'] = '2'
     const mockDate = new Date('2022-08-01T07:14:54.909Z')
     spy = jest.spyOn(Date, 'now').mockReturnValue(mockDate.getTime())
 
@@ -136,5 +163,63 @@ describe('Balance Endpoint', () => {
     const response = await testAdapter.request({ addresses: [] })
     expect(response.statusCode).toEqual(400)
     expect(response.json()).toMatchSnapshot()
+  })
+
+  it('should wait for the first group to finish before sending more requests', async () => {
+    delayResponse = true
+
+    const data = {
+      addresses: [
+        {
+          address: '100000000000000000000000000000000000000000000001',
+        },
+        {
+          address: '100000000000000000000000000000000000000000000002',
+        },
+        {
+          address: '100000000000000000000000000000000000000000000003',
+        },
+        {
+          address: '100000000000000000000000000000000000000000000004',
+        },
+        {
+          address: '100000000000000000000000000000000000000000000005',
+        },
+      ],
+    }
+
+    expect(resolvers.length).toBe(0)
+    const responsePromise = testAdapter.request(data)
+
+    await sleep(50)
+    expect(resolvers.length).toBe(2)
+
+    resolvers[0]()
+    resolvers[1]()
+
+    await sleep(50)
+    expect(resolvers.length).toBe(4)
+
+    resolvers[2]()
+    resolvers[3]()
+
+    await sleep(50)
+    expect(resolvers.length).toBe(5)
+
+    // Because BACKGROUND_EXECUTE_MS is set to 0, the background handler will
+    // immediately try to fetch the balance for addresses 1 and 2 again once
+    // it gets the response for address 5 and if that doesn't get a response,
+    // the test framework won't exit. So we disable delayResponse before
+    // resolving the last request.
+    delayResponse = false
+
+    resolvers[4]()
+
+    const response = await responsePromise
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toMatchSnapshot()
+
+    delayResponse = false
+    expect(resolvers.length).toBe(5)
   })
 })


### PR DESCRIPTION
## Description

The polkadot-balance external adapter batches RPCs but this was not tested.
In other EAs, batching refers to putting multiple addresses in a single RPC and
grouping refers to limiting the number of concurrent RPCs to the group size and waiting for the previous group to complete before initiating the next group of RPCs.
But polkadot-balance does not do this kind of batching and refers to grouping as batching.

## Changes

1. Extract the `getBalance` call outside the `jest.mock` call to allow it to refer to the global `delayResponse`.
2. Allow `getBalance` to delay responses and adding resolvers to an array to give the test control over when an RPC resolves.
3. Add an integration test that checks that one batch/group finishes before the next group of RPCs is made.

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

```
yarn test packages/sources/polkadot-balance
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
