### PR TITLE
Mock new fields for secure mint

### DIFF
--- a/.changeset/empty-forks-love.md
+++ b/.changeset/empty-forks-love.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/secure-mint-adapter': patch
+---
+
+Add v0.5 fields

--- a/packages/composites/secure-mint/src/transport/mintable.ts
+++ b/packages/composites/secure-mint/src/transport/mintable.ts
@@ -98,6 +98,10 @@ export class MintableTransport extends SubscriptionTransport<BaseEndpointTypes> 
               id,
               {
                 mintable: overmint ? '0' : data.mintable,
+                // TODO: Update these with actual values
+                nativeMint: '0',
+                totalAborts: '0',
+                mintablePacked: overmint ? '0' : data.mintable,
                 block: data.response_block,
               },
             ]),
@@ -105,6 +109,7 @@ export class MintableTransport extends SubscriptionTransport<BaseEndpointTypes> 
       reserveInfo: {
         reserveAmount: reserve.reserveAmount.toString(),
         timestamp: reserve.timestamp,
+        ripcord: reserve.ripcord,
       },
       latestBlocks: Object.fromEntries(
         Object.entries(supply.chains).map(([id, data]) => [id, data.latest_block]),

--- a/packages/composites/secure-mint/src/transport/reserve.ts
+++ b/packages/composites/secure-mint/src/transport/reserve.ts
@@ -8,8 +8,9 @@ type ReservesResponse = BitgoReservesResponse
 
 type BitgoReservesResponse = {
   result: number
+  ripcord: string
   timestamps: {
-    providerDataReceivedUnixMs: number
+    providerIndicatedTimeUnixMs: number
   }
 }
 
@@ -38,6 +39,13 @@ export const getReserve = async (
     return parseResponse(reserves, response.response.data)
   } catch (e) {
     if (e instanceof AdapterError) {
+      if ((e?.errorResponse as { ripcord: string })?.ripcord?.toString()?.toUpperCase() == 'TRUE') {
+        return {
+          reserveAmount: 0n,
+          timestamp: 0,
+          ripcord: true,
+        }
+      }
       e.message = `${e.message} ${JSON.stringify(e?.errorResponse) || e.name}`
     }
     throw e
@@ -55,6 +63,7 @@ const getRequest = (token: string, _reserves: 'Bitgo', config: BaseEndpointTypes
 const parseResponse = (_reserves: 'Bitgo', response: ReservesResponse) => {
   return {
     reserveAmount: parseUnits(response.result.toString(), 18),
-    timestamp: response.timestamps.providerDataReceivedUnixMs,
+    timestamp: response.timestamps.providerIndicatedTimeUnixMs,
+    ripcord: response.ripcord?.toString()?.toUpperCase() == 'TRUE',
   }
 }

--- a/packages/composites/secure-mint/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/composites/secure-mint/test/integration/__snapshots__/adapter.test.ts.snap
@@ -10,11 +10,15 @@ exports[`execute mintable endpoint should block overmint 1`] = `
       "1": {
         "block": 6,
         "mintable": "0",
+        "mintablePacked": "0",
+        "nativeMint": "0",
+        "totalAborts": "0",
       },
     },
     "overmint": true,
     "reserveInfo": {
       "reserveAmount": "1000000000000000000",
+      "ripcord": false,
       "timestamp": 2,
     },
     "supplyDetails": {
@@ -56,6 +60,7 @@ exports[`execute mintable endpoint should handle error 1`] = `
     "overmint": false,
     "reserveInfo": {
       "reserveAmount": "1000000000000000000",
+      "ripcord": false,
       "timestamp": 2,
     },
     "supplyDetails": {
@@ -86,11 +91,15 @@ exports[`execute mintable endpoint should return success 1`] = `
       "1": {
         "block": 6,
         "mintable": "8",
+        "mintablePacked": "8",
+        "nativeMint": "0",
+        "totalAborts": "0",
       },
     },
     "overmint": false,
     "reserveInfo": {
       "reserveAmount": "1000000000000000000",
+      "ripcord": false,
       "timestamp": 2,
     },
     "supplyDetails": {

--- a/packages/composites/secure-mint/test/integration/fixtures.ts
+++ b/packages/composites/secure-mint/test/integration/fixtures.ts
@@ -8,7 +8,7 @@ export const mockBitgoSuccess = (): nock.Scope =>
     .reply(200, () => ({
       result: 1,
       timestamps: {
-        providerDataReceivedUnixMs: 2,
+        providerIndicatedTimeUnixMs: 2,
       },
     }))
     .persist()
@@ -16,7 +16,7 @@ export const mockBitgoSuccess = (): nock.Scope =>
     .reply(200, () => ({
       result: 1,
       timestamps: {
-        providerDataReceivedUnixMs: 2,
+        providerIndicatedTimeUnixMs: 2,
       },
     }))
     .persist()
@@ -24,7 +24,7 @@ export const mockBitgoSuccess = (): nock.Scope =>
     .reply(200, () => ({
       result: 1,
       timestamps: {
-        providerDataReceivedUnixMs: 2,
+        providerIndicatedTimeUnixMs: 2,
       },
     }))
     .persist()

--- a/packages/composites/secure-mint/test/unit/mintable.test.ts
+++ b/packages/composites/secure-mint/test/unit/mintable.test.ts
@@ -121,8 +121,9 @@ describe('MintableTransport', () => {
         response: {
           data: {
             result: reserveResult,
+            ripcord: '',
             timestamps: {
-              providerDataReceivedUnixMs: Date.now(),
+              providerIndicatedTimeUnixMs: Date.now(),
             },
           },
         },
@@ -166,10 +167,14 @@ describe('MintableTransport', () => {
             '1': {
               block: responseBlock,
               mintable,
+              mintablePacked: mintable,
+              nativeMint: '0',
+              totalAborts: '0',
             },
           },
           reserveInfo: {
             reserveAmount: BigInt(reserveResult * 10 ** 18).toString(),
+            ripcord: false,
             timestamp: Date.now(),
           },
           supplyDetails: {
@@ -233,8 +238,9 @@ describe('MintableTransport', () => {
         response: {
           data: {
             result: reserveResult,
+            ripcord: '',
             timestamps: {
-              providerDataReceivedUnixMs: Date.now(),
+              providerIndicatedTimeUnixMs: Date.now(),
             },
           },
         },
@@ -278,11 +284,15 @@ describe('MintableTransport', () => {
             '1': {
               block: responseBlock,
               mintable: '0',
+              mintablePacked: '0',
+              nativeMint: '0',
+              totalAborts: '0',
             },
           },
           reserveInfo: {
             reserveAmount: BigInt(reserveResult * 10 ** 18).toString(),
             timestamp: Date.now(),
+            ripcord: false,
           },
           supplyDetails: {
             chains: {
@@ -342,8 +352,9 @@ describe('MintableTransport', () => {
         response: {
           data: {
             result: reserveResult,
+            ripcord: '',
             timestamps: {
-              providerDataReceivedUnixMs: Date.now(),
+              providerIndicatedTimeUnixMs: Date.now(),
             },
           },
         },
@@ -393,15 +404,22 @@ describe('MintableTransport', () => {
             '1': {
               block: 105,
               mintable: '104',
+              mintablePacked: '104',
+              nativeMint: '0',
+              totalAborts: '0',
             },
             '56': {
               block: 2105,
               mintable: '2104',
+              mintablePacked: '2104',
+              nativeMint: '0',
+              totalAborts: '0',
             },
           },
           reserveInfo: {
             reserveAmount: BigInt(reserveResult * 10 ** 18).toString(),
             timestamp: Date.now(),
+            ripcord: false,
           },
           supplyDetails: {
             chains: {
@@ -467,8 +485,9 @@ describe('MintableTransport', () => {
         response: {
           data: {
             result: reserveResult,
+            ripcord: '',
             timestamps: {
-              providerDataReceivedUnixMs: Date.now(),
+              providerIndicatedTimeUnixMs: Date.now(),
             },
           },
         },
@@ -517,6 +536,7 @@ describe('MintableTransport', () => {
           reserveInfo: {
             reserveAmount: BigInt(reserveResult * 10 ** 18).toString(),
             timestamp: Date.now(),
+            ripcord: false,
           },
           supplyDetails: {
             chains: {


### PR DESCRIPTION
Mock new fields in EA to unblock plugin and core development
- Add new `nativeMint` `totalAborts` `mintablePacked` fields
- Read `ripcord` from reserve, support read `ripcord` from both `success` response as well as `error` response
- Fix reserve timestamp bug, use `providerIndicatedTimeUnixMs` which is when DP updated reserve time