### PR TITLE
Fix test compilation for aleno

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Compile tests
         env:
           CHANGED_PACKAGES: ${{ needs.install-packages.outputs.changed-packages }}
-          FAILING_TESTS_PATTERN: '/composites/dydx-rewards/|/composites/glv-token/|/composites/gm-token/|/core/bootstrap/|/sources/aleno/|/sources/bitgo-reserves-test/|/sources/bitgo-reserves/|/sources/coinpaprika/|/sources/cryptocompare/|/sources/icap/|/sources/ipfs/|/sources/layer2-sequencer-health/|/sources/por-address-list/|/sources/s3-csv-reader/|/sources/token-balance/|/sources/view-function-multi-chain/|sources/view-function/'
+          FAILING_TESTS_PATTERN: '/composites/dydx-rewards/|/composites/glv-token/|/composites/gm-token/|/core/bootstrap/|/sources/bitgo-reserves-test/|/sources/bitgo-reserves/|/sources/coinpaprika/|/sources/cryptocompare/|/sources/icap/|/sources/ipfs/|/sources/layer2-sequencer-health/|/sources/por-address-list/|/sources/s3-csv-reader/|/sources/token-balance/|/sources/view-function-multi-chain/|sources/view-function/'
         run: |
           # Tests that should compile:
           yarn tsc -b --noEmit $(echo $CHANGED_PACKAGES | jq '.[].location + "/tsconfig.test.json"' -r | grep -v -E "$FAILING_TESTS_PATTERN")

--- a/packages/sources/aleno/test/unit/adapter-socket.test.ts
+++ b/packages/sources/aleno/test/unit/adapter-socket.test.ts
@@ -1,9 +1,9 @@
 import { EndpointContext } from '@chainlink/external-adapter-framework/adapter'
+import { LoggerFactoryProvider } from '@chainlink/external-adapter-framework/util'
+import { InputParameters } from '@chainlink/external-adapter-framework/validation'
+import * as socketIoClient from 'socket.io-client'
 import { SocketServerMock } from 'socket.io-mock-ts'
 import { config } from '../../src/config'
-import { InputParameters } from '@chainlink/external-adapter-framework/validation'
-import { LoggerFactoryProvider } from '@chainlink/external-adapter-framework/util'
-import * as socketIoClient from 'socket.io-client'
 import { type SocketIOTransportTypes, SocketIOTransport } from '../../src/transport/price-socketio'
 
 jest.mock('socket.io-client')

--- a/packages/sources/aleno/test/unit/adapter-socket.test.ts
+++ b/packages/sources/aleno/test/unit/adapter-socket.test.ts
@@ -1,13 +1,24 @@
+import { EndpointContext } from '@chainlink/external-adapter-framework/adapter'
 import { SocketServerMock } from 'socket.io-mock-ts'
 import { config } from '../../src/config'
 import { InputParameters } from '@chainlink/external-adapter-framework/validation'
-import { LoggerFactoryProvider, sleep } from '@chainlink/external-adapter-framework/util'
+import { LoggerFactoryProvider } from '@chainlink/external-adapter-framework/util'
 import * as socketIoClient from 'socket.io-client'
 import { type SocketIOTransportTypes, SocketIOTransport } from '../../src/transport/price-socketio'
 
 jest.mock('socket.io-client')
 
 LoggerFactoryProvider.set()
+
+type SubscribeCallback = (response: {
+  status: string
+  involvedSubscriptions: string[]
+  subscriptionsAfterUpdate: string[]
+}) => void
+type SubscribeCall = {
+  subscriptions: string[]
+  callback: SubscribeCallback
+}
 
 describe('SocketIOTransport', () => {
   const API_TIMEOUT = 30_000
@@ -34,7 +45,7 @@ describe('SocketIOTransport', () => {
     config.initialize()
 
     mockSocket = new SocketServerMock()
-    jest.spyOn(socketIoClient, 'io').mockReturnValue(mockSocket)
+    jest.spyOn(socketIoClient, 'io').mockReturnValue(mockSocket as unknown as socketIoClient.Socket)
   })
 
   it('should connect to endpoint', async () => {
@@ -85,10 +96,12 @@ describe('SocketIOTransport', () => {
   })
 
   it('should not subscribe again without new subscriptions', async () => {
-    const subscribeCalls = []
-    const subscribeSpy = jest.fn().mockImplementation((subscriptions, callback) => {
-      subscribeCalls.push({ subscriptions, callback })
-    })
+    const subscribeCalls: SubscribeCall[] = []
+    const subscribeSpy = jest
+      .fn()
+      .mockImplementation((subscriptions: string[], callback: SubscribeCallback) => {
+        subscribeCalls.push({ subscriptions, callback })
+      })
     mockSocket.clientMock.on('subscribe', subscribeSpy)
 
     const transport = new SocketIOTransport()
@@ -123,7 +136,7 @@ describe('SocketIOTransport', () => {
   })
 
   it('should unsubscribe', async () => {
-    const subscribeCalls = []
+    const subscribeCalls: SubscribeCall[] = []
     const subscribeSpy = jest.fn().mockImplementation((subscriptions, callback) => {
       subscribeCalls.push({ subscriptions, callback })
     })
@@ -169,13 +182,13 @@ describe('SocketIOTransport', () => {
   })
 
   it('should subscribe again after unsubscribe', async () => {
-    const subscribeCalls = []
+    const subscribeCalls: SubscribeCall[] = []
     const subscribeSpy = jest.fn().mockImplementation((subscriptions, callback) => {
       subscribeCalls.push({ subscriptions, callback })
     })
     mockSocket.clientMock.on('subscribe', subscribeSpy)
 
-    const unsubscribeCalls = []
+    const unsubscribeCalls: SubscribeCall[] = []
     const unsubscribeSpy = jest.fn().mockImplementation((subscriptions, callback) => {
       unsubscribeCalls.push({ subscriptions, callback })
     })
@@ -225,7 +238,7 @@ describe('SocketIOTransport', () => {
   })
 
   it('should subscribe and unsubscribe', async () => {
-    const subscribeCalls = []
+    const subscribeCalls: SubscribeCall[] = []
     const subscribeSpy = jest.fn().mockImplementation((subscriptions, callback) => {
       subscribeCalls.push({ subscriptions, callback })
     })
@@ -282,7 +295,7 @@ describe('SocketIOTransport', () => {
   })
 
   it('should subscribe again if previous subscribe call timed out', async () => {
-    const subscribeCalls = []
+    const subscribeCalls: SubscribeCall[] = []
     const subscribeSpy = jest.fn().mockImplementation((subscriptions, callback) => {
       subscribeCalls.push({ subscriptions, callback })
     })
@@ -332,7 +345,7 @@ describe('SocketIOTransport', () => {
   })
 
   it('should resubscribe even if unsubscribe timed out', async () => {
-    const subscribeCalls = []
+    const subscribeCalls: SubscribeCall[] = []
     const subscribeSpy = jest.fn().mockImplementation((subscriptions, callback) => {
       subscribeCalls.push({ subscriptions, callback })
     })


### PR DESCRIPTION
## Description

https://github.com/smartcontractkit/external-adapters-js/pull/3728 added a test which doesn't pass the compiler.
This wasn't caught because tests weren't compiled on CI.
https://github.com/smartcontractkit/external-adapters-js/pull/3785 added test compilation to CI with a whitelist for packages with existing compilation issues.

## Changes

1. Add type annotations to `packages/sources/aleno/test/unit/adapter-socket.test.ts` to make it compile.
2. Remove `/sources/aleno/` from `FAILING_TESTS_PATTERN` to prevent further test compilation errors in the package.

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

```
yarn tsc -b --noEmit packages/sources/aleno/tsconfig.test.json
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
