### PR TITLE
Use yarn instead of local prettier for lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "arrowParens": "always"
   },
   "lint-staged": {
-    "*.{js,css,md,ts,json,yml,yaml}": "prettier --write"
+    "*.{js,css,md,ts,json,yml,yaml}": "yarn prettier --write"
   },
   "packageManager": "yarn@4.5.3",
   "resolutions": {


### PR DESCRIPTION
## Description

My `git pre-commit` was changing the formatting of my PR in a way that was breaking PR checks.
I discovered that `yarn lint-staged` runs a locally installed version of `prettier` instead of yarn's version of `prettier`.

## Changes

Use `yarn prettier` in `lint-staged`, instead of just `prettier`.

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

Tested in https://github.com/smartcontractkit/external-adapters-js/pull/3809 and noticed that it makes the formatting consistent.

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
