### PR TITLE
Fix getPoRAddressListCall signature

### DIFF
--- a/.changeset/happy-cameras-wash.md
+++ b/.changeset/happy-cameras-wash.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/por-address-list-adapter': patch
+---
+
+Fix TypeScript function signature of AddressManager.getPoRAddressListCall

--- a/packages/sources/por-address-list/src/transport/addressManager.ts
+++ b/packages/sources/por-address-list/src/transport/addressManager.ts
@@ -54,14 +54,18 @@ export abstract class AddressManager<T> {
     return addresses
   }
 
-  abstract getPoRAddressListCall(start: ethers.BigNumber, end: number, blockTag: number): Promise<T>
+  abstract getPoRAddressListCall(
+    start: ethers.BigNumber,
+    end: ethers.BigNumber,
+    blockTag: number,
+  ): Promise<T>
 
   abstract processPoRAddressList(result: T[], network: string, chainId: string): PoRAddress[]
 }
 
 type DefaultAddressManagerResponseType = string[]
 export class DefaultAddressManager extends AddressManager<DefaultAddressManagerResponseType> {
-  getPoRAddressListCall(start: ethers.BigNumber, end: number, blockTag: number) {
+  getPoRAddressListCall(start: ethers.BigNumber, end: ethers.BigNumber, blockTag: number) {
     return this.contract.getPoRAddressList(start, end, { blockTag })
   }
 
@@ -83,7 +87,7 @@ export class DefaultAddressManager extends AddressManager<DefaultAddressManagerR
 
 type LombardAddressManagerResponseType = string[][]
 export class LombardAddressManager extends AddressManager<LombardAddressManagerResponseType> {
-  getPoRAddressListCall(start: ethers.BigNumber, end: number, blockTag: number) {
+  getPoRAddressListCall(start: ethers.BigNumber, end: ethers.BigNumber, blockTag: number) {
     return this.contract.getPoRAddressSignatureMessages(start.toNumber(), end, { blockTag })
   }
 

--- a/packages/sources/por-address-list/src/transport/multichainAddress.ts
+++ b/packages/sources/por-address-list/src/transport/multichainAddress.ts
@@ -132,7 +132,7 @@ export class AddressTransport extends SubscriptionTransport<AddressTransportType
 }
 
 class MultiAddressManager extends AddressManager<ResponseSchema[]> {
-  getPoRAddressListCall(start: ethers.BigNumber, end: number, blockTag: number) {
+  getPoRAddressListCall(start: ethers.BigNumber, end: ethers.BigNumber, blockTag: number) {
     return this.contract.getPoRAddressList(start, end, { blockTag })
   }
 


### PR DESCRIPTION
## Description

In por-address-list, the second parameter of `getPoRAddressListCall` (`end`) is declared as `number` but everywhere it's treated as `ethers.BigNumber`.
I'm not sure why this didn't cause a compiler error.
I tried reproducing it in a smaller case but then the compiler does complain.

I ran into this when trying to refactor the code and suddenly the compiler wasn't happy with the type.

## Changes

Fix the type of `end` to the correct type of `ethers.BigNumber`.

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

It doesn't change the resulting JS and it still (now correctly) compiles.

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
