### PR TITLE
Fix compilation errors in stader-balace test

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -73,7 +73,17 @@ jobs:
       - name: Compile tests
         env:
           CHANGED_PACKAGES: ${{ needs.install-packages.outputs.changed-packages }}
-        run: yarn tsc -b --noEmit $(echo $CHANGED_PACKAGES | jq '.[].location + "/tsconfig.test.json"' -r | grep -v -E '/composites/dydx-rewards/|/composites/glv-token/|/composites/gm-token/|/core/bootstrap/|/sources/aleno/|/sources/bitgo-reserves-test/|/sources/bitgo-reserves/|/sources/coinpaprika/|/sources/cryptocompare/|/sources/dlc-btc-por/|/sources/eth-beacon/|/sources/icap/|/sources/ipfs/|/sources/layer2-sequencer-health/|/sources/por-address-list/|/sources/s3-csv-reader/|/sources/stader-balance/|/sources/token-balance/|/sources/view-function-multi-chain/|sources/view-function/')
+          FAILING_TESTS_PATTERN: '/composites/dydx-rewards/|/composites/glv-token/|/composites/gm-token/|/core/bootstrap/|/sources/aleno/|/sources/bitgo-reserves-test/|/sources/bitgo-reserves/|/sources/coinpaprika/|/sources/cryptocompare/|/sources/dlc-btc-por/|/sources/eth-beacon/|/sources/icap/|/sources/ipfs/|/sources/layer2-sequencer-health/|/sources/por-address-list/|/sources/s3-csv-reader/|/sources/token-balance/|/sources/view-function-multi-chain/|sources/view-function/'
+        run: |
+          # Tests that should compile:
+          yarn tsc -b --noEmit $(echo $CHANGED_PACKAGES | jq '.[].location + "/tsconfig.test.json"' -r | grep -v -E "$FAILING_TESTS_PATTERN")
+          # Tests that should not compile:
+          for package in $(echo "$CHANGED_PACKAGES" | jq '.[].location + "/"' -r | grep -E "$FAILING_TESTS_PATTERN"); do
+            if yarn tsc -b --noEmit "${package}tsconfig.test.json"; then
+              echo "Compilation succeeded for $package. Remove it from FAILING_TESTS_PATTERN so it doesn't break again in the future."
+              exit 1
+            fi
+          done
 
   # Run unit tests
   unit-tests:

--- a/packages/sources/stader-balance/test/integration/adapter.test.ts
+++ b/packages/sources/stader-balance/test/integration/adapter.test.ts
@@ -1,3 +1,4 @@
+import type BigNumber from 'bignumber.js'
 import {
   addressData,
   mockCollateralEthMap,
@@ -17,11 +18,16 @@ import {
 import { deferredPromise, sleep } from '@chainlink/external-adapter-framework/util'
 import * as nock from 'nock'
 
-const totalPenaltyAmountCalls = {}
+type TotalPenaltyAmountCall = {
+  resolve: () => void
+  promise: Promise<BigNumber>
+}
 
-const getTotalPenaltyAmount = (address) => {
+const totalPenaltyAmountCalls: Record<string, TotalPenaltyAmountCall> = {}
+
+const getTotalPenaltyAmount = (address: string) => {
   if (!(address in totalPenaltyAmountCalls)) {
-    const [promise, resolve] = deferredPromise()
+    const [promise, resolve] = deferredPromise<BigNumber>()
     totalPenaltyAmountCalls[address] = {
       resolve: () => resolve(mockPenaltyMap[address]),
       promise,


### PR DESCRIPTION
## Description

https://github.com/smartcontractkit/external-adapters-js/pull/3779 introduced some compilation errors in the test.
These weren't caught because tests are not compiled on CI and the errors didn't prevent the test from running.
https://github.com/smartcontractkit/external-adapters-js/pull/3785 makes sure tests are now compiled on CI.
This PR fixes the compilation errors and also makes sure that the whitelist of broken tests is updated when tests are fixed.

## Changes

1. Fix type errors in `packages/sources/stader-balance/test/integration/adapter.test.ts`.
2. Add CI check that tests that are expected to fail, do indeed fail.
3. Update whitelist to remove `stader-balance`.

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

```
yarn tsc -b --noEmit packages/sources/stader-balance/tsconfig.test.json 
```

Also tested that the workflow requires that packages in the `FAILING_TESTS_PATTERN` are indeed failing:
https://github.com/smartcontractkit/external-adapters-js/actions/runs/14329992738/job/40163759935

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
