### PR TITLE
Aleno: resubscribe after reconnect

### DIFF
--- a/.changeset/pretty-goats-add.md
+++ b/.changeset/pretty-goats-add.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/aleno-adapter': patch
+---
+
+Bug fix: Recreate subscriptions after reconnecting

--- a/packages/sources/aleno/src/transport/price-socketio.ts
+++ b/packages/sources/aleno/src/transport/price-socketio.ts
@@ -1,14 +1,14 @@
-import { io, Socket } from 'socket.io-client'
+import { EndpointContext } from '@chainlink/external-adapter-framework/adapter'
 import { TransportDependencies } from '@chainlink/external-adapter-framework/transports'
-import { makeLogger, sleep } from '@chainlink/external-adapter-framework/util'
 import {
   StreamingTransport,
   SubscriptionDeltas,
 } from '@chainlink/external-adapter-framework/transports/abstract/streaming'
+import { makeLogger, sleep } from '@chainlink/external-adapter-framework/util'
 import { TypeFromDefinition } from '@chainlink/external-adapter-framework/validation/input-params'
-import { EndpointContext } from '@chainlink/external-adapter-framework/adapter'
-import { BaseEndpointTypes } from '../endpoint/price'
+import { io, Socket } from 'socket.io-client'
 import { config } from '../config'
+import { BaseEndpointTypes } from '../endpoint/price'
 
 const logger = makeLogger('SocketIOTransport')
 
@@ -220,6 +220,7 @@ export class SocketIOTransport extends StreamingTransport<SocketIOTransportTypes
 
       this.socket.on('connect', () => {
         logger.info({ msg: 'Connection open' })
+        this.confirmedSubscriptions = new Set<string>()
       })
 
       this.socket.on('disconnect', (reason, details) => {


### PR DESCRIPTION
[DF-21257](https://smartcontract-it.atlassian.net/browse/DF-21257)

## Description

There was a bug where after the Aleno server restarted, the EAs lost their subscriptions.
The fix is to reset the subscriptions the EA believes it has on reconnecting, so that it knows to resubscribe.

## Changes

Set `confirmedSubscriptions` to empty when receiving the `connect` event.

## Steps to Test

1. Unit test added.
2. Tested manually by disabling WiFi until the connection is lost. Then re-enabling WiFi. You can see in the logs that the subscriptions are re-established.
Use
```
curl -X POST http://localhost:8080 -H "Content-Type: application/json" -d '{
  "data": {
    "endpoint": "price",
    "transport": "rest",
    "base": "FRAX",
    "quote": "USD"
  }
}'
```
to create a subscription to begin with.

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[DF-21257]: https://smartcontract-it.atlassian.net/browse/DF-21257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ