### PR TITLE
TBILL: Only count withdrawal queue entries for the relevant addresses

### DIFF
--- a/packages/sources/token-balance/src/transport/tbill.ts
+++ b/packages/sources/token-balance/src/transport/tbill.ts
@@ -182,6 +182,7 @@ export class TbillTransport extends SubscriptionTransport<BaseEndpointTypes> {
     totalSharesUSD += await this.getWithdrawalQueueAum(
       queueLength,
       contract,
+      address.wallets,
       sharePriceUSD,
       sharesDecimals,
     )
@@ -212,6 +213,7 @@ export class TbillTransport extends SubscriptionTransport<BaseEndpointTypes> {
   async getWithdrawalQueueAum(
     queueLength: bigint,
     tbillWithrawalQueueContract: GroupedTokenContract,
+    wallets: string[],
     sharePriceUSD: SharePriceType,
     sharesDecimals: bigint,
   ) {
@@ -223,7 +225,11 @@ export class TbillTransport extends SubscriptionTransport<BaseEndpointTypes> {
       const results = await Promise.all(
         indices.map(async (index) => {
           const queueInfo = await tbillWithrawalQueueContract.getWithdrawalQueueInfo(index)
-          return queueInfo.shares
+          if (queueInfo.sender === queueInfo.receiver && wallets.includes(queueInfo.sender)) {
+            return queueInfo.shares
+          } else {
+            return 0n
+          }
         }),
       )
 

--- a/packages/sources/token-balance/src/transport/utils.ts
+++ b/packages/sources/token-balance/src/transport/utils.ts
@@ -50,7 +50,11 @@ export class GroupedTokenContract {
     return this.runner.run(() => this.contract.getWithdrawalQueueLength())
   }
 
-  async getWithdrawalQueueInfo(index: number): Promise<{ shares: bigint }> {
+  async getWithdrawalQueueInfo(index: number): Promise<{
+    sender: string
+    receiver: string
+    shares: bigint
+  }> {
     return this.runner.run(() => this.contract.getWithdrawalQueueInfo(index))
   }
 }

--- a/packages/sources/token-balance/test/unit/tbill.test.ts
+++ b/packages/sources/token-balance/test/unit/tbill.test.ts
@@ -522,15 +522,14 @@ describe('TbillTransport', () => {
       ethTbillContract.decimals.mockResolvedValue(balanceDecimals)
       ethTbillContract.balanceOf.mockResolvedValue(BigInt(balance * 10 ** balanceDecimals))
       ethTbillContract.getWithdrawalQueueLength.mockResolvedValue(2)
-      // TODO: Shouldn't we only count withdrawals from walletAddress?
       ethTbillContract.getWithdrawalQueueInfo.mockResolvedValueOnce({
-        sender: '0x01',
-        receiver: '0x02',
+        sender: walletAddress,
+        receiver: walletAddress,
         shares: BigInt(withDrawalQueueAmount1 * 10 ** balanceDecimals),
       })
       ethTbillContract.getWithdrawalQueueInfo.mockResolvedValueOnce({
-        sender: '0x03',
-        receiver: '0x04',
+        sender: walletAddress,
+        receiver: walletAddress,
         shares: BigInt(withDrawalQueueAmount2 * 10 ** balanceDecimals),
       })
 
@@ -574,6 +573,159 @@ describe('TbillTransport', () => {
       expect(ethTbillContract.getWithdrawalQueueInfo).toBeCalledWith(0)
       expect(ethTbillContract.getWithdrawalQueueInfo).toBeCalledWith(1)
       expect(ethTbillContract.getWithdrawalQueueInfo).toBeCalledTimes(2)
+    })
+
+    it('should ignore withdrawal queue entries unless both sender and receiver equal the wallet address', async () => {
+      const balance = 3
+      const balanceDecimals = 6
+      const price = 7
+      const priceDecimals = 8
+      const withDrawalQueueAmount1 = 1
+      const withDrawalQueueAmount2 = 2
+      const withDrawalQueueAmount3 = 3
+
+      const result = String(balance * price * 10 ** RESULT_DECIMALS)
+
+      const walletAddress = '0x5EaFF7af80488033Bc845709806D5Fae5291eB88'
+      ethTbillContract.decimals.mockResolvedValue(balanceDecimals)
+      ethTbillContract.balanceOf.mockResolvedValue(BigInt(balance * 10 ** balanceDecimals))
+      ethTbillContract.getWithdrawalQueueLength.mockResolvedValue(3)
+      ethTbillContract.getWithdrawalQueueInfo.mockResolvedValueOnce({
+        sender: '0x01',
+        receiver: walletAddress,
+        shares: BigInt(withDrawalQueueAmount1 * 10 ** balanceDecimals),
+      })
+      ethTbillContract.getWithdrawalQueueInfo.mockResolvedValueOnce({
+        sender: walletAddress,
+        receiver: '0x02',
+        shares: BigInt(withDrawalQueueAmount2 * 10 ** balanceDecimals),
+      })
+      ethTbillContract.getWithdrawalQueueInfo.mockResolvedValueOnce({
+        sender: '0x03',
+        receiver: '0x04',
+        shares: BigInt(withDrawalQueueAmount3 * 10 ** balanceDecimals),
+      })
+
+      ethTbillPriceContract.decimals.mockResolvedValue(priceDecimals)
+      ethTbillPriceContract.latestAnswer.mockResolvedValue(BigInt(price * 10 ** priceDecimals))
+
+      const param: RequestParams = {
+        addresses: [
+          {
+            chainId: ETHEREUM_RPC_CHAIN_ID,
+            contractAddress: ETHEREUM_TBILL_CONTRACT_ADDRESS,
+            priceOracleAddress: ETHEREUM_TBILL_PRICE_ORACLE_ADDRESS,
+            wallets: [walletAddress],
+          },
+        ],
+      } as RequestParams
+
+      const now = Date.now()
+      await transport.handleRequest(context, param)
+
+      expect(responseCache.write).toBeCalledWith(transportName, [
+        {
+          params: param,
+          response: {
+            data: {
+              decimals: RESULT_DECIMALS,
+              result,
+            },
+            result,
+            statusCode: 200,
+            timestamps: {
+              providerDataRequestedUnixMs: now,
+              providerDataReceivedUnixMs: now,
+            },
+          },
+        },
+      ])
+      expect(responseCache.write).toBeCalledTimes(1)
+
+      expect(ethTbillContract.getWithdrawalQueueLength).toBeCalledTimes(1)
+      expect(ethTbillContract.getWithdrawalQueueInfo).toBeCalledWith(0)
+      expect(ethTbillContract.getWithdrawalQueueInfo).toBeCalledWith(1)
+      expect(ethTbillContract.getWithdrawalQueueInfo).toBeCalledWith(2)
+      expect(ethTbillContract.getWithdrawalQueueInfo).toBeCalledTimes(3)
+    })
+
+    it('should not double count withdrawal queue entries for multiple addresses', async () => {
+      const balance1 = 3
+      const balance2 = 5
+      const balanceDecimals = 6
+      const price = 7
+      const priceDecimals = 8
+      const withDrawalQueueAmount1 = 1
+      const withDrawalQueueAmount2 = 2
+
+      const result = String(
+        (balance1 + balance2 + withDrawalQueueAmount1 + withDrawalQueueAmount2) *
+          price *
+          10 ** RESULT_DECIMALS,
+      )
+
+      const walletAddress1 = '0x5EaFF7af80488033Bc845709806D5Fae5291eB88'
+      const walletAddress2 = '0x1000000000000000000000000000000000000001'
+      ethTbillContract.decimals.mockResolvedValue(balanceDecimals)
+      ethTbillContract.balanceOf.mockResolvedValueOnce(BigInt(balance1 * 10 ** balanceDecimals))
+      ethTbillContract.balanceOf.mockResolvedValueOnce(BigInt(balance2 * 10 ** balanceDecimals))
+      ethTbillContract.getWithdrawalQueueLength.mockResolvedValue(2)
+      const withDrawalQueueEntries = [
+        {
+          sender: walletAddress1,
+          receiver: walletAddress1,
+          shares: BigInt(withDrawalQueueAmount1 * 10 ** balanceDecimals),
+        },
+        {
+          sender: walletAddress2,
+          receiver: walletAddress2,
+          shares: BigInt(withDrawalQueueAmount2 * 10 ** balanceDecimals),
+        },
+      ]
+      ethTbillContract.getWithdrawalQueueInfo.mockImplementation(
+        async (index: number) => withDrawalQueueEntries[index],
+      )
+
+      ethTbillPriceContract.decimals.mockResolvedValue(priceDecimals)
+      ethTbillPriceContract.latestAnswer.mockResolvedValue(BigInt(price * 10 ** priceDecimals))
+
+      const param: RequestParams = {
+        addresses: [walletAddress1, walletAddress2].map((walletAddress) => ({
+          chainId: ETHEREUM_RPC_CHAIN_ID,
+          contractAddress: ETHEREUM_TBILL_CONTRACT_ADDRESS,
+          priceOracleAddress: ETHEREUM_TBILL_PRICE_ORACLE_ADDRESS,
+          wallets: [walletAddress],
+        })),
+      } as RequestParams
+
+      const now = Date.now()
+      await transport.handleRequest(context, param)
+
+      expect(responseCache.write).toBeCalledWith(transportName, [
+        {
+          params: param,
+          response: {
+            data: {
+              decimals: RESULT_DECIMALS,
+              result,
+            },
+            result,
+            statusCode: 200,
+            timestamps: {
+              providerDataRequestedUnixMs: now,
+              providerDataReceivedUnixMs: now,
+            },
+          },
+        },
+      ])
+      expect(responseCache.write).toBeCalledTimes(1)
+
+      expect(ethTbillContract.getWithdrawalQueueLength).toBeCalledTimes(2)
+      expect(ethTbillContract.getWithdrawalQueueInfo).toHaveBeenNthCalledWith(1, 0)
+      expect(ethTbillContract.getWithdrawalQueueInfo).toHaveBeenNthCalledWith(2, 1)
+      expect(ethTbillContract.getWithdrawalQueueInfo).toHaveBeenNthCalledWith(3, 0)
+      expect(ethTbillContract.getWithdrawalQueueInfo).toHaveBeenNthCalledWith(4, 1)
+      expect(ethTbillContract.getWithdrawalQueueInfo).toBeCalledTimes(4)
     })
 
     it('should limit concurrent RPCs', async () => {


### PR DESCRIPTION
## [DF-21252](https://smartcontract-it.atlassian.net/browse/DF-21252)

## Description

Currently, the `tbill` endpoint of the `token-balance` EA adds the value of the entire withdrawal queue for each addresses in the input.
There 2 issues with this:
1. Add counts the same entries multiple times if there are multiple addresses.
2. It could entries which are irrelevant because they are for other addresses.

This PR filters the withdrawal queue entries to make sure we only count the relevant ones.

## Changes

1. 
<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. Steps
4. to
5. test

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
