### PR TITLE
Add missing tsconfig.test.json

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -76,9 +76,14 @@ jobs:
           FAILING_TESTS_PATTERN: '/composites/dydx-rewards/|/composites/glv-token/|/composites/gm-token/|/core/bootstrap/|/sources/bitgo-reserves-test/|/sources/bitgo-reserves/|/sources/coinpaprika/|/sources/cryptocompare/|/sources/icap/|/sources/ipfs/|/sources/layer2-sequencer-health/|/sources/por-address-list/|/sources/s3-csv-reader/|/sources/view-function-multi-chain/|sources/view-function/|/k6/|/observation/'
         run: |
           set -x
-          # Tests that should compile:
-          yarn tsc -b --noEmit $(echo $CHANGED_PACKAGES | jq '.[].location + "/tsconfig.test.json"' -r | grep -v -E "$FAILING_TESTS_PATTERN")
-          # Tests that should not compile:
+          echo "Tests that should compile:"
+          for package in $(echo "$CHANGED_PACKAGES" | jq '.[].location + "/"' -r | grep -v -E "\\.|$FAILING_TESTS_PATTERN"); do
+            if ! yarn tsc -b --noEmit "${package}tsconfig.test.json"; then
+              echo "Compilation failed for $package."
+              exit 1
+            fi
+          done
+          echo "Tests that should not compile:"
           for package in $(echo "$CHANGED_PACKAGES" | jq '.[].location + "/"' -r | grep -E "\\.|$FAILING_TESTS_PATTERN"); do
             if yarn tsc -b --noEmit "${package}tsconfig.test.json"; then
               echo "Compilation succeeded for $package. Remove it from FAILING_TESTS_PATTERN so it doesn't break again in the future."

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Compile tests
         env:
           CHANGED_PACKAGES: ${{ needs.install-packages.outputs.changed-packages }}
-          FAILING_TESTS_PATTERN: '/composites/dydx-rewards/|/composites/glv-token/|/composites/gm-token/|/core/bootstrap/|/sources/bitgo-reserves-test/|/sources/bitgo-reserves/|/sources/coinpaprika/|/sources/cryptocompare/|/sources/icap/|/sources/ipfs/|/sources/layer2-sequencer-health/|/sources/por-address-list/|/sources/s3-csv-reader/|/sources/view-function-multi-chain/|sources/view-function/'
+          FAILING_TESTS_PATTERN: '/composites/dydx-rewards/|/composites/glv-token/|/composites/gm-token/|/core/bootstrap/|/sources/bitgo-reserves-test/|/sources/bitgo-reserves/|/sources/coinpaprika/|/sources/cryptocompare/|/sources/icap/|/sources/ipfs/|/sources/layer2-sequencer-health/|/sources/por-address-list/|/sources/s3-csv-reader/|/sources/view-function-multi-chain/|sources/view-function/|/k6/|/observation/'
         run: |
           # Tests that should compile:
           yarn tsc -b --noEmit $(echo $CHANGED_PACKAGES | jq '.[].location + "/tsconfig.test.json"' -r | grep -v -E "$FAILING_TESTS_PATTERN")

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -75,7 +75,6 @@ jobs:
           CHANGED_PACKAGES: ${{ needs.install-packages.outputs.changed-packages }}
           FAILING_TESTS_PATTERN: '/composites/dydx-rewards/|/composites/glv-token/|/composites/gm-token/|/core/bootstrap/|/sources/bitgo-reserves-test/|/sources/bitgo-reserves/|/sources/coinpaprika/|/sources/cryptocompare/|/sources/icap/|/sources/ipfs/|/sources/layer2-sequencer-health/|/sources/por-address-list/|/sources/s3-csv-reader/|/sources/view-function-multi-chain/|sources/view-function/|/k6/|/observation/'
         run: |
-          set -x
           echo "Tests that should compile:"
           for package in $(echo "$CHANGED_PACKAGES" | jq '.[].location + "/"' -r | grep -v -E "\\.|$FAILING_TESTS_PATTERN"); do
             if ! yarn tsc -b --noEmit "${package}tsconfig.test.json"; then

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -75,6 +75,7 @@ jobs:
           CHANGED_PACKAGES: ${{ needs.install-packages.outputs.changed-packages }}
           FAILING_TESTS_PATTERN: '/composites/dydx-rewards/|/composites/glv-token/|/composites/gm-token/|/core/bootstrap/|/sources/bitgo-reserves-test/|/sources/bitgo-reserves/|/sources/coinpaprika/|/sources/cryptocompare/|/sources/icap/|/sources/ipfs/|/sources/layer2-sequencer-health/|/sources/por-address-list/|/sources/s3-csv-reader/|/sources/view-function-multi-chain/|sources/view-function/|/k6/|/observation/'
         run: |
+          set -x
           # Tests that should compile:
           yarn tsc -b --noEmit $(echo $CHANGED_PACKAGES | jq '.[].location + "/tsconfig.test.json"' -r | grep -v -E "$FAILING_TESTS_PATTERN")
           # Tests that should not compile:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -78,7 +78,7 @@ jobs:
           # Tests that should compile:
           yarn tsc -b --noEmit $(echo $CHANGED_PACKAGES | jq '.[].location + "/tsconfig.test.json"' -r | grep -v -E "$FAILING_TESTS_PATTERN")
           # Tests that should not compile:
-          for package in $(echo "$CHANGED_PACKAGES" | jq '.[].location + "/"' -r | grep -E "$FAILING_TESTS_PATTERN"); do
+          for package in $(echo "$CHANGED_PACKAGES" | jq '.[].location + "/"' -r | grep -E "\\.|$FAILING_TESTS_PATTERN"); do
             if yarn tsc -b --noEmit "${package}tsconfig.test.json"; then
               echo "Compilation succeeded for $package. Remove it from FAILING_TESTS_PATTERN so it doesn't break again in the future."
               exit 1

--- a/packages/k6/tsconfig.test.json
+++ b/packages/k6/tsconfig.test.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  }
+}

--- a/packages/observation/tsconfig.test.json
+++ b/packages/observation/tsconfig.test.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  }
+}


### PR DESCRIPTION
## Description

https://github.com/smartcontractkit/external-adapters-js/pull/3785 added a check to compile `tsconfig.test.json` for every changed package.
But when https://github.com/smartcontractkit/external-adapters-js/pull/3801 tried to update the `typescript` dependency, that [check failed](https://github.com/smartcontractkit/external-adapters-js/actions/runs/14407558850/job/40407830282?pr=3801) for 2 packages that don't have a `tsconfig.test.json` file:
* `packages/k6` and
* `packages/observation`.

There was also a bug where it tries to compile `/` if all changed packages are filtered out because they are known to fail.

## Changes

1. Add missing `tsconfig.test.json` file for the 2 packages.
2. Add the packages to the pattern of packages that don't pass test compilation, since both packages have compilation error.
3. Change the compilation for passing packages to a loop, similar to the failing packages, so that it doesn't try to compile anything if there are no eligible packages.

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

The check passed:
https://github.com/smartcontractkit/external-adapters-js/actions/runs/14431484692/job/40466829329

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
