### PR TITLE
Feat/DF-21361 emgemx

### DIFF
--- a/.changeset/afraid-wasps-add.md
+++ b/.changeset/afraid-wasps-add.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/the-network-firm-adapter': minor
+---
+
+Add emgemx endpoint

--- a/packages/sources/the-network-firm/src/config/index.ts
+++ b/packages/sources/the-network-firm/src/config/index.ts
@@ -6,4 +6,16 @@ export const config = new AdapterConfig({
     type: 'string',
     default: 'https://api.oracle-services.ledgerlens.io/v1/chainlink/proof-of-reserves/',
   },
+  V2_API_ENDPOINT: {
+    description: 'TNF v2 API Endpoint',
+    type: 'string',
+    default: 'https://api.ledgerlens.io/oc/v1',
+  },
+  EMGEMX_API_KEY: {
+    description: 'API key used for emgemx endpoint',
+    type: 'string',
+    required: false,
+    sensitive: true,
+    default: '',
+  },
 })

--- a/packages/sources/the-network-firm/src/config/index.ts
+++ b/packages/sources/the-network-firm/src/config/index.ts
@@ -6,8 +6,8 @@ export const config = new AdapterConfig({
     type: 'string',
     default: 'https://api.oracle-services.ledgerlens.io/v1/chainlink/proof-of-reserves/',
   },
-  V2_API_ENDPOINT: {
-    description: 'TNF v2 API Endpoint',
+  ALT_API_ENDPOINT: {
+    description: 'TNF alt API Endpoint',
     type: 'string',
     default: 'https://api.ledgerlens.io/oc/v1',
   },

--- a/packages/sources/the-network-firm/src/endpoint/emgemx.ts
+++ b/packages/sources/the-network-firm/src/endpoint/emgemx.ts
@@ -3,7 +3,7 @@ import {
   PoRProviderResponse,
 } from '@chainlink/external-adapter-framework/adapter/por'
 import { InputParameters } from '@chainlink/external-adapter-framework/validation'
-import { AdapterError } from '@chainlink/external-adapter-framework/validation/error'
+import { AdapterInputError } from '@chainlink/external-adapter-framework/validation/error'
 import { config } from '../config'
 import { httpTransport } from '../transport/emgemx'
 
@@ -19,9 +19,9 @@ export const endpoint = new PoRProviderEndpoint({
   name: 'emgemx',
   transport: httpTransport,
   inputParameters,
-  customInputValidation: (_, adapterSettings): AdapterError | undefined => {
+  customInputValidation: (_, adapterSettings): AdapterInputError | undefined => {
     if (!adapterSettings.EMGEMX_API_KEY) {
-      throw new AdapterError({
+      throw new AdapterInputError({
         statusCode: 500,
         message: 'missing EMGEMX_API_KEY env var',
       })

--- a/packages/sources/the-network-firm/src/endpoint/emgemx.ts
+++ b/packages/sources/the-network-firm/src/endpoint/emgemx.ts
@@ -1,0 +1,31 @@
+import {
+  PoRProviderEndpoint,
+  PoRProviderResponse,
+} from '@chainlink/external-adapter-framework/adapter/por'
+import { InputParameters } from '@chainlink/external-adapter-framework/validation'
+import { AdapterError } from '@chainlink/external-adapter-framework/validation/error'
+import { config } from '../config'
+import { httpTransport } from '../transport/emgemx'
+
+export const inputParameters = new InputParameters({})
+
+export type BaseEndpointTypes = {
+  Parameters: typeof inputParameters.definition
+  Response: PoRProviderResponse
+  Settings: typeof config.settings
+}
+
+export const endpoint = new PoRProviderEndpoint({
+  name: 'emgemx',
+  transport: httpTransport,
+  inputParameters,
+  customInputValidation: (_, adapterSettings): AdapterError | undefined => {
+    if (!adapterSettings.EMGEMX_API_KEY) {
+      throw new AdapterError({
+        statusCode: 500,
+        message: 'missing EMGEMX_API_KEY env var',
+      })
+    }
+    return
+  },
+})

--- a/packages/sources/the-network-firm/src/endpoint/index.ts
+++ b/packages/sources/the-network-firm/src/endpoint/index.ts
@@ -1,4 +1,5 @@
 export { endpoint as backed } from './backed'
+export { endpoint as emgemx } from './emgemx'
 export { endpoint as eurr } from './eurr'
 export { endpoint as gift } from './gift'
 export { endpoint as mco2 } from './mco2'

--- a/packages/sources/the-network-firm/src/index.ts
+++ b/packages/sources/the-network-firm/src/index.ts
@@ -1,13 +1,13 @@
 import { expose, ServerInstance } from '@chainlink/external-adapter-framework'
 import { PoRAdapter } from '@chainlink/external-adapter-framework/adapter/por'
 import { config } from './config'
-import { backed, eurr, gift, mco2, stbt, usdr } from './endpoint'
+import { backed, emgemx, eurr, gift, mco2, stbt, usdr } from './endpoint'
 
 export const adapter = new PoRAdapter({
   defaultEndpoint: mco2.name,
   name: 'THE_NETWORK_FIRM',
   config,
-  endpoints: [backed, eurr, gift, mco2, stbt, usdr],
+  endpoints: [backed, eurr, gift, mco2, stbt, usdr, emgemx],
   rateLimiting: {
     tiers: {
       default: {

--- a/packages/sources/the-network-firm/src/transport/emgemx.ts
+++ b/packages/sources/the-network-firm/src/transport/emgemx.ts
@@ -1,0 +1,81 @@
+import { HttpTransport } from '@chainlink/external-adapter-framework/transports'
+import { BaseEndpointTypes } from '../endpoint/emgemx'
+
+export interface ResponseSchema {
+  totalReserve: string
+  totalToken: string
+  ripcord: boolean
+  ripcordDetails: string[]
+  timestamp: string
+}
+
+export type HttpTransportTypes = BaseEndpointTypes & {
+  Provider: {
+    RequestBody: never
+    ResponseBody: ResponseSchema
+  }
+}
+
+export const httpTransport = new HttpTransport<HttpTransportTypes>({
+  prepareRequests: (params, config) => {
+    return {
+      params,
+      request: {
+        baseURL: config.V2_API_ENDPOINT,
+        url: '/emgemx-tdfkf3',
+        headers: {
+          apikey: config.EMGEMX_API_KEY,
+        },
+      },
+    }
+  },
+  parseResponse: (params, response) => {
+    return params.map((param) => {
+      const timestamps = {
+        providerIndicatedTimeUnixMs: new Date(response.data.timestamp).getTime(),
+      }
+
+      // Return error if ripcord == true
+      if (response.data.ripcord) {
+        const message = `Ripcord indicator true. Details: ${response.data.ripcordDetails.join(
+          ', ',
+        )}`
+        return {
+          params: param,
+          response: {
+            errorMessage: message,
+            ripcord: response.data.ripcord,
+            ripcordDetails: response.data.ripcordDetails.join(', '),
+            statusCode: 502,
+            timestamps,
+          },
+        }
+      }
+
+      const reserve = response.data.totalReserve
+      if (reserve == null || isNaN(Number(reserve))) {
+        return {
+          params: param,
+          response: {
+            errorMessage: 'Response is missing valid totalReserve field',
+            statusCode: 502,
+            timestamps,
+          },
+        }
+      }
+
+      const result = Number(reserve)
+      return {
+        params: param,
+        response: {
+          result,
+          data: {
+            result,
+            ripcord: response.data.ripcord,
+          },
+          timestamps,
+        },
+      }
+    })
+  },
+})

--- a/packages/sources/the-network-firm/src/transport/emgemx.ts
+++ b/packages/sources/the-network-firm/src/transport/emgemx.ts
@@ -21,7 +21,7 @@ export const httpTransport = new HttpTransport<HttpTransportTypes>({
     return {
       params,
       request: {
-        baseURL: config.V2_API_ENDPOINT,
+        baseURL: config.ALT_API_ENDPOINT,
         url: '/emgemx-tdfkf3',
         headers: {
           apikey: config.EMGEMX_API_KEY,

--- a/packages/sources/the-network-firm/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/the-network-firm/test/integration/__snapshots__/adapter.test.ts.snap
@@ -28,6 +28,22 @@ exports[`execute backed endpoint should return success 1`] = `
 }
 `;
 
+exports[`execute emgemx endpoint should return success 1`] = `
+{
+  "data": {
+    "result": 1000000,
+    "ripcord": false,
+  },
+  "result": 1000000,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 978347471111,
+    "providerDataRequestedUnixMs": 978347471111,
+    "providerIndicatedTimeUnixMs": 1748007917250,
+  },
+}
+`;
+
 exports[`execute eurr endpoint should return success 1`] = `
 {
   "data": {

--- a/packages/sources/the-network-firm/test/integration/__snapshots__/ripcord.test.ts.snap
+++ b/packages/sources/the-network-firm/test/integration/__snapshots__/ripcord.test.ts.snap
@@ -14,6 +14,20 @@ exports[`execute backed endpoint when ripcord true should return error 1`] = `
 }
 `;
 
+exports[`execute emgemx endpoint when ripcord true  should return error 1`] = `
+{
+  "errorMessage": "Ripcord indicator true. Details: Balances",
+  "ripcord": true,
+  "ripcordDetails": "Balances",
+  "statusCode": 502,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 978347471111,
+    "providerDataRequestedUnixMs": 978347471111,
+    "providerIndicatedTimeUnixMs": 1748007917250,
+  },
+}
+`;
+
 exports[`execute eurr endpoint when ripcord true  should return error 1`] = `
 {
   "errorMessage": "Ripcord indicator true. Details: Balances",

--- a/packages/sources/the-network-firm/test/integration/adapter.test.ts
+++ b/packages/sources/the-network-firm/test/integration/adapter.test.ts
@@ -5,6 +5,7 @@ import {
 import * as nock from 'nock'
 import {
   mockBackedResponseSuccess,
+  mockEmgemxResponseSuccess,
   mockEurrResponseSuccess,
   mockGiftResponseSuccess,
   mockMCO2Response,
@@ -21,6 +22,9 @@ describe('execute', () => {
     oldEnv = JSON.parse(JSON.stringify(process.env))
     const mockDate = new Date('2001-01-01T11:11:11.111Z')
     spy = jest.spyOn(Date, 'now').mockReturnValue(mockDate.getTime())
+
+    process.env.V2_API_ENDPOINT = 'http://test-endpoint-new'
+    process.env.EMGEMX_API_KEY = 'api-key'
 
     const adapter = (await import('./../../src')).adapter
     adapter.rateLimiting = undefined
@@ -115,6 +119,19 @@ describe('execute', () => {
         endpoint: 'gift',
       }
       mockGiftResponseSuccess()
+
+      const response = await testAdapter.request(data)
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toMatchSnapshot()
+    })
+  })
+
+  describe('emgemx endpoint', () => {
+    it('should return success', async () => {
+      const data = {
+        endpoint: 'emgemx',
+      }
+      mockEmgemxResponseSuccess()
 
       const response = await testAdapter.request(data)
       expect(response.statusCode).toBe(200)

--- a/packages/sources/the-network-firm/test/integration/adapter.test.ts
+++ b/packages/sources/the-network-firm/test/integration/adapter.test.ts
@@ -23,7 +23,7 @@ describe('execute', () => {
     const mockDate = new Date('2001-01-01T11:11:11.111Z')
     spy = jest.spyOn(Date, 'now').mockReturnValue(mockDate.getTime())
 
-    process.env.V2_API_ENDPOINT = 'http://test-endpoint-new'
+    process.env.ALT_API_ENDPOINT = 'http://test-endpoint-new'
     process.env.EMGEMX_API_KEY = 'api-key'
 
     const adapter = (await import('./../../src')).adapter

--- a/packages/sources/the-network-firm/test/integration/fixtures.ts
+++ b/packages/sources/the-network-firm/test/integration/fixtures.ts
@@ -228,3 +228,31 @@ export const mockGiftResponseFailure = (): nock.Scope =>
       ripcordDetails: ['Balances'],
     })
     .persist()
+
+export const mockEmgemxResponseSuccess = (): nock.Scope =>
+  nock('http://test-endpoint-new', {
+    encodedQueryParams: true,
+  })
+    .get('/emgemx-tdfkf3')
+    .reply(200, {
+      totalReserve: '1000000',
+      totalToken: '100000',
+      ripcord: false,
+      ripcordDetails: [],
+      timestamp: '2025-05-23T13:45:17.250Z',
+    })
+    .persist()
+
+export const mockEmgemxResponseRipcordFailure = (): nock.Scope =>
+  nock('http://test-endpoint-new', {
+    encodedQueryParams: true,
+  })
+    .get('/emgemx-tdfkf3')
+    .reply(200, {
+      totalReserve: '1000000',
+      totalToken: '100000',
+      ripcord: true,
+      ripcordDetails: ['Balances'],
+      timestamp: '2025-05-23T13:45:17.250Z',
+    })
+    .persist()

--- a/packages/sources/the-network-firm/test/integration/ripcord.test.ts
+++ b/packages/sources/the-network-firm/test/integration/ripcord.test.ts
@@ -5,6 +5,7 @@ import {
 import * as nock from 'nock'
 import {
   mockBackedResponseFailure,
+  mockEmgemxResponseRipcordFailure,
   mockEurrResponseFailure,
   mockGiftResponseFailure,
   mockSTBTResponseFailure,
@@ -22,6 +23,9 @@ describe('execute', () => {
     oldEnv = JSON.parse(JSON.stringify(process.env))
     const mockDate = new Date('2001-01-01T11:11:11.111Z')
     spy = jest.spyOn(Date, 'now').mockReturnValue(mockDate.getTime())
+
+    process.env.V2_API_ENDPOINT = 'http://test-endpoint-new'
+    process.env.EMGEMX_API_KEY = 'api-key'
 
     const adapter = (await import('../../src')).adapter
     adapter.rateLimiting = undefined
@@ -93,6 +97,18 @@ describe('execute', () => {
         endpoint: 'gift',
       }
       mockGiftResponseFailure()
+      const response = await testAdapter.request(data)
+      expect(response.statusCode).toBe(502)
+      expect(response.json()).toMatchSnapshot()
+    })
+  })
+
+  describe('emgemx endpoint when ripcord true ', () => {
+    it('should return error', async () => {
+      const data = {
+        endpoint: 'emgemx',
+      }
+      mockEmgemxResponseRipcordFailure()
       const response = await testAdapter.request(data)
       expect(response.statusCode).toBe(502)
       expect(response.json()).toMatchSnapshot()

--- a/packages/sources/the-network-firm/test/integration/ripcord.test.ts
+++ b/packages/sources/the-network-firm/test/integration/ripcord.test.ts
@@ -24,7 +24,7 @@ describe('execute', () => {
     const mockDate = new Date('2001-01-01T11:11:11.111Z')
     spy = jest.spyOn(Date, 'now').mockReturnValue(mockDate.getTime())
 
-    process.env.V2_API_ENDPOINT = 'http://test-endpoint-new'
+    process.env.ALT_API_ENDPOINT = 'http://test-endpoint-new'
     process.env.EMGEMX_API_KEY = 'api-key'
 
     const adapter = (await import('../../src')).adapter


### PR DESCRIPTION
## Closes #[DF-21361](https://smartcontract-it.atlassian.net/browse/DF-21361)

## Description
Added emgemx endpoint to the-network-firm EA

## Changes
- Added emgemx endpoint to the-network-firm EA
- Added extra required env vars as needed -- `V2_API_ENDPOINT`, `EMGEMX_API_KEY`

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. yarn test the-network-firm
2. Set `EMGEMX_API_KEY` env var and use payload
```json
{
    "data": {
        "endpoint": "emgemx"
    }
}
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[DF-21361]: https://smartcontract-it.atlassian.net/browse/DF-21361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ