### PR TITLE
Check that yarn cache in complete

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -254,7 +254,9 @@ jobs:
         env:
           # Disable hardened mode to replicate local behavior.
           YARN_ENABLE_HARDENED_MODE: 0
-        run: yarn
+        run: |
+          touch .yarn/cache/foo-bar.zip
+          # yarn
       - name: Check no relavant files were added
         run: |
           if [[ "$(git status --porcelain)" != "" ]]; then

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -244,7 +244,7 @@ jobs:
 
   yarn-cache-complete:
     name: Check that running yarn doesn't create untracked files in .yarn/cache
-    runs-on: [ubuntu-latest]
+    runs-on: [macos-latest]
     permissions:
       contents: read
     steps:
@@ -254,9 +254,7 @@ jobs:
         env:
           # Disable hardened mode to replicate local behavior.
           YARN_ENABLE_HARDENED_MODE: 0
-        run: |
-          touch .yarn/cache/foo-bar.zip
-          # yarn
+        run: yarn
       - name: Check no relavant files were added
         run: |
           if [[ "$(git status --porcelain)" != "" ]]; then

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -241,3 +241,20 @@ jobs:
             done
             exit 1
           fi
+
+  yarn-cache-complete:
+    name: Check that running yarn doesn't create untracked files in .yarn/cache
+    runs-on: [ubuntu-latest]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Run yarn
+        run: yarn
+      - name: Check no relavant files were added
+        run: |
+          if [[ "$(git status --porcelain)" != "" ]]; then
+            echo "Yarn created untracked changes. Please add them to the PR."
+            git status
+            exit 1
+          fi
+          echo "Yarn did not create untracked changes."

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -251,9 +251,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
       - name: Run yarn
-        env:
-          # Disable hardened mode to replicate local behavior.
-          YARN_ENABLE_HARDENED_MODE: 0
         run: yarn
       - name: Check no relavant files were added
         run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -251,6 +251,9 @@ jobs:
       - name: Run yarn
         run: yarn
       - name: Check no relavant files were added
+        env:
+          # Disable hardened mode to replicate local behavior.
+          YARN_ENABLE_HARDENED_MODE: false
         run: |
           if [[ "$(git status --porcelain)" != "" ]]; then
             echo "Yarn created untracked changes. Please add them to the PR."

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -245,15 +245,17 @@ jobs:
   yarn-cache-complete:
     name: Check that running yarn doesn't create untracked files in .yarn/cache
     runs-on: [ubuntu-latest]
+    permissions:
+      contents: read
     steps:
       - name: Check out code
         uses: actions/checkout@v4
       - name: Run yarn
-        run: yarn
-      - name: Check no relavant files were added
         env:
           # Disable hardened mode to replicate local behavior.
-          YARN_ENABLE_HARDENED_MODE: false
+          YARN_ENABLE_HARDENED_MODE: 0
+        run: yarn
+      - name: Check no relavant files were added
         run: |
           if [[ "$(git status --porcelain)" != "" ]]; then
             echo "Yarn created untracked changes. Please add them to the PR."


### PR DESCRIPTION
## Description

Sometimes the repository gets into a state where running `yarn` on a clean branch creates some zip files in `.yarn/cache`.
See for example https://github.com/smartcontractkit/external-adapters-js/pull/3836

This PR adds a check to detect that.

NOTE: The repo is currently in such a state so this PR should only be merged after https://github.com/smartcontractkit/external-adapters-js/pull/3836

## Changes

Add a workflow check that runs `yarn` and then checks there aren't any untracked changes.

## Steps to Test



## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
