### PR TITLE
Test request grouping in dlc-btc-por

### DIFF
--- a/packages/sources/dlc-btc-por/test/integration/__snapshots__/adapter-rpc-grouping.test.ts.snap
+++ b/packages/sources/dlc-btc-por/test/integration/__snapshots__/adapter-rpc-grouping.test.ts.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`execute por endpoint should wait before sending the next group of RPCs 1`] = `
+{
+  "data": {
+    "result": 60000000.00000001,
+  },
+  "result": 60000000.00000001,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 978347471111,
+    "providerDataRequestedUnixMs": 978347471111,
+  },
+}
+`;

--- a/packages/sources/dlc-btc-por/test/integration/adapter-rpc-grouping.test.ts
+++ b/packages/sources/dlc-btc-por/test/integration/adapter-rpc-grouping.test.ts
@@ -1,0 +1,94 @@
+import {
+  TestAdapter,
+  setEnvVariables,
+} from '@chainlink/external-adapter-framework/util/testing-utils'
+import * as nock from 'nock'
+import { mockBitcoinRPCResponseSuccess } from './fixtures'
+import { ethers } from 'ethers'
+
+jest.mock('ethers', () => {
+  const actualModule = jest.requireActual('ethers')
+  return {
+    ...actualModule,
+    ethers: {
+      ...actualModule.ethers,
+      providers: {
+        JsonRpcProvider: function (): ethers.providers.JsonRpcProvider {
+          return {} as ethers.providers.JsonRpcProvider
+        },
+      },
+      Contract: function () {
+        return {
+          attestorGroupPubKey: jest.fn().mockImplementation(() => {
+            return 'xpub6C1F2SwADP3TNajQjg2PaniEGpZLvWdMiFP8ChPjQBRWD1XUBeMdE4YkQYvnNhAYGoZKfcQbsRCefserB5DyJM7R9VR6ce6vLrXHVfeqyH3'
+          }),
+          getAllDLCs: jest.fn().mockImplementation(() => {
+            return [
+              {
+                uuid: '0x9399fc7c386e7357fc101e638f3e208dcb95fbe06c47e3ff4219d5c726635222',
+                protocolContract: '0x2940FcBb3C32901Df405da0E96fd97D1E2a53f34',
+                timestamp: 0x665f1dd7,
+                valueLocked: 0x01312d00,
+                creator: '0x0DD4f29E21F10cb2E485cf9bDAb9F2dD1f240Bfa',
+                status: 1,
+                fundingTxId: '2d64eefe48cd209c4d549b065d3c04dcb29af57b01ca2a98c24274eae2732029',
+                closingTxId: '',
+                btcFeeRecipient:
+                  '021b34f36d8487ce3a7a6f0124f58854d561cb52077593d1e86973fac0fea1a8b1',
+                btcMintFeeBasisPoints: 0x64,
+                btcRedeemFeeBasisPoints: 0x64,
+                taprootPubKey: 'b362931e3e4cf3cc20f75ae11ff5a4c115ec1548cb5f2c7c48294929f1e8979c',
+              },
+            ]
+          }),
+        }
+      },
+    },
+  }
+})
+
+describe('execute', () => {
+  let spy: jest.SpyInstance
+  let testAdapter: TestAdapter
+  let oldEnv: NodeJS.ProcessEnv
+
+  beforeAll(async () => {
+    oldEnv = JSON.parse(JSON.stringify(process.env))
+
+    process.env.ARBITRUM_RPC_URL = process.env.ARBITRUM_RPC_URL ?? 'http://localhost:8545'
+    process.env.ARBITRUM_CHAIN_ID = process.env.ARBITRUM_CHAIN_ID ?? '11155111'
+    process.env.BITCOIN_NETWORK = process.env.BITCOIN_NETWORK ?? 'mainnet'
+    process.env.BITCOIN_RPC_URL = process.env.BITCOIN_RPC_URL ?? 'http://localhost:8554'
+    process.env.BACKGROUND_EXECUTE_MS = process.env.BACKGROUND_EXECUTE_MS ?? '100'
+    process.env.RETRY = process.env.RETRY ?? '0'
+
+    const mockDate = new Date('2001-01-01T11:11:11.111Z')
+    spy = jest.spyOn(Date, 'now').mockReturnValue(mockDate.getTime())
+
+    const adapter = (await import('./../../src')).adapter
+    adapter.rateLimiting = undefined
+    testAdapter = await TestAdapter.startWithMockedCache(adapter, {
+      testAdapter: {} as TestAdapter<never>,
+    })
+  })
+
+  afterAll(async () => {
+    setEnvVariables(oldEnv)
+    await testAdapter.api.close()
+    nock.restore()
+    nock.cleanAll()
+    spy.mockRestore()
+  })
+
+  describe('por endpoint', () => {
+    it('should return success', async () => {
+      mockBitcoinRPCResponseSuccess()
+      const response = await testAdapter.request({
+        network: 'arbitrum',
+        dlcContract: '0x334d9890b339a1b2e0f592f26b5374e22afdfbdf',
+      })
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toMatchSnapshot()
+    })
+  })
+})

--- a/packages/sources/dlc-btc-por/test/integration/adapter-rpc-grouping.test.ts
+++ b/packages/sources/dlc-btc-por/test/integration/adapter-rpc-grouping.test.ts
@@ -3,8 +3,32 @@ import {
   setEnvVariables,
 } from '@chainlink/external-adapter-framework/util/testing-utils'
 import * as nock from 'nock'
-import { mockBitcoinRPCResponseSuccess } from './fixtures'
+import { mockBitcoinRPCResponseSuccessForTxId } from './fixtures'
 import { ethers } from 'ethers'
+import { sleep } from '@chainlink/external-adapter-framework/util'
+
+const fundingTxIds = [
+  '1d64eefe48cd209c4d549b065d3c04dcb29af57b01ca2a98c24274eae2732029',
+  '2d64eefe48cd209c4d549b065d3c04dcb29af57b01ca2a98c24274eae2732029',
+  '3d64eefe48cd209c4d549b065d3c04dcb29af57b01ca2a98c24274eae2732029',
+]
+
+const getAllDLCs = () => {
+  return fundingTxIds.map((fundingTxId) => ({
+    uuid: '0x9399fc7c386e7357fc101e638f3e208dcb95fbe06c47e3ff4219d5c726635222',
+    protocolContract: '0x2940FcBb3C32901Df405da0E96fd97D1E2a53f34',
+    timestamp: 0x665f1dd7,
+    valueLocked: 0x01312d00,
+    creator: '0x0DD4f29E21F10cb2E485cf9bDAb9F2dD1f240Bfa',
+    status: 1,
+    fundingTxId,
+    closingTxId: '',
+    btcFeeRecipient: '021b34f36d8487ce3a7a6f0124f58854d561cb52077593d1e86973fac0fea1a8b1',
+    btcMintFeeBasisPoints: 0x64,
+    btcRedeemFeeBasisPoints: 0x64,
+    taprootPubKey: 'b362931e3e4cf3cc20f75ae11ff5a4c115ec1548cb5f2c7c48294929f1e8979c',
+  }))
+}
 
 jest.mock('ethers', () => {
   const actualModule = jest.requireActual('ethers')
@@ -22,25 +46,7 @@ jest.mock('ethers', () => {
           attestorGroupPubKey: jest.fn().mockImplementation(() => {
             return 'xpub6C1F2SwADP3TNajQjg2PaniEGpZLvWdMiFP8ChPjQBRWD1XUBeMdE4YkQYvnNhAYGoZKfcQbsRCefserB5DyJM7R9VR6ce6vLrXHVfeqyH3'
           }),
-          getAllDLCs: jest.fn().mockImplementation(() => {
-            return [
-              {
-                uuid: '0x9399fc7c386e7357fc101e638f3e208dcb95fbe06c47e3ff4219d5c726635222',
-                protocolContract: '0x2940FcBb3C32901Df405da0E96fd97D1E2a53f34',
-                timestamp: 0x665f1dd7,
-                valueLocked: 0x01312d00,
-                creator: '0x0DD4f29E21F10cb2E485cf9bDAb9F2dD1f240Bfa',
-                status: 1,
-                fundingTxId: '2d64eefe48cd209c4d549b065d3c04dcb29af57b01ca2a98c24274eae2732029',
-                closingTxId: '',
-                btcFeeRecipient:
-                  '021b34f36d8487ce3a7a6f0124f58854d561cb52077593d1e86973fac0fea1a8b1',
-                btcMintFeeBasisPoints: 0x64,
-                btcRedeemFeeBasisPoints: 0x64,
-                taprootPubKey: 'b362931e3e4cf3cc20f75ae11ff5a4c115ec1548cb5f2c7c48294929f1e8979c',
-              },
-            ]
-          }),
+          getAllDLCs,
         }
       },
     },
@@ -61,6 +67,7 @@ describe('execute', () => {
     process.env.BITCOIN_RPC_URL = process.env.BITCOIN_RPC_URL ?? 'http://localhost:8554'
     process.env.BACKGROUND_EXECUTE_MS = process.env.BACKGROUND_EXECUTE_MS ?? '100'
     process.env.RETRY = process.env.RETRY ?? '0'
+    process.env.BITCOIN_RPC_GROUP_SIZE = '2'
 
     const mockDate = new Date('2001-01-01T11:11:11.111Z')
     spy = jest.spyOn(Date, 'now').mockReturnValue(mockDate.getTime())
@@ -81,12 +88,31 @@ describe('execute', () => {
   })
 
   describe('por endpoint', () => {
-    it('should return success', async () => {
-      mockBitcoinRPCResponseSuccess()
-      const response = await testAdapter.request({
+    it('should wait before sending the next group of RPCs', async () => {
+      const requests = fundingTxIds.map((txid) => mockBitcoinRPCResponseSuccessForTxId(txid))
+
+      const responsePromise = testAdapter.request({
         network: 'arbitrum',
         dlcContract: '0x334d9890b339a1b2e0f592f26b5374e22afdfbdf',
       })
+
+      await requests[0].hasHappenedPromise
+      await sleep(50)
+      expect(requests[0].hasHappened).toBe(true)
+      expect(requests[1].hasHappened).toBe(true)
+      expect(requests[2].hasHappened).toBe(false)
+
+      requests[0].resolve()
+      await sleep(50)
+      expect(requests[2].hasHappened).toBe(false)
+
+      requests[1].resolve()
+      await sleep(50)
+      expect(requests[2].hasHappened).toBe(true)
+
+      requests[2].resolve()
+
+      const response = await responsePromise
       expect(response.statusCode).toBe(200)
       expect(response.json()).toMatchSnapshot()
     })

--- a/packages/sources/dlc-btc-por/test/integration/fixtures.ts
+++ b/packages/sources/dlc-btc-por/test/integration/fixtures.ts
@@ -1,6 +1,20 @@
 import nock from 'nock'
+import { deferredPromise } from '@chainlink/external-adapter-framework/util'
 
-export const mockBitcoinRPCResponseSuccess = (): nock.Scope =>
+type DeferredRequest = {
+  hasHappened: boolean
+  hasHappenedPromise: Promise<void>
+  resolve: () => void
+}
+
+export const mockBitcoinRPCResponseSuccessForTxId = (txid: string): DeferredRequest => {
+  const [waitBeforeResolving, resolve] = deferredPromise()
+  const [hasHappenedPromise, resolveHasHappened] = deferredPromise()
+  const request = {
+    hasHappened: false,
+    hasHappenedPromise,
+    resolve,
+  }
   nock('http://localhost:8554', {
     encodedQueryParams: true,
   })
@@ -8,79 +22,84 @@ export const mockBitcoinRPCResponseSuccess = (): nock.Scope =>
     .post('/', {
       id: 'dlc-btc-por-ea',
       method: 'getrawtransaction',
-      params: ['2d64eefe48cd209c4d549b065d3c04dcb29af57b01ca2a98c24274eae2732029', true, null],
+      params: [txid, true, null],
       jsonrpc: '2.0',
     })
     .reply(
       200,
-      (_, request) => ({
-        result: {
-          txid: '2d64eefe48cd209c4d549b065d3c04dcb29af57b01ca2a98c24274eae2732029',
-          hash: '6ad243335f2fd3fc9a9fbdc22f274dc3b3d7b5d751d7250f6952a4d4195156da',
-          version: 2,
-          size: 265,
-          vsize: 184,
-          weight: 733,
-          locktime: 0,
-          vin: [
-            {
-              txid: 'e0fea50a2612b77636b28eb3bf8c8e28828222b1630781a08fad9ff301f5c686',
-              vout: 0,
-              scriptSig: {
-                asm: '',
-                hex: '',
+      async (_, _request) => {
+        request.hasHappened = true
+        resolveHasHappened()
+        await waitBeforeResolving
+        return {
+          result: {
+            txid,
+            hash: '6ad243335f2fd3fc9a9fbdc22f274dc3b3d7b5d751d7250f6952a4d4195156da',
+            version: 2,
+            size: 265,
+            vsize: 184,
+            weight: 733,
+            locktime: 0,
+            vin: [
+              {
+                txid: 'e0fea50a2612b77636b28eb3bf8c8e28828222b1630781a08fad9ff301f5c686',
+                vout: 0,
+                scriptSig: {
+                  asm: '',
+                  hex: '',
+                },
+                txinwitness: [
+                  '3044022038e610786660d77694446393e2357ac00b112b446695d61ea218d4d203a08a98022042826be31f000e7fbcb0097e9d4cb453c6aa4c7b390d55dbcc7c1039f878d55301',
+                  '023481876b8dce7bb7ce58d0bbe7b13a3973b8c52de6b81bacfe3fb43499b0bea2',
+                ],
+                sequence: 4294967295,
               },
-              txinwitness: [
-                '3044022038e610786660d77694446393e2357ac00b112b446695d61ea218d4d203a08a98022042826be31f000e7fbcb0097e9d4cb453c6aa4c7b390d55dbcc7c1039f878d55301',
-                '023481876b8dce7bb7ce58d0bbe7b13a3973b8c52de6b81bacfe3fb43499b0bea2',
-              ],
-              sequence: 4294967295,
-            },
-          ],
-          vout: [
-            {
-              value: 0.2,
-              n: 0,
-              scriptPubKey: {
-                asm: '1 849ca80d8b8975f263bdd02b1148630c7304690c9aa3125b9de0aeebeaa5cffe',
-                desc: 'rawtr(849ca80d8b8975f263bdd02b1148630c7304690c9aa3125b9de0aeebeaa5cffe)#hfs92zrd',
-                hex: '5120849ca80d8b8975f263bdd02b1148630c7304690c9aa3125b9de0aeebeaa5cffe',
-                address: 'bc1psjw2srvt396lycaa6q43zjrrp3esg6gvn233ykuauzhwh649ellq84v25w',
-                type: 'witness_v1_taproot',
+            ],
+            vout: [
+              {
+                value: 0.2,
+                n: 0,
+                scriptPubKey: {
+                  asm: '1 849ca80d8b8975f263bdd02b1148630c7304690c9aa3125b9de0aeebeaa5cffe',
+                  desc: 'rawtr(849ca80d8b8975f263bdd02b1148630c7304690c9aa3125b9de0aeebeaa5cffe)#hfs92zrd',
+                  hex: '5120849ca80d8b8975f263bdd02b1148630c7304690c9aa3125b9de0aeebeaa5cffe',
+                  address: 'bc1psjw2srvt396lycaa6q43zjrrp3esg6gvn233ykuauzhwh649ellq84v25w',
+                  type: 'witness_v1_taproot',
+                },
               },
-            },
-            {
-              value: 0.002,
-              n: 1,
-              scriptPubKey: {
-                asm: '0 2d2d0c13815a141129c9df2ab9b68344398de74b',
-                desc: 'addr(bc1q95kscyuptg2pz2wfmu4tnd5rgsucme6tpx900g)#dyf9q8ne',
-                hex: '00142d2d0c13815a141129c9df2ab9b68344398de74b',
-                address: 'bc1q95kscyuptg2pz2wfmu4tnd5rgsucme6tpx900g',
-                type: 'witness_v0_keyhash',
+              {
+                value: 0.002,
+                n: 1,
+                scriptPubKey: {
+                  asm: '0 2d2d0c13815a141129c9df2ab9b68344398de74b',
+                  desc: 'addr(bc1q95kscyuptg2pz2wfmu4tnd5rgsucme6tpx900g)#dyf9q8ne',
+                  hex: '00142d2d0c13815a141129c9df2ab9b68344398de74b',
+                  address: 'bc1q95kscyuptg2pz2wfmu4tnd5rgsucme6tpx900g',
+                  type: 'witness_v0_keyhash',
+                },
               },
-            },
-            {
-              value: 0.00792272,
-              n: 2,
-              scriptPubKey: {
-                asm: '0 05b8d44eb1d67d47192c6168a24cb4e5b5a7b438',
-                desc: 'addr(bc1qqkudgn436e75wxfvv952yn95uk660dpc7ve7vq)#qux6ypdg',
-                hex: '001405b8d44eb1d67d47192c6168a24cb4e5b5a7b438',
-                address: 'bc1qqkudgn436e75wxfvv952yn95uk660dpc7ve7vq',
-                type: 'witness_v0_keyhash',
+              {
+                value: 0.00792272,
+                n: 2,
+                scriptPubKey: {
+                  asm: '0 05b8d44eb1d67d47192c6168a24cb4e5b5a7b438',
+                  desc: 'addr(bc1qqkudgn436e75wxfvv952yn95uk660dpc7ve7vq)#qux6ypdg',
+                  hex: '001405b8d44eb1d67d47192c6168a24cb4e5b5a7b438',
+                  address: 'bc1qqkudgn436e75wxfvv952yn95uk660dpc7ve7vq',
+                  type: 'witness_v0_keyhash',
+                },
               },
-            },
-          ],
-          hex: '0200000000010186c6f501f39fad8fa0810763b1228282288e8cbfb38eb23676b712260aa5fee00000000000ffffffff03002d310100000000225120849ca80d8b8975f263bdd02b1148630c7304690c9aa3125b9de0aeebeaa5cffe400d0300000000001600142d2d0c13815a141129c9df2ab9b68344398de74bd0160c000000000016001405b8d44eb1d67d47192c6168a24cb4e5b5a7b43802473044022038e610786660d77694446393e2357ac00b112b446695d61ea218d4d203a08a98022042826be31f000e7fbcb0097e9d4cb453c6aa4c7b390d55dbcc7c1039f878d5530121023481876b8dce7bb7ce58d0bbe7b13a3973b8c52de6b81bacfe3fb43499b0bea200000000',
-          blockhash: '000000000000000000014cd79802b29c1dcd7fc6debee1e3968cfc216b59bf16',
-          confirmations: 360,
-          time: 1717510168,
-          blocktime: 1717510168,
-        },
-        error: null,
-        id: null,
-      }),
+            ],
+            hex: '0200000000010186c6f501f39fad8fa0810763b1228282288e8cbfb38eb23676b712260aa5fee00000000000ffffffff03002d310100000000225120849ca80d8b8975f263bdd02b1148630c7304690c9aa3125b9de0aeebeaa5cffe400d0300000000001600142d2d0c13815a141129c9df2ab9b68344398de74bd0160c000000000016001405b8d44eb1d67d47192c6168a24cb4e5b5a7b43802473044022038e610786660d77694446393e2357ac00b112b446695d61ea218d4d203a08a98022042826be31f000e7fbcb0097e9d4cb453c6aa4c7b390d55dbcc7c1039f878d5530121023481876b8dce7bb7ce58d0bbe7b13a3973b8c52de6b81bacfe3fb43499b0bea200000000',
+            blockhash: '000000000000000000014cd79802b29c1dcd7fc6debee1e3968cfc216b59bf16',
+            confirmations: 360,
+            time: 1717510168,
+            blocktime: 1717510168,
+          },
+          error: null,
+          id: null,
+        }
+      },
       [
         'Content-Type',
         'application/json',
@@ -93,3 +112,10 @@ export const mockBitcoinRPCResponseSuccess = (): nock.Scope =>
       ],
     )
     .persist()
+  return request
+}
+
+export const mockBitcoinRPCResponseSuccess = (): void =>
+  mockBitcoinRPCResponseSuccessForTxId(
+    '2d64eefe48cd209c4d549b065d3c04dcb29af57b01ca2a98c24274eae2732029',
+  ).resolve()


### PR DESCRIPTION
## Description

dlc-btc-por uses request grouping for the `getrawtransaction` calls to limit the number of concurrent RPCs.
This was not tested.

Reviewing note: adapter.test.ts was copied without changes in the first commit, to make reviewing the difference between adapter.test.ts and adapter-rpc-grouping.test.ts easier.

## Changes

1. Copy `adapter.test.ts` to `adapter-rpc-grouping.test.ts`.
2. Add `mockBitcoinRPCResponseSuccessForTxId` to support mocking multiple transactions and the control when the responses resolve.
3. Change `adapter-rpc-grouping.test.ts` to test that the second group of RPCs is only made once the first group resolves.


## Steps to Test

```
yarn test packages/sources/dlc-btc-por/
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
