### PR TITLE
Fix test compilation for token-balance

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Compile tests
         env:
           CHANGED_PACKAGES: ${{ needs.install-packages.outputs.changed-packages }}
-          FAILING_TESTS_PATTERN: '/composites/dydx-rewards/|/composites/glv-token/|/composites/gm-token/|/core/bootstrap/|/sources/bitgo-reserves-test/|/sources/bitgo-reserves/|/sources/coinpaprika/|/sources/cryptocompare/|/sources/icap/|/sources/ipfs/|/sources/layer2-sequencer-health/|/sources/por-address-list/|/sources/s3-csv-reader/|/sources/token-balance/|/sources/view-function-multi-chain/|sources/view-function/'
+          FAILING_TESTS_PATTERN: '/composites/dydx-rewards/|/composites/glv-token/|/composites/gm-token/|/core/bootstrap/|/sources/bitgo-reserves-test/|/sources/bitgo-reserves/|/sources/coinpaprika/|/sources/cryptocompare/|/sources/icap/|/sources/ipfs/|/sources/layer2-sequencer-health/|/sources/por-address-list/|/sources/s3-csv-reader/|/sources/view-function-multi-chain/|sources/view-function/'
         run: |
           # Tests that should compile:
           yarn tsc -b --noEmit $(echo $CHANGED_PACKAGES | jq '.[].location + "/tsconfig.test.json"' -r | grep -v -E "$FAILING_TESTS_PATTERN")

--- a/packages/sources/token-balance/test/integration/fixtures.ts
+++ b/packages/sources/token-balance/test/integration/fixtures.ts
@@ -3,8 +3,7 @@ import nock from 'nock'
 type JsonRpcPayload = {
   id: number
   method: string
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  params: Array<any> | Record<string, any>
+  params: Array<{ to: string; data: string }>
   jsonrpc: '2.0'
 }
 
@@ -13,7 +12,7 @@ export const mockETHMainnetContractCallResponseSuccess = (): nock.Scope =>
     .post('/', (body: any) => Array.isArray(body))
     .reply(
       200,
-      (uri, requestBody: any[]) => {
+      (_uri, requestBody: any[]) => {
         return requestBody.map((request: JsonRpcPayload) => {
           if (request.method === 'eth_chainId') {
             return {
@@ -83,7 +82,7 @@ export const mockBASEMainnetContractCallResponseSuccess = (): nock.Scope =>
     .post('/', (body: any) => Array.isArray(body))
     .reply(
       200,
-      (uri, requestBody: any[]) => {
+      (_uri, requestBody: any[]) => {
         return requestBody.map((request: JsonRpcPayload) => {
           if (request.method === 'eth_chainId') {
             return {
@@ -141,7 +140,7 @@ export const mockETHContractCallResponseSuccess = (): nock.Scope =>
     .post('/', (body: any) => Array.isArray(body))
     .reply(
       200,
-      (uri, requestBody: any[]) => {
+      (_uri, requestBody: any[]) => {
         return requestBody.map((request: JsonRpcPayload) => {
           if (request.method === 'eth_chainId') {
             return {


### PR DESCRIPTION
## Description

When making changes to `token-balance` it's useful to be able to compile the test and see if any error were introduced.
This is made difficult by existing error.

## Changes

1. Fix existing compilation errors in `token-balance` tests.
2. Include `token-balance` in test compilation CI workflow.

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

```
yarn tsc -b --noEmit packages/sources/token-balance/tsconfig.test.json
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
