### PR TITLE
Scaffolding of xrpl endpoint of token-balance

### DIFF
--- a/.changeset/chatty-dolphins-juggle.md
+++ b/.changeset/chatty-dolphins-juggle.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/token-balance-adapter': patch
+---
+
+Adding not-yet used code for future new endpoint

--- a/packages/sources/token-balance/src/endpoint/xrpl.ts
+++ b/packages/sources/token-balance/src/endpoint/xrpl.ts
@@ -1,0 +1,48 @@
+import { AdapterEndpoint } from '@chainlink/external-adapter-framework/adapter'
+import { InputParameters } from '@chainlink/external-adapter-framework/validation'
+import { config } from '../config'
+import { xrplTransport } from '../transport/xrpl'
+
+export const inputParameters = new InputParameters(
+  {
+    addresses: {
+      required: true,
+      type: {
+        address: {
+          required: true,
+          type: 'string',
+          description: 'Address of the account to fetch the balance of',
+        },
+      },
+      array: true,
+      description: 'List of addresses to read',
+    },
+  },
+  [
+    {
+      addresses: [
+        {
+          address: 'rGSA6YCGzywj2hsPA8DArSsLr1DMTBi2LH',
+        },
+      ],
+    },
+  ],
+)
+
+export type BaseEndpointTypes = {
+  Parameters: typeof inputParameters.definition
+  Response: {
+    Result: string
+    Data: {
+      result: string
+      decimals: number
+    }
+  }
+  Settings: typeof config.settings
+}
+
+export const endpoint = new AdapterEndpoint({
+  name: 'xrpl',
+  transport: xrplTransport,
+  inputParameters,
+})

--- a/packages/sources/token-balance/src/transport/xrpl.ts
+++ b/packages/sources/token-balance/src/transport/xrpl.ts
@@ -1,0 +1,82 @@
+import { EndpointContext } from '@chainlink/external-adapter-framework/adapter'
+import { TransportDependencies } from '@chainlink/external-adapter-framework/transports'
+import { SubscriptionTransport } from '@chainlink/external-adapter-framework/transports/abstract/subscription'
+import { AdapterResponse, makeLogger, sleep } from '@chainlink/external-adapter-framework/util'
+import { AdapterInputError } from '@chainlink/external-adapter-framework/validation/error'
+import { BaseEndpointTypes, inputParameters } from '../endpoint/xrpl'
+
+const logger = makeLogger('Token Balance - XRPL')
+
+type RequestParams = typeof inputParameters.validated
+
+const RESULT_DECIMALS = 18
+
+export class XrplTransport extends SubscriptionTransport<BaseEndpointTypes> {
+  config!: BaseEndpointTypes['Settings']
+  endpointName!: string
+
+  async initialize(
+    dependencies: TransportDependencies<BaseEndpointTypes>,
+    adapterSettings: BaseEndpointTypes['Settings'],
+    endpointName: string,
+    transportName: string,
+  ): Promise<void> {
+    await super.initialize(dependencies, adapterSettings, endpointName, transportName)
+    this.config = adapterSettings
+    this.endpointName = endpointName
+  }
+
+  async backgroundHandler(context: EndpointContext<BaseEndpointTypes>, entries: RequestParams[]) {
+    await Promise.all(entries.map(async (param) => this.handleRequest(context, param)))
+    await sleep(context.adapterSettings.BACKGROUND_EXECUTE_MS)
+  }
+
+  async handleRequest(_context: EndpointContext<BaseEndpointTypes>, param: RequestParams) {
+    let response: AdapterResponse<BaseEndpointTypes['Response']>
+    try {
+      response = await this._handleRequest(param)
+    } catch (e: unknown) {
+      const errorMessage = e instanceof Error ? e.message : 'Unknown error occurred'
+      logger.error(e, errorMessage)
+      response = {
+        statusCode: (e as AdapterInputError)?.statusCode || 502,
+        errorMessage,
+        timestamps: {
+          providerDataRequestedUnixMs: 0,
+          providerDataReceivedUnixMs: 0,
+          providerIndicatedTimeUnixMs: undefined,
+        },
+      }
+    }
+    await this.responseCache.write(this.name, [{ params: param, response }])
+  }
+
+  async _handleRequest(
+    _param: RequestParams,
+  ): Promise<AdapterResponse<BaseEndpointTypes['Response']>> {
+    const providerDataRequestedUnixMs = Date.now()
+
+    // TODO: Implement the logic
+    const result = '0'
+
+    return {
+      data: {
+        result,
+        decimals: RESULT_DECIMALS,
+      },
+      statusCode: 200,
+      result,
+      timestamps: {
+        providerDataRequestedUnixMs,
+        providerDataReceivedUnixMs: Date.now(),
+        providerIndicatedTimeUnixMs: undefined,
+      },
+    }
+  }
+
+  getSubscriptionTtlFromConfig(adapterSettings: BaseEndpointTypes['Settings']): number {
+    return adapterSettings.WARMUP_SUBSCRIPTION_TTL
+  }
+}
+
+export const xrplTransport = new XrplTransport()

--- a/packages/sources/token-balance/test/unit/xrpl.test.ts
+++ b/packages/sources/token-balance/test/unit/xrpl.test.ts
@@ -1,0 +1,133 @@
+import { EndpointContext } from '@chainlink/external-adapter-framework/adapter'
+import { TransportDependencies } from '@chainlink/external-adapter-framework/transports'
+import { LoggerFactoryProvider } from '@chainlink/external-adapter-framework/util'
+import { makeStub } from '@chainlink/external-adapter-framework/util/testing-utils'
+import { BaseEndpointTypes } from '../../src/endpoint/xrpl'
+import { XrplTransport } from '../../src/transport/xrpl'
+
+const log = jest.fn()
+const logger = {
+  fatal: log,
+  error: log,
+  warn: log,
+  info: log,
+  debug: log,
+  trace: log,
+}
+
+const loggerFactory = { child: () => logger }
+
+LoggerFactoryProvider.set(loggerFactory)
+
+describe('XrplTransport', () => {
+  const transportName = 'default_single_transport'
+  const endpointName = 'xrpl'
+  const BACKGROUND_EXECUTE_MS = 1500
+
+  const adapterSettings = makeStub('adapterSettings', {
+    WARMUP_SUBSCRIPTION_TTL: 10_000,
+    BACKGROUND_EXECUTE_MS,
+  } as unknown as BaseEndpointTypes['Settings'])
+
+  const context = makeStub('context', {
+    adapterSettings,
+  } as EndpointContext<BaseEndpointTypes>)
+
+  const responseCache = {
+    write: jest.fn(),
+  }
+
+  const dependencies = makeStub('dependencies', {
+    responseCache,
+    subscriptionSetFactory: {
+      buildSet: jest.fn(),
+    },
+  } as unknown as TransportDependencies<BaseEndpointTypes>)
+
+  let transport: XrplTransport
+
+  beforeEach(async () => {
+    jest.resetAllMocks()
+    jest.useFakeTimers()
+
+    transport = new XrplTransport()
+
+    await transport.initialize(dependencies, adapterSettings, endpointName, transportName)
+  })
+
+  afterEach(() => {
+    expect(log).not.toBeCalled()
+  })
+
+  describe('backgroundHandler', () => {
+    it('should sleep after handleRequest', async () => {
+      const t0 = Date.now()
+      let t1 = 0
+      transport.backgroundHandler(context, []).then(() => {
+        t1 = Date.now()
+      })
+      await jest.runAllTimersAsync()
+      expect(t1 - t0).toBe(BACKGROUND_EXECUTE_MS)
+    })
+  })
+
+  describe('handleRequest', () => {
+    it('should cache response', async () => {
+      const address = 'r101'
+
+      const param = makeStub('param', {
+        addresses: [{ address }],
+      })
+      await transport.handleRequest(context, param)
+
+      const expectedResult = '0'
+      const expectedResponse = {
+        statusCode: 200,
+        result: expectedResult,
+        data: {
+          decimals: 18,
+          result: expectedResult,
+        },
+        timestamps: {
+          providerDataRequestedUnixMs: Date.now(),
+          providerDataReceivedUnixMs: Date.now(),
+          providerIndicatedTimeUnixMs: undefined,
+        },
+      }
+
+      expect(responseCache.write).toBeCalledWith(transportName, [
+        {
+          params: param,
+          response: expectedResponse,
+        },
+      ])
+      expect(responseCache.write).toBeCalledTimes(1)
+    })
+  })
+
+  describe('_handleRequest', () => {
+    it('should return a response', async () => {
+      const address = 'r101'
+
+      const param = makeStub('param', {
+        addresses: [{ address }],
+      })
+      const response = await transport._handleRequest(param)
+
+      const expectedResult = '0'
+      expect(response).toEqual({
+        statusCode: 200,
+        result: expectedResult,
+        data: {
+          decimals: 18,
+          result: expectedResult,
+        },
+        timestamps: {
+          providerDataRequestedUnixMs: Date.now(),
+          providerDataReceivedUnixMs: Date.now(),
+          providerIndicatedTimeUnixMs: undefined,
+        },
+      })
+    })
+  })
+})


### PR DESCRIPTION
[DATA-87](https://smartcontract-it.atlassian.net/browse/DATA-87)

## Description

Add scaffolding for new `xrpl` endpoint of `token-balance`.
Eventually the endpoint should fetch balances of addresses from the XRPL network, convert them to USD and add them together.
But no logic is implemented in this PR.
Having the scaffolding in place will make it easier to review the PRs that add the logic.

## Changes

1. Add `xrpl` endpoint.
2. Add `xrpl` transport.

## Steps to Test

1. Added limited unit tests for the transport scaffolding.
2. Tested manually in another branch with more changes.


## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[DATA-87]: https://smartcontract-it.atlassian.net/browse/DATA-87?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ