### PR TITLE
Update/df 21604 kaiko state wbtc quote as btc

### DIFF
--- a/.changeset/hot-zebras-cross.md
+++ b/.changeset/hot-zebras-cross.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/kaiko-state-adapter': minor
+---
+
+Cache wbtc quotes as /btc

--- a/packages/sources/kaiko-state/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/kaiko-state/test/integration/__snapshots__/adapter.test.ts.snap
@@ -14,3 +14,30 @@ exports[`execute state endpoint should return success 1`] = `
 }
 `;
 
+exports[`execute state endpoint should return success with BTC quote 1`] = `
+{
+  "data": {
+    "result": 100.5,
+  },
+  "result": 100.5,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 978347471111,
+    "providerDataRequestedUnixMs": 978347471111,
+  },
+}
+`;
+
+exports[`execute state endpoint should return success with ETH quote 1`] = `
+{
+  "data": {
+    "result": 100.3,
+  },
+  "result": 100.3,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 978347471111,
+    "providerDataRequestedUnixMs": 978347471111,
+  },
+}
+`;

--- a/packages/sources/kaiko-state/test/integration/adapter.test.ts
+++ b/packages/sources/kaiko-state/test/integration/adapter.test.ts
@@ -49,5 +49,23 @@ describe('execute', () => {
       expect(response.statusCode).toBe(200)
       expect(response.json()).toMatchSnapshot()
     })
+    it('should return success with ETH quote', async () => {
+      const data = {
+        base: 'RETH',
+        quote: 'ETH',
+      }
+      const response = await testAdapter.request(data)
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toMatchSnapshot()
+    })
+    it('should return success with BTC quote', async () => {
+      const data = {
+        base: 'SOLVBTC',
+        quote: 'BTC',
+      }
+      const response = await testAdapter.request(data)
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toMatchSnapshot()
+    })
   })
 })

--- a/packages/sources/kaiko-state/test/integration/fixtures.ts
+++ b/packages/sources/kaiko-state/test/integration/fixtures.ts
@@ -7,6 +7,18 @@ export class MockClientReadableStream {
         getLstQuote: jest.fn(() => 'WETH'),
         getAggregatedPriceUsd: jest.fn(() => '100.2'),
       })
+      handler({
+        getBase: jest.fn(() => 'RETH'),
+        getAggregatedPriceLst: jest.fn(() => '100.3'),
+        getLstQuote: jest.fn(() => 'WETH'),
+        getAggregatedPriceUsd: jest.fn(() => '100.4'),
+      })
+      handler({
+        getBase: jest.fn(() => 'SOLVBTC'),
+        getAggregatedPriceLst: jest.fn(() => '100.5'),
+        getLstQuote: jest.fn(() => 'WBTC'),
+        getAggregatedPriceUsd: jest.fn(() => '100.6'),
+      })
     }
     return this
   })


### PR DESCRIPTION
## Closes #[DF-21604](https://smartcontract-it.atlassian.net/browse/DF-21604)

## Description
Similar to WETH -> ETH, cache WBTC -> BTC

## Changes
- Allow for wbtc quotes to be interpreted as btc
- add tests specifically for /ETH and /BTC pairs

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test
1. yarn test kaiko-state/
2. sanity test functionality with payloads

**BTC**
```json
{
    "data": {
        "endpoint": "crypto",
        "from": "TBTC",
        "to": "BTC"
    }
}
```

**ETH**
```json
{
    "data": {
        "endpoint": "crypto",
        "from": "RETH",
        "to": "ETH"
    }
}
```
## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[DF-21604]: https://smartcontract-it.atlassian.net/browse/DF-21604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ