### PR TITLE
Patch/DF-21368 lido por remove ripcord

### DIFF
--- a/.changeset/brown-pets-compete.md
+++ b/.changeset/brown-pets-compete.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/lido-por-adapter': patch
+---
+
+remove ripcord

--- a/packages/sources/lido-por/src/transport/reserve.ts
+++ b/packages/sources/lido-por/src/transport/reserve.ts
@@ -80,10 +80,6 @@ export class BalanceTransport extends SubscriptionTransport<BaseEndpointTypes> {
     if (beaconBalance.isNegative()) {
       return {
         errorMessage: `ethereum-cl-indexer balance endpoint returns negative value ${beaconBalance}`,
-        ripcord: true,
-        ripcordDetails: JSON.stringify(
-          `ethereum-cl-indexer balance endpoint returns negative value`,
-        ),
         statusCode: 502,
         timestamps: {
           providerDataRequestedUnixMs,
@@ -100,7 +96,6 @@ export class BalanceTransport extends SubscriptionTransport<BaseEndpointTypes> {
     return {
       data: {
         result: balance,
-        ripcord: false,
       },
       result: balance,
       timestamps: {

--- a/packages/sources/lido-por/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/lido-por/test/integration/__snapshots__/adapter.test.ts.snap
@@ -1,10 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`execute reserve endpoint should return ripcord 1`] = `
+exports[`execute reserve endpoint should return error 1`] = `
 {
   "errorMessage": "ethereum-cl-indexer balance endpoint returns negative value -1",
-  "ripcord": true,
-  "ripcordDetails": ""ethereum-cl-indexer balance endpoint returns negative value"",
   "statusCode": 502,
   "timestamps": {
     "providerDataReceivedUnixMs": 978347471111,
@@ -17,7 +15,6 @@ exports[`execute reserve endpoint should return success 1`] = `
 {
   "data": {
     "result": "800",
-    "ripcord": false,
   },
   "result": "800",
   "statusCode": 200,

--- a/packages/sources/lido-por/test/integration/adapter.test.ts
+++ b/packages/sources/lido-por/test/integration/adapter.test.ts
@@ -4,7 +4,7 @@ import {
 } from '@chainlink/external-adapter-framework/util/testing-utils'
 import { ethers } from 'ethers'
 import * as nock from 'nock'
-import { mockResponseSuccess, mockResponseFailure } from './fixtures'
+import { mockResponseFailure, mockResponseSuccess } from './fixtures'
 
 jest.mock('ethers', () => {
   const actualModule = jest.requireActual('ethers')
@@ -77,7 +77,7 @@ describe('execute', () => {
       expect(response.json()).toMatchSnapshot()
     })
 
-    it('should return ripcord', async () => {
+    it('should return error', async () => {
       const data = {
         lidoContract: 'invalid',
       }


### PR DESCRIPTION
## Closes #[DF-21368](https://smartcontract-it.atlassian.net/browse/DF-21368)

## Description
Follow up to https://github.com/smartcontractkit/external-adapters-js/pull/3887, entirely removing ripcord from lido-por EA since it isn't being used for it's regular purpose here.

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test
1. yarn test lido-por
2. sanity test with payload
```json
{
    "data": {
        "endpoint": "reserve",
        "lidoContract": "0xae7ab96520de3a18e5e111b5eaab095312d7fe84"
    }
}
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[DF-21368]: https://smartcontract-it.atlassian.net/browse/DF-21368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ