### PR TITLE
tradinghours: Add support for NYSE market

### DIFF
--- a/.changeset/late-dingos-push.md
+++ b/.changeset/late-dingos-push.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/tradinghours-adapter': minor
+---
+
+Add support for NYSE market

--- a/packages/sources/tradinghours/src/endpoint/market-status.ts
+++ b/packages/sources/tradinghours/src/endpoint/market-status.ts
@@ -1,8 +1,10 @@
 import {
-  MarketStatusResultResponse,
   MarketStatusEndpoint,
+  MarketStatusResultResponse,
 } from '@chainlink/external-adapter-framework/adapter'
+import { AdapterRequest } from '@chainlink/external-adapter-framework/util'
 import { InputParameters } from '@chainlink/external-adapter-framework/validation'
+import { TypeFromDefinition } from '@chainlink/external-adapter-framework/validation/input-params'
 
 import { config } from '../config'
 import { markets, transport } from '../transport/market-status'
@@ -12,7 +14,7 @@ const inputParameters = new InputParameters({
     aliases: [],
     type: 'string',
     description: 'The name of the market',
-    options: markets,
+    options: [...markets, ...markets.map((market) => market.toUpperCase())],
     required: true,
   },
 })
@@ -28,4 +30,11 @@ export const marketStatusEndpoint = new MarketStatusEndpoint({
   aliases: markets.map((market) => `${market}-market-status`),
   transport,
   inputParameters,
+  requestTransforms: [
+    (req: AdapterRequest<TypeFromDefinition<typeof inputParameters.definition>>) => {
+      const data = req.requestContext.data
+      data.market = data.market.toLowerCase()
+      return req
+    },
+  ],
 })

--- a/packages/sources/tradinghours/src/transport/market-status.ts
+++ b/packages/sources/tradinghours/src/transport/market-status.ts
@@ -4,7 +4,7 @@ import { makeLogger } from '@chainlink/external-adapter-framework/util'
 
 import type { BaseEndpointTypes } from '../endpoint/market-status'
 
-export const markets = ['forex', 'metals', 'wti'] as const
+export const markets = ['forex', 'metals', 'wti', 'nyse'] as const
 
 export type Market = (typeof markets)[number]
 
@@ -12,9 +12,10 @@ const marketToFinId: Record<Market, string> = {
   forex: 'US.CHNLNK.FX',
   metals: 'US.CHNLNK.METAL',
   wti: 'US.CHNLNK.WTI',
+  nyse: 'US.NYSE',
 }
 
-function isMarket(v: any): v is Market {
+function isMarket(v: string): v is Market {
   return markets.includes(v as Market)
 }
 
@@ -32,10 +33,6 @@ type ResponseBody = {
       until: string // 2024-06-02T16:00:00-05:00
       next_bell: string // 2024-06-02T17:00:00-05:00
     }
-  }
-  meta: {
-    utc_time: string // 2024-05-31T21:37:34+00:00
-    time: string // 2024-05-31T21:37:34+00:00
   }
 }
 
@@ -92,9 +89,6 @@ export const transport = new HttpTransport<HttpEndpointTypes>({
             result: marketStatus,
             data: {
               result: marketStatus,
-            },
-            timestamps: {
-              providerIndicatedTimeUnixMs: new Date(res.data.meta.time).getTime(),
             },
           },
         },

--- a/packages/sources/tradinghours/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/tradinghours/test/integration/__snapshots__/adapter.test.ts.snap
@@ -10,7 +10,6 @@ exports[`Market status endpoint should return success with closed 1`] = `
   "timestamps": {
     "providerDataReceivedUnixMs": 1641035471111,
     "providerDataRequestedUnixMs": 1641035471111,
-    "providerIndicatedTimeUnixMs": 1717191454000,
   },
 }
 `;
@@ -25,7 +24,20 @@ exports[`Market status endpoint should return success with open 1`] = `
   "timestamps": {
     "providerDataReceivedUnixMs": 1641035471111,
     "providerDataRequestedUnixMs": 1641035471111,
-    "providerIndicatedTimeUnixMs": 1717191454000,
+  },
+}
+`;
+
+exports[`Market status endpoint should return success with open with uppercase market 1`] = `
+{
+  "data": {
+    "result": 2,
+  },
+  "result": 2,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 1641035471111,
+    "providerDataRequestedUnixMs": 1641035471111,
   },
 }
 `;

--- a/packages/sources/tradinghours/test/integration/adapter.test.ts
+++ b/packages/sources/tradinghours/test/integration/adapter.test.ts
@@ -43,6 +43,12 @@ describe('Market status endpoint', () => {
       market: 'forex',
     },
   }
+  const openDataUppercase = {
+    data: {
+      endpoint: 'market-status',
+      market: 'FOREX',
+    },
+  }
   const closedData = {
     data: {
       endpoint: 'market-status',
@@ -76,5 +82,19 @@ describe('Market status endpoint', () => {
       .expect(200)
     expect(response.body).toMatchSnapshot()
     expect(response.body.result).toEqual(MarketStatus.CLOSED)
+  })
+
+  it('should return success with open with uppercase market', async () => {
+    mockResponseSuccess()
+
+    const response = await (context.req as SuperTest<Test>)
+      .post('/')
+      .send(openDataUppercase)
+      .set('Accept', '*/*')
+      .set('Content-Type', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200)
+    expect(response.body).toMatchSnapshot()
+    expect(response.body.result).toEqual(MarketStatus.OPEN)
   })
 })

--- a/packages/sources/tradinghours/test/integration/fixtures.ts
+++ b/packages/sources/tradinghours/test/integration/fixtures.ts
@@ -27,10 +27,6 @@ export const mockResponseSuccess = (): nock.Scope =>
             next_bell: '2024-06-02T17:00:00-05:00',
           },
         },
-        meta: {
-          utc_time: '2024-05-31T21:37:34+00:00',
-          time: '2024-05-31T21:37:34+00:00',
-        },
       },
       ['Content-Type', 'application/json'],
     )
@@ -65,10 +61,6 @@ export const mockResponseSuccess = (): nock.Scope =>
             until: '2024-06-02T16:00:00-05:00',
             next_bell: '2024-06-02T17:00:00-05:00',
           },
-        },
-        meta: {
-          utc_time: '2024-05-31T21:37:34+00:00',
-          time: '2024-05-31T21:37:34+00:00',
         },
       },
       ['Content-Type', 'application/json'],


### PR DESCRIPTION
Changes:
* Tradinghours no longer includes the `meta` field in its response so stop using it.
* Add finId mapping for `nyse` market.
* Allow upper case market param, i.e. `nyse` or `NYSE`.