### PR TITLE
Add unit test for openEdenUSDOAddress transport of por-address-list

### DIFF
--- a/packages/sources/por-address-list/test/unit/openEdenUSDOAddress.test.ts
+++ b/packages/sources/por-address-list/test/unit/openEdenUSDOAddress.test.ts
@@ -1,7 +1,10 @@
+import { TransportDependencies } from '@chainlink/external-adapter-framework/transports'
 import { LoggerFactoryProvider } from '@chainlink/external-adapter-framework/util'
 import { makeStub } from '@chainlink/external-adapter-framework/util/testing-utils'
-import { BaseEndpointTypes } from '../../src/endpoint/openEdenUSDOAddress'
+import { BaseEndpointTypes, inputParameters } from '../../src/endpoint/openEdenUSDOAddress'
 import { AddressTransport } from '../../src/transport/openEdenUSDOAddress'
+
+type RequestParams = typeof inputParameters.validated
 
 const originalEnv = { ...process.env }
 
@@ -71,10 +74,6 @@ describe('AddressTransport', () => {
     WARMUP_SUBSCRIPTION_TTL: 10_000,
   } as unknown as BaseEndpointTypes['Settings'])
 
-  const context = makeStub('context', {
-    adapterSettings,
-  } as EndpointContext<BaseEndpointTypes>)
-
   const responseCache = {
     write: jest.fn(),
   }
@@ -89,6 +88,7 @@ describe('AddressTransport', () => {
   let transport: AddressTransport
 
   beforeEach(async () => {
+    restoreEnv()
     jest.restoreAllMocks()
     jest.useFakeTimers()
 
@@ -106,7 +106,7 @@ describe('AddressTransport', () => {
         contractAddress: ADDRESS_LIST_CONTRACT_ADDRESS,
         contractAddressNetwork: 'BASE',
         type: 'tbill',
-      })
+      } as RequestParams)
       const response = await transport._handleRequest(params)
       expect(response).toEqual({
         statusCode: 200,
@@ -130,7 +130,7 @@ describe('AddressTransport', () => {
         contractAddress: ADDRESS_LIST_CONTRACT_ADDRESS,
         contractAddressNetwork: 'BASE',
         type: 'tbill',
-      })
+      } as RequestParams)
       const response = await transport._handleRequest(params)
       expect(response).toEqual({
         statusCode: 200,
@@ -163,7 +163,7 @@ describe('AddressTransport', () => {
         contractAddress: ADDRESS_LIST_CONTRACT_ADDRESS,
         contractAddressNetwork: 'BASE',
         type: 'other',
-      })
+      } as RequestParams)
       const response = await transport._handleRequest(params)
       expect(response).toEqual({
         statusCode: 200,


### PR DESCRIPTION
## Description

`por-address-list` is missing unit test coverage making it hard to make changes.

This PR adds a unit test just for the `_handleRequest` method of the `openEdenUSDOAddress` transport.
It's limit coverage but it should help with making changes to the filtering logic of this transport.

## Changes

Add `openEdenUSDOAddress.test.ts` with tests for filtering based on `type` parameter.

## Steps to Test

```
yarn jest packages/sources/por-address-list/test/unit/openEdenUSDOAddress.test.ts
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
