### PR TITLE
CMETH: use unscaled number as result

### DIFF
--- a/.changeset/purple-coins-hear.md
+++ b/.changeset/purple-coins-hear.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/cmeth-adapter': major
+---
+
+Use unscaled number as result instead of decimals.

--- a/packages/sources/cmeth/src/endpoint/price.ts
+++ b/packages/sources/cmeth/src/endpoint/price.ts
@@ -144,10 +144,9 @@ export const inputParameters = new InputParameters(
 export type BaseEndpointTypes = {
   Parameters: typeof inputParameters.definition
   Response: {
-    Result: string
+    Result: number
     Data: {
-      result: string
-      decimals: number
+      result: number
       balances: {
         [tokenContract: string]: {
           [address: string]: string

--- a/packages/sources/cmeth/src/transport/price.ts
+++ b/packages/sources/cmeth/src/transport/price.ts
@@ -27,8 +27,6 @@ export type ContractBalanceMap<T> = {
   }
 }
 
-const RESULT_DECIMALS = 18
-
 // Exported for testing
 export const sumBigints = (bigints: bigint[]): bigint => {
   return bigints.reduce((sum, value) => sum + value)
@@ -134,15 +132,13 @@ export class CmethTransport extends SubscriptionTransport<BaseEndpointTypes> {
 
     this.checkForUnusedAddresses(addressMap)
 
-    const unit = 10n ** BigInt(RESULT_DECIMALS)
-    const exchangeRate = totalSupply === 0n ? 0n : (totalReserve * unit) / totalSupply
+    const exchangeRate = totalSupply === 0n ? 0 : Number(totalReserve) / Number(totalSupply)
 
-    const result = String(exchangeRate > unit ? unit : exchangeRate)
+    const result = Math.min(1.0, exchangeRate)
 
     const response = {
       data: {
         result,
-        decimals: RESULT_DECIMALS,
         blockHeight,
         balances: contractBalanceMapToString(balances),
         totalLpts: Object.fromEntries(

--- a/packages/sources/cmeth/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/cmeth/test/integration/__snapshots__/adapter.test.ts.snap
@@ -20,8 +20,7 @@ exports[`execute price endpoint should return success 1`] = `
       },
     },
     "blockHeight": 23030750,
-    "decimals": 18,
-    "result": "1000000000000000000",
+    "result": 1,
     "totalLpts": {
       "PositionManager-Karak": "26378",
       "V1:PositionManager-Eigen_A41": "0",
@@ -33,7 +32,7 @@ exports[`execute price endpoint should return success 1`] = `
     "totalReserve": "196661942552891045624577",
     "totalSupply": "196661942552891045624577",
   },
-  "result": "1000000000000000000",
+  "result": 1,
   "statusCode": 200,
   "timestamps": {
     "providerDataReceivedUnixMs": 978347471111,

--- a/packages/sources/cmeth/test/unit/price.test.ts
+++ b/packages/sources/cmeth/test/unit/price.test.ts
@@ -23,8 +23,6 @@ const POSITION_MANAGER_2_ADDRESS = '0x919531146f9a25dfc161d5ab23b117feae2c1d36'
 const RESTAKING_POOL_ADDRESS = '0x475d3eb031d250070b63fa145f0fcfc5d97c304a'
 const DELAYED_WITHDRAW_ADDRESS = '0x12Be34bE067Ebd201f6eAf78a861D90b2a66B113'
 
-const RESULT_DECIMALS = 18
-
 const BLOCK_HEIGHT = 12345678
 
 const ethProvider = makeStub('ethProvider', {
@@ -160,7 +158,7 @@ describe('CmethTransport', () => {
       const now = Date.now()
       await transport.handleRequest(param)
 
-      const result = '987000000000000000'
+      const result = 0.987
 
       expect(responseCache.write).toBeCalledWith(transportName, [
         {
@@ -168,7 +166,6 @@ describe('CmethTransport', () => {
           response: {
             data: {
               result,
-              decimals: RESULT_DECIMALS,
               blockHeight: BLOCK_HEIGHT,
               balances: {
                 mETH: {
@@ -227,12 +224,11 @@ describe('CmethTransport', () => {
       const now = Date.now()
       const response = await transport._handleRequest(param)
 
-      const result = '987000000000000000'
+      const result = 0.987
 
       expect(response).toEqual({
         data: {
           result,
-          decimals: RESULT_DECIMALS,
           blockHeight: BLOCK_HEIGHT,
           balances: {
             mETH: {
@@ -292,12 +288,11 @@ describe('CmethTransport', () => {
       const now = Date.now()
       const response = await transport._handleRequest(param)
 
-      const result = '1000000000000000000'
+      const result = 1.0
 
       expect(response).toEqual({
         data: {
           result,
-          decimals: RESULT_DECIMALS,
           blockHeight: BLOCK_HEIGHT,
           balances: {
             mETH: {
@@ -363,12 +358,11 @@ describe('CmethTransport', () => {
       const now = Date.now()
       const response = await transport._handleRequest(param)
 
-      const result = '900000000000000000'
+      const result = 0.9
 
       expect(response).toEqual({
         data: {
           result,
-          decimals: RESULT_DECIMALS,
           blockHeight: BLOCK_HEIGHT,
           balances: {
             mETH: {
@@ -472,12 +466,11 @@ describe('CmethTransport', () => {
       const now = Date.now()
       const response = await transport._handleRequest(param)
 
-      const result = '50001500000000000'
+      const result = 0.0500015
 
       expect(response).toEqual({
         data: {
           result,
-          decimals: RESULT_DECIMALS,
           blockHeight: BLOCK_HEIGHT,
           balances: {
             mETH: {


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/OPDATA-2259

## Description

We want to multiply the result of the `cmeth` EA with the result of a `view-function-multi-chain` call, using the `implied-price` EA.

Currently, both `cmeth` and `view-function-multi-chain` return a result with 18 decimals, so the product is very large and returned by `implied-price` as scientific notation: `"result":"1.072054927869435044e+36"`

It's also more consistent with other price EAs to return the cmETH/mETH price as an unscaled fractional number.

## Changes

Change the transport to return a normal `number` type instead of BigInt+decimals.

## Steps to Test

1. Unit/integration tests were updated.
2. Tested with `implied-price`:
```
curl --silent -X POST http://localhost:8082 -H "Content-Type: application/json" -d '{
  "data": {
    "endpoint": "computedPrice",
    "operand1Sources": ["cmeth"],
    "operand1Input": {
      "addresses": [
        { "name": "cmETH", "address": "0xE6829d9a7eE3040e1276Fa75293Bde931859e8fA" },
        { "name": "mETH", "address": "0xd5F7838F5C461fefF7FE49ea5ebaF7728bB0ADfa" },
        { "name": "BoringVault", "address": "0x33272D40b247c4cd9C646582C9bbAD44e85D4fE4" },
        { "name": "DelayedWithdraw", "address": "0x12Be34bE067Ebd201f6eAf78a861D90b2a66B113" },
        { "name": "PositionManager-Karak", "address": "0x52EA8E95378d01B0aaD3B034Ca0656b0F0cc21A2" },
        {
          "name": "V1:PositionManager-Symbiotic",
          "address": "0x919531146f9a25dfc161d5ab23b117feae2c1d36"
        },
        {
          "name": "V1:PositionManager-Eigen_A41",
          "address": "0x6DfbE3A1a0e835C125EEBb7712Fffc36c4D93b25"
        },
        {
          "name": "V1:PositionManager-Eigen_P2P",
          "address": "0x021180A06Aa65A7B5fF891b5C146FbDaFC06e2DA"
        },
        {
          "name": "V1:SymbioticRestakingPool",
          "address": "0x475d3eb031d250070b63fa145f0fcfc5d97c304a"
        },
        {
          "name": "V2:PositionManager-Symbiotic",
          "address": "0x5bb8e5e8602b71b182e0Efe256896a931489A135"
        },
        {
          "name": "V2:PositionManager-Eigen_A41",
          "address": "0xCaC15044a1F67238D761Aa4C7650DaB59cEF849D"
        },
        {
          "name": "V2:PositionManager-Eigen_P2P",
          "address": "0x0b5d15445b715bf117ba0482b7a9f772af46d93a"
        }
      ],
      "balanceOf": [
        {
          "tokenContract": "mETH",
          "account": "BoringVault"
        },
        {
          "tokenContract": "mETH",
          "account": "PositionManager-Karak"
        },
        {
          "tokenContract": "mETH",
          "account": "V1:PositionManager-Symbiotic"
        },
        {
          "tokenContract": "mETH",
          "account": "V1:PositionManager-Eigen_A41"
        },
        {
          "tokenContract": "mETH",
          "account": "V1:PositionManager-Eigen_P2P"
        },
        {
          "tokenContract": "mETH",
          "account": "V2:PositionManager-Symbiotic"
        },
        {
          "tokenContract": "mETH",
          "account": "V2:PositionManager-Eigen_A41"
        },
        {
          "tokenContract": "mETH",
          "account": "V2:PositionManager-Eigen_P2P"
        },
        {
          "tokenContract": "V1:SymbioticRestakingPool",
          "account": "V1:PositionManager-Symbiotic"
        },
        {
          "tokenContract": "mETH",
          "account": "DelayedWithdraw"
        }
      ],
      "getTotalLPT": [
        "PositionManager-Karak",
        "V1:PositionManager-Eigen_A41",
        "V1:PositionManager-Eigen_P2P",
        "V2:PositionManager-Symbiotic",
        "V2:PositionManager-Eigen_A41",
        "V2:PositionManager-Eigen_P2P"
      ]
    },
    "operand2Sources": ["view_function_multi_chain"],
    "operand2Input": {
      "signature": "function mETHToETH(uint256 mETHAmount) public view returns (uint256)",
      "address": "0xe3cBd06D7dadB3F4e6557bAb7EdD924CD1489E8f",
      "network": "ethereum",
      "endpoint": "function",
      "inputParams": ["1000000000000000000"]
    },
    "operation": "multiply"
  }
}'

{
  "result": "1072054927869435044",
  "providerStatusCode": 200,
  "maxAge": 30000,
  "statusCode": 200,
  "data": {
    "result": "1072054927869435044"
  },
  "meta": {
    "adapterName": "IMPLIED_PRICE"
  },
  "metricsMeta": {
    "feedId": "c137413cd90317730f52fe8d78303795"
  }
}
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
