### PR TITLE
Add getTokenPrice util to token-balance

### DIFF
--- a/.changeset/poor-sloths-tickle.md
+++ b/.changeset/poor-sloths-tickle.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/token-balance-adapter': patch
+---
+
+Adding not-yet used code for future new endpoint

--- a/packages/sources/token-balance/src/transport/priceFeed.ts
+++ b/packages/sources/token-balance/src/transport/priceFeed.ts
@@ -1,8 +1,12 @@
-import { ethers } from 'ethers'
 import { AdapterInputError } from '@chainlink/external-adapter-framework/validation/error'
+import { ethers } from 'ethers'
 import EACAggregatorProxy from '../config/EACAggregatorProxy.json'
+import { SharePriceType, getNetworkEnvVar } from './utils'
 
-export const getRate = async (contractAddress: string, provider?: ethers.JsonRpcProvider) => {
+export const getRate = async (
+  contractAddress: string,
+  provider?: ethers.JsonRpcProvider,
+): Promise<SharePriceType> => {
   if (!provider) {
     throw new AdapterInputError({
       statusCode: 400,
@@ -20,4 +24,21 @@ export const getRate = async (contractAddress: string, provider?: ethers.JsonRpc
     value,
     decimal: Number(decimal),
   }
+}
+
+export const getTokenPrice = ({
+  priceOracleAddress,
+  priceOracleNetwork,
+}: {
+  priceOracleAddress: string
+  priceOracleNetwork: string
+}): Promise<SharePriceType> => {
+  const provider = getEvmProvider(priceOracleNetwork)
+  return getRate(priceOracleAddress, provider)
+}
+
+export const getEvmProvider = (network: string): ethers.JsonRpcProvider => {
+  const rpcUrl = getNetworkEnvVar(network, '_RPC_URL')
+  const chainId = getNetworkEnvVar(network, '_RPC_CHAIN_ID')
+  return new ethers.JsonRpcProvider(rpcUrl, Number(chainId))
 }

--- a/packages/sources/token-balance/test/unit/priceFeed.test.ts
+++ b/packages/sources/token-balance/test/unit/priceFeed.test.ts
@@ -1,0 +1,118 @@
+import { makeStub } from '@chainlink/external-adapter-framework/util/testing-utils'
+import { ethers } from 'ethers'
+import EACAggregatorProxy from '../../src//config/EACAggregatorProxy.json'
+import { getEvmProvider, getRate, getTokenPrice } from '../../src/transport/priceFeed'
+
+const originalEnv = { ...process.env }
+
+const restoreEnv = () => {
+  for (const key of Object.keys(process.env)) {
+    if (key in originalEnv) {
+      process.env[key] = originalEnv[key]
+    } else {
+      delete process.env[key]
+    }
+  }
+}
+
+const ethersNewContract = jest.fn()
+const ethersNewJsonRpcProvider = jest.fn()
+
+const makeEthers = () => {
+  return {
+    JsonRpcProvider: function (...args: [string, number]) {
+      return ethersNewJsonRpcProvider(...args)
+    },
+    Contract: function (...args: [string, unknown, ethers.JsonRpcProvider]) {
+      return ethersNewContract(...args)
+    },
+  }
+}
+
+jest.mock('ethers', () => ({
+  ethers: makeEthers(),
+}))
+
+describe('priceFeed', () => {
+  beforeEach(async () => {
+    restoreEnv()
+    jest.resetAllMocks()
+  })
+
+  describe('getRate', () => {
+    it('should return the token price', async () => {
+      const priceOracleAddress = '0x123'
+      const expectedPrice = {
+        value: 12345678n,
+        decimal: 8,
+      }
+
+      const provider = makeStub('provider', {} as ethers.JsonRpcProvider)
+
+      const contract = makeStub('contract', {
+        decimals: jest.fn().mockResolvedValue(expectedPrice.decimal),
+        latestAnswer: jest.fn().mockResolvedValue(expectedPrice.value),
+      })
+      ethersNewContract.mockReturnValue(contract)
+
+      const price = await getRate(priceOracleAddress, provider)
+      expect(price).toEqual(expectedPrice)
+
+      expect(ethersNewContract).toBeCalledWith(priceOracleAddress, EACAggregatorProxy, provider)
+      expect(ethersNewContract).toBeCalledTimes(1)
+    })
+  })
+
+  describe('getTokenPrice', () => {
+    it('should return the token price', async () => {
+      const arbitrumRpcUrl = 'https://arb.rpc.url'
+      const arbitrumChainId = 42161
+      process.env.ARBITRUM_RPC_URL = arbitrumRpcUrl
+      process.env.ARBITRUM_RPC_CHAIN_ID = arbitrumChainId.toString()
+
+      const priceOracleAddress = '0x123'
+      const priceOracleNetwork = 'arbitrum'
+      const expectedPrice = {
+        value: 12345678n,
+        decimal: 8,
+      }
+
+      const provider = makeStub('provider', {})
+      ethersNewJsonRpcProvider.mockReturnValue(provider)
+
+      const contract = makeStub('contract', {
+        decimals: jest.fn().mockResolvedValue(expectedPrice.decimal),
+        latestAnswer: jest.fn().mockResolvedValue(expectedPrice.value),
+      })
+      ethersNewContract.mockReturnValue(contract)
+
+      const price = await getTokenPrice({
+        priceOracleAddress,
+        priceOracleNetwork,
+      })
+      expect(price).toEqual(expectedPrice)
+
+      expect(ethersNewJsonRpcProvider).toBeCalledWith(arbitrumRpcUrl, arbitrumChainId)
+      expect(ethersNewJsonRpcProvider).toBeCalledTimes(1)
+      expect(ethersNewContract).toBeCalledWith(priceOracleAddress, EACAggregatorProxy, provider)
+      expect(ethersNewContract).toBeCalledTimes(1)
+    })
+  })
+
+  describe('getEvmProvider', () => {
+    it('should create new JsonRpcProvider with given URL and chain ID', () => {
+      const arbitrumRpcUrl = 'https://arb.rpc.url'
+      const arbitrumChainId = 42161
+      process.env.ARBITRUM_RPC_URL = arbitrumRpcUrl
+      process.env.ARBITRUM_RPC_CHAIN_ID = arbitrumChainId.toString()
+
+      const provider = makeStub('provider', {})
+      ethersNewJsonRpcProvider.mockReturnValue(provider)
+
+      expect(ethersNewJsonRpcProvider).toBeCalledTimes(0)
+      expect(getEvmProvider('arbitrum')).toBe(provider)
+      expect(ethersNewJsonRpcProvider).toBeCalledWith(arbitrumRpcUrl, arbitrumChainId)
+      expect(ethersNewJsonRpcProvider).toBeCalledTimes(1)
+    })
+  })
+})


### PR DESCRIPTION
[DF-21340](https://smartcontract-it.atlassian.net/browse/DF-21340)

## Description

We already have `getRate` which returns token price based on `JsonRpcProvider` and contract address.
This PR adds `getTokenPrice` which takes `network: string` parameter instead of `JsonRpcProvider` and creates the `JsonRpcProvider` for you as long as `${network}_RPC_URL` and `${network}_RPC_CHAIN_ID` are specified in the environment.

This will be used in `XrplTransport` in a subsequent PR.

## Changes

1. Add `getEvmProvider` and `getTokenPrice`, using `getRate`.
2. Add return type annotation on `getRate`.

## Steps to Test

1. Add unit tests for `getRate`, `getTokenPrice` and `getEvmProvider`.
3. Tested end-to-end in another branch with more changes.

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.

[DF-21340]: https://smartcontract-it.atlassian.net/browse/DF-21340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ