### PR TITLE
Compile tests on CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -51,6 +51,27 @@ jobs:
         id: changed-adapters
         run: ./.github/scripts/changed-adapters.sh
 
+  # Check that there are no compilation errors in test.
+  # There are many existing test with compilation errors, so we skip them
+  # until we can fix them.
+  compile-tests:
+    name: Compile tests
+    runs-on: [ubuntu-latest]
+    needs:
+      - check-changesets
+      - install-packages
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set up and install dependencies
+        uses: ./.github/actions/setup
+      - name: Compile tests
+        run: |
+          ls packages/*/*/tsconfig.test.json |
+            grep -v -E \
+              '/composites/dydx-rewards/|/composites/glv-token/|/composites/gm-token/|/core/bootstrap/|/sources/aleno/|/sources/bitgo-reserves-test/|/sources/bitgo-reserves/|/sources/coinpaprika/|/sources/cryptocompare/|/sources/dlc-btc-por/|/sources/eth-beacon/|/sources/icap/|/sources/ipfs/|/sources/layer2-sequencer-health/|/sources/por-address-list/|/sources/s3-csv-reader/|/sources/stader-balance/|/sources/token-balance/|/sources/view-function-multi-chain/' |
+            xargs yarn tsc -b --noEmit
+
   # ---------- Adapter checks (only for changed EAs) ----------
 
   # Run unit tests


### PR DESCRIPTION
## Description

I discovered that there are a lot of tests that don't pass the compiler.
The tests might still be able to run but being able to compile tests can help uncover issues so it's useful to keep tests in a compiling state.

## Changes

1. Add a step to CI to check that all tests compile.
2. Exclude packages that currently have tests that don't compile.

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

I left out one package with failing tests to verify that it would be caught correctly:

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
