### PR TITLE
OPDATA-2382 ondo EA initial commit

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -747,6 +747,10 @@ const RAW_RUNTIME_STATE =
       "reference": "workspace:packages/sources/onchain-gas"\
     },\
     {\
+      "name": "@chainlink/ondo-adapter",\
+      "reference": "workspace:packages/sources/ondo"\
+    },\
+    {\
       "name": "@chainlink/onre-adapter",\
       "reference": "workspace:packages/sources/onre"\
     },\
@@ -1146,6 +1150,7 @@ const RAW_RUNTIME_STATE =
     ["@chainlink/observation", ["workspace:packages/observation"]],\
     ["@chainlink/oilpriceapi-adapter", ["workspace:packages/sources/oilpriceapi"]],\
     ["@chainlink/onchain-gas-adapter", ["workspace:packages/sources/onchain-gas"]],\
+    ["@chainlink/ondo-adapter", ["workspace:packages/sources/ondo"]],\
     ["@chainlink/onre-adapter", ["workspace:packages/sources/onre"]],\
     ["@chainlink/openexchangerates-adapter", ["workspace:packages/sources/openexchangerates"]],\
     ["@chainlink/orchid-bandwidth-adapter", ["workspace:packages/sources/orchid-bandwidth"]],\
@@ -8247,6 +8252,21 @@ const RAW_RUNTIME_STATE =
           ["nock", "npm:13.5.6"],\
           ["supertest", "npm:6.2.4"],\
           ["tslib", "npm:2.8.1"],\
+          ["typescript", "patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"]\
+        ],\
+        "linkType": "SOFT"\
+      }]\
+    ]],\
+    ["@chainlink/ondo-adapter", [\
+      ["workspace:packages/sources/ondo", {\
+        "packageLocation": "./packages/sources/ondo/",\
+        "packageDependencies": [\
+          ["@chainlink/ondo-adapter", "workspace:packages/sources/ondo"],\
+          ["@chainlink/external-adapter-framework", "npm:2.6.0"],\
+          ["@types/jest", "npm:29.5.14"],\
+          ["@types/node", "npm:22.14.1"],\
+          ["nock", "npm:13.5.6"],\
+          ["tslib", "npm:2.4.1"],\
           ["typescript", "patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"]\
         ],\
         "linkType": "SOFT"\

--- a/packages/sources/ondo/README.md
+++ b/packages/sources/ondo/README.md
@@ -1,0 +1,3 @@
+# Chainlink External Adapter for ondo
+
+This README will be generated automatically when code is merged to `main`. If you would like to generate a preview of the README, please run `yarn generate:readme ondo`.

--- a/packages/sources/ondo/package.json
+++ b/packages/sources/ondo/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@chainlink/ondo-adapter",
+  "version": "0.0.0",
+  "description": "Chainlink ondo adapter.",
+  "keywords": [
+    "Chainlink",
+    "LINK",
+    "blockchain",
+    "oracle",
+    "ondo"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "url": "https://github.com/smartcontractkit/external-adapters-js",
+    "type": "git"
+  },
+  "license": "MIT",
+  "scripts": {
+    "clean": "rm -rf dist && rm -f tsconfig.tsbuildinfo",
+    "prepack": "yarn build",
+    "build": "tsc -b",
+    "server": "node -e 'require(\"./index.js\").server()'",
+    "server:dist": "node -e 'require(\"./dist/index.js\").server()'",
+    "start": "yarn server:dist"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "@types/node": "22.14.1",
+    "nock": "13.5.6",
+    "typescript": "5.8.3"
+  },
+  "dependencies": {
+    "@chainlink/external-adapter-framework": "2.6.0",
+    "tslib": "2.4.1"
+  }
+}

--- a/packages/sources/ondo/src/config/index.ts
+++ b/packages/sources/ondo/src/config/index.ts
@@ -1,0 +1,15 @@
+import { AdapterConfig } from '@chainlink/external-adapter-framework/config'
+
+export const config = new AdapterConfig({
+  API_ENDPOINT: {
+    description: 'The API endpoint for Ondo',
+    type: 'string',
+    default: 'https://api.gm.ondo.finance/',
+  },
+  API_KEY: {
+    description: 'An API key required to access the API_ENDPOINT',
+    type: 'string',
+    required: true,
+    sensitive: true,
+  },
+})

--- a/packages/sources/ondo/src/endpoint/index.ts
+++ b/packages/sources/ondo/src/endpoint/index.ts
@@ -1,0 +1,1 @@
+export { endpoint as price } from './price'

--- a/packages/sources/ondo/src/endpoint/price.ts
+++ b/packages/sources/ondo/src/endpoint/price.ts
@@ -7,6 +7,7 @@ import { httpTransport } from '../transport/price'
 export const inputParameters = new InputParameters(
   {
     asset: {
+      aliases: ['symbol'],
       required: true,
       type: 'string',
       description: 'Asset price to request from Data Provider',

--- a/packages/sources/ondo/src/endpoint/price.ts
+++ b/packages/sources/ondo/src/endpoint/price.ts
@@ -1,0 +1,32 @@
+import { AdapterEndpoint } from '@chainlink/external-adapter-framework/adapter'
+import { SingleNumberResultResponse } from '@chainlink/external-adapter-framework/util'
+import { InputParameters } from '@chainlink/external-adapter-framework/validation'
+import { config } from '../config'
+import { httpTransport } from '../transport/price'
+
+export const inputParameters = new InputParameters(
+  {
+    asset: {
+      required: true,
+      type: 'string',
+      description: 'Asset price to request from Data Provider',
+    },
+  },
+  [
+    {
+      asset: 'AAPLon',
+    },
+  ],
+)
+
+export type BaseEndpointTypes = {
+  Parameters: typeof inputParameters.definition
+  Response: SingleNumberResultResponse
+  Settings: typeof config.settings
+}
+
+export const endpoint = new AdapterEndpoint({
+  name: 'price',
+  transport: httpTransport,
+  inputParameters,
+})

--- a/packages/sources/ondo/src/index.ts
+++ b/packages/sources/ondo/src/index.ts
@@ -1,0 +1,20 @@
+import { expose, ServerInstance } from '@chainlink/external-adapter-framework'
+import { Adapter } from '@chainlink/external-adapter-framework/adapter'
+import { config } from './config'
+import { price } from './endpoint'
+
+export const adapter = new Adapter({
+  defaultEndpoint: price.name,
+  name: 'ONDO',
+  config,
+  endpoints: [price],
+  rateLimiting: {
+    tiers: {
+      default: {
+        rateLimit1s: 2, // setting a rate limit so we don't go over per-key limits
+      },
+    },
+  },
+})
+
+export const server = (): Promise<ServerInstance | undefined> => expose(adapter)

--- a/packages/sources/ondo/src/transport/price.ts
+++ b/packages/sources/ondo/src/transport/price.ts
@@ -1,0 +1,69 @@
+import { HttpTransport } from '@chainlink/external-adapter-framework/transports'
+import { BaseEndpointTypes } from '../endpoint/price'
+
+export interface ProviderResponseSchema {
+  primaryMarket: {
+    symbol: string
+    price: string
+  }
+  underlyingMarket: {
+    ticker: string
+    price: string
+  }
+  timestamp: number
+}
+
+export type HttpTransportTypes = BaseEndpointTypes & {
+  Provider: {
+    RequestBody: never
+    ResponseBody: ProviderResponseSchema
+  }
+}
+
+export const httpTransport = new HttpTransport<HttpTransportTypes>({
+  prepareRequests: (params, config) => {
+    return params.map((param) => {
+      return {
+        params: [param],
+        request: {
+          baseURL: config.API_ENDPOINT,
+          url: `v1/assets/${param.asset}/prices/latest`,
+          headers: {
+            'x-api-key': config.API_KEY,
+          },
+        },
+      }
+    })
+  },
+  parseResponse: (params, response) => {
+    if (!response.data || isNaN(Number(response.data.primaryMarket?.price))) {
+      return params.map((param) => {
+        return {
+          params: param,
+          response: {
+            errorMessage: `The data provider didn't return any value for ${param.asset}`,
+            statusCode: 502,
+          },
+        }
+      })
+    }
+
+    const timestamps = {
+      providerIndicatedTimeUnixMs: response.data.timestamp,
+    }
+    const result = Number(response.data.primaryMarket.price)
+
+    return params.map((param) => {
+      return {
+        params: param,
+        response: {
+          result,
+          data: {
+            result,
+          },
+          timestamps,
+        },
+      }
+    })
+  },
+})

--- a/packages/sources/ondo/test-payload.json
+++ b/packages/sources/ondo/test-payload.json
@@ -1,0 +1,6 @@
+{
+ "requests": [{
+  "from": "BTC",
+  "to": "USD"
+ }]
+}

--- a/packages/sources/ondo/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/ondo/test/integration/__snapshots__/adapter.test.ts.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`execute price endpoint should return success 1`] = `
+{
+  "data": {
+    "result": 12.345,
+  },
+  "result": 12.345,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 978347471111,
+    "providerDataRequestedUnixMs": 978347471111,
+    "providerIndicatedTimeUnixMs": 1234567890,
+  },
+}
+`;

--- a/packages/sources/ondo/test/integration/adapter.test.ts
+++ b/packages/sources/ondo/test/integration/adapter.test.ts
@@ -1,0 +1,47 @@
+import {
+  TestAdapter,
+  setEnvVariables,
+} from '@chainlink/external-adapter-framework/util/testing-utils'
+import * as nock from 'nock'
+import { mockResponseSuccess } from './fixtures'
+
+describe('execute', () => {
+  let spy: jest.SpyInstance
+  let testAdapter: TestAdapter
+  let oldEnv: NodeJS.ProcessEnv
+
+  beforeAll(async () => {
+    oldEnv = JSON.parse(JSON.stringify(process.env))
+    process.env.API_KEY = process.env.API_KEY ?? 'fake-api-key'
+
+    const mockDate = new Date('2001-01-01T11:11:11.111Z')
+    spy = jest.spyOn(Date, 'now').mockReturnValue(mockDate.getTime())
+
+    const adapter = (await import('./../../src')).adapter
+    adapter.rateLimiting = undefined
+    testAdapter = await TestAdapter.startWithMockedCache(adapter, {
+      testAdapter: {} as TestAdapter<never>,
+    })
+  })
+
+  afterAll(async () => {
+    setEnvVariables(oldEnv)
+    await testAdapter.api.close()
+    nock.restore()
+    nock.cleanAll()
+    spy.mockRestore()
+  })
+
+  describe('price endpoint', () => {
+    it('should return success', async () => {
+      const data = {
+        endpoint: 'price',
+        asset: 'AAPLon',
+      }
+      mockResponseSuccess()
+      const response = await testAdapter.request(data)
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toMatchSnapshot()
+    })
+  })
+})

--- a/packages/sources/ondo/test/integration/fixtures.ts
+++ b/packages/sources/ondo/test/integration/fixtures.ts
@@ -1,0 +1,32 @@
+import nock from 'nock'
+
+export const mockResponseSuccess = (): nock.Scope =>
+  nock('https://api.gm.ondo.finance/', {
+    encodedQueryParams: true,
+  })
+    .get('/v1/assets/AAPLon/prices/latest')
+    .reply(
+      200,
+      () => ({
+        primaryMarket: {
+          symbol: 'AAPLon',
+          price: '12.345',
+        },
+        underlyingMarket: {
+          symbol: 'AAPL',
+          price: '12.3456',
+        },
+        timestamp: 1234567890,
+      }),
+      [
+        'Content-Type',
+        'application/json',
+        'Connection',
+        'close',
+        'Vary',
+        'Accept-Encoding',
+        'Vary',
+        'Origin',
+      ],
+    )
+    .persist()

--- a/packages/sources/ondo/tsconfig.json
+++ b/packages/sources/ondo/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*", "src/**/*.json"],
+  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]
+}

--- a/packages/sources/ondo/tsconfig.test.json
+++ b/packages/sources/ondo/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*", "**/test", "src/**/*.json"],
+  "compilerOptions": {
+    "noEmit": true
+  }
+}

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -540,6 +540,9 @@
       "path": "./sources/onchain-gas"
     },
     {
+      "path": "./sources/ondo"
+    },
+    {
       "path": "./sources/onre"
     },
     {

--- a/packages/tsconfig.test.json
+++ b/packages/tsconfig.test.json
@@ -540,6 +540,9 @@
       "path": "./sources/onchain-gas/tsconfig.test.json"
     },
     {
+      "path": "./sources/ondo/tsconfig.test.json"
+    },
+    {
       "path": "./sources/onre/tsconfig.test.json"
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5173,6 +5173,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@chainlink/ondo-adapter@workspace:packages/sources/ondo":
+  version: 0.0.0-use.local
+  resolution: "@chainlink/ondo-adapter@workspace:packages/sources/ondo"
+  dependencies:
+    "@chainlink/external-adapter-framework": "npm:2.6.0"
+    "@types/jest": "npm:^29.5.14"
+    "@types/node": "npm:22.14.1"
+    nock: "npm:13.5.6"
+    tslib: "npm:2.4.1"
+    typescript: "npm:5.8.3"
+  languageName: unknown
+  linkType: soft
+
 "@chainlink/onre-adapter@workspace:packages/sources/onre":
   version: 0.0.0-use.local
   resolution: "@chainlink/onre-adapter@workspace:packages/sources/onre"


### PR DESCRIPTION
## Closes #[OPDATA-2382](https://smartcontract-it.atlassian.net/browse/OPDATA-2382)

## Description
New EA for Ondo. Only contains logic for single value answer.

## Changes
- Introduce new EA for Ondo price

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test
1. yarn test ondo/
2. test using payload
```json
{
    "data": {
        "endpoint": "price",
        "asset": "AAPLon"
    }
}
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
