### PR TITLE
Log warning for missing XRPL_RPC_URL

### DIFF
--- a/.changeset/tender-pigs-shake.md
+++ b/.changeset/tender-pigs-shake.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/token-balance-adapter': patch
+---
+
+Log warning instead of error when XRPL_RPC_URL is not set.

--- a/packages/sources/token-balance/src/transport/xrpl.ts
+++ b/packages/sources/token-balance/src/transport/xrpl.ts
@@ -56,7 +56,7 @@ export class XrplTransport extends SubscriptionTransport<BaseEndpointTypes> {
     this.requester = dependencies.requester
 
     if (!adapterSettings.XRPL_RPC_URL) {
-      logger.error('Environment variable XRPL_RPC_URL is missing')
+      logger.warn('Environment variable XRPL_RPC_URL is missing')
     }
   }
 

--- a/packages/sources/token-balance/test/unit/xrpl.test.ts
+++ b/packages/sources/token-balance/test/unit/xrpl.test.ts
@@ -39,10 +39,11 @@ jest.mock('ethers', () => ({
 }))
 
 const log = jest.fn()
+const warningLog = jest.fn()
 const logger = {
   fatal: log,
   error: log,
-  warn: log,
+  warn: warningLog,
   info: log,
   debug: log,
   trace: log,
@@ -169,6 +170,7 @@ describe('XrplTransport', () => {
 
   afterEach(() => {
     expect(log).not.toBeCalled()
+    expect(warningLog).not.toBeCalled()
   })
 
   describe('initialize', () => {
@@ -184,9 +186,9 @@ describe('XrplTransport', () => {
         transportName,
       )
 
-      expect(log).toBeCalledWith('Environment variable XRPL_RPC_URL is missing')
-      expect(log).toBeCalledTimes(1)
-      log.mockClear()
+      expect(warningLog).toBeCalledWith('Environment variable XRPL_RPC_URL is missing')
+      expect(warningLog).toBeCalledTimes(1)
+      warningLog.mockClear()
     })
   })
 
@@ -562,9 +564,9 @@ describe('XrplTransport', () => {
           tokenIssuerAddress,
         }),
       ).rejects.toThrow('Environment variable XRPL_RPC_URL is missing')
-      expect(log).toBeCalledWith('Environment variable XRPL_RPC_URL is missing')
-      expect(log).toBeCalledTimes(1)
-      log.mockClear()
+      expect(warningLog).toBeCalledWith('Environment variable XRPL_RPC_URL is missing')
+      expect(warningLog).toBeCalledTimes(1)
+      warningLog.mockClear()
     })
   })
 })


### PR DESCRIPTION
## Description

We currently log an error when `token-balance` starts up and `XRPL_RPC_URL` is not set on the environment.
But this env var is only needed when the `xrpl` endpoint is used and not all NOPs will be receiving requests on this endpoint.
So logging this as an error can be confusing and it's better to log it as a warning.

## Changes

Change the message about missing `XRPL_RPC_URL` from an error to a warning.

## Steps to Test

1. Unit tests were adjusted.
2. Tested manually by starting the EA and seeing `"level":"warn"` in
```
{"level":"warn","time":1748849605640,"isoTime":"2025-06-02T07:33:25.640Z","pid":65575,"hostname":"MB-LYCC91HP2M","layer":"Token Balance - XRPL","msg":"Environment variable XRPL_RPC_URL is missing"}
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
