### PR TITLE
Fix test compilation for por-address-list

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Compile tests
         env:
           CHANGED_PACKAGES: ${{ needs.install-packages.outputs.changed-packages }}
-          FAILING_TESTS_PATTERN: '/composites/dydx-rewards/|/composites/glv-token/|/composites/gm-token/|/core/bootstrap/|/sources/bitgo-reserves-test/|/sources/bitgo-reserves/|/sources/coinpaprika/|/sources/cryptocompare/|/sources/icap/|/sources/ipfs/|/sources/layer2-sequencer-health/|/sources/por-address-list/|/sources/s3-csv-reader/|/sources/view-function-multi-chain/|sources/view-function/|/k6/|/observation/'
+          FAILING_TESTS_PATTERN: '/composites/dydx-rewards/|/composites/glv-token/|/composites/gm-token/|/core/bootstrap/|/sources/bitgo-reserves-test/|/sources/bitgo-reserves/|/sources/coinpaprika/|/sources/cryptocompare/|/sources/icap/|/sources/ipfs/|/sources/layer2-sequencer-health/|/sources/s3-csv-reader/|/sources/view-function-multi-chain/|sources/view-function/|/k6/|/observation/'
         run: |
           echo "Tests that should compile:"
           for package in $(echo "$CHANGED_PACKAGES" | jq '.[].location + "/"' -r | grep -v -E "$FAILING_TESTS_PATTERN"); do

--- a/packages/sources/por-address-list/test/integration/fixtures-api.ts
+++ b/packages/sources/por-address-list/test/integration/fixtures-api.ts
@@ -1,5 +1,11 @@
 import nock from 'nock'
 
+type JsonRpcPayload = {
+  id: number
+  method: string
+  params: Array<{ to: string; data: string }>
+}
+
 export const mockCoinbaseResponseSuccess = (): nock.Scope =>
   nock('http://coinbase', {
     encodedQueryParams: true,
@@ -199,7 +205,7 @@ export const mockBaseContractCallResponseSuccess = (): nock.Scope =>
   nock('http://localhost-base:8080')
     .persist()
     .post('/')
-    .reply(200, (uri, request) => {
+    .reply(200, (_uri, request: JsonRpcPayload) => {
       if (request.method === 'eth_chainId') {
         return {
           jsonrpc: '2.0',

--- a/packages/sources/por-address-list/tsconfig.test.json
+++ b/packages/sources/por-address-list/tsconfig.test.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src/**/*", "**/test", "src/**/*.json"],
   "compilerOptions": {
+    "lib": ["es2024"],
     "noEmit": true
   }
 }

--- a/packages/sources/por-address-list/tsconfig.test.json
+++ b/packages/sources/por-address-list/tsconfig.test.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src/**/*", "**/test", "src/**/*.json"],
   "compilerOptions": {
-    "lib": ["es2024"],
+    "target": "ESNext",
     "noEmit": true
   }
 }


### PR DESCRIPTION
## Description

`por-addresses-list` is one of the packages excluded from test compilation because it has compilation errors.

## Changes

1. Remove `por-addresses-list` from packages excluded from test compilation.
2. Prefix unused variable `uri` with underscore.
3. Add `JsonRpcPayload` type annotation.
4. Add `"target": "ESNext"` to compiler options (same as in [tsconfig.json](https://github.com/smartcontractkit/external-adapters-js/blob/6b11b6099a0711973476d8f7b2ad2a73a60121fa/packages/sources/por-address-list/tsconfig.json#L6)) to support [the use](https://github.com/smartcontractkit/external-adapters-js/blob/6b11b6099a0711973476d8f7b2ad2a73a60121fa/packages/sources/por-address-list/src/transport/multichainAddress.ts#L147) of [Map.groupBy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/groupBy), which is a new ES feature.

## Steps to Test

```
yarn tsc -b --noEmit packages/sources/por-address-list/tsconfig.test.json
```
Workflow passes:
https://github.com/smartcontractkit/external-adapters-js/actions/runs/14463554136/job/40560756312

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
