### PR TITLE
DF-21369 fix Utils.sanitize(url) to also handle partial urls

### DIFF
--- a/packages/sources/ice/src/transport/netdania/index.ts
+++ b/packages/sources/ice/src/transport/netdania/index.ts
@@ -105,12 +105,20 @@ export class Utils {
     }
   }
 
-  static sanitize(url: string): string {
-    const urlObj = new URL(url)
-    if (urlObj.searchParams.has('h')) {
-      urlObj.searchParams.set('h', 'redacted')
+  static sanitize(urlStr: string): string {
+    try {
+      const url = new URL(urlStr)
+      if (url.searchParams.has('h')) url.searchParams.set('h', 'redacted')
+      return decodeURIComponent(url.toString())
+    } catch {
+      try {
+        const url = new URL(`https://fake-but-irrelevant.com${urlStr}`)
+        if (url.searchParams.has('h')) url.searchParams.set('h', 'redacted')
+        return '?' + decodeURIComponent(url.searchParams.toString())
+      } catch {
+        return 'redacted'
+      }
     }
-    return urlObj.toString()
   }
 }
 

--- a/packages/sources/ice/test/unit/transport-netdania-utils.test.ts
+++ b/packages/sources/ice/test/unit/transport-netdania-utils.test.ts
@@ -60,12 +60,21 @@ describe('PartialPriceUpdate', () => {
     )
   })
 
-  it('must sanitize a url by idempotently redacting the h parameter', () => {
-    expect(Utils.sanitize('https://example.com/path?h=12345&otherParam=value')).toBe(
-      'https://example.com/path?h=redacted&otherParam=value',
+  it('must sanitize a full url by idempotently redacting the h parameter', () => {
+    expect(Utils.sanitize('https://example.com/path?h=12345&otherParam=value&cb=?')).toBe(
+      'https://example.com/path?h=redacted&otherParam=value&cb=?',
     )
 
     const urlWithoutH = 'https://example.com/path?sessid=UP12345&otherParam=value'
+    expect(Utils.sanitize(urlWithoutH)).toBe(urlWithoutH)
+  })
+
+  it('must sanitize a partial url by idempotently redacting the h parameter', () => {
+    expect(Utils.sanitize('?xstream=1&v=5&dt=0&h=eyJnIjoiY2hhaW4ubGluayIsImFpIjoiTm9kZUpTQVBJdjEuNS4yIiwicHIiOjIsImF1IjoibG9jYWxob3N0OjgwODAiLCJxdXAiOjEsInAiOiJmYWtlLWFwaS1rZXkifQ..&xcmd=W3sidCI6MSwiaSI6MSwibSI6MSwicyI6IkVVUlVTRCIsInAiOiJpZGMifV0.&cb=?&ts=1752653143000')).toBe(
+      '?xstream=1&v=5&dt=0&h=redacted&xcmd=W3sidCI6MSwiaSI6MSwibSI6MSwicyI6IkVVUlVTRCIsInAiOiJpZGMifV0.&cb=?&ts=1752653143000',
+    )
+
+    const urlWithoutH = '?xstream=1&v=5&dt=0&xcmd=W3sidCI6MSwiaSI6MSwibSI6MSwicyI6IkVVUlVTRCIsInAiOiJpZGMifV0.&cb=?&ts=1752653143000'
     expect(Utils.sanitize(urlWithoutH)).toBe(urlWithoutH)
   })
 })


### PR DESCRIPTION
## Description

ONDISCONNECT handler calls `sanitize(url)` before logging the event. `sanitize()` wasn't expecting partial urls, i.e. those starting with '?'.

Tests do not exercise `StreamingClient.connection`'s ONDISCONNECT handler locally, but they do in CI. The reason for that is not known. Do note though that the handler does nothing beyond logging the event.

## Changes

- `sanitize()` now also handles partial URLs.

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. yarn test packages/sources/ice/test/unit/transport-netdania-utils.test.ts - specifically for these changes
2. yarn test packages/sources/ice - otherwise

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [x] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [x] This is related to a maximum of one Jira story or GitHub issue.
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
