### PR TITLE
Disable Soak test

### DIFF
--- a/.github/workflows/soak-test-cleanup.yml
+++ b/.github/workflows/soak-test-cleanup.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   cleanup-ephemeral-adapters-on-pr-close:
+    skip: true
     name: Cleanup Ephemeral Adapters used for testing
     runs-on: ubuntu-latest
     environment: QA

--- a/.github/workflows/soak-test-cleanup.yml
+++ b/.github/workflows/soak-test-cleanup.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     types: [closed]
     paths:
-      - '**'
       - 'packages/sources/**'
       - 'packages/composites/**'
       - 'packages/targets/**'
@@ -12,6 +11,7 @@ on:
 
 jobs:
   cleanup-ephemeral-adapters-on-pr-close:
+    # TODO(DF-21181): Fix or delete the soak test
     if: false
     name: Cleanup Ephemeral Adapters used for testing
     runs-on: ubuntu-latest

--- a/.github/workflows/soak-test-cleanup.yml
+++ b/.github/workflows/soak-test-cleanup.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     types: [closed]
     paths:
+      - '**'
       - 'packages/sources/**'
       - 'packages/composites/**'
       - 'packages/targets/**'
@@ -11,7 +12,7 @@ on:
 
 jobs:
   cleanup-ephemeral-adapters-on-pr-close:
-    skip: true
+    if: false
     name: Cleanup Ephemeral Adapters used for testing
     runs-on: ubuntu-latest
     environment: QA

--- a/.github/workflows/soak-test-start.yml
+++ b/.github/workflows/soak-test-start.yml
@@ -3,7 +3,6 @@ name: Soak test
 on:
   pull_request:
     paths:
-      - '**'
       - 'packages/sources/**'
       - 'packages/composites/**'
       - 'packages/targets/**'
@@ -11,6 +10,7 @@ on:
 
 jobs:
   run-soak-tests:
+    # TODO(DF-21181): Fix or delete the soak test
     if: false
     name: Run Soak Tests Against Changed Adapters
     runs-on: ubuntu-latest-16cores-64GB

--- a/.github/workflows/soak-test-start.yml
+++ b/.github/workflows/soak-test-start.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   run-soak-tests:
+    skip: true
     name: Run Soak Tests Against Changed Adapters
     runs-on: ubuntu-latest-16cores-64GB
     environment: QA

--- a/.github/workflows/soak-test-start.yml
+++ b/.github/workflows/soak-test-start.yml
@@ -3,6 +3,7 @@ name: Soak test
 on:
   pull_request:
     paths:
+      - '**'
       - 'packages/sources/**'
       - 'packages/composites/**'
       - 'packages/targets/**'
@@ -10,7 +11,7 @@ on:
 
 jobs:
   run-soak-tests:
-    skip: true
+    if: false
     name: Run Soak Tests Against Changed Adapters
     runs-on: ubuntu-latest-16cores-64GB
     environment: QA


### PR DESCRIPTION
[DF-21181](https://smartcontract-it.atlassian.net/browse/DF-21181)

## Description

The soak test hasn't worked for months.
The team has been hesitant to delete it.
But having it run and fail is not useful.
So let's at least disable it if not delete it.

## Changes

Added `if: false` to the soak test jobs.

## Steps to Test

Soak test was successfully skipped: https://github.com/smartcontractkit/external-adapters-js/actions/runs/14732150675

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[DF-21181]: https://smartcontract-it.atlassian.net/browse/DF-21181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ