### PR TITLE
Adds Coinmetric LWBA EA

### DIFF
--- a/.changeset/big-numbers-heal.md
+++ b/.changeset/big-numbers-heal.md
@@ -1,0 +1,6 @@
+---
+'@chainlink/coinmetrics-lwba-adapter': major
+'@chainlink/coinmetrics-adapter': minor
+---
+
+Adds Coinmetrics LWBA EA

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -383,6 +383,10 @@ const RAW_RUNTIME_STATE =
       "reference": "workspace:packages/sources/coinmetrics"\
     },\
     {\
+      "name": "@chainlink/coinmetrics-lwba-adapter",\
+      "reference": "workspace:packages/sources/coinmetrics-lwba"\
+    },\
+    {\
       "name": "@chainlink/coinpaprika-adapter",\
       "reference": "workspace:packages/sources/coinpaprika"\
     },\
@@ -1034,6 +1038,7 @@ const RAW_RUNTIME_STATE =
     ["@chainlink/coinlore-adapter", ["workspace:packages/sources/coinlore"]],\
     ["@chainlink/coinmarketcap-adapter", ["workspace:packages/sources/coinmarketcap"]],\
     ["@chainlink/coinmetrics-adapter", ["workspace:packages/sources/coinmetrics"]],\
+    ["@chainlink/coinmetrics-lwba-adapter", ["workspace:packages/sources/coinmetrics-lwba"]],\
     ["@chainlink/coinpaprika-adapter", ["workspace:packages/sources/coinpaprika"]],\
     ["@chainlink/coinranking-adapter", ["workspace:packages/sources/coinranking"]],\
     ["@chainlink/conflux-adapter", ["workspace:packages/targets/conflux"]],\
@@ -6021,6 +6026,24 @@ const RAW_RUNTIME_STATE =
           ["ethers", "npm:5.8.0"],\
           ["nock", "npm:13.5.6"],\
           ["tslib", "npm:2.8.1"],\
+          ["typescript", "patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"]\
+        ],\
+        "linkType": "SOFT"\
+      }]\
+    ]],\
+    ["@chainlink/coinmetrics-lwba-adapter", [\
+      ["workspace:packages/sources/coinmetrics-lwba", {\
+        "packageLocation": "./packages/sources/coinmetrics-lwba/",\
+        "packageDependencies": [\
+          ["@chainlink/coinmetrics-lwba-adapter", "workspace:packages/sources/coinmetrics-lwba"],\
+          ["@chainlink/coinmetrics-adapter", "workspace:packages/sources/coinmetrics"],\
+          ["@chainlink/external-adapter-framework", "npm:2.6.0"],\
+          ["@sinonjs/fake-timers", "npm:9.1.2"],\
+          ["@types/jest", "npm:29.5.14"],\
+          ["@types/node", "npm:22.14.1"],\
+          ["@types/sinonjs__fake-timers", "npm:8.1.5"],\
+          ["nock", "npm:13.5.6"],\
+          ["tslib", "npm:2.4.1"],\
           ["typescript", "patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"]\
         ],\
         "linkType": "SOFT"\

--- a/packages/sources/coinmetrics-lwba/README.md
+++ b/packages/sources/coinmetrics-lwba/README.md
@@ -1,0 +1,3 @@
+# Chainlink External Adapter for coinmetrics-lwba
+
+This README will be generated automatically when code is merged to `main`. If you would like to generate a preview of the README, please run `yarn generate:readme coinmetrics-lwba`.

--- a/packages/sources/coinmetrics-lwba/package.json
+++ b/packages/sources/coinmetrics-lwba/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "@chainlink/coinmetrics-adapter",
-  "version": "3.8.3",
-  "description": "Chainlink coinmetrics adapter.",
+  "name": "@chainlink/coinmetrics-lwba-adapter",
+  "version": "0.0.0",
+  "description": "Chainlink coinmetrics-lwba adapter.",
   "keywords": [
     "Chainlink",
     "LINK",
     "blockchain",
     "oracle",
-    "coinmetrics"
+    "coinmetrics-lwba"
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -27,11 +27,6 @@
     "server:dist": "node -e 'require(\"./dist/index.js\").server()'",
     "start": "yarn server:dist"
   },
-  "dependencies": {
-    "@chainlink/external-adapter-framework": "2.6.0",
-    "ethers": "^5.4.6",
-    "tslib": "^2.3.1"
-  },
   "devDependencies": {
     "@sinonjs/fake-timers": "9.1.2",
     "@types/jest": "^29.5.14",
@@ -40,10 +35,9 @@
     "nock": "13.5.6",
     "typescript": "5.8.3"
   },
-  "exports": {
-    "./endpoint/lwba": "./dist/endpoint/lwba.js",
-    "./transport/lwba": "./dist/transport/lwba.js",
-    "./transport/error-handling": "./dist/transport/error-handling.js",
-    "./config": "./dist/config/index.js"
+  "dependencies": {
+    "@chainlink/coinmetrics-adapter": "workspace:*",
+    "@chainlink/external-adapter-framework": "2.6.0",
+    "tslib": "2.4.1"
   }
 }

--- a/packages/sources/coinmetrics-lwba/package.json
+++ b/packages/sources/coinmetrics-lwba/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/coinmetrics-lwba-adapter",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "description": "Chainlink coinmetrics-lwba adapter.",
   "keywords": [
     "Chainlink",

--- a/packages/sources/coinmetrics-lwba/package.json
+++ b/packages/sources/coinmetrics-lwba/package.json
@@ -36,7 +36,7 @@
     "typescript": "5.8.3"
   },
   "dependencies": {
-    "@chainlink/coinmetrics-adapter": "workspace:*",
+    "@chainlink/coinmetrics-adapter": "workspace:^",
     "@chainlink/external-adapter-framework": "2.6.0",
     "tslib": "2.4.1"
   }

--- a/packages/sources/coinmetrics-lwba/src/index.ts
+++ b/packages/sources/coinmetrics-lwba/src/index.ts
@@ -18,7 +18,6 @@ export const config = makeConfig({
 })
 
 const newEndpoint = Object.assign(Object.create(Object.getPrototypeOf(endpoint)), endpoint)
-newEndpoint.rateLimiting = { allocationPercentage: 100 }
 
 export const adapter = new Adapter({
   defaultEndpoint: newEndpoint.name,

--- a/packages/sources/coinmetrics-lwba/src/index.ts
+++ b/packages/sources/coinmetrics-lwba/src/index.ts
@@ -17,11 +17,14 @@ export const config = makeConfig({
   },
 })
 
+const newEndpoint = Object.assign(Object.create(Object.getPrototypeOf(endpoint)), endpoint)
+newEndpoint.rateLimiting = { allocationPercentage: 100 }
+
 export const adapter = new Adapter({
-  defaultEndpoint: endpoint.name,
+  defaultEndpoint: newEndpoint.name,
   name: 'COINMETRICS_LWBA',
   config,
-  endpoints: [endpoint],
+  endpoints: [newEndpoint],
   rateLimiting: {
     tiers: {
       community: {

--- a/packages/sources/coinmetrics-lwba/src/index.ts
+++ b/packages/sources/coinmetrics-lwba/src/index.ts
@@ -1,0 +1,27 @@
+import { makeConfig } from '@chainlink/coinmetrics-adapter/config'
+import { endpoint } from '@chainlink/coinmetrics-adapter/endpoint/lwba'
+import { expose, ServerInstance } from '@chainlink/external-adapter-framework'
+import { Adapter } from '@chainlink/external-adapter-framework/adapter'
+
+export const config = makeConfig({
+  NAME: 'COINMETRICS_LWBA',
+  API_KEY: {
+    description: 'Unused in LWBA',
+    type: 'string',
+    required: false,
+  },
+  API_ENDPOINT: {
+    description: 'Unused in LWBA',
+    type: 'string',
+    required: false,
+  },
+})
+
+export const adapter = new Adapter({
+  defaultEndpoint: endpoint.name,
+  name: 'COINMETRICS_LWBA',
+  config,
+  endpoints: [endpoint],
+})
+
+export const server = (): Promise<ServerInstance | undefined> => expose(adapter)

--- a/packages/sources/coinmetrics-lwba/src/index.ts
+++ b/packages/sources/coinmetrics-lwba/src/index.ts
@@ -22,6 +22,16 @@ export const adapter = new Adapter({
   name: 'COINMETRICS_LWBA',
   config,
   endpoints: [endpoint],
+  rateLimiting: {
+    tiers: {
+      community: {
+        rateLimit1m: 100,
+      },
+      paid: {
+        rateLimit1s: 300,
+      },
+    },
+  },
 })
 
 export const server = (): Promise<ServerInstance | undefined> => expose(adapter)

--- a/packages/sources/coinmetrics-lwba/test-payload.json
+++ b/packages/sources/coinmetrics-lwba/test-payload.json
@@ -1,0 +1,7 @@
+{
+ "requests": [{
+    "from": "ETH",
+    "to": "USD",
+    "endpoint": "crypto-lwba"
+ }]
+}

--- a/packages/sources/coinmetrics-lwba/test/integration/__snapshots__/adapter-ws.test.ts.snap
+++ b/packages/sources/coinmetrics-lwba/test/integration/__snapshots__/adapter-ws.test.ts.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`crypto-lwba websocket happy path returns a successful response 1`] = `
+{
+  "data": {
+    "ask": 1562.4083581615457,
+    "bid": 1562.3384315992228,
+    "mid": 1562.3733948803842,
+  },
+  "result": null,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 1024,
+    "providerDataStreamEstablishedUnixMs": 1010,
+    "providerIndicatedTimeUnixMs": 1678248273750,
+  },
+}
+`;
+
+exports[`crypto-lwba websocket invariant violation handling handles a violation payload from the stream 1`] = `
+{
+  "error": {
+    "message": "Invariant violation. Mid price must be between bid and ask prices. Got: (bid: 1562.3384315992228, mid: 1562.3733948803842, ask: 1562.2733948803843)",
+    "name": "AdapterLWBAError",
+  },
+  "status": "errored",
+  "statusCode": 500,
+}
+`;

--- a/packages/sources/coinmetrics-lwba/test/integration/adapter-ws.test.ts
+++ b/packages/sources/coinmetrics-lwba/test/integration/adapter-ws.test.ts
@@ -1,0 +1,91 @@
+import { WebSocketClassProvider } from '@chainlink/external-adapter-framework/transports'
+import {
+  mockWebSocketProvider,
+  MockWebsocketServer,
+  setEnvVariables,
+  TestAdapter,
+} from '@chainlink/external-adapter-framework/util/testing-utils'
+import FakeTimers from '@sinonjs/fake-timers'
+import { mockCryptoLwbaWebSocketServer } from './fixtures'
+
+describe('crypto-lwba websocket', () => {
+  let mockWsServer: MockWebsocketServer | undefined
+  let testAdapter: TestAdapter
+  let oldEnv: NodeJS.ProcessEnv
+
+  const wsEndpoint = 'ws://localhost:9090/v4/timeseries-stream/asset-quotes'
+
+  const requestPayload = {
+    endpoint: 'crypto-lwba',
+    base: 'ETH',
+    quote: 'USD',
+  }
+
+  beforeAll(async () => {
+    // snapshot current env and set the ones we need for tests
+    oldEnv = { ...process.env }
+    process.env['WS_SUBSCRIPTION_TTL'] = '5000'
+    process.env['CACHE_MAX_AGE'] = '5000'
+    process.env['CACHE_POLLING_MAX_RETRIES'] = '0'
+    process.env['WS_API_ENDPOINT'] = wsEndpoint
+
+    // mock WS provider + server
+    mockWebSocketProvider(WebSocketClassProvider)
+    mockWsServer = mockCryptoLwbaWebSocketServer(wsEndpoint)
+
+    // start adapter with fake timers
+    const { adapter } = await import('./../../src')
+    testAdapter = await TestAdapter.startWithMockedCache(adapter, {
+      clock: FakeTimers.install(),
+    })
+
+    // warm the cache once so background execute starts
+    await testAdapter.request(requestPayload)
+    await testAdapter.waitForCache(1)
+  })
+
+  afterAll(async () => {
+    setEnvVariables(oldEnv)
+    mockWsServer?.close()
+    testAdapter.clock?.uninstall()
+    await testAdapter.api.close()
+  })
+
+  describe('happy path', () => {
+    it('returns a successful response', async () => {
+      const response = await testAdapter.request(requestPayload)
+      expect(response.json()).toMatchSnapshot()
+    })
+  })
+
+  describe('validation errors', () => {
+    it('fails on empty body', async () => {
+      const response = await testAdapter.request({})
+      expect(response.statusCode).toEqual(400)
+    })
+
+    it('fails on empty data', async () => {
+      const response = await testAdapter.request({ endpoint: 'crypto-lwba' })
+      expect(response.statusCode).toEqual(400)
+    })
+
+    it('fails on missing base', async () => {
+      const response = await testAdapter.request({ endpoint: 'crypto-lwba', quote: 'USD' })
+      expect(response.statusCode).toEqual(400)
+    })
+
+    it('fails on missing quote', async () => {
+      const response = await testAdapter.request({ endpoint: 'crypto-lwba', base: 'ETH' })
+      expect(response.statusCode).toEqual(400)
+    })
+  })
+
+  describe('invariant violation handling', () => {
+    it('handles a violation payload from the stream', async () => {
+      // advance the fake clock so the mocked server pushes the next message
+      testAdapter.clock.tick(1000)
+      const response = await testAdapter.request(requestPayload)
+      expect(response.json()).toMatchSnapshot()
+    })
+  })
+})

--- a/packages/sources/coinmetrics-lwba/test/integration/adapter-ws.test.ts
+++ b/packages/sources/coinmetrics-lwba/test/integration/adapter-ws.test.ts
@@ -34,7 +34,8 @@ describe('crypto-lwba websocket', () => {
     mockWsServer = mockCryptoLwbaWebSocketServer(wsEndpoint)
 
     // start adapter with fake timers
-    const { adapter } = await import('./../../src')
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { adapter } = require('../../src')
     testAdapter = await TestAdapter.startWithMockedCache(adapter, {
       clock: FakeTimers.install(),
     })

--- a/packages/sources/coinmetrics-lwba/test/integration/fixtures.ts
+++ b/packages/sources/coinmetrics-lwba/test/integration/fixtures.ts
@@ -1,16 +1,5 @@
-import { WsCryptoLwbaSuccessResponse } from '@chainlink/coinmetrics-adapter/src/transport/lwba'
+import { WsCryptoLwbaSuccessResponse } from '@chainlink/coinmetrics-adapter/transport/lwba'
 import { MockWebsocketServer } from '@chainlink/external-adapter-framework/util/testing-utils'
-
-export const mockWebSocketServer = (URL: string) => {
-  const mockWsServer = new MockWebsocketServer(URL, { mock: false })
-  mockWsServer.on('connection', (socket) => {
-    const parseMessage = () => {
-      setTimeout(() => socket.send(JSON.stringify(wsResponseBody)), 10)
-    }
-    parseMessage()
-  })
-  return mockWsServer
-}
 
 const wsLwbaResponseBody: WsCryptoLwbaSuccessResponse = {
   pair: 'eth-usd',

--- a/packages/sources/coinmetrics-lwba/test/integration/fixtures.ts
+++ b/packages/sources/coinmetrics-lwba/test/integration/fixtures.ts
@@ -1,0 +1,41 @@
+import { WsCryptoLwbaSuccessResponse } from '@chainlink/coinmetrics-adapter/src/transport/lwba'
+import { MockWebsocketServer } from '@chainlink/external-adapter-framework/util/testing-utils'
+
+export const mockWebSocketServer = (URL: string) => {
+  const mockWsServer = new MockWebsocketServer(URL, { mock: false })
+  mockWsServer.on('connection', (socket) => {
+    const parseMessage = () => {
+      setTimeout(() => socket.send(JSON.stringify(wsResponseBody)), 10)
+    }
+    parseMessage()
+  })
+  return mockWsServer
+}
+
+const wsLwbaResponseBody: WsCryptoLwbaSuccessResponse = {
+  pair: 'eth-usd',
+  time: '2023-03-08T04:04:33.750000000Z',
+  ask_price: '1562.4083581615457',
+  ask_size: '31.63132041',
+  bid_price: '1562.3384315992228',
+  bid_size: '64.67517577',
+  mid_price: '1562.3733948803842',
+  spread: '0.000044756626394287605',
+  cm_sequence_id: '282',
+}
+export const mockCryptoLwbaWebSocketServer = (URL: string) => {
+  const mockWsServer = new MockWebsocketServer(URL, { mock: false })
+  mockWsServer.on('connection', (socket) => {
+    const parseMessage = () => {
+      setTimeout(() => socket.send(JSON.stringify(wsLwbaResponseBody)), 10)
+
+      const wsLwbaResponseBodyInvariantViolation = {
+        ...wsLwbaResponseBody,
+        ask_price: Number(wsLwbaResponseBody.mid_price) - 0.1,
+      }
+      setTimeout(() => socket.send(JSON.stringify(wsLwbaResponseBodyInvariantViolation)), 50)
+    }
+    parseMessage()
+  })
+  return mockWsServer
+}

--- a/packages/sources/coinmetrics-lwba/tsconfig.json
+++ b/packages/sources/coinmetrics-lwba/tsconfig.json
@@ -6,8 +6,8 @@
     "moduleResolution": "node16",
     "module": "node16",
     "paths": {
-      "@chainlink/coinmetrics-adapter/*": ["../../coinmetrics/src/*"],
-      "@chainlink/coinmetrics-adapter": ["../../coinmetrics/src"]
+      "@chainlink/coinmetrics-adapter/*": ["../coinmetrics/src/*"],
+      "@chainlink/coinmetrics-adapter": ["../coinmetrics/src"]
     }
   },
   "include": ["src/**/*", "src/**/*.json"],

--- a/packages/sources/coinmetrics-lwba/tsconfig.json
+++ b/packages/sources/coinmetrics-lwba/tsconfig.json
@@ -4,7 +4,11 @@
     "outDir": "dist",
     "rootDir": "src",
     "moduleResolution": "node16",
-    "module": "node16"
+    "module": "node16",
+    "paths": {
+      "@chainlink/coinmetrics-adapter/*": ["../../coinmetrics/src/*"],
+      "@chainlink/coinmetrics-adapter": ["../../coinmetrics/src"]
+    }
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/coinmetrics-lwba/tsconfig.json
+++ b/packages/sources/coinmetrics-lwba/tsconfig.json
@@ -4,11 +4,7 @@
     "outDir": "dist",
     "rootDir": "src",
     "moduleResolution": "node16",
-    "module": "node16",
-    "paths": {
-      "@chainlink/coinmetrics-adapter/*": ["../coinmetrics/src/*"],
-      "@chainlink/coinmetrics-adapter": ["../coinmetrics/src"]
-    }
+    "module": "node16"
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/coinmetrics-lwba/tsconfig.json
+++ b/packages/sources/coinmetrics-lwba/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "moduleResolution": "node16",
+    "module": "node16"
+  },
+  "include": ["src/**/*", "src/**/*.json"],
+  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]
+}

--- a/packages/sources/coinmetrics-lwba/tsconfig.json
+++ b/packages/sources/coinmetrics-lwba/tsconfig.json
@@ -7,5 +7,6 @@
     "module": "node16"
   },
   "include": ["src/**/*", "src/**/*.json"],
-  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]
+  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
+  "references": [{ "path": "../coinmetrics" }]
 }

--- a/packages/sources/coinmetrics-lwba/tsconfig.test.json
+++ b/packages/sources/coinmetrics-lwba/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*", "**/test", "src/**/*.json"],
+  "compilerOptions": {
+    "noEmit": true
+  }
+}

--- a/packages/sources/coinmetrics-lwba/tsconfig.test.json
+++ b/packages/sources/coinmetrics-lwba/tsconfig.test.json
@@ -2,6 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src/**/*", "**/test", "src/**/*.json"],
   "compilerOptions": {
-    "noEmit": true
+    "noEmit": false,
+    "moduleResolution": "node16",
+    "module": "node16"
   }
 }

--- a/packages/sources/coinmetrics/package.json
+++ b/packages/sources/coinmetrics/package.json
@@ -41,9 +41,25 @@
     "typescript": "5.8.3"
   },
   "exports": {
-    "./endpoint/lwba": "./dist/endpoint/lwba.js",
-    "./transport/lwba": "./dist/transport/lwba.js",
-    "./transport/error-handling": "./dist/transport/error-handling.js",
-    "./config": "./dist/config/index.js"
+    ".": {
+      "default": "./dist/index.js",
+      "types": "./src/index.ts"
+    },
+    "./endpoint/lwba": {
+      "default": "./dist/endpoint/lwba.js",
+      "types": "./dist/endpoint/lwba.d.ts"
+    },
+    "./transport/lwba": {
+      "default": "./dist/transport/lwba.js",
+      "types": "./dist/transport/lwba.d.ts"
+    },
+    "./transport/error-handling": {
+      "default": "./dist/transport/error-handling.js",
+      "types": "./dist/transport/error-handling.d.ts"
+    },
+    "./config": {
+      "default": "./dist/config/index.js",
+      "types": "./dist/config/index.d.ts"
+    }
   }
 }

--- a/packages/sources/coinmetrics/src/config/index.ts
+++ b/packages/sources/coinmetrics/src/config/index.ts
@@ -10,21 +10,25 @@ export enum VALID_QUOTES {
   BTC = 'BTC',
 }
 
-export const config = new AdapterConfig({
-  API_KEY: {
-    description: 'The coinmetrics API key',
-    type: 'string',
-    required: true,
-    sensitive: true,
-  },
-  WS_API_ENDPOINT: {
-    description: 'The websocket url for coinmetrics',
-    type: 'string',
-    default: 'wss://api.coinmetrics.io/v4',
-  },
-  API_ENDPOINT: {
-    description: 'The API url for coinmetrics',
-    type: 'string',
-    default: 'https://api.coinmetrics.io/v4',
-  },
-})
+export const makeConfig = (overrides: Partial<Record<string, unknown>> = {}) =>
+  new AdapterConfig({
+    API_KEY: {
+      description: 'The coinmetrics API key',
+      type: 'string',
+      required: true,
+      sensitive: true,
+    },
+    WS_API_ENDPOINT: {
+      description: 'The websocket url for coinmetrics',
+      type: 'string',
+      default: 'wss://api.coinmetrics.io/v4',
+    },
+    API_ENDPOINT: {
+      description: 'The API url for coinmetrics',
+      type: 'string',
+      default: 'https://api.coinmetrics.io/v4',
+    },
+    ...overrides,
+  })
+
+export const config = makeConfig()

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -267,6 +267,9 @@
       "path": "./sources/coinmetrics"
     },
     {
+      "path": "./sources/coinmetrics-lwba"
+    },
+    {
       "path": "./sources/coinpaprika"
     },
     {

--- a/packages/tsconfig.test.json
+++ b/packages/tsconfig.test.json
@@ -267,6 +267,9 @@
       "path": "./sources/coinmetrics/tsconfig.test.json"
     },
     {
+      "path": "./sources/coinmetrics-lwba/tsconfig.test.json"
+    },
+    {
       "path": "./sources/coinpaprika/tsconfig.test.json"
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3167,7 +3167,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@chainlink/coinmetrics-adapter@workspace:*, @chainlink/coinmetrics-adapter@workspace:packages/sources/coinmetrics":
+"@chainlink/coinmetrics-adapter@workspace:*, @chainlink/coinmetrics-adapter@workspace:^, @chainlink/coinmetrics-adapter@workspace:packages/sources/coinmetrics":
   version: 0.0.0-use.local
   resolution: "@chainlink/coinmetrics-adapter@workspace:packages/sources/coinmetrics"
   dependencies:
@@ -3187,7 +3187,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@chainlink/coinmetrics-lwba-adapter@workspace:packages/sources/coinmetrics-lwba"
   dependencies:
-    "@chainlink/coinmetrics-adapter": "workspace:*"
+    "@chainlink/coinmetrics-adapter": "workspace:^"
     "@chainlink/external-adapter-framework": "npm:2.6.0"
     "@sinonjs/fake-timers": "npm:9.1.2"
     "@types/jest": "npm:^29.5.14"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3183,6 +3183,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@chainlink/coinmetrics-lwba-adapter@workspace:packages/sources/coinmetrics-lwba":
+  version: 0.0.0-use.local
+  resolution: "@chainlink/coinmetrics-lwba-adapter@workspace:packages/sources/coinmetrics-lwba"
+  dependencies:
+    "@chainlink/coinmetrics-adapter": "workspace:*"
+    "@chainlink/external-adapter-framework": "npm:2.6.0"
+    "@sinonjs/fake-timers": "npm:9.1.2"
+    "@types/jest": "npm:^29.5.14"
+    "@types/node": "npm:22.14.1"
+    "@types/sinonjs__fake-timers": "npm:8.1.5"
+    nock: "npm:13.5.6"
+    tslib: "npm:2.4.1"
+    typescript: "npm:5.8.3"
+  languageName: unknown
+  linkType: soft
+
 "@chainlink/coinpaprika-adapter@workspace:*, @chainlink/coinpaprika-adapter@workspace:packages/sources/coinpaprika":
   version: 0.0.0-use.local
   resolution: "@chainlink/coinpaprika-adapter@workspace:packages/sources/coinpaprika"


### PR DESCRIPTION
## Closes [DF-21310](https://smartcontract-it.atlassian.net/browse/DF-21310)

## Description
This pull request introduces `coinmetrics-lwba` as a dedicated External Adapter. 
The new package is implemented as a lightweight wrapper that imports the LWBA endpoint, WebSocket transport, and shared utilities directly from the core @chainlink/coinmetrics module,


## Changes

- Adds a new external adapter `coinmetrics-lwba` 
- Minor changes to `coinmetrics` EA to export configs and make them modifiable.

## Steps to Test

1. Integration tests
2. Via local server

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[DF-21483]: https://smartcontract-it.atlassian.net/browse/DF-21483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DF-21310]: https://smartcontract-it.atlassian.net/browse/DF-21310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ