### PR TITLE
run yarn new-tsconfig

### DIFF
--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -420,6 +420,9 @@
       "path": "./sources/harris-and-trotter"
     },
     {
+      "path": "./sources/hashnote"
+    },
+    {
       "path": "./sources/icap"
     },
     {
@@ -526,6 +529,9 @@
     },
     {
       "path": "./sources/onchain-gas"
+    },
+    {
+      "path": "./sources/onre"
     },
     {
       "path": "./sources/openexchangerates"

--- a/packages/tsconfig.test.json
+++ b/packages/tsconfig.test.json
@@ -420,6 +420,9 @@
       "path": "./sources/harris-and-trotter/tsconfig.test.json"
     },
     {
+      "path": "./sources/hashnote/tsconfig.test.json"
+    },
+    {
       "path": "./sources/icap/tsconfig.test.json"
     },
     {
@@ -526,6 +529,9 @@
     },
     {
       "path": "./sources/onchain-gas/tsconfig.test.json"
+    },
+    {
+      "path": "./sources/onre/tsconfig.test.json"
     },
     {
       "path": "./sources/openexchangerates/tsconfig.test.json"


### PR DESCRIPTION
Fixing missing tsconfig for 2 new EAs

## Description
hashnote and onre are missing tsconfig, likely due to 2-step process when creating new EAs. This is part of what is causing the master-list step in the upsert release job to fail since they are not getting built.

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test
- run `yarn generate:master-list -v` and ensure no errors for hashnote or onre pop up

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
