### PR TITLE
Use new signature of fastify.listen

### DIFF
--- a/packages/core/bootstrap/test/helpers/server.ts
+++ b/packages/core/bootstrap/test/helpers/server.ts
@@ -108,7 +108,7 @@ export class Server {
       res.status(200).send(ERROR_CUSTOM_RESPONSE)
     })
 
-    app.listen(this.port, '::')
+    app.listen({ port: this.port, host: '::' })
     this.app = app
   }
 

--- a/packages/targets/agoric/test/e2e/adapter.test.ts
+++ b/packages/targets/agoric/test/e2e/adapter.test.ts
@@ -1,6 +1,5 @@
-import { AdapterError, Requester } from '@chainlink/ea-bootstrap'
+import { AdapterError, AdapterRequest, Requester } from '@chainlink/ea-bootstrap'
 import { assertError, assertSuccess } from '@chainlink/ea-test-helpers'
-import { AdapterRequest } from '@chainlink/ea-bootstrap'
 import Fastify, { FastifyInstance } from 'fastify'
 import { Action, makeExecute, TInputParameters } from '../../src/adapter'
 import { makeConfig } from '../../src/config'
@@ -128,7 +127,7 @@ describe('execute', () => {
             }
           })
 
-          server.listen(port, '0.0.0.0')
+          server.listen({ port, host: '0.0.0.0' })
           resolve(true)
         }),
     )


### PR DESCRIPTION
## Description

The update to Fastify 5 breaks because it allows fewer ways of calling `listen`.
The allowed ways are already also allowed in the current version of Fastify that we are using (3.29.4).

## Changes

1. Update calls to `listen` to the signature that is allowed by Fastify 5.
2. Automatic sorting of imports (done in pre-commit).

## Steps to Test

https://github.com/smartcontractkit/external-adapters-js/pull/3844 combines both the version update and the changes from this PR and has tests passing.

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
