### PR TITLE
Fix Zeus test nock setup

### DIFF
--- a/packages/sources/por-address-list/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/por-address-list/test/integration/__snapshots__/adapter.test.ts.snap
@@ -224,16 +224,6 @@ exports[`execute apiAddress endpoint zeus BTC should return success 1`] = `
         "chainId": "mainnet",
         "network": "bitcoin",
       },
-      {
-        "address": "bc1pq7pr972ckfwrwrprqw5en54ytr58jndcaafr780hm35ttz4ekmas3fctx4",
-        "chainId": "mainnet",
-        "network": "bitcoin",
-      },
-      {
-        "address": "bc1pxdp8fy8nmkytn450x6drjujvu6jmcymq0agjgfecc5xdlecw566s07mjzx",
-        "chainId": "mainnet",
-        "network": "bitcoin",
-      },
     ],
   },
   "result": null,

--- a/packages/sources/por-address-list/test/integration/fixtures-api.ts
+++ b/packages/sources/por-address-list/test/integration/fixtures-api.ts
@@ -1,10 +1,10 @@
 import nock from 'nock'
 
 export const mockZeusResponseSuccess = (): nock.Scope =>
-  nock('http://indexer.zeuslayer.io', {
+  nock('https://indexer.zeuslayer.io', {
     encodedQueryParams: true,
   })
-    .get('/')
+    .get('/api/v2/chainlink/proof-of-reserves')
     .reply(
       200,
       () => ({


### PR DESCRIPTION
## Description

`packages/sources/por-address-list/test/integration/adapter.test.ts` currently fails when run.
This happens because it's connecting to the real `https://indexer.zeuslayer.io/api/v2/chainlink/proof-of-reserves` because the mock is set up with the wrong URL and since the test was merged, the real data source has started returning a different value.
Sometimes the test also fails because the real data source is too slow.

## Changes

1. Changed the `nock` url to use `https` instead of `http`.
2. Use path `/api/v2/chainlink/proof-of-reserves` instead of `/`.
3. Update snapshot with `yarn test packages/sources/por-address-list/test/integration/adapter.test.ts -u`.

## Steps to Test

1. The test passes again.
2. I also verified that if I change the mock return value, the test fails.

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
