### PR TITLE
OPDATA-3889: FTSE: Use latin1 encoding

### DIFF
--- a/packages/sources/ftse-sftp/test/fixtures/index.ts
+++ b/packages/sources/ftse-sftp/test/fixtures/index.ts
@@ -3,7 +3,7 @@ import path from 'path'
 
 // Helper function to read fixture files
 export function readFixtureFile(filename: string): string {
-  return fs.readFileSync(path.join(__dirname, filename), 'utf-8')
+  return fs.readFileSync(path.join(__dirname, filename), 'latin1')
 }
 
 // Raw CSV fixture data
@@ -20,7 +20,7 @@ export const expectedFtseData = {
 }
 
 export const expectedRussellData = {
-  indexName: 'Russell 1000� Index',
+  indexName: 'Russell 1000® Index',
   close: 3547.4,
 }
 

--- a/packages/sources/ftse-sftp/test/unit/parsing/russell.test.ts
+++ b/packages/sources/ftse-sftp/test/unit/parsing/russell.test.ts
@@ -5,7 +5,7 @@ describe('RussellDailyValuesParser', () => {
   let parser: RussellDailyValuesParser
 
   beforeEach(() => {
-    parser = new RussellDailyValuesParser('Russell 1000� Index')
+    parser = new RussellDailyValuesParser('Russell 1000® Index')
   })
 
   describe('parse', () => {
@@ -39,7 +39,7 @@ Russell 1000® Index,Some Value`
 "As of August 27, 2025",,,,,,,,"Last 5 Trading Days",,,,"1 Year Ending",,
 ,,,,,,,,"Closing Values",,,,"Closing Values",,
 ,"Open","High","Low","Close","Net Chg","% Chg","High","Low","Net Chg","% Chg","High","Low","Net Chg","% Chg"
-Russell 1000� Index,3538.25,3550.79,3534.60,,9.16,0.26,3547.40,3483.25,51.20,1.46,3547.40,2719.99,496.76,16.28`
+Russell 1000® Index,3538.25,3550.79,3534.60,,9.16,0.26,3547.40,3483.25,51.20,1.46,3547.40,2719.99,496.76,16.28`
 
       await expect(parser.parse(csvWithNullValues)).rejects.toThrow(
         'Empty values found in required columns: Close',
@@ -67,8 +67,8 @@ Russell 2000® Index,1234.56,1245.67,1230.45,1240.00,5.44,0.44,1245.67,1200.00,3
 "As of August 27, 2025",,,,,,,,"Last 5 Trading Days",,,,"1 Year Ending",,
 ,,,,,,,,"Closing Values",,,,"Closing Values",,
 ,"Open","High","Low","Close","Net Chg","% Chg","High","Low","Net Chg","% Chg","High","Low","Net Chg","% Chg"
-Russell 1000� Index,3538.25,3550.79,3534.60,3547.40,9.16,0.26,3547.40,3483.25,51.20,1.46,3547.40,2719.99,496.76,16.28
-Russell 1000� Index,3538.25,3550.79,3534.60,3547.50,9.16,0.26,3547.40,3483.25,51.20,1.46,3547.40,2719.99,496.76,16.28`
+Russell 1000® Index,3538.25,3550.79,3534.60,3547.40,9.16,0.26,3547.40,3483.25,51.20,1.46,3547.40,2719.99,496.76,16.28
+Russell 1000® Index,3538.25,3550.79,3534.60,3547.50,9.16,0.26,3547.40,3483.25,51.20,1.46,3547.40,2719.99,496.76,16.28`
 
       await expect(parser.parse(csvWithDuplicateRussell)).rejects.toThrow(
         'Multiple matching Russell index records found, expected only one',
@@ -83,12 +83,12 @@ Russell 1000� Index,3538.25,3550.79,3534.60,3547.50,9.16,0.26,3547.40,3483.25,
 "As of August 27, 2025",,,,,,,,"Last 5 Trading Days",,,,"1 Year Ending",,
 ,,,,,,,,"Closing Values",,,,"Closing Values",,
 ,"Open","High","Low","Close","Net Chg","% Chg","High","Low","Net Chg","% Chg","High","Low","Net Chg","% Chg"
-Russell 1000� Index,3538.25,3550.79,3534.60,3547.40,9.16,0.26,3547.40,3483.25,51.20,1.46,3547.40,2719.99,496.76,16.28
+Russell 1000® Index,3538.25,3550.79,3534.60,3547.40,9.16,0.26,3547.40,3483.25,51.20,1.46,3547.40,2719.99,496.76,16.28
 Russell 2000® Index,1234.56,1245.67,1230.45,1240.00,5.44,0.44
 XXXXXXXX`
 
       const { parsedData } = await parser.parse(csvWithInconsistentColumns)
-      expect(parsedData.indexName).toBe('Russell 1000� Index')
+      expect(parsedData.indexName).toBe('Russell 1000® Index')
       expect(parsedData.close).toBe(3547.4)
     })
   })


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/OPDATA-3889

## Description

The files we download over SFTP from FTSE are not UTF-8 encoded but rather Latin1 encoded.
This matters because there is a "Ⓡ" (registered trademark) symbol in the Russell index names.
We also have one such file in the `fixtures` directory but we currently read it with `utf-8` encoding.
This means that in the unit tests we need to expect "�" instead of "Ⓡ".
I realized this when trying to add integration tests which failed when using the `utf-8` decoded fixtures.

## Changes

1. Decode fixture files with `latin1` encoding.
2. Replace "�" with "Ⓡ" in tests.

## Steps to Test

```
yarn test packages/sources/ftse-sftp/test
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
