### PR TITLE
Aleno: Remove unused config variable API_ENDPOINT

### DIFF
--- a/.changeset/hungry-deers-beam.md
+++ b/.changeset/hungry-deers-beam.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/aleno-adapter': patch
+---
+
+Remove unused config variable API_ENDPOINT.

--- a/packages/sources/aleno/README.md
+++ b/packages/sources/aleno/README.md
@@ -9,7 +9,6 @@ This document was generated automatically. Please see [README Generator](../../s
 | Required? |         Name          |                                        Description                                        |  Type  | Options |                Default                |
 | :-------: | :-------------------: | :---------------------------------------------------------------------------------------: | :----: | :-----: | :-----------------------------------: |
 |    ✅     |        API_KEY        |                                   An API key for Aleno                                    | string |         |                                       |
-|           |     API_ENDPOINT      |                             An API endpoint for Data Provider                             | string |         |    `https://state-price.aleno.ai`     |
 |           |    WS_API_ENDPOINT    |                                   WS endpoint for Aleno                                   | string |         | `https://state-price-socket.aleno.ai` |
 |           | BACKGROUND_EXECUTE_MS | The amount of time the background execute should sleep before performing the next request | number |         |                `10000`                |
 

--- a/packages/sources/aleno/src/config/index.ts
+++ b/packages/sources/aleno/src/config/index.ts
@@ -7,11 +7,6 @@ export const config = new AdapterConfig({
     required: true,
     sensitive: true,
   },
-  API_ENDPOINT: {
-    description: 'An API endpoint for Data Provider',
-    type: 'string',
-    default: 'https://state-price.aleno.ai',
-  },
   WS_API_ENDPOINT: {
     description: 'WS endpoint for Aleno',
     type: 'string',


### PR DESCRIPTION
## Description

In https://github.com/smartcontractkit/external-adapters-js/pull/3754 we removed the REST transport from the Aleno EA.
This means the `API_ENDPOINT` config variable is no longer used.

## Changes

1. Remove the unused `API_ENDPOINT` config variable.
2. Ran `yarn generate:readme aleno`

## Steps to Test

```
yarn test aleno
```
Also ran the EA locally and tested with
```
curl -X POST http://localhost:8080 -H "Content-Type: application/json" -d '{
  "data": {
    "endpoint": "price",
    "transport": "rest",
    "base": "FRAX",
    "quote": "USD"
  }
}'

{"data":{"result":0.9998692313465063},"result":0.9998692313465063,"timestamps":{"providerDataStreamEstablishedUnixMs":1746439815256,"providerDataReceivedUnixMs":1746439824874,"providerIndicatedTimeUnixMs":1746439732000},"statusCode":200,"meta":{"adapterName":"ALENO","metrics":{"feedId":"{\"base\":\"frax\",\"quote\":\"usd\"}"}}}
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
