### PR TITLE
Secure mint handle errors

### DIFF
--- a/.changeset/short-cheetahs-promise.md
+++ b/.changeset/short-cheetahs-promise.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/secure-mint-adapter': patch
+---
+
+Handle errors

--- a/packages/composites/secure-mint/src/transport/mintable.ts
+++ b/packages/composites/secure-mint/src/transport/mintable.ts
@@ -82,16 +82,16 @@ export class MintableTransport extends SubscriptionTransport<BaseEndpointTypes> 
       ),
     ])
 
-    const supplyError = Object.values(supply.chains).some((data) => 'error_message' in data)
+    const hasSupplyError = Object.values(supply.chains).some((data) => 'error_message' in data)
 
     // We will prevent minting if there is more supply + pre-mint than reserve
-    const overmint = supplyError
+    const overmint = hasSupplyError
       ? false
       : BigInt(supply.premint) + BigInt(supply.supply) > reserve.reserveAmount
 
     const data = {
       overmint,
-      mintables: supplyError
+      mintables: hasSupplyError
         ? {}
         : Object.fromEntries(
             Object.entries(supply.chains).map(([id, data]) => [

--- a/packages/composites/secure-mint/src/transport/mintable.ts
+++ b/packages/composites/secure-mint/src/transport/mintable.ts
@@ -82,20 +82,26 @@ export class MintableTransport extends SubscriptionTransport<BaseEndpointTypes> 
       ),
     ])
 
+    const supplyError = Object.values(supply.chains).some((data) => 'error_message' in data)
+
     // We will prevent minting if there is more supply + pre-mint than reserve
-    const overmint = BigInt(supply.premint) + BigInt(supply.supply) > reserve.reserveAmount
+    const overmint = supplyError
+      ? false
+      : BigInt(supply.premint) + BigInt(supply.supply) > reserve.reserveAmount
 
     const data = {
       overmint,
-      mintables: Object.fromEntries(
-        Object.entries(supply.chains).map(([id, data]) => [
-          id,
-          {
-            mintable: overmint ? '0' : data.mintable,
-            block: data.response_block,
-          },
-        ]),
-      ),
+      mintables: supplyError
+        ? {}
+        : Object.fromEntries(
+            Object.entries(supply.chains).map(([id, data]) => [
+              id,
+              {
+                mintable: overmint ? '0' : data.mintable,
+                block: data.response_block,
+              },
+            ]),
+          ),
       reserveInfo: {
         reserveAmount: reserve.reserveAmount.toString(),
         timestamp: reserve.timestamp,

--- a/packages/composites/secure-mint/src/transport/supply.ts
+++ b/packages/composites/secure-mint/src/transport/supply.ts
@@ -4,6 +4,7 @@ import { AdapterError } from '@chainlink/external-adapter-framework/validation/e
 import { BaseEndpointTypes, inputParameters } from '../endpoint/mintable'
 
 type ChainData = {
+  error_message: string
   latest_block: number
   response_block: number
   request_block: number

--- a/packages/composites/secure-mint/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/composites/secure-mint/test/integration/__snapshots__/adapter.test.ts.snap
@@ -45,6 +45,36 @@ exports[`execute mintable endpoint should block overmint 1`] = `
 }
 `;
 
+exports[`execute mintable endpoint should handle error 1`] = `
+{
+  "data": {
+    "latestBlocks": {
+      "1": 5,
+    },
+    "mintables": {},
+    "overmint": false,
+    "reserveInfo": {
+      "reserveAmount": "1000000000000000000",
+      "timestamp": 2,
+    },
+    "supplyDetails": {
+      "chains": {
+        "1": {
+          "error_message": "some error messages",
+          "latest_block": 5,
+        },
+      },
+    },
+  },
+  "result": 0,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 978347471111,
+    "providerDataRequestedUnixMs": 978347471111,
+  },
+}
+`;
+
 exports[`execute mintable endpoint should return success 1`] = `
 {
   "data": {

--- a/packages/composites/secure-mint/test/integration/adapter.test.ts
+++ b/packages/composites/secure-mint/test/integration/adapter.test.ts
@@ -64,5 +64,21 @@ describe('execute', () => {
       expect(response.statusCode).toBe(200)
       expect(response.json()).toMatchSnapshot()
     })
+
+    it('should handle error', async () => {
+      mockBitgoSuccess()
+      mockIndexerSuccess()
+
+      const data = {
+        token: 'token3',
+        reserves: 'Bitgo',
+        supplyChains: ['1'],
+        supplyChainBlocks: [0],
+      }
+      const response = await testAdapter.request(data)
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toMatchSnapshot()
+    })
   })
 })

--- a/packages/composites/secure-mint/test/integration/fixtures.ts
+++ b/packages/composites/secure-mint/test/integration/fixtures.ts
@@ -20,6 +20,14 @@ export const mockBitgoSuccess = (): nock.Scope =>
       },
     }))
     .persist()
+    .post('/', { data: { client: 'token3' } })
+    .reply(200, () => ({
+      result: 1,
+      timestamps: {
+        providerDataReceivedUnixMs: 2,
+      },
+    }))
+    .persist()
 
 export const mockIndexerSuccess = (): nock.Scope =>
   nock('http://fake-indexer', {
@@ -71,6 +79,21 @@ export const mockIndexerSuccess = (): nock.Scope =>
           token_ccip_burn: '12',
           token_pre_mint: '13',
           aggregate_pre_mint: false,
+        },
+      },
+    }))
+    .persist()
+    .post('/data', {
+      token: 'token3',
+      chains: {
+        '1': 0,
+      },
+    })
+    .reply(200, () => ({
+      chains: {
+        '1': {
+          error_message: 'some error messages',
+          latest_block: 5,
         },
       },
     }))

--- a/packages/composites/secure-mint/test/unit/supply.test.ts
+++ b/packages/composites/secure-mint/test/unit/supply.test.ts
@@ -19,6 +19,10 @@ const requester = makeStub('requester', {
   request: jest.fn(),
 })
 
+beforeEach(() => {
+  requester.request.mockReset()
+})
+
 describe('getReserve', () => {
   it('returns parsed reserveAmount and timestamp', async () => {
     const response = {
@@ -78,6 +82,48 @@ describe('getReserve', () => {
         chains: {
           '1': 100,
           '56': 200,
+        },
+      },
+    })
+
+    expect(result).toStrictEqual(response)
+  })
+
+  it('returns parsed error_message', async () => {
+    const response = {
+      chains: {
+        '1': {
+          latest_block: 300,
+          error_message: 'error',
+        },
+      },
+    }
+    requester.request.mockResolvedValueOnce(
+      makeStub('reservesResponse', {
+        response: {
+          data: response,
+        },
+      }),
+    )
+
+    const result = await getSupply(
+      token,
+      ['1'],
+      [100],
+      requester as unknown as Requester,
+      config,
+      endpointName,
+      transportName,
+    )
+
+    expect(requester.request).toHaveBeenNthCalledWith(1, expect.any(String), {
+      method: 'post',
+      baseURL: config.SECURE_MINT_INDEXER_URL,
+      url: 'data',
+      data: {
+        token,
+        chains: {
+          '1': 100,
         },
       },
     })


### PR DESCRIPTION
## Description

The indexer would return error message instead of throwing errors. The EA need to still return latestBlocks when getting an error as well as report the error

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
