### PR TITLE
Remove '.' from failing tests pattern

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -76,14 +76,14 @@ jobs:
           FAILING_TESTS_PATTERN: '/composites/dydx-rewards/|/composites/glv-token/|/composites/gm-token/|/core/bootstrap/|/sources/bitgo-reserves-test/|/sources/bitgo-reserves/|/sources/coinpaprika/|/sources/cryptocompare/|/sources/icap/|/sources/ipfs/|/sources/layer2-sequencer-health/|/sources/por-address-list/|/sources/s3-csv-reader/|/sources/view-function-multi-chain/|sources/view-function/|/k6/|/observation/'
         run: |
           echo "Tests that should compile:"
-          for package in $(echo "$CHANGED_PACKAGES" | jq '.[].location + "/"' -r | grep -v -E "\\.|$FAILING_TESTS_PATTERN"); do
+          for package in $(echo "$CHANGED_PACKAGES" | jq '.[].location + "/"' -r | grep -v -E "$FAILING_TESTS_PATTERN"); do
             if ! yarn tsc -b --noEmit "${package}tsconfig.test.json"; then
               echo "Compilation failed for $package."
               exit 1
             fi
           done
           echo "Tests that should not compile:"
-          for package in $(echo "$CHANGED_PACKAGES" | jq '.[].location + "/"' -r | grep -E "\\.|$FAILING_TESTS_PATTERN"); do
+          for package in $(echo "$CHANGED_PACKAGES" | jq '.[].location + "/"' -r | grep -E "$FAILING_TESTS_PATTERN"); do
             if yarn tsc -b --noEmit "${package}tsconfig.test.json"; then
               echo "Compilation succeeded for $package. Remove it from FAILING_TESTS_PATTERN so it doesn't break again in the future."
               exit 1


### PR DESCRIPTION
## Description

When I was debugging the failure that I was trying to fix in https://github.com/smartcontractkit/external-adapters-js/pull/3804, I noticed that
```
yarn workspaces list -R --json
```
also includes
```
{"location":".","name":"@chainlink/external-adapters-js"}
```
So I thought maybe the problem was that it was trying to compile `./tsconfig.test.json`.
This turned out not to be the case but I still added `\.` to the pattern of packages not to compile.
Unfortunately I also added it to the pattern of packages that are expected to fail and the dot matches `packages/blockchain.com` which is therefore expected to fail to compile even though it passes.
This resulted in https://github.com/smartcontractkit/external-adapters-js/actions/runs/14432569319/job/40469154882?pr=3801

## Changes

Remove `\.` from the pattern of packages to include/exclude when compiling tests.

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

I added this fix to https://github.com/smartcontractkit/external-adapters-js/pull/3801 and created https://github.com/smartcontractkit/external-adapters-js/pull/3806 where the compilation check passes:
https://github.com/smartcontractkit/external-adapters-js/actions/runs/14432722767/job/40469476900

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
