### PR TITLE
Aleno: Fix logging of confirmedSubscriptions

### DIFF
--- a/.changeset/polite-singers-worry.md
+++ b/.changeset/polite-singers-worry.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/aleno-adapter': patch
+---
+
+Log confirmedSubscriptions properly

--- a/packages/sources/aleno/src/transport/price-socketio.ts
+++ b/packages/sources/aleno/src/transport/price-socketio.ts
@@ -190,7 +190,7 @@ export class SocketIOTransport extends StreamingTransport<SocketIOTransportTypes
       logger.info({
         msg: 'Changing subscriptions',
         subscriptions,
-        confirmedSubscriptions: this.confirmedSubscriptions,
+        confirmedSubscriptions: Array.from(this.confirmedSubscriptions),
         toAdd,
         toRemove,
       })


### PR DESCRIPTION
## Description

While debugging another issue with Aleno, I noticed that the logged `confirmedSubscriptions` are always `{}`.
`confirmedSubscriptions` is a `Set`, and apparently the logger doesn't log the contents of the set.
So we convert the set to an `Array` before logging it.

## Changes

Pass `confirmedSubscriptions` to `Array.from` before logging it.

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. Start the EA.
2.
```
curl -X POST http://localhost:8080 -H "Content-Type: application/json" -d '{   "data": {
    "endpoint": "price",
    "base": "FRAX",
    "quote": "USD"
  }
}'
```
3. Look at the logs and wait for the subscriptions to update.
4.
```
curl -X POST http://localhost:8080 -H "Content-Type: application/json" -d '{   "data": {
    "endpoint": "price",
    "base": "LBTC",
    "quote": "USD"
  }
}'
```
5. Look at the logs and check that the `confirmedSubscriptions` in the latest log were not empty.
```
{"level":"info","time":1744872650542,"isoTime":"2025-04-17T06:50:50.542Z","pid":64158,"hostname":"MB-LYCC91HP2M","layer":"SocketIOTransport","correlationId":"Endpoint: price - Transport: SocketIOTransport","msg":"Changing subscriptions","subscriptions":{"desired":[{"base":"FRAX","quote":"USD"},{"base":"lbtc","quote":"USD"}],"new":[{"base":"lbtc","quote":"USD"}],"stale":[]},"confirmedSubscriptions":["FRAX/USD"],"toAdd":["LBTC/USD"],"toRemove":[]}
{"level":"info","time":1744872650562,"isoTime":"2025-04-17T06:50:50.562Z","pid":64158,"hostname":"MB-LYCC91HP2M","layer":"SocketIOTransport","correlationId":"Endpoint: price - Transport: SocketIOTransport","msg":"Subscription update successful:","response":{"status":"ok","involvedSubscriptions":["lbtc/usd"],"subscriptionsAfterUpdate":["frax/usd","lbtc/usd"]}}
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
