### PR TITLE
Update mobula state EA to ignore nil values for exchange if not returned

### DIFF
--- a/.changeset/gentle-horses-applaud.md
+++ b/.changeset/gentle-horses-applaud.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/mobula-state-adapter': patch
+---
+
+When a specific exchange returns nil ignore its funding rate value

--- a/packages/sources/mobula-state/src/transport/funding-rate.ts
+++ b/packages/sources/mobula-state/src/transport/funding-rate.ts
@@ -75,6 +75,11 @@ export const wsTransport = new WebSocketTransport<WsTransportTypes>({
           return
         }
 
+        if (!value) {
+          // Dont add results when the value is null - one of the exchanges could be unavailable
+          return
+        }
+
         const exchange = key.slice(0, -'FundingRate'.length).toLowerCase()
         results.push(getFundingRateResult(exchange, queryDetails, value as FundingRateResponse))
       })

--- a/packages/sources/mobula-state/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/mobula-state/test/integration/__snapshots__/adapter.test.ts.snap
@@ -16,6 +16,22 @@ exports[`websocket funding rate endpoint have data should return success 1`] = `
 }
 `;
 
+exports[`websocket funding rate endpoint have partial data return success 1`] = `
+{
+  "data": {
+    "epochDuration": 14400,
+    "fundingRate": -0.00059603,
+    "fundingTimestamp": 1747368000,
+  },
+  "result": null,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 4048,
+    "providerDataStreamEstablishedUnixMs": 4040,
+  },
+}
+`;
+
 exports[`websocket funding rate endpoint no data should return failure 1`] = `
 {
   "error": {

--- a/packages/sources/mobula-state/test/integration/adapter.test.ts
+++ b/packages/sources/mobula-state/test/integration/adapter.test.ts
@@ -28,6 +28,13 @@ describe('websocket', () => {
     endpoint: 'funding-rate',
   }
 
+  const dataFundingRateAergo = {
+    base: 'AERGO',
+    quote: '',
+    exchange: 'binance',
+    endpoint: 'funding-rate',
+  }
+
   beforeAll(async () => {
     oldEnv = JSON.parse(JSON.stringify(process.env))
     process.env['WS_API_ENDPOINT'] = wsEndpoint
@@ -74,6 +81,11 @@ describe('websocket', () => {
   describe('funding rate endpoint', () => {
     it('have data should return success', async () => {
       const response = await testAdapter.request(dataFundingRate)
+      expect(response.json()).toMatchSnapshot()
+    })
+
+    it('have partial data return success', async () => {
+      const response = await testAdapter.request(dataFundingRateAergo)
       expect(response.json()).toMatchSnapshot()
     })
 

--- a/packages/sources/mobula-state/test/integration/fixtures.ts
+++ b/packages/sources/mobula-state/test/integration/fixtures.ts
@@ -35,6 +35,22 @@ export const mockWebsocketServer = (URL: string): MockWebsocketServer => {
           queryDetails: { base: 'BTC', quote: null },
         }),
       )
+
+      socket.send(
+        JSON.stringify({
+          binanceFundingRate: {
+            symbol: 'AERGOUSDT',
+            fundingTime: 1747368000001,
+            fundingRate: -0.00059603,
+            marketPrice: '0.15456000',
+            epochDurationMs: 14400000,
+            fundingRateCap: 2,
+            fundingRateFloor: -2,
+          },
+          deribitFundingRate: null,
+          queryDetails: { base: 'AERGO', quote: null },
+        }),
+      )
     })
   })
 


### PR DESCRIPTION
## Description

https://smartcontract-it.atlassian.net/browse/MERC-6963

Update the mobula state adapter to not attempt add results when the value is no present

## Changes

- Check for value back from funding rate EA 

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
