### PR TITLE
OPDATA-3889: Return a specific result from FTSE parsers

### DIFF
--- a/.changeset/light-suns-appear.md
+++ b/.changeset/light-suns-appear.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/ftse-sftp-adapter': patch
+---
+
+Change interface of parser that isn't used yet

--- a/packages/sources/ftse-sftp/src/parsing/base-parser.ts
+++ b/packages/sources/ftse-sftp/src/parsing/base-parser.ts
@@ -15,7 +15,10 @@ export abstract class BaseCSVParser<T extends ParsedData = ParsedData> implement
   /**
    * Abstract method that must be implemented by concrete classes
    */
-  abstract parse(csvContent: string): Promise<T>
+  abstract parse(csvContent: string): Promise<{
+    result: number
+    parsedData: T
+  }>
 
   /**
    * Helper method to parse CSV content as records with column headers

--- a/packages/sources/ftse-sftp/src/parsing/ftse100.ts
+++ b/packages/sources/ftse-sftp/src/parsing/ftse100.ts
@@ -29,9 +29,9 @@ export { EXPECTED_HEADERS, HEADER_ROW_NUMBER }
 export interface FTSE100Data extends ParsedData {
   indexCode: string
   indexSectorName: string
-  numberOfConstituents: number | null
+  numberOfConstituents: number
   indexBaseCurrency: string
-  gbpIndex: number | null
+  gbpIndex: number
 }
 
 /**
@@ -51,7 +51,10 @@ export class FTSE100Parser extends BaseCSVParser {
     })
   }
 
-  async parse(csvContent: string): Promise<FTSE100Data> {
+  async parse(csvContent: string): Promise<{
+    result: number
+    parsedData: FTSE100Data
+  }> {
     const parsed = this.parseCSVRecords(csvContent, {
       from_line: HEADER_ROW_NUMBER,
     })
@@ -68,7 +71,11 @@ export class FTSE100Parser extends BaseCSVParser {
       throw new Error('No FTSE 100 index record found')
     }
 
-    return results[0]
+    const parsedData = results[0]
+    return {
+      result: parsedData.gbpIndex,
+      parsedData,
+    }
   }
 
   /**

--- a/packages/sources/ftse-sftp/src/parsing/interfaces.ts
+++ b/packages/sources/ftse-sftp/src/parsing/interfaces.ts
@@ -7,7 +7,10 @@ export interface CSVParser<T extends ParsedData = ParsedData> {
    * @param csvContent - Raw CSV content as string
    * @returns Promise of parsed data
    */
-  parse(csvContent: string): Promise<T>
+  parse(csvContent: string): Promise<{
+    result: number
+    parsedData: T
+  }>
 }
 
 /**

--- a/packages/sources/ftse-sftp/src/parsing/russell.ts
+++ b/packages/sources/ftse-sftp/src/parsing/russell.ts
@@ -37,7 +37,10 @@ export class RussellDailyValuesParser extends BaseCSVParser {
     this.instrument = instrument
   }
 
-  async parse(csvContent: string): Promise<RussellDailyValuesData> {
+  async parse(csvContent: string): Promise<{
+    result: number
+    parsedData: RussellDailyValuesData
+  }> {
     this.validateCloseColumn(csvContent)
 
     const parsed = this.parseCSVArrays(csvContent, {
@@ -56,7 +59,11 @@ export class RussellDailyValuesParser extends BaseCSVParser {
       throw new Error('Multiple matching Russell index records found, expected only one')
     }
 
-    return results[0]
+    const parsedData = results[0]
+    return {
+      result: parsedData.close,
+      parsedData,
+    }
   }
 
   /**

--- a/packages/sources/ftse-sftp/test/unit/parsing/ftse100.test.ts
+++ b/packages/sources/ftse-sftp/test/unit/parsing/ftse100.test.ts
@@ -10,9 +10,9 @@ describe('FTSE100Parser', () => {
 
   describe('parse', () => {
     it('should parse the actual FTSE CSV file correctly', async () => {
-      const result = await parser.parse(ftseCsvFixture)
-      expect(result).toBeDefined()
-      expect(result).toEqual(expectedFtseData)
+      const { parsedData, result } = await parser.parse(ftseCsvFixture)
+      expect(parsedData).toEqual(expectedFtseData)
+      expect(result).toBe(expectedFtseData.gbpIndex)
     })
 
     it('should throw error for invalid CSV format', async () => {
@@ -76,13 +76,12 @@ UKX,FTSE 100 Index,100,GBP,4659.89,4926.97,4523.90
 AS0,FTSE All-Small Index,234,GBP,4535.81973790,4918.68240124,4401.18006784
 XXXXXXXX`
 
-      const result = await parser.parse(csvWithInconsistentColumns)
-      expect(result).toBeDefined()
-      expect(result.indexCode).toBe('UKX')
-      expect(result.indexSectorName).toBe('FTSE 100 Index')
-      expect(result.numberOfConstituents).toBe(100)
-      expect(result.indexBaseCurrency).toBe('GBP')
-      expect(result.gbpIndex).toBe(4926.97)
+      const { parsedData } = await parser.parse(csvWithInconsistentColumns)
+      expect(parsedData.indexCode).toBe('UKX')
+      expect(parsedData.indexSectorName).toBe('FTSE 100 Index')
+      expect(parsedData.numberOfConstituents).toBe(100)
+      expect(parsedData.indexBaseCurrency).toBe('GBP')
+      expect(parsedData.gbpIndex).toBe(4926.97)
     })
   })
 })

--- a/packages/sources/ftse-sftp/test/unit/parsing/russell.test.ts
+++ b/packages/sources/ftse-sftp/test/unit/parsing/russell.test.ts
@@ -10,9 +10,9 @@ describe('RussellDailyValuesParser', () => {
 
   describe('parse', () => {
     it('should parse the actual Russell CSV file correctly', async () => {
-      const result = await parser.parse(russellCsvFixture)
-      expect(result).toBeDefined()
-      expect(result).toEqual(expectedRussellData)
+      const { parsedData, result } = await parser.parse(russellCsvFixture)
+      expect(parsedData).toEqual(expectedRussellData)
+      expect(result).toBe(expectedRussellData.close)
     })
 
     it('should throw error for invalid CSV format', async () => {
@@ -87,10 +87,9 @@ Russell 1000� Index,3538.25,3550.79,3534.60,3547.40,9.16,0.26,3547.40,3483.25,
 Russell 2000® Index,1234.56,1245.67,1230.45,1240.00,5.44,0.44
 XXXXXXXX`
 
-      const result = await parser.parse(csvWithInconsistentColumns)
-      expect(result).toBeDefined()
-      expect(result.indexName).toBe('Russell 1000� Index')
-      expect(result.close).toBe(3547.4)
+      const { parsedData } = await parser.parse(csvWithInconsistentColumns)
+      expect(parsedData.indexName).toBe('Russell 1000� Index')
+      expect(parsedData.close).toBe(3547.4)
     })
   })
 })


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/OPDATA-3889

## Description

The FTSE parsers return records with multiple values for each of the index types.
But the EA should return one of those numbers as the main `result`.
The right place to determine which piece of the record should be the main result is in the individual parsers.

So in this PR we change the interface of the parsers to include one number as `result` and the whole record of values as `parsedData`.

## Changes

1. Change parsers interface.
2. In FTSE parser, return `gbpIndex` as the `result`.
3. In Russell parsers, return `close` as the `result`.
4. Drive-by fix: Change the type of `numberOfConstituents` and `gbpIndex` from `number | null` to just `number` as there is no way for them to be `null`.

## Steps to Test

1. Unit tests updated.
2. Tested end-to-end in another branch.

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
