### PR TITLE
Add fsevents files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ dist
 # Yarn 2
 .yarn/*
 !.yarn/cache
+# fsevents files are specific to Mac so Renovate keeps removing them and then
+# they appear again during development.
+.yarn/cache/fsevents-patch-*.zip
 !.yarn/patches
 !.yarn/plugins
 !.yarn/releases


### PR DESCRIPTION
## Description

Sometimes the EA repo gets into a state where running `yarn` adds some files to `.yarn/cache`.
I just assumed this meant that someone (or Renovate) forgot to run `yarn` after adding a dependency.
But it seems that a lot (if not all) of these cases are specific to `.yarn/cache/fsevents-patch-6b67494872-10.zip` and `.yarn/cache/fsevents-patch-afc6995412-10.zip`.
For example, last week these files were removed in [PR 3826](https://github.com/smartcontractkit/external-adapters-js/pull/3826) and they are about to be added back in [PR 3834](https://github.com/smartcontractkit/external-adapters-js/pull/3834).
And it seems that these files are MacOS specific. So Renovate removes them because it doesn't care about MacOS. And then we end up adding them back again when we run `yarn` on our Macs.
The result is a [history of commits](https://github.com/smartcontractkit/external-adapters-js/commits/main/.yarn/cache/fsevents-patch-6b67494872-10.zip) which alternates between adding and removing these 2 files.
I don't think it makes sense to continue like this.
I looked for a way to make Renovate care about MacOS but couldn't find one.

This PR adds the files to `.gitignore` so that we stop trying to include them in our PRs.

## Changes

Add `.yarn/cache/fsevents-patch-*.zip` to `.gitignore`.

## Steps to Test

```
yarn
git status
```
No untracked files.

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
