### PR TITLE
Fail workflow if test compilation fails

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -76,6 +76,7 @@ jobs:
           FAILING_TESTS_PATTERN: '/composites/dydx-rewards/|/composites/glv-token/|/composites/gm-token/|/core/bootstrap/|/sources/aleno/|/sources/bitgo-reserves-test/|/sources/bitgo-reserves/|/sources/coinpaprika/|/sources/cryptocompare/|/sources/icap/|/sources/ipfs/|/sources/layer2-sequencer-health/|/sources/por-address-list/|/sources/s3-csv-reader/|/sources/token-balance/|/sources/view-function-multi-chain/|sources/view-function/'
         run: |
           set -ex
+          yarn tsc --version
           # Tests that should compile:
           yarn tsc -b --noEmit $(echo $CHANGED_PACKAGES | jq '.[].location + "/tsconfig.test.json"' -r | grep -v -E "$FAILING_TESTS_PATTERN")
           # Tests that should not compile:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -75,6 +75,7 @@ jobs:
           CHANGED_PACKAGES: ${{ needs.install-packages.outputs.changed-packages }}
           FAILING_TESTS_PATTERN: '/composites/dydx-rewards/|/composites/glv-token/|/composites/gm-token/|/core/bootstrap/|/sources/aleno/|/sources/bitgo-reserves-test/|/sources/bitgo-reserves/|/sources/coinpaprika/|/sources/cryptocompare/|/sources/icap/|/sources/ipfs/|/sources/layer2-sequencer-health/|/sources/por-address-list/|/sources/s3-csv-reader/|/sources/token-balance/|/sources/view-function-multi-chain/|sources/view-function/'
         run: |
+          set -ex
           # Tests that should compile:
           yarn tsc -b --noEmit $(echo $CHANGED_PACKAGES | jq '.[].location + "/tsconfig.test.json"' -r | grep -v -E "$FAILING_TESTS_PATTERN")
           # Tests that should not compile:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -75,8 +75,8 @@ jobs:
           CHANGED_PACKAGES: ${{ needs.install-packages.outputs.changed-packages }}
           FAILING_TESTS_PATTERN: '/composites/dydx-rewards/|/composites/glv-token/|/composites/gm-token/|/core/bootstrap/|/sources/aleno/|/sources/bitgo-reserves-test/|/sources/bitgo-reserves/|/sources/coinpaprika/|/sources/cryptocompare/|/sources/icap/|/sources/ipfs/|/sources/layer2-sequencer-health/|/sources/por-address-list/|/sources/s3-csv-reader/|/sources/token-balance/|/sources/view-function-multi-chain/|sources/view-function/'
         run: |
-          set -ex
           yarn tsc --version
+          false
           # Tests that should compile:
           yarn tsc -b --noEmit $(echo $CHANGED_PACKAGES | jq '.[].location + "/tsconfig.test.json"' -r | grep -v -E "$FAILING_TESTS_PATTERN")
           # Tests that should not compile:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -75,6 +75,7 @@ jobs:
           CHANGED_PACKAGES: ${{ needs.install-packages.outputs.changed-packages }}
           FAILING_TESTS_PATTERN: '/composites/dydx-rewards/|/composites/glv-token/|/composites/gm-token/|/core/bootstrap/|/sources/aleno/|/sources/bitgo-reserves-test/|/sources/bitgo-reserves/|/sources/coinpaprika/|/sources/cryptocompare/|/sources/icap/|/sources/ipfs/|/sources/layer2-sequencer-health/|/sources/por-address-list/|/sources/s3-csv-reader/|/sources/token-balance/|/sources/view-function-multi-chain/|sources/view-function/'
         run: |
+          set -e
           # Tests that should compile:
           yarn tsc -b --noEmit $(echo $CHANGED_PACKAGES | jq '.[].location + "/tsconfig.test.json"' -r | grep -v -E "$FAILING_TESTS_PATTERN")
           # Tests that should not compile:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -75,7 +75,6 @@ jobs:
           CHANGED_PACKAGES: ${{ needs.install-packages.outputs.changed-packages }}
           FAILING_TESTS_PATTERN: '/composites/dydx-rewards/|/composites/glv-token/|/composites/gm-token/|/core/bootstrap/|/sources/aleno/|/sources/bitgo-reserves-test/|/sources/bitgo-reserves/|/sources/coinpaprika/|/sources/cryptocompare/|/sources/icap/|/sources/ipfs/|/sources/layer2-sequencer-health/|/sources/por-address-list/|/sources/s3-csv-reader/|/sources/token-balance/|/sources/view-function-multi-chain/|sources/view-function/'
         run: |
-          set -e
           # Tests that should compile:
           yarn tsc -b --noEmit $(echo $CHANGED_PACKAGES | jq '.[].location + "/tsconfig.test.json"' -r | grep -v -E "$FAILING_TESTS_PATTERN")
           # Tests that should not compile:

--- a/packages/core/bootstrap/test/unit/server.test.ts
+++ b/packages/core/bootstrap/test/unit/server.test.ts
@@ -2,8 +2,6 @@ import { AdapterResponse, Execute } from '../../src/types'
 import axios from 'axios'
 import { expose } from '../../src'
 
-// trigger
-
 // Mock metrics since the variable is initialized on import
 jest.mock('../../src/lib/metrics', () => ({
   ...(jest.requireActual('../../src/lib/metrics') as Record<string, unknown>),

--- a/packages/core/bootstrap/test/unit/server.test.ts
+++ b/packages/core/bootstrap/test/unit/server.test.ts
@@ -2,6 +2,8 @@ import { AdapterResponse, Execute } from '../../src/types'
 import axios from 'axios'
 import { expose } from '../../src'
 
+// trigger
+
 // Mock metrics since the variable is initialized on import
 jest.mock('../../src/lib/metrics', () => ({
   ...(jest.requireActual('../../src/lib/metrics') as Record<string, unknown>),

--- a/packages/non-deployable/reduce/test/integration/adapter.test.ts
+++ b/packages/non-deployable/reduce/test/integration/adapter.test.ts
@@ -4,6 +4,7 @@ import { setupExternalAdapterTest } from '@chainlink/ea-test-helpers'
 import type { SuiteContext } from '@chainlink/ea-test-helpers'
 import { SuperTest, Test } from 'supertest'
 
+// trigger
 describe('execute', () => {
   const id = '1'
   const context: SuiteContext = {


### PR DESCRIPTION
## Description

In http://github.com/smartcontractkit/external-adapters-js/actions/runs/14356649047/job/40247734286 there were test compilation issues, but the workflow passed anyway.
This is because the step runs [multiple commands](https://github.com/smartcontractkit/external-adapters-js/blob/b607cdeb3c319e2c89ef76cdea7a38c587bdb4d4/.github/workflows/checks.yml#L77-L86) and in this case it only fails if the last command fails.
`set -e` makes it fail as soon as any command fails.

## Changes

1. Add `set -e` before compiling tests in the workflow.

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. Steps
3. to
4. test

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
