### PR TITLE
Fix view-function test

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Compile tests
         env:
           CHANGED_PACKAGES: ${{ needs.install-packages.outputs.changed-packages }}
-          FAILING_TESTS_PATTERN: '/composites/dydx-rewards/|/composites/glv-token/|/composites/gm-token/|/core/bootstrap/|/sources/bitgo-reserves-test/|/sources/bitgo-reserves/|/sources/coinpaprika/|/sources/cryptocompare/|/sources/icap/|/sources/ipfs/|/sources/layer2-sequencer-health/|/sources/s3-csv-reader/|sources/view-function/|/k6/|/observation/'
+          FAILING_TESTS_PATTERN: '/composites/dydx-rewards/|/composites/glv-token/|/composites/gm-token/|/core/bootstrap/|/sources/bitgo-reserves-test/|/sources/bitgo-reserves/|/sources/coinpaprika/|/sources/cryptocompare/|/sources/icap/|/sources/ipfs/|/sources/layer2-sequencer-health/|/sources/s3-csv-reader/|/k6/|/observation/'
         run: |
           echo "Tests that should compile:"
           configs_to_compile=($(echo "$CHANGED_PACKAGES" | jq '.[].location + "/tsconfig.test.json"' -r | grep -v -E "$FAILING_TESTS_PATTERN" || true))

--- a/packages/sources/view-function/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/view-function/test/integration/__snapshots__/adapter.test.ts.snap
@@ -1,16 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`execute function endpoint should return error for invalid input 1`] = `
-{
-  "errorMessage": "no matching function (argument="key", value="symbol() view returns (string)", code=INVALID_ARGUMENT, version=6.13.5)",
-  "statusCode": 502,
-  "timestamps": {
-    "providerDataReceivedUnixMs": 0,
-    "providerDataRequestedUnixMs": 0,
-  },
-}
-`;
-
 exports[`execute function endpoint should return success 1`] = `
 {
   "data": {

--- a/packages/sources/view-function/test/integration/adapter.test.ts
+++ b/packages/sources/view-function/test/integration/adapter.test.ts
@@ -73,7 +73,13 @@ describe('execute', () => {
       }
       const response = await testAdapter.request(data)
       expect(response.statusCode).toBe(502)
-      expect(response.json()).toMatchSnapshot()
+      expect(response.json()).toEqual({
+        errorMessage: expect.stringMatching(
+          /no matching function \(argument="key", value="symbol\(\) view returns \(string\)", code=INVALID_ARGUMENT, version=/,
+        ),
+        statusCode: 502,
+        timestamps: { providerDataReceivedUnixMs: 0, providerDataRequestedUnixMs: 0 },
+      })
     })
   })
 })

--- a/packages/sources/view-function/test/integration/fixtures.ts
+++ b/packages/sources/view-function/test/integration/fixtures.ts
@@ -3,8 +3,10 @@ import nock from 'nock'
 type JsonRpcPayload = {
   id: number
   method: string
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  params: Array<any> | Record<string, any>
+  params: {
+    to: string
+    data: string
+  }[]
   jsonrpc: '2.0'
 }
 
@@ -16,7 +18,7 @@ export const mockContractCallResponseSuccess = (): nock.Scope =>
     .post('/', (body: any) => Array.isArray(body))
     .reply(
       200,
-      (uri, requestBody: any[]) => {
+      (_uri, requestBody: any[]) => {
         return requestBody.map((request: JsonRpcPayload) => {
           if (request.method === 'eth_chainId') {
             return {


### PR DESCRIPTION
## Description

https://github.com/smartcontractkit/external-adapters-js/pull/3860 fixed the integration test in `view-function-multi-chain`.
This PR does the same for `view-function`.

## Changes

1. Instead of using `toMatchSnapshot` to match the exact error, expect an error message without a specific version.
2. Run `yarn test packages/sources/view-function-multi-chain -u` to remove the now unused snapshot.
3. Prefix unused variables with `_`.
4. Make the `JsonRpcPayload` type in `fixtures.ts` more explicit.
5. Remove `view-function-multi-chain` from the pattern of adapters known to fail test compilation.

## Steps to Test

1. `yarn test packages/sources/view-function-multi-chain`
2. `yarn tsc -b --noEmit packages/sources/view-function-multi-chain/tsconfig.test.json`
3. Searched if there were other snapshots checking specific versions but `git grep 'version='` does not come up with any more snapshot files.

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
