### PR TITLE
Add unit test for proof-of-reserve with ethereum-cl-indexer

### DIFF
--- a/packages/composites/proof-of-reserves/test/unit/reduce.test.ts
+++ b/packages/composites/proof-of-reserves/test/unit/reduce.test.ts
@@ -15,7 +15,7 @@ describe('reduce', () => {
             isValid: true,
             totalBalance,
           },
-        } as AdapterResponse)
+        } as unknown as AdapterResponse)
 
         const response = await runReduceAdapter('ETHEREUM_CL_INDEXER', context, input)
 
@@ -40,7 +40,7 @@ describe('reduce', () => {
             isValid: false,
             totalBalance,
           },
-        } as AdapterResponse)
+        } as unknown as AdapterResponse)
 
         await expect(() => runReduceAdapter('ETHEREUM_CL_INDEXER', context, input)).rejects.toThrow(
           `ETHEREUM_CL_INDEXER ripcord is true: ${JSON.stringify(input.data)}`,


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/OPDATA-3674

## Description

Currently when `proof-of-reserves` uses `ethereum-cl-indexer` it assumes the `etherFiBalance` endpoint was used when interpreting the result.
We want to start using the `porBalance` endpoint.
Currently there is no test coverage for using `proof-of-reserves` with `ethereum-cl-indexer` so I want to add some test coverage before I start changing it.

## Changes

Add a unit test for interpreting the response from `ethereum-cl-indexer`.

## Steps to Test

```
yarn test packages/composites/proof-of-reserves/test/unit/reduce.test.ts
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
