### PR TITLE
Add getNetworkEnvVar util to token-balance

### DIFF
--- a/.changeset/gentle-mice-suffer.md
+++ b/.changeset/gentle-mice-suffer.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/token-balance-adapter': patch
+---
+
+Adding not-yet used code for future new endpoint

--- a/packages/sources/token-balance/src/transport/utils.ts
+++ b/packages/sources/token-balance/src/transport/utils.ts
@@ -1,4 +1,5 @@
 import { GroupRunner } from '@chainlink/external-adapter-framework/util/group-runner'
+import { AdapterInputError } from '@chainlink/external-adapter-framework/validation/error'
 import { ethers } from 'ethers'
 import EACAggregatorProxy from '../config/EACAggregatorProxy.json'
 import OpenEdenTBILLProxy from '../config/OpenEdenTBILLProxy.json'
@@ -85,4 +86,16 @@ export class GroupedPriceOracleContract {
       decimal: Number(decimal),
     }
   }
+}
+
+export const getNetworkEnvVar = (network: string, suffix: string): string => {
+  const envVarName = `${network.toUpperCase()}${suffix}`
+  const envVar = process.env[envVarName]
+  if (!envVar) {
+    throw new AdapterInputError({
+      statusCode: 400,
+      message: `Environment variable ${envVarName} is missing`,
+    })
+  }
+  return envVar
 }


### PR DESCRIPTION
[MERC-6937](https://smartcontract-it.atlassian.net/browse/MERC-6937)

## Description

While working on a new `xrpl` endpoint for `token-balance` I found it useful to have this utility function to get network specific environment variables. So I decided to already make a PR for it to keep the other PRs smaller.

## Changes

Add `getNetworkEnvVar` which returns an environment variable for a specific network and throws if it doesn't exist.

## Steps to Test

Unit tests were added.
I also used it in another branch where the `xrpl` endpoint is working end-to-end.

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
