### PR TITLE
Fix rounding error in dlc-btc-por

### DIFF
--- a/.changeset/good-elephants-drive.md
+++ b/.changeset/good-elephants-drive.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/dlc-btc-por-adapter': minor
+---
+
+Fix rounding error

--- a/packages/sources/dlc-btc-por/test/integration/__snapshots__/adapter-rpc-grouping.test.ts.snap
+++ b/packages/sources/dlc-btc-por/test/integration/__snapshots__/adapter-rpc-grouping.test.ts.snap
@@ -3,9 +3,9 @@
 exports[`execute por endpoint should wait before sending the next group of RPCs 1`] = `
 {
   "data": {
-    "result": 60000000.00000001,
+    "result": 60000000,
   },
-  "result": 60000000.00000001,
+  "result": 60000000,
   "statusCode": 200,
   "timestamps": {
     "providerDataReceivedUnixMs": 978347471111,

--- a/packages/sources/dlc-btc-por/test/unit/proof-of-reserves.test.ts
+++ b/packages/sources/dlc-btc-por/test/unit/proof-of-reserves.test.ts
@@ -1,0 +1,169 @@
+import { TransportDependencies } from '@chainlink/external-adapter-framework/transports'
+import { LoggerFactoryProvider } from '@chainlink/external-adapter-framework/util'
+import { makeStub } from '@chainlink/external-adapter-framework/util/testing-utils'
+import { ethers } from 'ethers'
+import { BaseEndpointTypes } from '../../src/endpoint/proof-of-reserves'
+import { DLCBTCPorTransport } from '../../src/transport/proof-of-reserves'
+
+const attestorGroupPubKey =
+  'xpub6C1F2SwADP3TNajQjg2PaniEGpZLvWdMiFP8ChPjQBRWD1XUBeMdE4YkQYvnNhAYGoZKfcQbsRCefserB5DyJM7R9VR6ce6vLrXHVfeqyH3'
+
+const dclContract = makeStub('dclContract', {
+  getAllDLCs: jest.fn(),
+  attestorGroupPubKey: () => attestorGroupPubKey,
+})
+
+const ethersNewJsonRpcProvider = jest.fn()
+
+const makeEthers = () => {
+  return {
+    providers: {
+      JsonRpcProvider: function (...args: [string, number]) {
+        return ethersNewJsonRpcProvider(...args)
+      },
+    },
+    Contract: function (..._args: [string, unknown, ethers.providers.JsonRpcProvider]) {
+      return dclContract
+    },
+  }
+}
+
+jest.mock('ethers', () => ({
+  ethers: makeEthers(),
+}))
+
+LoggerFactoryProvider.set()
+
+describe('DLCBTCPorTransport', () => {
+  const transportName = 'default_single_transport'
+  const endpointName = 'proof-of-reserves'
+
+  const requester = makeStub('requester', {
+    request: jest.fn(),
+  })
+
+  let transport: DLCBTCPorTransport
+
+  const mockDepositValues = (values: number[]) => {
+    const vault = makeStub('vault', {
+      taprootPubKey: '0ca680937aea8ba2bfb28caff303e0e65a8ce601992dcb7054be9207be28e600',
+      valueLocked: 1_000_000n,
+      wdTxId: '0031e30e65294aabcf23f492d9ffd8643203ce1e42040e428eabacda13402e02',
+      uuid: '0xaa69d154f104614970f761bc8784999505720e84d58b9cfc3ae1ee115e14e6c2',
+    })
+    dclContract.getAllDLCs.mockResolvedValue(values.map((_value) => vault))
+
+    // Should match the script from createTaprootMultisigPayment to filter
+    // the vouts correctly.
+    const scriptHex = '5120b8d03525a233dc5e20558613459ce3d29ecae11c5d4862910d6bae846a7754e6'
+
+    for (const value of values) {
+      const bitcoinRpcResponse = makeStub('bitcoinRpcResponse', {
+        response: {
+          data: {
+            result: {
+              confirmations: 200,
+              vout: [
+                {
+                  value,
+                  scriptPubKey: {
+                    hex: scriptHex,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      })
+      requester.request.mockResolvedValueOnce(bitcoinRpcResponse)
+    }
+  }
+
+  beforeEach(async () => {
+    jest.restoreAllMocks()
+    jest.useFakeTimers()
+
+    transport = new DLCBTCPorTransport()
+
+    const responseCache = {
+      write: jest.fn(),
+    }
+
+    const dependencies = makeStub('dependencies', {
+      requester,
+      responseCache,
+      subscriptionSetFactory: {
+        buildSet: jest.fn(),
+      },
+    } as unknown as TransportDependencies<BaseEndpointTypes>)
+
+    const adapterSettings = makeStub('adapterSettings', {
+      BITCOIN_NETWORK: 'mainnet',
+      BITCOIN_RPC_URL: 'http://localhost:8332',
+      BITCOIN_RPC_GROUP_SIZE: 3,
+      CONFIRMATIONS: 6,
+      EVM_RPC_BATCH_SIZE: 100,
+      WARMUP_SUBSCRIPTION_TTL: 10_000,
+    } as unknown as BaseEndpointTypes['Settings'])
+
+    await transport.initialize(dependencies, adapterSettings, endpointName, transportName)
+  })
+
+  describe('_handleRequest', () => {
+    it('should return a result with the sum of deposits', async () => {
+      const values = [1, 2, 3]
+
+      mockDepositValues(values)
+
+      const params = makeStub('params', {
+        network: 'arbitrum',
+        dlcContract: '0x20157DBAbb84e3BBFE68C349d0d44E48AE7B5AD2',
+      })
+      const response = await transport._handleRequest(params)
+
+      const expectedResult = 600_000_000
+
+      expect(response).toEqual({
+        data: {
+          result: expectedResult,
+        },
+        result: expectedResult,
+        statusCode: 200,
+        timestamps: {
+          providerDataReceivedUnixMs: Date.now(),
+          providerDataRequestedUnixMs: Date.now(),
+        },
+      })
+    })
+
+    it('should avoid rounding errors', async () => {
+      const values = [0.5, 1, 2, 4, 1.5648, 0.4701, 2, 4.91415422, 3.2, 0.898, 0.01, 15, 0.01]
+
+      mockDepositValues(values)
+
+      const params = makeStub('params', {
+        network: 'arbitrum',
+        dlcContract: '0x20157DBAbb84e3BBFE68C349d0d44E48AE7B5AD2',
+      })
+      const response = await transport._handleRequest(params)
+
+      const expectedResult = 3556705422
+
+      // Demonstrate how naively adding these values leads to rounding errors:
+      const sum = values.reduce((acc, value) => acc + value, 0)
+      expect(sum * 10 ** 8).toBe(3556705421.9999995)
+
+      expect(response).toEqual({
+        data: {
+          result: expectedResult,
+        },
+        result: expectedResult,
+        statusCode: 200,
+        timestamps: {
+          providerDataReceivedUnixMs: Date.now(),
+          providerDataRequestedUnixMs: Date.now(),
+        },
+      })
+    })
+  })
+})


### PR DESCRIPTION
[DF-21353](https://smartcontract-it.atlassian.net/browse/DF-21353)

## Description

The [DLC BTC PoR feed](https://arbiscan.io/address/0x0543Bb6b5A57E3e7569237b67321eAB773e41401#readContract) reports a reserve which is off by 1 satoshi.
This seems to happen because of a rounding error which results in a fractional amount of satoshi which then get rounded down.

The total number of satoshi on all of BTC actually fits in a float64 so as long as we work with integer numbers of satoshi, using `Number` should not be a problem.
But the Bitcoin RPC interface returns decimal numbers of BTC and the EA adds those decimal numbers together because converting them to Satoshi.

## Changes

Convert numbers to satoshi (and round to integers) before adding them together.

## Steps to Test

1. Unit test added.
2. Snapshot updated.
3. Tested manually with the input from the actual feed.
```
curl -X POST http://localhost:8080 -H "Content-Type: application/json" -d '{
  "data": {
    "dlcContract": "0x20157DBAbb84e3BBFE68C349d0d44E48AE7B5AD2",
    "endpoint": "reserves",
    "network": "arbitrum"
  }
}' | jq

{
  "data": {
    "result": 3556705422
  },
  "statusCode": 200,
  "result": 3556705422,
  "timestamps": {
    "providerDataRequestedUnixMs": 1747930027212,
    "providerDataReceivedUnixMs": 1747930030874
  },
  "meta": {
    "adapterName": "DLC_BTC_POR",
    "metrics": {
      "feedId": "{\"network\":\"arbitrum\",\"dlcContract\":\"0x20157dbabb84e3bbfe68c349d0d44e48ae7b5ad2\"}"
    }
  }
}
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[DF-21353]: https://smartcontract-it.atlassian.net/browse/DF-21353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ