### PR TITLE
Use splitArrayIntoChunks in eth-beacon

### DIFF
--- a/.changeset/spicy-bugs-trade.md
+++ b/.changeset/spicy-bugs-trade.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/eth-beacon-adapter': patch
+---
+
+Small refactoring in address batching.

--- a/packages/sources/eth-beacon/src/transport/balance.ts
+++ b/packages/sources/eth-beacon/src/transport/balance.ts
@@ -117,16 +117,12 @@ export class BalanceTransport extends SubscriptionTransport<BalanceTransportType
       const addresses = params.addresses.map(({ address }) => address)
       responses.push(await this.queryBeaconChain(url, addresses, statusList))
     } else {
-      const batchedAddresses: string[][] = []
       // Separate the address set into the specified batch size
       // Add the batches as comma-separated lists to a new list used to make the requests
-      for (let i = 0; i < params.addresses.length / batchSize; i++) {
-        batchedAddresses.push(
-          params.addresses
-            .slice(i * batchSize, i * batchSize + batchSize)
-            .map(({ address }) => address),
-        )
-      }
+      const batchedAddresses = splitArrayIntoChunks(
+        params.addresses.map(({ address }) => address),
+        batchSize,
+      )
 
       const groupSize = this.config.GROUP_SIZE
       const requestGroups = splitArrayIntoChunks(batchedAddresses, groupSize)


### PR DESCRIPTION
## Description

eth-beacon has custom code to group addresses into batches.
But `@chainlink/external-adapter-framework` has a function for that which is already used right below to group batches into groups.

## Changes

Use `splitArrayIntoChunks` to create batches.

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

Covered by existing [integration test](https://github.com/smartcontractkit/external-adapters-js/blob/724302365d21e8eea448357bd92b54f0bf78003a/packages/sources/eth-beacon/test/integration/adapter.test.ts#L170).
```
yarn test packages/sources/eth-beacon
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
