### PR TITLE
Add getTotalTokenBalance to XrplTransport

### DIFF
--- a/.changeset/tidy-turkeys-move.md
+++ b/.changeset/tidy-turkeys-move.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/token-balance-adapter': patch
+---
+
+Adding not-yet used code for future new endpoint

--- a/packages/sources/token-balance/src/transport/xrpl.ts
+++ b/packages/sources/token-balance/src/transport/xrpl.ts
@@ -106,7 +106,7 @@ export class XrplTransport extends SubscriptionTransport<BaseEndpointTypes> {
     }
   }
 
-  getTokenBalances({
+  async getTotalTokenBalance({
     addresses,
     tokenIssuerAddress,
   }: {
@@ -114,12 +114,13 @@ export class XrplTransport extends SubscriptionTransport<BaseEndpointTypes> {
       address: string
     }[]
     tokenIssuerAddress: string
-  }): Promise<Decimal[]> {
+  }): Promise<Decimal> {
     const runner = new GroupRunner(this.config.GROUP_SIZE)
     const getBalance = runner.wrapFunction(({ address }: { address: string }) =>
       this.getTokenBalance({ address: address, tokenIssuerAddress }),
     )
-    return Promise.all(addresses.map(getBalance))
+    const balances = await Promise.all(addresses.map(getBalance))
+    return balances.reduce((acc, balance) => acc.plus(balance), new Decimal(0))
   }
 
   async getTokenBalance({

--- a/packages/sources/token-balance/test/unit/xrpl.test.ts
+++ b/packages/sources/token-balance/test/unit/xrpl.test.ts
@@ -230,7 +230,7 @@ describe('XrplTransport', () => {
     })
   })
 
-  describe('getTokenBalances', () => {
+  describe('getTotalTokenBalance', () => {
     it('should return the token balance of multiple addresses', async () => {
       const address1 = 'r101'
       const address2 = 'r102'
@@ -250,12 +250,12 @@ describe('XrplTransport', () => {
       })
       const expectedRequestKey2 = requestKeyForConfig(expectedRequestConfig2)
 
-      const balance = await transport.getTokenBalances({
+      const balance = await transport.getTotalTokenBalance({
         addresses: [{ address: address1 }, { address: address2 }],
         tokenIssuerAddress,
       })
 
-      expect(balance).toEqual([new Decimal(100), new Decimal(200)])
+      expect(balance).toEqual(new Decimal(300))
 
       expect(requester.request).toHaveBeenNthCalledWith(
         1,
@@ -297,7 +297,7 @@ describe('XrplTransport', () => {
       mockLineBalances(lines3)
       mockLineBalances(lines4)
 
-      const balancePromise = transport.getTokenBalances({
+      const balancePromise = transport.getTotalTokenBalance({
         addresses: [
           { address: address1 },
           { address: address2 },
@@ -325,12 +325,7 @@ describe('XrplTransport', () => {
 
       resolveLines4(['104.0'])
 
-      expect(await balancePromise).toEqual([
-        new Decimal(101),
-        new Decimal(102),
-        new Decimal(103),
-        new Decimal(104),
-      ])
+      expect(await balancePromise).toEqual(new Decimal(410))
 
       expect(log).toHaveBeenNthCalledWith(
         1,


### PR DESCRIPTION
[DATA-87](https://smartcontract-it.atlassian.net/browse/DATA-87)

## Description

Eventually the `xrpl` endpoint should fetch balances of addresses from the XRPL network, convert them to USD and add them together.

This PR only adds the ability to fetch multiple balances in groups and add them together. It is not yet used. The transport and endpoint also aren't hooked up to the adapter yet. There are more PRs to come.

## Changes

1. Add `getTotalTokenBalance` which calls `getTokenBalance`  for each of the addresses and adds the result.
2. Use `GroupRunner` to group requests.

## Steps to Test

1. Unit tests were added.
2. Was tested manually end-to-end in a branch with more changes.

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.

[DATA-87]: https://smartcontract-it.atlassian.net/browse/DATA-87?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ