### PR TITLE
Use GroupRunner in por-address-list

### DIFF
--- a/.changeset/fresh-turkeys-sniff.md
+++ b/.changeset/fresh-turkeys-sniff.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/por-address-list-adapter': patch
+---
+
+Refactor how RPCs are grouped


### PR DESCRIPTION
## Description

There are several places in `external-adapters-js` where we group RPCs to limit the number of concurrent RPCs and they all implement it in different ways.
[GroupRunner](https://github.com/smartcontractkit/ea-framework-js/pull/457) was created to standardize this.
This PR uses `GroupRunner` to replace custom code in `por-address-list` to limit concurrent RPCs.

## Changes

1. Replace custom RPC grouping in `por-address-list` with using `GroupRunner`.

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

```
yarn test packages/sources/por-address-list
```
Relevant test coverage was added in https://github.com/smartcontractkit/external-adapters-js/pull/3769

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
