### PR TITLE
Add grouped RPC provider util to token-balance

### DIFF
--- a/.changeset/chilled-seas-reflect.md
+++ b/.changeset/chilled-seas-reflect.md
@@ -2,4 +2,4 @@
 '@chainlink/token-balance-adapter': patch
 ---
 
-Utility to limit concurrent contract RPC
+Utility to limit concurrent contract RPCs

--- a/.changeset/chilled-seas-reflect.md
+++ b/.changeset/chilled-seas-reflect.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/token-balance-adapter': patch
+---
+
+Utility to limit concurrent contract RPC

--- a/packages/sources/token-balance/src/transport/utils.ts
+++ b/packages/sources/token-balance/src/transport/utils.ts
@@ -1,7 +1,7 @@
-import OpenEdenTBILLProxy from '../config/OpenEdenTBILLProxy.json'
-import EACAggregatorProxy from '../config/EACAggregatorProxy.json'
 import { GroupRunner } from '@chainlink/external-adapter-framework/util/group-runner'
 import { ethers } from 'ethers'
+import EACAggregatorProxy from '../config/EACAggregatorProxy.json'
+import OpenEdenTBILLProxy from '../config/OpenEdenTBILLProxy.json'
 
 export type SharePriceType = {
   value: bigint

--- a/packages/sources/token-balance/src/transport/utils.ts
+++ b/packages/sources/token-balance/src/transport/utils.ts
@@ -1,0 +1,87 @@
+import OpenEdenTBILLProxy from '../config/OpenEdenTBILLProxy.json'
+import EACAggregatorProxy from '../config/EACAggregatorProxy.json'
+import { GroupRunner } from '@chainlink/external-adapter-framework/util/group-runner'
+import { ethers } from 'ethers'
+
+export type SharePriceType = {
+  value: bigint
+  decimal: number
+}
+
+// Wraps a JsonRpcProvider to allow for grouping of requests to limit the
+// number of concurrent requests.
+// Its lifetime should not be longer than the lifetime of a request to the EA.
+export class GroupedProvider {
+  private readonly runner: GroupRunner
+
+  constructor(
+    private readonly provider: ethers.JsonRpcProvider,
+    groupSize: number,
+  ) {
+    this.runner = new GroupRunner(groupSize)
+  }
+
+  createTokenContract(address: string): GroupedTokenContract {
+    return new GroupedTokenContract(address, this.provider, this.runner)
+  }
+
+  createPriceOracleContract(address: string): GroupedPriceOracleContract {
+    return new GroupedPriceOracleContract(address, this.provider, this.runner)
+  }
+}
+
+export class GroupedTokenContract {
+  private readonly contract: ethers.Contract
+
+  constructor(
+    address: string,
+    provider: ethers.JsonRpcProvider,
+    private readonly runner: GroupRunner,
+  ) {
+    this.contract = new ethers.Contract(address, OpenEdenTBILLProxy, provider)
+  }
+
+  async decimals(): Promise<bigint> {
+    return this.runner.run(() => this.contract.decimals())
+  }
+
+  async balanceOf(walletAddress: string): Promise<bigint> {
+    return this.runner.run(() => this.contract.balanceOf(walletAddress))
+  }
+
+  async getWithdrawalQueueLength(): Promise<bigint> {
+    return this.runner.run(() => this.contract.getWithdrawalQueueLength())
+  }
+
+  async getWithdrawalQueueInfo(index: number): Promise<{ shares: bigint }> {
+    return this.runner.run(() => this.contract.getWithdrawalQueueInfo(index))
+  }
+}
+
+export class GroupedPriceOracleContract {
+  private readonly contract: ethers.Contract
+
+  constructor(
+    address: string,
+    provider: ethers.JsonRpcProvider,
+    private readonly runner: GroupRunner,
+  ) {
+    this.contract = new ethers.Contract(address, EACAggregatorProxy, provider)
+  }
+
+  async decimals(): Promise<bigint> {
+    return this.runner.run(() => this.contract.decimals())
+  }
+
+  async latestAnswer(): Promise<bigint> {
+    return this.runner.run(() => this.contract.latestAnswer())
+  }
+
+  async getRate(): Promise<SharePriceType> {
+    const [value, decimal] = await Promise.all([this.latestAnswer(), this.decimals()])
+    return {
+      value,
+      decimal: Number(decimal),
+    }
+  }
+}

--- a/packages/sources/token-balance/src/transport/utils.ts
+++ b/packages/sources/token-balance/src/transport/utils.ts
@@ -14,10 +14,7 @@ export type SharePriceType = {
 export class GroupedProvider {
   private readonly runner: GroupRunner
 
-  constructor(
-    private readonly provider: ethers.JsonRpcProvider,
-    groupSize: number,
-  ) {
+  constructor(private readonly provider: ethers.JsonRpcProvider, groupSize: number) {
     this.runner = new GroupRunner(groupSize)
   }
 

--- a/packages/sources/token-balance/test/unit/utils.test.ts
+++ b/packages/sources/token-balance/test/unit/utils.test.ts
@@ -1,0 +1,264 @@
+import EACAggregatorProxy from '../../src/config/EACAggregatorProxy.json'
+import { deferredPromise } from '@chainlink/external-adapter-framework/util'
+import OpenEdenTBILLProxy from '../../src/config/OpenEdenTBILLProxy.json'
+import { GroupedProvider } from '../../src/transport/utils'
+
+const ethersNewContract = jest.fn()
+
+const makeEthers = () => {
+  return {
+    JsonRpcProvider: jest.fn(),
+    Contract: function (...args) {
+      return ethersNewContract(...args)
+    },
+  }
+}
+
+jest.mock('ethers', () => ({
+  ethers: makeEthers(),
+}))
+
+describe('transport/utils.ts', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    jest.resetAllMocks()
+  })
+
+  describe('GroupedProvider', () => {
+    const mockProvider = {}
+    const groupSize = 3
+    const tokenContractAddress = '0x0123'
+    const priceOracleAddress = '0x4567'
+
+    it('should create a token Contract', () => {
+      const groupedProvider = new GroupedProvider(mockProvider, groupSize)
+
+      expect(ethersNewContract).toBeCalledTimes(0)
+
+      groupedProvider.createTokenContract(tokenContractAddress)
+
+      expect(ethersNewContract).toBeCalledWith(
+        tokenContractAddress,
+        OpenEdenTBILLProxy,
+        mockProvider,
+      )
+      expect(ethersNewContract).toBeCalledTimes(1)
+    })
+
+    it('should call decimals on a token Contract', async () => {
+      const groupedProvider = new GroupedProvider(mockProvider, groupSize)
+      const decimals = 12n
+      const mockTokenContract = {
+        decimals: jest.fn().mockResolvedValue(decimals),
+      }
+      ethersNewContract.mockReturnValueOnce(mockTokenContract)
+      const groupedTokenContract = groupedProvider.createTokenContract(tokenContractAddress)
+
+      expect(await groupedTokenContract.decimals()).toBe(decimals)
+      expect(mockTokenContract.decimals).toBeCalledTimes(1)
+    })
+
+    it('should call balanceOf on a token Contract', async () => {
+      const groupedProvider = new GroupedProvider(mockProvider, groupSize)
+      const walletAddress = '0x7890'
+      const balance = 1234n
+      const mockTokenContract = {
+        balanceOf: jest.fn().mockResolvedValue(balance),
+      }
+      ethersNewContract.mockReturnValueOnce(mockTokenContract)
+      const groupedTokenContract = groupedProvider.createTokenContract(tokenContractAddress)
+
+      expect(await groupedTokenContract.balanceOf(walletAddress)).toBe(balance)
+      expect(mockTokenContract.balanceOf).toBeCalledWith(walletAddress)
+      expect(mockTokenContract.balanceOf).toBeCalledTimes(1)
+    })
+
+    it('should call getWithdrawalQueueLength on a token Contract', async () => {
+      const groupedProvider = new GroupedProvider(mockProvider, groupSize)
+      const queueLength = 5n
+      const mockTokenContract = {
+        getWithdrawalQueueLength: jest.fn().mockResolvedValue(queueLength),
+      }
+      ethersNewContract.mockReturnValueOnce(mockTokenContract)
+      const groupedTokenContract = groupedProvider.createTokenContract(tokenContractAddress)
+
+      expect(await groupedTokenContract.getWithdrawalQueueLength()).toBe(queueLength)
+      expect(mockTokenContract.getWithdrawalQueueLength).toBeCalledTimes(1)
+    })
+
+    it('should call getWithdrawalQueueInfo on a token Contract', async () => {
+      const groupedProvider = new GroupedProvider(mockProvider, groupSize)
+      const queueIndex = 3
+      const queueInfo = { shares: 65n }
+      const mockTokenContract = {
+        getWithdrawalQueueInfo: jest.fn().mockResolvedValue(queueInfo),
+      }
+      ethersNewContract.mockReturnValueOnce(mockTokenContract)
+      const groupedTokenContract = groupedProvider.createTokenContract(tokenContractAddress)
+
+      expect(await groupedTokenContract.getWithdrawalQueueInfo(queueIndex)).toBe(queueInfo)
+      expect(mockTokenContract.getWithdrawalQueueInfo).toBeCalledWith(queueIndex)
+      expect(mockTokenContract.getWithdrawalQueueInfo).toBeCalledTimes(1)
+    })
+
+    it('should create a price oracle Contract', () => {
+      const groupedProvider = new GroupedProvider(mockProvider, groupSize)
+
+      expect(ethersNewContract).toBeCalledTimes(0)
+
+      groupedProvider.createPriceOracleContract(priceOracleAddress)
+
+      expect(ethersNewContract).toBeCalledWith(priceOracleAddress, EACAggregatorProxy, mockProvider)
+      expect(ethersNewContract).toBeCalledTimes(1)
+    })
+
+    it('should call decimals on a price oracle Contract', async () => {
+      const groupedProvider = new GroupedProvider(mockProvider, groupSize)
+      const decimals = 14n
+      const mockPriceOracleContract = {
+        decimals: jest.fn().mockResolvedValue(decimals),
+      }
+      ethersNewContract.mockReturnValueOnce(mockPriceOracleContract)
+      const groupedPriceOracleContract =
+        groupedProvider.createPriceOracleContract(priceOracleAddress)
+
+      expect(await groupedPriceOracleContract.decimals()).toBe(decimals)
+      expect(mockPriceOracleContract.decimals).toBeCalledTimes(1)
+    })
+
+    it('should call latestAnswer on a price oracle Contract', async () => {
+      const groupedProvider = new GroupedProvider(mockProvider, groupSize)
+      const value = 142536n
+      const mockPriceOracleContract = {
+        latestAnswer: jest.fn().mockResolvedValue(value),
+      }
+      ethersNewContract.mockReturnValueOnce(mockPriceOracleContract)
+      const groupedPriceOracleContract =
+        groupedProvider.createPriceOracleContract(priceOracleAddress)
+
+      expect(await groupedPriceOracleContract.latestAnswer()).toBe(value)
+      expect(mockPriceOracleContract.latestAnswer).toBeCalledTimes(1)
+    })
+
+    it('should call decimals and latestAnswer for getRate', async () => {
+      const groupedProvider = new GroupedProvider(mockProvider, groupSize)
+      const value = 142537n
+      const decimals = 15n
+      const mockPriceOracleContract = {
+        decimals: jest.fn().mockResolvedValue(decimals),
+        latestAnswer: jest.fn().mockResolvedValue(value),
+      }
+      ethersNewContract.mockReturnValueOnce(mockPriceOracleContract)
+      const groupedPriceOracleContract =
+        groupedProvider.createPriceOracleContract(priceOracleAddress)
+
+      expect(await groupedPriceOracleContract.getRate()).toEqual({
+        value,
+        decimal: Number(decimals),
+      })
+      expect(mockPriceOracleContract.decimals).toBeCalledTimes(1)
+      expect(mockPriceOracleContract.latestAnswer).toBeCalledTimes(1)
+    })
+
+    it('should limit the number of concurrent requests to the group size', async () => {
+      const groupedProvider = new GroupedProvider(mockProvider, groupSize)
+      const walletAddresses = Array.from({ length: 7 }, (_, i) => `0x${i.toString(16)}`)
+
+      const resolvers: Array<() => void> = []
+      const mockTokenContract = {
+        balanceOf: () => {
+          const [promise, resolve] = deferredPromise()
+          resolvers.push(resolve)
+          return promise
+        },
+      }
+      ethersNewContract.mockReturnValueOnce(mockTokenContract)
+      const groupedTokenContract = groupedProvider.createTokenContract(tokenContractAddress)
+
+      expect(walletAddresses).toHaveLength(7)
+
+      const promises = walletAddresses.map((walletAddress) =>
+        groupedTokenContract.balanceOf(walletAddress),
+      )
+      await jest.runAllTimersAsync()
+
+      expect(resolvers).toHaveLength(3)
+
+      resolvers[0](0n)
+      resolvers[1](1n)
+      await jest.runAllTimersAsync()
+      expect(resolvers).toHaveLength(3)
+
+      resolvers[2](2n)
+      await jest.runAllTimersAsync()
+      expect(resolvers).toHaveLength(6)
+
+      resolvers[3](3n)
+      resolvers[4](4n)
+      await jest.runAllTimersAsync()
+      expect(resolvers).toHaveLength(6)
+
+      resolvers[5](5n)
+      await jest.runAllTimersAsync()
+      expect(resolvers).toHaveLength(7)
+
+      resolvers[6](6n)
+      await jest.runAllTimersAsync()
+      for (let i = 0; i < walletAddresses.length; i++) {
+        expect(await promises[i]).toBe(BigInt(i))
+      }
+    })
+
+    it('should concurrent requests across methods and contracts', async () => {
+      const resolvers: (() => void)[] = []
+      const deferred = <T>(value: T) => {
+        return () => {
+          const count = resolvers.length
+          const [promise, resolve] = deferredPromise<T>()
+          resolvers.push(() => {
+            resolve(value)
+          })
+          return promise
+        }
+      }
+
+      const groupedProvider = new GroupedProvider(mockProvider, groupSize)
+      const mockTokenContract = {
+        decimals: deferred(18n),
+        balanceOf: deferred(100n),
+        getWithdrawalQueueLength: deferred(1n),
+        getWithdrawalQueueInfo: deferred({ shares: 50n }),
+      }
+      ethersNewContract.mockReturnValueOnce(mockTokenContract)
+      const groupedTokenContract = groupedProvider.createTokenContract(tokenContractAddress)
+
+      const mockPriceOracleContract = {
+        decimals: deferred(18n),
+        latestAnswer: deferred(1235n),
+      }
+      ethersNewContract.mockReturnValueOnce(mockPriceOracleContract)
+      const groupedPriceOracleContract =
+        groupedProvider.createPriceOracleContract(priceOracleAddress)
+
+      groupedTokenContract.decimals()
+      groupedPriceOracleContract.decimals()
+      groupedTokenContract.balanceOf('0x1234')
+
+      groupedTokenContract.getWithdrawalQueueLength()
+      groupedTokenContract.getWithdrawalQueueInfo(0n)
+      groupedPriceOracleContract.latestAnswer()
+
+      await jest.runAllTimersAsync()
+      expect(resolvers).toHaveLength(3)
+
+      resolvers[0]()
+      resolvers[1]()
+      await jest.runAllTimersAsync()
+      expect(resolvers).toHaveLength(3)
+
+      resolvers[2]()
+      await jest.runAllTimersAsync()
+      expect(resolvers).toHaveLength(6)
+    })
+  })
+})

--- a/packages/sources/token-balance/test/unit/utils.test.ts
+++ b/packages/sources/token-balance/test/unit/utils.test.ts
@@ -1,5 +1,5 @@
-import EACAggregatorProxy from '../../src/config/EACAggregatorProxy.json'
 import { deferredPromise } from '@chainlink/external-adapter-framework/util'
+import EACAggregatorProxy from '../../src/config/EACAggregatorProxy.json'
 import OpenEdenTBILLProxy from '../../src/config/OpenEdenTBILLProxy.json'
 import { GroupedProvider } from '../../src/transport/utils'
 


### PR DESCRIPTION
## [DF-21086](https://smartcontract-it.atlassian.net/browse/DF-21086)

## Description

We want to limit the number of concurrent RPCs made by the token-balance EA for tbill balances to prevent hitting rate limits or timeouts.

This PR adds some utility classes to facilitate this.
They are still unused by the made code but will be used in a subsequent PR.

## Changes

Add `GroupedProvider` which can be used to create `GroupedProvider` and `GroupedPriceOracleContract`.
They all share the same `GroupRunner` to limit concurrent requests to the shared `JsonRpcProvider`.

## Steps to Test

Unit tests were added.
```
yarn test packages/sources/token-balance
```

Also tested manually in a branch with subsequent changes running `token-balance`, `por-address-list` and `proof-of-reserves`.

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[DF-21086]: https://smartcontract-it.atlassian.net/browse/DF-21086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ