### PR TITLE
Backed-Fi EA

### DIFF
--- a/.changeset/purple-cobras-double.md
+++ b/.changeset/purple-cobras-double.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/backed-fi-adapter': major
+---
+
+Version 1.0.0 of Backed-Fi EA

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -251,6 +251,10 @@ const RAW_RUNTIME_STATE =
       "reference": "workspace:packages/sources/avalanche-platform"\
     },\
     {\
+      "name": "@chainlink/backed-fi-adapter",\
+      "reference": "workspace:packages/sources/backed-fi"\
+    },\
+    {\
       "name": "@chainlink/bank-frick-adapter",\
       "reference": "workspace:packages/sources/bank-frick"\
     },\
@@ -978,6 +982,7 @@ const RAW_RUNTIME_STATE =
     ["@chainlink/apy-finance-test-adapter", ["workspace:packages/composites/apy-finance-test"]],\
     ["@chainlink/augur-adapter", ["workspace:packages/composites/augur"]],\
     ["@chainlink/avalanche-platform-adapter", ["workspace:packages/sources/avalanche-platform"]],\
+    ["@chainlink/backed-fi-adapter", ["workspace:packages/sources/backed-fi"]],\
     ["@chainlink/bank-frick-adapter", ["workspace:packages/sources/bank-frick"]],\
     ["@chainlink/bea-adapter", ["workspace:packages/sources/bea"]],\
     ["@chainlink/binance-adapter", ["workspace:packages/sources/binance"]],\
@@ -5357,6 +5362,21 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./packages/sources/avalanche-platform/",\
         "packageDependencies": [\
           ["@chainlink/avalanche-platform-adapter", "workspace:packages/sources/avalanche-platform"],\
+          ["@chainlink/external-adapter-framework", "npm:2.6.0"],\
+          ["@types/jest", "npm:29.5.14"],\
+          ["@types/node", "npm:22.14.1"],\
+          ["nock", "npm:13.5.6"],\
+          ["tslib", "npm:2.4.1"],\
+          ["typescript", "patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"]\
+        ],\
+        "linkType": "SOFT"\
+      }]\
+    ]],\
+    ["@chainlink/backed-fi-adapter", [\
+      ["workspace:packages/sources/backed-fi", {\
+        "packageLocation": "./packages/sources/backed-fi/",\
+        "packageDependencies": [\
+          ["@chainlink/backed-fi-adapter", "workspace:packages/sources/backed-fi"],\
           ["@chainlink/external-adapter-framework", "npm:2.6.0"],\
           ["@types/jest", "npm:29.5.14"],\
           ["@types/node", "npm:22.14.1"],\

--- a/packages/sources/backed-fi/README.md
+++ b/packages/sources/backed-fi/README.md
@@ -1,0 +1,54 @@
+# BACKED_FI
+
+![0.0.0](https://img.shields.io/github/package-json/v/smartcontractkit/external-adapters-js?filename=packages/sources/backed-fi/package.json) ![v3](https://img.shields.io/badge/framework%20version-v3-blueviolet)
+
+This document was generated automatically. Please see [README Generator](../../scripts#readme-generator) for more info.
+
+## Environment Variables
+
+| Required? |     Name     |          Description          |  Type  | Options |               Default                |
+| :-------: | :----------: | :---------------------------: | :----: | :-----: | :----------------------------------: |
+|           | API_ENDPOINT | An API endpoint for Backed-Fi | string |         | `https://api.backed.fi/api/v1/token` |
+
+---
+
+## Data Provider Rate Limits
+
+There are no rate limits for this adapter.
+
+---
+
+## Input Parameters
+
+| Required? |   Name   |     Description     |  Type  |              Options               |   Default    |
+| :-------: | :------: | :-----------------: | :----: | :--------------------------------: | :----------: |
+|           | endpoint | The endpoint to use | string | [multiplier](#multiplier-endpoint) | `multiplier` |
+
+## Multiplier Endpoint
+
+`multiplier` is the only supported name for this endpoint.
+
+### Input Params
+
+| Required? |    Name     | Aliases |            Description             |  Type  | Options | Default | Depends On | Not Valid With |
+| :-------: | :---------: | :-----: | :--------------------------------: | :----: | :-----: | :-----: | :--------: | :------------: |
+|    ✅     | tokenSymbol |         |    The symbol of token to query    | string |         |         |            |                |
+|    ✅     |   network   |         | The symbol of the network to query | string |         |         |            |                |
+
+### Example
+
+Request:
+
+```json
+{
+  "data": {
+    "endpoint": "multiplier",
+    "tokenSymbol": "AMZNx",
+    "network": "Solana"
+  }
+}
+```
+
+---
+
+MIT License

--- a/packages/sources/backed-fi/package.json
+++ b/packages/sources/backed-fi/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@chainlink/backed-fi-adapter",
+  "version": "0.0.0",
+  "description": "Chainlink backed-fi adapter.",
+  "keywords": [
+    "Chainlink",
+    "LINK",
+    "blockchain",
+    "oracle",
+    "backed-fi"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "url": "https://github.com/smartcontractkit/external-adapters-js",
+    "type": "git"
+  },
+  "license": "MIT",
+  "scripts": {
+    "clean": "rm -rf dist && rm -f tsconfig.tsbuildinfo",
+    "prepack": "yarn build",
+    "build": "tsc -b",
+    "server": "node -e 'require(\"./index.js\").server()'",
+    "server:dist": "node -e 'require(\"./dist/index.js\").server()'",
+    "start": "yarn server:dist"
+  },
+  "devDependencies": {
+    "@types/jest": "29.5.14",
+    "@types/node": "22.14.1",
+    "nock": "13.5.6",
+    "typescript": "5.8.3"
+  },
+  "dependencies": {
+    "@chainlink/external-adapter-framework": "2.6.0",
+    "tslib": "2.4.1"
+  }
+}

--- a/packages/sources/backed-fi/src/config/index.ts
+++ b/packages/sources/backed-fi/src/config/index.ts
@@ -1,0 +1,9 @@
+import { AdapterConfig } from '@chainlink/external-adapter-framework/config'
+
+export const config = new AdapterConfig({
+  API_ENDPOINT: {
+    description: 'An API endpoint for Backed-Fi',
+    type: 'string',
+    default: 'https://api.backed.fi/api/v1/token',
+  },
+})

--- a/packages/sources/backed-fi/src/endpoint/index.ts
+++ b/packages/sources/backed-fi/src/endpoint/index.ts
@@ -1,0 +1,1 @@
+export { endpoint as multiplier } from './multiplier'

--- a/packages/sources/backed-fi/src/endpoint/multiplier.ts
+++ b/packages/sources/backed-fi/src/endpoint/multiplier.ts
@@ -1,0 +1,48 @@
+import { AdapterEndpoint } from '@chainlink/external-adapter-framework/adapter'
+import { InputParameters } from '@chainlink/external-adapter-framework/validation'
+import { config } from '../config'
+import { httpTransport } from '../transport/multiplier'
+
+export const inputParameters = new InputParameters(
+  {
+    tokenSymbol: {
+      required: true,
+      type: 'string',
+      description: 'The symbol of token to query',
+    },
+    network: {
+      required: true,
+      type: 'string',
+      description: 'The symbol of the network to query',
+    },
+  },
+  [
+    {
+      tokenSymbol: 'AMZNx',
+      network: 'Solana',
+    },
+  ],
+)
+
+export type GMCIResultResponse = {
+  Result: number
+  Data: {
+    currentMultiplier: number
+    newMultiplier: number
+    activationDateTime: number
+    reason: string | null
+  }
+}
+
+export type BaseEndpointTypes = {
+  Parameters: typeof inputParameters.definition
+  Response: GMCIResultResponse
+  Settings: typeof config.settings
+}
+
+export const endpoint = new AdapterEndpoint({
+  name: 'multiplier',
+  aliases: [],
+  transport: httpTransport,
+  inputParameters,
+})

--- a/packages/sources/backed-fi/src/index.ts
+++ b/packages/sources/backed-fi/src/index.ts
@@ -1,0 +1,13 @@
+import { expose, ServerInstance } from '@chainlink/external-adapter-framework'
+import { Adapter } from '@chainlink/external-adapter-framework/adapter'
+import { config } from './config'
+import { multiplier } from './endpoint'
+
+export const adapter = new Adapter({
+  defaultEndpoint: multiplier.name,
+  name: 'BACKED_FI',
+  config,
+  endpoints: [multiplier],
+})
+
+export const server = (): Promise<ServerInstance | undefined> => expose(adapter)

--- a/packages/sources/backed-fi/src/transport/multiplier.ts
+++ b/packages/sources/backed-fi/src/transport/multiplier.ts
@@ -1,0 +1,54 @@
+import { HttpTransport } from '@chainlink/external-adapter-framework/transports'
+import { BaseEndpointTypes } from '../endpoint/multiplier'
+
+export interface ResponseSchema {
+  activationDateTime: number
+  currentMultiplier: number
+  newMultiplier: number
+  reason: string | null
+}
+
+export type HttpTransportTypes = BaseEndpointTypes & {
+  Provider: {
+    RequestBody: never
+    ResponseBody: ResponseSchema
+  }
+}
+export const httpTransport = new HttpTransport<HttpTransportTypes>({
+  prepareRequests: (params, config) => {
+    return params.map((param) => {
+      return {
+        params: [param],
+        request: {
+          baseURL: config.API_ENDPOINT,
+          url: `${param.tokenSymbol}/multiplier?network=${param.network}`,
+          params: {},
+        },
+      }
+    })
+  },
+  parseResponse: (params, response) => {
+    if (!response.data) {
+      return params.map((param) => {
+        return {
+          params: param,
+          response: {
+            errorMessage: `The data provider didn't return any value for ${param.tokenSymbol} on network ${param.network}`,
+            statusCode: 502,
+          },
+        }
+      })
+    }
+
+    return params.map((param) => {
+      const result = response.data.currentMultiplier
+      return {
+        params: param,
+        response: {
+          result,
+          data: { ...response.data },
+        },
+      }
+    })
+  },
+})

--- a/packages/sources/backed-fi/test-payload.json
+++ b/packages/sources/backed-fi/test-payload.json
@@ -1,0 +1,6 @@
+{
+ "requests": [{
+    "tokenSymbol": "METAx",
+    "network": "Arbitrum"
+ }]
+}

--- a/packages/sources/backed-fi/test/integration/adapter.test.ts
+++ b/packages/sources/backed-fi/test/integration/adapter.test.ts
@@ -1,0 +1,49 @@
+import {
+  TestAdapter,
+  setEnvVariables,
+} from '@chainlink/external-adapter-framework/util/testing-utils'
+import * as nock from 'nock'
+import { mockResponseSuccess } from './fixtures'
+
+describe('execute', () => {
+  let spy: jest.SpyInstance
+  let testAdapter: TestAdapter
+  let oldEnv: NodeJS.ProcessEnv
+
+  beforeAll(async () => {
+    oldEnv = JSON.parse(JSON.stringify(process.env))
+    process.env.API_KEY = process.env.API_KEY ?? 'fake-api-key'
+
+    const mockDate = new Date('2001-01-01T11:11:11.111Z')
+    spy = jest.spyOn(Date, 'now').mockReturnValue(mockDate.getTime())
+
+    const adapter = (await import('./../../src')).adapter
+    adapter.rateLimiting = undefined
+    testAdapter = await TestAdapter.startWithMockedCache(adapter, {
+      testAdapter: {} as TestAdapter<never>,
+    })
+  })
+
+  afterAll(async () => {
+    setEnvVariables(oldEnv)
+    await testAdapter.api.close()
+    nock.restore()
+    nock.cleanAll()
+    spy.mockRestore()
+  })
+
+  describe('multiplier endpoint', () => {
+    it('should return success', async () => {
+      const data = {
+        base: 'ETH',
+        quote: 'USD',
+        endpoint: 'multiplier',
+        transport: 'rest',
+      }
+      mockResponseSuccess()
+      const response = await testAdapter.request(data)
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toMatchSnapshot()
+    })
+  })
+})

--- a/packages/sources/backed-fi/test/integration/fixtures.ts
+++ b/packages/sources/backed-fi/test/integration/fixtures.ts
@@ -1,0 +1,22 @@
+import nock from 'nock'
+
+export const mockResponseSuccess = (): nock.Scope =>
+  nock('https://dataproviderapi.com', {
+    encodedQueryParams: true,
+  })
+    .get('/cryptocurrency/price')
+    .query({
+      symbol: 'ETH',
+      convert: 'USD',
+    })
+    .reply(200, () => ({ ETH: { price: 10000 } }), [
+      'Content-Type',
+      'application/json',
+      'Connection',
+      'close',
+      'Vary',
+      'Accept-Encoding',
+      'Vary',
+      'Origin',
+    ])
+    .persist()

--- a/packages/sources/backed-fi/tsconfig.json
+++ b/packages/sources/backed-fi/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*", "src/**/*.json"],
+  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]
+}

--- a/packages/sources/backed-fi/tsconfig.test.json
+++ b/packages/sources/backed-fi/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*", "**/test", "src/**/*.json"],
+  "compilerOptions": {
+    "noEmit": true
+  }
+}

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -168,6 +168,9 @@
       "path": "./sources/avalanche-platform"
     },
     {
+      "path": "./sources/backed-fi"
+    },
+    {
       "path": "./sources/bank-frick"
     },
     {

--- a/packages/tsconfig.test.json
+++ b/packages/tsconfig.test.json
@@ -168,6 +168,9 @@
       "path": "./sources/avalanche-platform/tsconfig.test.json"
     },
     {
+      "path": "./sources/backed-fi/tsconfig.test.json"
+    },
+    {
       "path": "./sources/bank-frick/tsconfig.test.json"
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2621,6 +2621,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@chainlink/backed-fi-adapter@workspace:packages/sources/backed-fi":
+  version: 0.0.0-use.local
+  resolution: "@chainlink/backed-fi-adapter@workspace:packages/sources/backed-fi"
+  dependencies:
+    "@chainlink/external-adapter-framework": "npm:2.6.0"
+    "@types/jest": "npm:29.5.14"
+    "@types/node": "npm:22.14.1"
+    nock: "npm:13.5.6"
+    tslib: "npm:2.4.1"
+    typescript: "npm:5.8.3"
+  languageName: unknown
+  linkType: soft
+
 "@chainlink/bank-frick-adapter@workspace:packages/sources/bank-frick":
   version: 0.0.0-use.local
   resolution: "@chainlink/bank-frick-adapter@workspace:packages/sources/bank-frick"


### PR DESCRIPTION
## Closes #OPDATA-2381
https://github.com/smartcontractkit/external-adapters-js/pull/new/OPDATA-2381-BackedFi-EA

## Description
New EA - BackedFi

## Changes
Add a new http transport EA - BackedFi

## Steps to Test
yarn test packages/source/backed-fi

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [x] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [x] This is related to a maximum of one Jira story or GitHub issue.
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
