### PR TITLE
OPDATA-3674: Skip custom logic for token-balance when xrp endpoint is used

### DIFF
--- a/.changeset/many-eagles-wonder.md
+++ b/.changeset/many-eagles-wonder.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/proof-of-reserves-adapter': minor
+---
+
+Skip custom logic for token-balance when xrp endpoint is used

--- a/packages/composites/proof-of-reserves/src/utils/reduce.ts
+++ b/packages/composites/proof-of-reserves/src/utils/reduce.ts
@@ -58,7 +58,11 @@ export const runReduceAdapter = async (
     case bitcoinPorIndexer.name:
       return returnParsedUnits(input.jobRunID, input.data.result as string, 8)
     case tokenBalance.name:
-      return returnParsedUnits(input.jobRunID, input.data.result as string, 18, true)
+      // For xrp, we use the default processing below the switch block.
+      if (indexerEndpoint !== 'xrp') {
+        return returnParsedUnits(input.jobRunID, input.data.result as string, 18, true)
+      }
+      break
     case ceffu.name:
       return returnParsedUnits(
         input.jobRunID,


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/OPDATA-3674

## Description

The new `xrp` endpoint of `token-balance` assumes the default behavior of `proof-of-reserves` is used.
But `proof-of-reserves` has custom logic for `token-balance`.

## Changes

1. Don't use the custom logic for `token-balance` if `indexerEndpoint` is `xrp`.

## Steps to Test

1. Unit tests added.
2.
```
curl --silent -S -X POST http://localhost:8080 -H 'Content-Type: application/json' -d '{
  "data": {
  "protocol": "por_address_list",
  "protocolEndpoint": "virtune",
  "accountId": "VIRXRP",
  "network": "xrp",
  "chainId": "xrp",
  "indexer": "token_balance",
  "indexerEndpoint": "xrp"
}
}'
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
