### PR TITLE
update/OPDATA-2664 tiingo lowercase

### DIFF
--- a/.changeset/lazy-monkeys-sparkle.md
+++ b/.changeset/lazy-monkeys-sparkle.md
@@ -1,0 +1,6 @@
+---
+'@chainlink/tiingo-state-adapter': patch
+'@chainlink/tiingo-adapter': patch
+---
+
+use toLowerCase on all WS subscriptions

--- a/packages/sources/tiingo-state/src/endpoint/price.ts
+++ b/packages/sources/tiingo-state/src/endpoint/price.ts
@@ -2,11 +2,12 @@ import {
   PriceEndpoint,
   priceEndpointInputParametersDefinition,
 } from '@chainlink/external-adapter-framework/adapter'
-import { InputParameters } from '@chainlink/external-adapter-framework/validation'
-import { SingleNumberResultResponse } from '@chainlink/external-adapter-framework/util'
 import { TransportRoutes } from '@chainlink/external-adapter-framework/transports'
-import { wsTransport } from '../transport/price'
+import { SingleNumberResultResponse } from '@chainlink/external-adapter-framework/util'
+import { InputParameters } from '@chainlink/external-adapter-framework/validation'
 import { config } from '../config'
+import { wsTransport } from '../transport/price'
+import { tiingoCommonSubscriptionRequestTransform } from './utils'
 
 export const inputParameters = new InputParameters(priceEndpointInputParametersDefinition, [
   {
@@ -27,4 +28,5 @@ export const endpoint = new PriceEndpoint({
   transportRoutes: new TransportRoutes<BaseCryptoEndpointTypes>().register('ws', wsTransport),
   defaultTransport: 'ws',
   inputParameters: inputParameters,
+  requestTransforms: [tiingoCommonSubscriptionRequestTransform],
 })

--- a/packages/sources/tiingo-state/src/endpoint/utils.ts
+++ b/packages/sources/tiingo-state/src/endpoint/utils.ts
@@ -1,0 +1,8 @@
+import { AdapterRequest } from '@chainlink/external-adapter-framework/util'
+
+export function tiingoCommonSubscriptionRequestTransform() {
+  return (req: AdapterRequest<{ base: string; quote: string }>) => {
+    req.requestContext.data.base = req.requestContext.data.base.toLowerCase()
+    req.requestContext.data.quote = req.requestContext.data.quote.toLowerCase()
+  }
+}

--- a/packages/sources/tiingo-state/src/transport/price.ts
+++ b/packages/sources/tiingo-state/src/transport/price.ts
@@ -1,5 +1,6 @@
 import { WebSocketTransport } from '@chainlink/external-adapter-framework/transports'
 import { BaseCryptoEndpointTypes } from '../endpoint/price'
+import { wsMessageContent } from './utils'
 
 interface Message {
   service: string
@@ -21,6 +22,7 @@ export const wsTransport = new WebSocketTransport<WsTransportTypes>({
   url: (context) => {
     return `${context.adapterSettings.WS_API_ENDPOINT}/crypto-synth-state`
   },
+
   handlers: {
     message(message) {
       if (!message?.data?.length || message.messageType !== 'A' || !message.data[priceIndex]) {
@@ -46,18 +48,22 @@ export const wsTransport = new WebSocketTransport<WsTransportTypes>({
 
   builders: {
     subscribeMessage: (params, context) => {
-      return {
-        eventName: 'subscribe',
-        authorization: context.adapterSettings.API_KEY,
-        eventData: { thresholdLevel: 8, tickers: [`${params.base}/${params.quote}`] },
-      }
+      return wsMessageContent(
+        'subscribe',
+        context.adapterSettings.API_KEY,
+        8,
+        params.base,
+        params.quote,
+      )
     },
     unsubscribeMessage: (params, context) => {
-      return {
-        eventName: 'unsubscribe',
-        authorization: context.adapterSettings.API_KEY,
-        eventData: { thresholdLevel: 8, tickers: [`${params.base}/${params.quote}`] },
-      }
+      return wsMessageContent(
+        'unsubscribe',
+        context.adapterSettings.API_KEY,
+        8,
+        params.base,
+        params.quote,
+      )
     },
   },
 })

--- a/packages/sources/tiingo-state/src/transport/utils.ts
+++ b/packages/sources/tiingo-state/src/transport/utils.ts
@@ -4,13 +4,15 @@ export const wsMessageContent = (
   thresholdLevel: number,
   base: string,
   quote: string,
+  skipSlash = false,
 ) => {
+  const ticker = skipSlash ? `${base}${quote}` : `${base}/${quote}`
   return {
     eventName,
     authorization: apiKey,
     eventData: {
       thresholdLevel,
-      tickers: [`${base}/${quote}`.toLowerCase()],
+      tickers: [ticker.toLowerCase()],
     },
   }
 }

--- a/packages/sources/tiingo-state/src/transport/utils.ts
+++ b/packages/sources/tiingo-state/src/transport/utils.ts
@@ -1,0 +1,16 @@
+export const wsMessageContent = (
+  eventName: 'subscribe' | 'unsubscribe',
+  apiKey: string,
+  thresholdLevel: number,
+  base: string,
+  quote: string,
+) => {
+  return {
+    eventName,
+    authorization: apiKey,
+    eventData: {
+      thresholdLevel,
+      tickers: [`${base}/${quote}`.toLowerCase()],
+    },
+  }
+}

--- a/packages/sources/tiingo-state/test/unit/transport-utils.test.ts
+++ b/packages/sources/tiingo-state/test/unit/transport-utils.test.ts
@@ -1,0 +1,10 @@
+import { wsMessageContent } from '../../src/transport/utils'
+
+describe('transport-utils', () => {
+  describe('wsMessageContent', () => {
+    it('returns a lowercased base/quote pair', () => {
+      const response = wsMessageContent('subscribe', 'test-api-key', 1234, 'BaSe', 'quoTE')
+      expect(response.eventData.tickers[0]).toEqual('base/quote')
+    })
+  })
+})

--- a/packages/sources/tiingo/src/endpoint/crypto-lwba.ts
+++ b/packages/sources/tiingo/src/endpoint/crypto-lwba.ts
@@ -1,12 +1,13 @@
-import { InputParameters } from '@chainlink/external-adapter-framework/validation'
-import { config } from '../config'
-import overrides from '../config/overrides.json'
-import { transport } from '../transport/crypto-lwba'
 import {
   LwbaEndpoint,
   LwbaResponseDataFields,
   lwbaEndpointInputParametersDefinition,
 } from '@chainlink/external-adapter-framework/adapter'
+import { InputParameters } from '@chainlink/external-adapter-framework/validation'
+import { config } from '../config'
+import overrides from '../config/overrides.json'
+import { transport } from '../transport/crypto-lwba'
+import { tiingoCommonSubscriptionRequestTransform } from './utils'
 
 export const inputParameters = new InputParameters(lwbaEndpointInputParametersDefinition)
 
@@ -21,10 +22,5 @@ export const endpoint = new LwbaEndpoint({
   transport,
   inputParameters: inputParameters,
   overrides: overrides.tiingo,
-  requestTransforms: [
-    (req) => {
-      req.requestContext.data.base = req.requestContext.data.base.toUpperCase()
-      req.requestContext.data.quote = req.requestContext.data.quote.toUpperCase()
-    },
-  ],
+  requestTransforms: [tiingoCommonSubscriptionRequestTransform],
 })

--- a/packages/sources/tiingo/src/endpoint/crypto.ts
+++ b/packages/sources/tiingo/src/endpoint/crypto.ts
@@ -1,9 +1,14 @@
 import { CryptoPriceEndpoint } from '@chainlink/external-adapter-framework/adapter'
+import { TransportRoutes } from '@chainlink/external-adapter-framework/transports'
+import overrides from '../config/overrides.json'
 import { httpTransport } from '../transport/crypto-http'
 import { wsTransport } from '../transport/crypto-ws'
-import overrides from '../config/overrides.json'
-import { TransportRoutes } from '@chainlink/external-adapter-framework/transports'
-import { BaseCryptoEndpointTypes, inputParameters } from './utils'
+import {
+  BaseCryptoEndpointTypes,
+  inputParameters,
+  tiingoCommonSubscriptionRequestTransform,
+} from './utils'
+
 export const endpoint = new CryptoPriceEndpoint({
   name: 'crypto',
   aliases: ['price', 'prices', 'crypto-synth'],
@@ -13,4 +18,5 @@ export const endpoint = new CryptoPriceEndpoint({
   defaultTransport: 'ws',
   inputParameters: inputParameters,
   overrides: overrides.tiingo,
+  requestTransforms: [tiingoCommonSubscriptionRequestTransform],
 })

--- a/packages/sources/tiingo/src/endpoint/forex.ts
+++ b/packages/sources/tiingo/src/endpoint/forex.ts
@@ -9,6 +9,7 @@ import { config } from '../config'
 import overrides from '../config/overrides.json'
 import { httpTransport } from '../transport/forex-http'
 import { wsTransport } from '../transport/forex-ws'
+import { tiingoCommonSubscriptionRequestTransform } from './utils'
 
 const inputParameters = new InputParameters(priceEndpointInputParametersDefinition, [
   {
@@ -32,4 +33,5 @@ export const endpoint = new ForexPriceEndpoint({
   defaultTransport: 'ws',
   inputParameters: inputParameters,
   overrides: overrides.tiingo,
+  requestTransforms: [tiingoCommonSubscriptionRequestTransform],
 })

--- a/packages/sources/tiingo/src/endpoint/iex.ts
+++ b/packages/sources/tiingo/src/endpoint/iex.ts
@@ -9,6 +9,7 @@ import { config } from '../config'
 import overrides from '../config/overrides.json'
 import { httpTransport } from '../transport/iex-http'
 import { wsTransport } from '../transport/iex-ws'
+import { tiingoCommonSubscriptionRequestTransform } from './utils'
 
 const inputParameters = new InputParameters(stockEndpointInputParametersDefinition, [
   {
@@ -31,4 +32,5 @@ export const endpoint = new StockEndpoint({
   defaultTransport: 'ws',
   inputParameters: inputParameters,
   overrides: overrides.tiingo,
+  requestTransforms: [tiingoCommonSubscriptionRequestTransform],
 })

--- a/packages/sources/tiingo/src/endpoint/utils.ts
+++ b/packages/sources/tiingo/src/endpoint/utils.ts
@@ -1,7 +1,10 @@
-import { config } from '../config'
-import { InputParameters } from '@chainlink/external-adapter-framework/validation'
 import { priceEndpointInputParametersDefinition } from '@chainlink/external-adapter-framework/adapter'
-import { SingleNumberResultResponse } from '@chainlink/external-adapter-framework/util'
+import {
+  AdapterRequest,
+  SingleNumberResultResponse,
+} from '@chainlink/external-adapter-framework/util'
+import { InputParameters } from '@chainlink/external-adapter-framework/validation'
+import { config } from '../config'
 
 export const inputParameters = new InputParameters(priceEndpointInputParametersDefinition, [
   {
@@ -14,4 +17,11 @@ export type BaseCryptoEndpointTypes = {
   Parameters: typeof inputParameters.definition
   Settings: typeof config.settings
   Response: SingleNumberResultResponse
+}
+
+export function tiingoCommonSubscriptionRequestTransform() {
+  return (req: AdapterRequest<{ base: string; quote: string }>) => {
+    req.requestContext.data.base = req.requestContext.data.base.toLowerCase()
+    req.requestContext.data.quote = req.requestContext.data.quote.toLowerCase()
+  }
 }

--- a/packages/sources/tiingo/src/transport/crypto-lwba.ts
+++ b/packages/sources/tiingo/src/transport/crypto-lwba.ts
@@ -1,5 +1,5 @@
-import { TiingoWebsocketTransport } from './utils'
 import { BaseEndpointTypes } from '../endpoint/crypto-lwba'
+import { TiingoWebsocketTransport, wsMessageContent } from './utils'
 
 interface Message {
   service: string
@@ -31,7 +31,6 @@ export const transport: TiingoWebsocketTransport<WsTransportTypes> =
       transport.apiKey = context.adapterSettings.API_KEY
       return `${context.adapterSettings.WS_API_ENDPOINT}/crypto-synth-top`
     },
-
     handlers: {
       message(message) {
         if (!message?.data?.length || message.messageType !== 'A') {
@@ -56,27 +55,12 @@ export const transport: TiingoWebsocketTransport<WsTransportTypes> =
         ]
       },
     },
-
     builders: {
       subscribeMessage: (params) => {
-        return {
-          eventName: 'subscribe',
-          authorization: transport.apiKey,
-          eventData: {
-            thresholdLevel: 4,
-            tickers: [`${params.base}/${params.quote}`],
-          },
-        }
+        return wsMessageContent('subscribe', transport.apiKey, 4, params.base, params.quote)
       },
       unsubscribeMessage: (params) => {
-        return {
-          eventName: 'unsubscribe',
-          authorization: transport.apiKey,
-          eventData: {
-            thresholdLevel: 4,
-            tickers: [`${params.base}/${params.quote}`],
-          },
-        }
+        return wsMessageContent('unsubscribe', transport.apiKey, 4, params.base, params.quote)
       },
     },
   })

--- a/packages/sources/tiingo/src/transport/crypto-ws.ts
+++ b/packages/sources/tiingo/src/transport/crypto-ws.ts
@@ -1,6 +1,6 @@
-import { TiingoWebsocketTransport } from './utils'
-import { BaseCryptoEndpointTypes } from '../endpoint/utils'
 import { makeLogger } from '@chainlink/external-adapter-framework/util'
+import { BaseCryptoEndpointTypes } from '../endpoint/utils'
+import { TiingoWebsocketTransport, wsMessageContent } from './utils'
 
 const logger = makeLogger('TiingoWebsocketTransport')
 
@@ -63,18 +63,10 @@ export const wsTransport: TiingoWebsocketTransport<WsTransportTypes> =
 
     builders: {
       subscribeMessage: (params) => {
-        return {
-          eventName: 'subscribe',
-          authorization: wsTransport.apiKey,
-          eventData: { thresholdLevel: 6, tickers: [`${params.base}/${params.quote}`] },
-        }
+        return wsMessageContent('subscribe', wsTransport.apiKey, 6, params.base, params.quote)
       },
       unsubscribeMessage: (params) => {
-        return {
-          eventName: 'unsubscribe',
-          authorization: wsTransport.apiKey,
-          eventData: { thresholdLevel: 6, tickers: [`${params.base}/${params.quote}`] },
-        }
+        return wsMessageContent('unsubscribe', wsTransport.apiKey, 6, params.base, params.quote)
       },
     },
   })

--- a/packages/sources/tiingo/src/transport/forex-ws.ts
+++ b/packages/sources/tiingo/src/transport/forex-ws.ts
@@ -1,6 +1,6 @@
-import { BaseEndpointTypes } from '../endpoint/forex'
-import { TiingoWebsocketReverseMappingTransport } from './utils'
 import { makeLogger } from '@chainlink/external-adapter-framework/util'
+import { BaseEndpointTypes } from '../endpoint/forex'
+import { TiingoWebsocketReverseMappingTransport, wsMessageContent } from './utils'
 
 const logger = makeLogger('TiingoWebsocketReverseMappingTransport')
 
@@ -63,24 +63,17 @@ export const wsTransport: TiingoWebsocketReverseMappingTransport<WsTransportType
     builders: {
       subscribeMessage: (params) => {
         wsTransport.setReverseMapping(`${params.base}${params.quote}`.toLowerCase(), params)
-        return {
-          eventName: 'subscribe',
-          authorization: wsTransport.apiKey,
-          eventData: {
-            thresholdLevel: 5,
-            tickers: [`${params.base}${params.quote}`.toLowerCase()],
-          },
-        }
+        return wsMessageContent('subscribe', wsTransport.apiKey, 5, params.base, params.quote, true)
       },
       unsubscribeMessage: (params) => {
-        return {
-          eventName: 'unsubscribe',
-          authorization: wsTransport.apiKey,
-          eventData: {
-            thresholdLevel: 5,
-            tickers: [`${params.base}${params.quote}`.toLowerCase()],
-          },
-        }
+        return wsMessageContent(
+          'unsubscribe',
+          wsTransport.apiKey,
+          5,
+          params.base,
+          params.quote,
+          true,
+        )
       },
     },
   })

--- a/packages/sources/tiingo/src/transport/iex-ws.ts
+++ b/packages/sources/tiingo/src/transport/iex-ws.ts
@@ -1,7 +1,7 @@
 import { WebSocketTransport } from '@chainlink/external-adapter-framework/transports/websocket'
+import { makeLogger } from '@chainlink/external-adapter-framework/util'
 import { BaseEndpointTypes } from '../endpoint/iex'
 import { TiingoWebsocketTransport } from './utils'
-import { makeLogger } from '@chainlink/external-adapter-framework/util'
 
 const logger = makeLogger('TiingoWebsocketTransport')
 
@@ -87,7 +87,7 @@ export const wsTransport: TiingoWebsocketTransport<WsTransportTypes> =
           authorization: wsTransport.apiKey,
           eventData: {
             thresholdLevel: 6,
-            tickers: [params.base],
+            tickers: [params.base.toLowerCase()],
           },
         }
       },
@@ -97,7 +97,7 @@ export const wsTransport: TiingoWebsocketTransport<WsTransportTypes> =
           authorization: wsTransport.apiKey,
           eventData: {
             thresholdLevel: 6,
-            tickers: [params.base],
+            tickers: [params.base.toLowerCase()],
           },
         }
       },

--- a/packages/sources/tiingo/src/transport/utils.ts
+++ b/packages/sources/tiingo/src/transport/utils.ts
@@ -1,11 +1,11 @@
-import { BaseCryptoEndpointTypes, inputParameters } from '../endpoint/utils'
 import { WebsocketTransportGenerics } from '@chainlink/external-adapter-framework/transports'
 import {
   WebsocketReverseMappingTransport,
   WebSocketTransport,
 } from '@chainlink/external-adapter-framework/transports/websocket'
-import { config } from '../config'
 import { splitArrayIntoChunks } from '@chainlink/external-adapter-framework/util'
+import { config } from '../config'
+import { BaseCryptoEndpointTypes, inputParameters } from '../endpoint/utils'
 export interface ProviderResponseBody {
   ticker: string
   baseCurrency: string
@@ -115,6 +115,25 @@ export const constructEntry = <T extends typeof inputParameters.validated>(
       },
     }
   })
+}
+
+export const wsMessageContent = (
+  eventName: 'subscribe' | 'unsubscribe',
+  apiKey: string,
+  thresholdLevel: number,
+  base: string,
+  quote: string,
+  skipSlash = false, // needed for forex
+) => {
+  const ticker = skipSlash ? `${base}${quote}` : `${base}/${quote}`
+  return {
+    eventName,
+    authorization: apiKey,
+    eventData: {
+      thresholdLevel,
+      tickers: [ticker.toLowerCase()],
+    },
+  }
 }
 
 export class TiingoWebsocketTransport<

--- a/packages/sources/tiingo/test/unit/transport-utils.test.ts
+++ b/packages/sources/tiingo/test/unit/transport-utils.test.ts
@@ -1,0 +1,14 @@
+import { wsMessageContent } from '../../src/transport/utils'
+
+describe('transport-utils', () => {
+  describe('wsMessageContent', () => {
+    it('returns a lowercased base/quote pair', () => {
+      const response = wsMessageContent('subscribe', 'test-api-key', 1234, 'BaSe', 'quoTE')
+      expect(response.eventData.tickers[0]).toEqual('base/quote')
+    })
+    it('with skipSlash skips slash', () => {
+      const response = wsMessageContent('subscribe', 'test-api-key', 1234, 'BaSe', 'quoTE', true)
+      expect(response.eventData.tickers[0]).toEqual('basequote')
+    })
+  })
+})


### PR DESCRIPTION
## Closes #[OPDATA-2664](https://smartcontract-it.atlassian.net/browse/OPDATA-2664)

## Description
Update tiingo WS subscriptions to use .toLowerCase()

## Changes
- refactor subscription payload to use .toLowerCase()
- update all tiingo and tiingo state WS transports

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test
1. `yarn test tiingo/`, `yarn test tiingo-state`
2. test with payloads

### Tiingo
**stock**
```json
{
    "data": {
        "base": "AAPL",
        "quote": "USD",
        "endpoint": "iex"
    }
}
```
**crypto**
```json
{
    "data": {
        "base": "Eth",
        "quote": "USD",
        "endpoint": "crypto"
    }
}
```
**cryptolwba**
```json
{
    "data": {
        "base": "Eth",
        "quote": "USD",
        "endpoint": "cryptolwba"
    }
}
```
**forex**
```json
{
    "data": {
        "base": "ZAR",
        "quote": "USD",
        "endpoint": "forex"
    }
}
```

### Tiingo State
**state**
```json
{
    "data": {
        "base": "USDe",
        "quote": "USD",
        "endpoint": "price"
    }
}
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
