### PR TITLE
Add support for USYC

### DIFF
--- a/.changeset/breezy-hairs-yell.md
+++ b/.changeset/breezy-hairs-yell.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/por-address-list-adapter': minor
+---
+
+Support USYC token

--- a/packages/sources/por-address-list/src/transport/openEdenUSDOAddress.ts
+++ b/packages/sources/por-address-list/src/transport/openEdenUSDOAddress.ts
@@ -1,10 +1,10 @@
-import { SubscriptionTransport } from '@chainlink/external-adapter-framework/transports/abstract/subscription'
 import { EndpointContext } from '@chainlink/external-adapter-framework/adapter'
 import { TransportDependencies } from '@chainlink/external-adapter-framework/transports'
+import { SubscriptionTransport } from '@chainlink/external-adapter-framework/transports/abstract/subscription'
 import { AdapterResponse, sleep } from '@chainlink/external-adapter-framework/util'
+import { ethers } from 'ethers'
 import OpenEdenUSDOPoRAddressList from '../config/OpenEdenUSDOPoRAddressList.json'
 import { BaseEndpointTypes, inputParameters } from '../endpoint/openEdenUSDOAddress'
-import { ethers } from 'ethers'
 import { addProvider, getProvider } from './providerUtils'
 
 export type AddressTransportTypes = BaseEndpointTypes
@@ -123,7 +123,7 @@ const buildOtherResponse = (addressList: ResponseSchema[]) => {
 
 const buildTBILLResponse = (addressList: ResponseSchema[]) => {
   return addressList
-    .filter((addr) => addr.tokenSymbol == 'TBILL')
+    .filter((addr) => ['TBILL', 'USYC'].includes(addr.tokenSymbol))
     .map((addr) => ({
       contractAddress: addr.tokenAddress,
       network: addr.chain,


### PR DESCRIPTION
## Closes #DF-21354 - Part 1

## Description
Add support for USYC in por-address-list EA

## Steps to Test
yarn test packages/sources/por-address-list/test

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [x] This is related to a maximum of one Jira story or GitHub issue.
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
