### PR TITLE
Fix test compilation workflow

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -76,7 +76,7 @@ jobs:
           FAILING_TESTS_PATTERN: '/composites/dydx-rewards/|/composites/glv-token/|/composites/gm-token/|/core/bootstrap/|/sources/bitgo-reserves-test/|/sources/bitgo-reserves/|/sources/coinpaprika/|/sources/cryptocompare/|/sources/icap/|/sources/ipfs/|/sources/layer2-sequencer-health/|/sources/s3-csv-reader/|/sources/view-function-multi-chain/|sources/view-function/|/k6/|/observation/'
         run: |
           echo "Tests that should compile:"
-          configs_to_compile=($(echo "$CHANGED_PACKAGES" | jq '.[].location + "/tsconfig.test.json"' -r | grep -v -E "$FAILING_TESTS_PATTERN"))
+          configs_to_compile=($(echo "$CHANGED_PACKAGES" | jq '.[].location + "/tsconfig.test.json"' -r | grep -v -E "$FAILING_TESTS_PATTERN" || true))
           if [ ${#configs_to_compile[@]} -eq 0 ]; then
             echo "No tests to compile."
           else


### PR DESCRIPTION
## Description

We have a workflow which checks if tests in changed adapters compile without errors.
There is a pattern with a list of adapter that are known to fail compilation.
We use `grep` to filter the list of changed adapters to get only the ones that are not expected to fail.
But if `grep` does not find any matches (i.e., if all changed adapters are known to fail compilation) then `grep` exits with non-zero status code and this causes the workflow to fail.

## Changes

Add `|| true` at the end of the `grep` command to ignore non-zero exit code from grep.

## Steps to Test

1. Ran workflow with [only changes in an adapter which is known to fail compilation](https://github.com/smartcontractkit/external-adapters-js/actions/runs/15015059583/job/42191070424?pr=3862).
2. Ran workflow with [only changes in an adapter which is not known to fail compilation](https://github.com/smartcontractkit/external-adapters-js/actions/runs/15015336230/job/42191945182?pr=3862).
3. Ran workflow with [changes in both types of adapters](https://github.com/smartcontractkit/external-adapters-js/actions/runs/15015253566/job/42191690295?pr=3862).
4. Ran workflow with [broken changes in both types of adapters](https://github.com/smartcontractkit/external-adapters-js/actions/runs/15015166239/job/42191405256?pr=3862).
5. Ran workflow [without any changed adapters](https://github.com/smartcontractkit/external-adapters-js/actions/runs/15014987860/job/42190847720?pr=3862).

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
