### PR TITLE
Fix example request in CMETH

### DIFF
--- a/.changeset/dull-pianos-march.md
+++ b/.changeset/dull-pianos-march.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/cmeth-adapter': patch
+---
+
+Fix example input

--- a/packages/sources/cmeth/README.md
+++ b/packages/sources/cmeth/README.md
@@ -60,10 +60,6 @@ Request:
         "address": "0xd5F7838F5C461fefF7FE49ea5ebaF7728bB0ADfa"
       },
       {
-        "name": "KmETH",
-        "address": "0x7c22725d1e0871f0043397c9761ad99a86ffd498"
-      },
-      {
         "name": "BoringVault",
         "address": "0x33272D40b247c4cd9C646582C9bbAD44e85D4fE4"
       },
@@ -106,35 +102,35 @@ Request:
     ],
     "balanceOf": [
       {
-        "tokenContract": "cmETH",
+        "tokenContract": "mETH",
         "account": "BoringVault"
       },
       {
-        "tokenContract": "cmETH",
+        "tokenContract": "mETH",
         "account": "PositionManager-Karak"
       },
       {
-        "tokenContract": "cmETH",
+        "tokenContract": "mETH",
         "account": "V1:PositionManager-Symbiotic"
       },
       {
-        "tokenContract": "cmETH",
+        "tokenContract": "mETH",
         "account": "V1:PositionManager-Eigen_A41"
       },
       {
-        "tokenContract": "cmETH",
+        "tokenContract": "mETH",
         "account": "V1:PositionManager-Eigen_P2P"
       },
       {
-        "tokenContract": "cmETH",
+        "tokenContract": "mETH",
         "account": "V2:PositionManager-Symbiotic"
       },
       {
-        "tokenContract": "cmETH",
+        "tokenContract": "mETH",
         "account": "V2:PositionManager-Eigen_A41"
       },
       {
-        "tokenContract": "cmETH",
+        "tokenContract": "mETH",
         "account": "V2:PositionManager-Eigen_P2P"
       },
       {
@@ -142,7 +138,7 @@ Request:
         "account": "V1:PositionManager-Symbiotic"
       },
       {
-        "tokenContract": "cmETH",
+        "tokenContract": "mETH",
         "account": "DelayedWithdraw"
       }
     ],

--- a/packages/sources/cmeth/README.md
+++ b/packages/sources/cmeth/README.md
@@ -64,10 +64,6 @@ Request:
         "address": "0x33272D40b247c4cd9C646582C9bbAD44e85D4fE4"
       },
       {
-        "name": "DelayedWithdraw",
-        "address": "0x12Be34bE067Ebd201f6eAf78a861D90b2a66B113"
-      },
-      {
         "name": "PositionManager-Karak",
         "address": "0x52EA8E95378d01B0aaD3B034Ca0656b0F0cc21A2"
       },
@@ -76,28 +72,8 @@ Request:
         "address": "0x919531146f9a25dfc161d5ab23b117feae2c1d36"
       },
       {
-        "name": "V1:PositionManager-Eigen_A41",
-        "address": "0x6DfbE3A1a0e835C125EEBb7712Fffc36c4D93b25"
-      },
-      {
-        "name": "V1:PositionManager-Eigen_P2P",
-        "address": "0x021180A06Aa65A7B5fF891b5C146FbDaFC06e2DA"
-      },
-      {
         "name": "V1:SymbioticRestakingPool",
         "address": "0x475d3eb031d250070b63fa145f0fcfc5d97c304a"
-      },
-      {
-        "name": "V2:PositionManager-Symbiotic",
-        "address": "0x5bb8e5e8602b71b182e0Efe256896a931489A135"
-      },
-      {
-        "name": "V2:PositionManager-Eigen_A41",
-        "address": "0xCaC15044a1F67238D761Aa4C7650DaB59cEF849D"
-      },
-      {
-        "name": "V2:PositionManager-Eigen_P2P",
-        "address": "0x0b5d15445b715bf117ba0482b7a9f772af46d93a"
       }
     ],
     "balanceOf": [
@@ -110,46 +86,11 @@ Request:
         "account": "PositionManager-Karak"
       },
       {
-        "tokenContract": "mETH",
-        "account": "V1:PositionManager-Symbiotic"
-      },
-      {
-        "tokenContract": "mETH",
-        "account": "V1:PositionManager-Eigen_A41"
-      },
-      {
-        "tokenContract": "mETH",
-        "account": "V1:PositionManager-Eigen_P2P"
-      },
-      {
-        "tokenContract": "mETH",
-        "account": "V2:PositionManager-Symbiotic"
-      },
-      {
-        "tokenContract": "mETH",
-        "account": "V2:PositionManager-Eigen_A41"
-      },
-      {
-        "tokenContract": "mETH",
-        "account": "V2:PositionManager-Eigen_P2P"
-      },
-      {
         "tokenContract": "V1:SymbioticRestakingPool",
         "account": "V1:PositionManager-Symbiotic"
-      },
-      {
-        "tokenContract": "mETH",
-        "account": "DelayedWithdraw"
       }
     ],
-    "getTotalLPT": [
-      "PositionManager-Karak",
-      "V1:PositionManager-Eigen_A41",
-      "V1:PositionManager-Eigen_P2P",
-      "V2:PositionManager-Symbiotic",
-      "V2:PositionManager-Eigen_A41",
-      "V2:PositionManager-Eigen_P2P"
-    ]
+    "getTotalLPT": ["PositionManager-Karak"]
   }
 }
 ```

--- a/packages/sources/cmeth/src/endpoint/price.ts
+++ b/packages/sources/cmeth/src/endpoint/price.ts
@@ -51,10 +51,6 @@ export const inputParameters = new InputParameters(
       addresses: [
         { name: 'cmETH', address: '0xE6829d9a7eE3040e1276Fa75293Bde931859e8fA' },
         { name: 'mETH', address: '0xd5F7838F5C461fefF7FE49ea5ebaF7728bB0ADfa' },
-        {
-          name: 'KmETH',
-          address: '0x7c22725d1e0871f0043397c9761ad99a86ffd498',
-        },
         { name: 'BoringVault', address: '0x33272D40b247c4cd9C646582C9bbAD44e85D4fE4' },
         { name: 'DelayedWithdraw', address: '0x12Be34bE067Ebd201f6eAf78a861D90b2a66B113' },
         { name: 'PositionManager-Karak', address: '0x52EA8E95378d01B0aaD3B034Ca0656b0F0cc21A2' },
@@ -89,35 +85,35 @@ export const inputParameters = new InputParameters(
       ],
       balanceOf: [
         {
-          tokenContract: 'cmETH',
+          tokenContract: 'mETH',
           account: 'BoringVault',
         },
         {
-          tokenContract: 'cmETH',
+          tokenContract: 'mETH',
           account: 'PositionManager-Karak',
         },
         {
-          tokenContract: 'cmETH',
+          tokenContract: 'mETH',
           account: 'V1:PositionManager-Symbiotic',
         },
         {
-          tokenContract: 'cmETH',
+          tokenContract: 'mETH',
           account: 'V1:PositionManager-Eigen_A41',
         },
         {
-          tokenContract: 'cmETH',
+          tokenContract: 'mETH',
           account: 'V1:PositionManager-Eigen_P2P',
         },
         {
-          tokenContract: 'cmETH',
+          tokenContract: 'mETH',
           account: 'V2:PositionManager-Symbiotic',
         },
         {
-          tokenContract: 'cmETH',
+          tokenContract: 'mETH',
           account: 'V2:PositionManager-Eigen_A41',
         },
         {
-          tokenContract: 'cmETH',
+          tokenContract: 'mETH',
           account: 'V2:PositionManager-Eigen_P2P',
         },
         {
@@ -125,7 +121,7 @@ export const inputParameters = new InputParameters(
           account: 'V1:PositionManager-Symbiotic',
         },
         {
-          tokenContract: 'cmETH',
+          tokenContract: 'mETH',
           account: 'DelayedWithdraw',
         },
       ],

--- a/packages/sources/cmeth/src/endpoint/price.ts
+++ b/packages/sources/cmeth/src/endpoint/price.ts
@@ -52,35 +52,14 @@ export const inputParameters = new InputParameters(
         { name: 'cmETH', address: '0xE6829d9a7eE3040e1276Fa75293Bde931859e8fA' },
         { name: 'mETH', address: '0xd5F7838F5C461fefF7FE49ea5ebaF7728bB0ADfa' },
         { name: 'BoringVault', address: '0x33272D40b247c4cd9C646582C9bbAD44e85D4fE4' },
-        { name: 'DelayedWithdraw', address: '0x12Be34bE067Ebd201f6eAf78a861D90b2a66B113' },
         { name: 'PositionManager-Karak', address: '0x52EA8E95378d01B0aaD3B034Ca0656b0F0cc21A2' },
         {
           name: 'V1:PositionManager-Symbiotic',
           address: '0x919531146f9a25dfc161d5ab23b117feae2c1d36',
         },
         {
-          name: 'V1:PositionManager-Eigen_A41',
-          address: '0x6DfbE3A1a0e835C125EEBb7712Fffc36c4D93b25',
-        },
-        {
-          name: 'V1:PositionManager-Eigen_P2P',
-          address: '0x021180A06Aa65A7B5fF891b5C146FbDaFC06e2DA',
-        },
-        {
           name: 'V1:SymbioticRestakingPool',
           address: '0x475d3eb031d250070b63fa145f0fcfc5d97c304a',
-        },
-        {
-          name: 'V2:PositionManager-Symbiotic',
-          address: '0x5bb8e5e8602b71b182e0Efe256896a931489A135',
-        },
-        {
-          name: 'V2:PositionManager-Eigen_A41',
-          address: '0xCaC15044a1F67238D761Aa4C7650DaB59cEF849D',
-        },
-        {
-          name: 'V2:PositionManager-Eigen_P2P',
-          address: '0x0b5d15445b715bf117ba0482b7a9f772af46d93a',
         },
       ],
       balanceOf: [
@@ -93,46 +72,11 @@ export const inputParameters = new InputParameters(
           account: 'PositionManager-Karak',
         },
         {
-          tokenContract: 'mETH',
-          account: 'V1:PositionManager-Symbiotic',
-        },
-        {
-          tokenContract: 'mETH',
-          account: 'V1:PositionManager-Eigen_A41',
-        },
-        {
-          tokenContract: 'mETH',
-          account: 'V1:PositionManager-Eigen_P2P',
-        },
-        {
-          tokenContract: 'mETH',
-          account: 'V2:PositionManager-Symbiotic',
-        },
-        {
-          tokenContract: 'mETH',
-          account: 'V2:PositionManager-Eigen_A41',
-        },
-        {
-          tokenContract: 'mETH',
-          account: 'V2:PositionManager-Eigen_P2P',
-        },
-        {
           tokenContract: 'V1:SymbioticRestakingPool',
           account: 'V1:PositionManager-Symbiotic',
         },
-        {
-          tokenContract: 'mETH',
-          account: 'DelayedWithdraw',
-        },
       ],
-      getTotalLPT: [
-        'PositionManager-Karak',
-        'V1:PositionManager-Eigen_A41',
-        'V1:PositionManager-Eigen_P2P',
-        'V2:PositionManager-Symbiotic',
-        'V2:PositionManager-Eigen_A41',
-        'V2:PositionManager-Eigen_P2P',
-      ],
+      getTotalLPT: ['PositionManager-Karak'],
     },
   ],
 )

--- a/packages/sources/cmeth/test/unit/price.test.ts
+++ b/packages/sources/cmeth/test/unit/price.test.ts
@@ -544,6 +544,18 @@ describe('CmethTransport', () => {
       expect(ethers.Contract).toHaveBeenCalledTimes(5)
     })
 
+    it('should handle example input as a valid request', async () => {
+      const cmethTotalSupply = 10000000n
+
+      methContract.balanceOf.mockResolvedValue(0n)
+      restakingPoolContract.balanceOf.mockResolvedValueOnce(0n)
+      positionManagerContract.getTotalLPT.mockResolvedValueOnce(0n)
+      positionManager2Contract.getTotalLPT.mockResolvedValueOnce(0n)
+      cmethContract.totalSupply.mockResolvedValueOnce(cmethTotalSupply)
+
+      await transport._handleRequest(inputParameters.examples![0])
+    })
+
     describe('with invalid input', () => {
       it('should throw if address is missing', async () => {
         const param = makeStub('param', {


### PR DESCRIPTION
## Description

In https://github.com/smartcontractkit/external-adapters-js/pull/3945, I added the example input before adding some extra checks that made the example input invalid.

## Changes

1. Make sure the example input is valid.
2. Reduce the example input in size to make it more manageable while still demonstrating the type. Previously it matched the exact input we'll use for the feed but this is not necessary for an example.
3. Regenerate the README.

## Steps to Test

1. I added a unit test which makes sure the example input passes validation. I made sure the test fails if the example input is incorrect.
2. I copied the example input from the README and used it in our prod CMETH adapter:
```
$ curl --silent -X POST https://adapters.main.prod.cldev.sh/cmeth -H "Content-Type: application/json" -d '{
  "data": {
    "endpoint": "price",
    "addresses": [
      {
        "name": "cmETH",
        "address": "0xE6829d9a7eE3040e1276Fa75293Bde931859e8fA"
      },
      {
        "name": "mETH",
        "address": "0xd5F7838F5C461fefF7FE49ea5ebaF7728bB0ADfa"
      },
      {
        "name": "BoringVault",
        "address": "0x33272D40b247c4cd9C646582C9bbAD44e85D4fE4"
      },
      {
        "name": "PositionManager-Karak",
        "address": "0x52EA8E95378d01B0aaD3B034Ca0656b0F0cc21A2"
      },
      {
        "name": "V1:PositionManager-Symbiotic",
        "address": "0x919531146f9a25dfc161d5ab23b117feae2c1d36"
      },
      {
        "name": "V1:SymbioticRestakingPool",
        "address": "0x475d3eb031d250070b63fa145f0fcfc5d97c304a"
      }
    ],
    "balanceOf": [
      {
        "tokenContract": "mETH",
        "account": "BoringVault"
      },
      {
        "tokenContract": "mETH",
        "account": "PositionManager-Karak"
      },
      {
        "tokenContract": "V1:SymbioticRestakingPool",
        "account": "V1:PositionManager-Symbiotic"
      }
    ],
    "getTotalLPT": [
      "PositionManager-Karak"
    ]
  }
}' | jq
{
  "data": {
    "result": "3233848721544331",
    "decimals": 18,
    "blockHeight": 23073281,
    "balances": {
      "mETH": {
        "BoringVault": "634740287891045598199",
        "PositionManager-Karak": "0"
      },
      "V1:SymbioticRestakingPool": {
        "V1:PositionManager-Symbiotic": "0"
      }
    },
    "totalLpts": {
      "PositionManager-Karak": "26378"
    },
    "totalReserve": "634740287891045624577",
    "totalSupply": "196280142500891045624577"
  },
  "statusCode": 200,
  "result": "3233848721544331",
  "timestamps": {
    "providerDataRequestedUnixMs": 1754377838431,
    "providerDataReceivedUnixMs": 1754377838786
  },
  "meta": {
    "adapterName": "CMETH",
    "metrics": {
      "feedId": "+DfmQOQvpDSFA1tLOinRN2/tr70="
    }
  }
}
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
