### PR TITLE
finalto: Support overrides for stock symbols

### DIFF
--- a/.changeset/healthy-islands-stare.md
+++ b/.changeset/healthy-islands-stare.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/finalto-adapter': minor
+---
+
+Add support for stock assets

--- a/packages/sources/finalto/src/endpoint/index.ts
+++ b/packages/sources/finalto/src/endpoint/index.ts
@@ -1,1 +1,1 @@
-export { endpoint as forex } from './forex'
+export { endpoint as quote } from './quote'

--- a/packages/sources/finalto/src/endpoint/quote.ts
+++ b/packages/sources/finalto/src/endpoint/quote.ts
@@ -1,11 +1,11 @@
 import {
-  ForexPriceEndpoint,
+  PriceEndpoint,
   priceEndpointInputParametersDefinition,
 } from '@chainlink/external-adapter-framework/adapter'
-import { InputParameters } from '@chainlink/external-adapter-framework/validation'
 import { SingleNumberResultResponse } from '@chainlink/external-adapter-framework/util'
+import { InputParameters } from '@chainlink/external-adapter-framework/validation'
 import { config } from '../config'
-import { wsTransport } from '../transport/forex'
+import { wsTransport } from '../transport/quote'
 
 export const inputParameters = new InputParameters(
   {
@@ -25,9 +25,9 @@ export type BaseEndpointTypes = {
   Settings: typeof config.settings
 }
 
-export const endpoint = new ForexPriceEndpoint({
-  name: 'forex',
-  aliases: ['fx', 'commodities'],
+export const endpoint = new PriceEndpoint({
+  name: 'quote',
+  aliases: ['forex', 'fx', 'commodities', 'stock'],
   transport: wsTransport,
   inputParameters,
 })

--- a/packages/sources/finalto/src/index.ts
+++ b/packages/sources/finalto/src/index.ts
@@ -1,14 +1,14 @@
 import { expose, ServerInstance } from '@chainlink/external-adapter-framework'
 import { PriceAdapter } from '@chainlink/external-adapter-framework/adapter'
 import { config } from './config'
-import { forex } from './endpoint'
 import includes from './config/includes.json'
+import { quote } from './endpoint'
 
 export const adapter = new PriceAdapter({
-  defaultEndpoint: forex.name,
+  defaultEndpoint: quote.name,
   name: 'FINALTO',
   config,
-  endpoints: [forex],
+  endpoints: [quote],
   includes,
 })
 

--- a/packages/sources/finalto/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/finalto/test/integration/__snapshots__/adapter.test.ts.snap
@@ -3,12 +3,51 @@
 exports[`websocket forex endpoint should return success 1`] = `
 {
   "data": {
+    "ask": 6.82543,
+    "bid": 6.82427,
+    "mid": 6.82485,
     "result": 6.82485,
   },
   "result": 6.82485,
   "statusCode": 200,
   "timestamps": {
-    "providerDataReceivedUnixMs": 1022,
+    "providerDataReceivedUnixMs": 3042,
+    "providerDataStreamEstablishedUnixMs": 1010,
+    "providerIndicatedTimeUnixMs": 1704951160198,
+  },
+}
+`;
+
+exports[`websocket stock endpoint should return success 1`] = `
+{
+  "data": {
+    "ask": 200.88,
+    "bid": 200.84,
+    "mid": 200.86,
+    "result": 200.86,
+  },
+  "result": 200.86,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 3042,
+    "providerDataStreamEstablishedUnixMs": 1010,
+    "providerIndicatedTimeUnixMs": 1704951160198,
+  },
+}
+`;
+
+exports[`websocket stock endpoint should return success with base override 1`] = `
+{
+  "data": {
+    "ask": 461.96,
+    "bid": 461.92,
+    "mid": 461.94,
+    "result": 461.94,
+  },
+  "result": 461.94,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 3042,
     "providerDataStreamEstablishedUnixMs": 1010,
     "providerIndicatedTimeUnixMs": 1704951160198,
   },

--- a/packages/sources/finalto/test/integration/fixtures.ts
+++ b/packages/sources/finalto/test/integration/fixtures.ts
@@ -12,7 +12,7 @@ export const mockWebsocketServer = (URL: string): MockWebsocketServer => {
           }),
         )
       }
-      return socket.send(
+      socket.send(
         JSON.stringify({
           MsgSeqNum: '12',
           MsgType: 'SymbolPrices',
@@ -31,6 +31,48 @@ export const mockWebsocketServer = (URL: string): MockWebsocketServer => {
           SendTime: '20240111-05:32:40.198',
           SubID: parsed.SubID,
           Symbol: 'GBPUSD',
+        }),
+      )
+      socket.send(
+        JSON.stringify({
+          MsgSeqNum: '12',
+          MsgType: 'SymbolPrices',
+          Prices: [
+            {
+              Px: '200.84',
+              Type: 'B',
+              Vol: '1000000',
+            },
+            {
+              Px: '200.88',
+              Type: 'O',
+              Vol: '1000000',
+            },
+          ],
+          SendTime: '20240111-05:32:40.198',
+          SubID: parsed.SubID,
+          Symbol: 'AAPL.xnas',
+        }),
+      )
+      socket.send(
+        JSON.stringify({
+          MsgSeqNum: '12',
+          MsgType: 'SymbolPrices',
+          Prices: [
+            {
+              Px: '461.92',
+              Type: 'B',
+              Vol: '1000000',
+            },
+            {
+              Px: '461.96',
+              Type: 'O',
+              Vol: '1000000',
+            },
+          ],
+          SendTime: '20240111-05:32:40.198',
+          SubID: parsed.SubID,
+          Symbol: 'MSFT.xnas',
         }),
       )
     })


### PR DESCRIPTION
This PR adds support for stock assets for Finalto. Unlike FX, Finalto's stock symbols (e.g. `AAPL.xnas`) have a suffix that is market / exchange specific.

Changes:
* Converts the forex endpoint to a more general quote endpoint.
* Added `forex` (for back compat) and `stock` as aliases of this quote endpoint.
* If the base symbol contains a `.` then use it as the symbol, ignoring the quote.
* Additionally return the `bid`, `mid`, and `ask` fields, similar to crypt LWBA EAs.