### PR TITLE
Fix recently introduced test compilation issues

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Compile tests
         env:
           CHANGED_PACKAGES: ${{ needs.install-packages.outputs.changed-packages }}
-          FAILING_TESTS_PATTERN: '/composites/dydx-rewards/|/composites/glv-token/|/composites/gm-token/|/core/bootstrap/|/sources/aleno/|/sources/bitgo-reserves-test/|/sources/bitgo-reserves/|/sources/coinpaprika/|/sources/cryptocompare/|/sources/dlc-btc-por/|/sources/eth-beacon/|/sources/icap/|/sources/ipfs/|/sources/layer2-sequencer-health/|/sources/por-address-list/|/sources/s3-csv-reader/|/sources/token-balance/|/sources/view-function-multi-chain/|sources/view-function/'
+          FAILING_TESTS_PATTERN: '/composites/dydx-rewards/|/composites/glv-token/|/composites/gm-token/|/core/bootstrap/|/sources/aleno/|/sources/bitgo-reserves-test/|/sources/bitgo-reserves/|/sources/coinpaprika/|/sources/cryptocompare/|/sources/icap/|/sources/ipfs/|/sources/layer2-sequencer-health/|/sources/por-address-list/|/sources/s3-csv-reader/|/sources/token-balance/|/sources/view-function-multi-chain/|sources/view-function/'
         run: |
           # Tests that should compile:
           yarn tsc -b --noEmit $(echo $CHANGED_PACKAGES | jq '.[].location + "/tsconfig.test.json"' -r | grep -v -E "$FAILING_TESTS_PATTERN")

--- a/packages/sources/dlc-btc-por/test/integration/fixtures.ts
+++ b/packages/sources/dlc-btc-por/test/integration/fixtures.ts
@@ -8,8 +8,8 @@ type DeferredRequest = {
 }
 
 export const mockBitcoinRPCResponseSuccessForTxId = (txid: string): DeferredRequest => {
-  const [waitBeforeResolving, resolve] = deferredPromise()
-  const [hasHappenedPromise, resolveHasHappened] = deferredPromise()
+  const [waitBeforeResolving, resolve] = deferredPromise<void>()
+  const [hasHappenedPromise, resolveHasHappened] = deferredPromise<void>()
   const request = {
     hasHappened: false,
     hasHappenedPromise,

--- a/packages/sources/eth-beacon/test/integration/fixtures.ts
+++ b/packages/sources/eth-beacon/test/integration/fixtures.ts
@@ -1,3 +1,4 @@
+import { deferredPromise } from '@chainlink/external-adapter-framework/util'
 import nock from 'nock'
 
 export const mockBalanceSuccess = (): nock.Scope =>
@@ -200,22 +201,21 @@ export const mockBalanceLimboValidator = (): void => {
     .persist()
 }
 
+type DeferredRequest = {
+  hasHappened: boolean
+  resolve: () => void
+}
+
 // Mocks responses for the given addresses, batched into batches of 3.
 // Returns an array of request objects which can be used to check if the
 // request has happened and to resolve the request.
-export const mockBalanceBatchedAddresses = (addresses: string[]): void => {
+export const mockBalanceBatchedAddresses = (addresses: string[]): DeferredRequest[] => {
   const batchSize = 3
-  const requests: {
-    hasHappened: boolean
-    resolve: () => void
-  }[] = []
+  const requests: DeferredRequest[] = []
 
-  const mockAddresses = (startIndex, endIndex) => {
+  const mockAddresses = (startIndex: number, endIndex: number) => {
     const addressesToMock = addresses.slice(startIndex, endIndex)
-    let resolve
-    const waitBeforeResolving = new Promise((r) => {
-      resolve = r
-    })
+    const [waitBeforeResolving, resolve] = deferredPromise<void>()
     const request = {
       hasHappened: false,
       resolve,

--- a/packages/sources/por-address-list/test/unit/utils.test.ts
+++ b/packages/sources/por-address-list/test/unit/utils.test.ts
@@ -165,7 +165,7 @@ describe('address endpoint', () => {
         new ethers.providers.JsonRpcProvider(),
       )
 
-      const resolvers = []
+      const resolvers: (() => void)[] = []
       const getAddressesDelayed = (startIdx: ethers.BigNumber, endIdx: ethers.BigNumber) => {
         const answer = getAddresses(startIdx, endIdx)
         return new Promise((resolve) => {


### PR DESCRIPTION
## Description

In recent PRs (https://github.com/smartcontractkit/external-adapters-js/pull/3780, https://github.com/smartcontractkit/external-adapters-js/pull/3771, and https://github.com/smartcontractkit/external-adapters-js/pull/3769) I introduced some test compilation issues which weren't caught because test weren't compiled on CI.
Since https://github.com/smartcontractkit/external-adapters-js/pull/3785 tests for some packages are now compiled on CI.

## Changes

1. Fix the issues that I recently introduced.
2. Remove `dlc-btc-por` and `eth-beacon` from the packages that are not compiled on CI. There are still some issues left in `por-address-list` which I didn't introduce (I'll need to have another look) so I couldn't remove it yet.

## Steps to Test

```
yarn tsc -b --noEmit packages/sources/dlc-btc-por/tsconfig.test.json
yarn tsc -b --noEmit packages/sources/eth-beacon/tsconfig.test.json
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
