### PR TITLE
Reduce code duplication in virtune endpoints of por-adddress-list

### DIFF
--- a/.changeset/selfish-kiwis-heal.md
+++ b/.changeset/selfish-kiwis-heal.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/por-address-list-adapter': patch
+---
+
+Refactor virtune endpoints

--- a/packages/sources/por-address-list/src/endpoint/virtune-token.ts
+++ b/packages/sources/por-address-list/src/endpoint/virtune-token.ts
@@ -3,26 +3,11 @@ import { PoRTokenAddress } from '@chainlink/external-adapter-framework/adapter/p
 import { InputParameters } from '@chainlink/external-adapter-framework/validation'
 import { config } from '../config'
 import { virtuneTokenTransport } from '../transport/virtune-token'
+import { sharedVirtuneInputParameters } from './virtune'
 
 export const inputParameters = new InputParameters(
   {
-    accountId: {
-      description: 'The account ID to fetch addresses for',
-      type: 'string',
-      required: true,
-    },
-    network: {
-      description:
-        'The network the addresses are on. This is only used to include in the response.',
-      type: 'string',
-      required: true,
-    },
-    chainId: {
-      description:
-        'The chainId of the network the addresses are on. This is only used to include in the response.',
-      type: 'string',
-      required: true,
-    },
+    ...sharedVirtuneInputParameters,
     contractAddress: {
       description: 'The contract address of the token, to pass be included in the response',
       type: 'string',

--- a/packages/sources/por-address-list/src/endpoint/virtune.ts
+++ b/packages/sources/por-address-list/src/endpoint/virtune.ts
@@ -4,25 +4,28 @@ import { InputParameters } from '@chainlink/external-adapter-framework/validatio
 import { config } from '../config'
 import { virtuneTransport } from '../transport/virtune'
 
+export const sharedVirtuneInputParameters = {
+  accountId: {
+    description: 'The account ID to fetch addresses for',
+    type: 'string',
+    required: true,
+  },
+  network: {
+    description: 'The network the addresses are on. This is only used to include in the response.',
+    type: 'string',
+    required: true,
+  },
+  chainId: {
+    description:
+      'The chainId of the network the addresses are on. This is only used to include in the response.',
+    type: 'string',
+    required: true,
+  },
+} as const
+
 export const inputParameters = new InputParameters(
   {
-    accountId: {
-      description: 'The account ID to fetch addresses for',
-      type: 'string',
-      required: true,
-    },
-    network: {
-      description:
-        'The network the addresses are on. This is only used to include in the response.',
-      type: 'string',
-      required: true,
-    },
-    chainId: {
-      description:
-        'The chainId of the network the addresses are on. This is only used to include in the response.',
-      type: 'string',
-      required: true,
-    },
+    ...sharedVirtuneInputParameters,
   },
   [
     {

--- a/packages/sources/por-address-list/src/transport/virtune-token.ts
+++ b/packages/sources/por-address-list/src/transport/virtune-token.ts
@@ -4,7 +4,13 @@ import {
   HttpTransportConfig,
 } from '@chainlink/external-adapter-framework/transports'
 import { BaseEndpointTypes } from '../endpoint/virtune-token'
-import { createVirtuneTransportConfig, ResponseSchema, VirtuneParams } from './virtune-utils'
+import {
+  createVirtuneTransportConfig,
+  getUrl,
+  ResponseSchema,
+  VirtuneParams,
+} from './virtune-utils'
+
 export type HttpTransportTypes = BaseEndpointTypes & {
   Provider: {
     RequestBody: never
@@ -14,20 +20,15 @@ export type HttpTransportTypes = BaseEndpointTypes & {
 
 type Params = VirtuneParams<HttpTransportTypes>
 
-const getUrl = (params: Params): string => {
-  return params.accountId
-}
-
-const getAddresses = ({
-  data,
+const getResultFromAddresses = ({
+  addresses,
   params,
 }: {
-  data: ResponseSchema
+  addresses: string[]
   params: Params
 }): PoRTokenAddress[] => {
   const { network, chainId, contractAddress } = params
-  const wallets = data.result.flatMap((r) => r.wallets.map((w) => w.address))
-  if (wallets.length === 0) {
+  if (addresses.length === 0) {
     return []
   }
   return [
@@ -35,13 +36,13 @@ const getAddresses = ({
       chainId,
       network,
       contractAddress,
-      wallets,
+      wallets: addresses,
     },
   ]
 }
 
 const transportConfig: HttpTransportConfig<HttpTransportTypes> =
-  createVirtuneTransportConfig<HttpTransportTypes>(getUrl, getAddresses)
+  createVirtuneTransportConfig<HttpTransportTypes>(getUrl, getResultFromAddresses)
 
 // Exported for testing
 export class VirtuneTokenTransport extends HttpTransport<HttpTransportTypes> {

--- a/packages/sources/por-address-list/src/transport/virtune.ts
+++ b/packages/sources/por-address-list/src/transport/virtune.ts
@@ -4,7 +4,12 @@ import {
   HttpTransportConfig,
 } from '@chainlink/external-adapter-framework/transports'
 import { BaseEndpointTypes } from '../endpoint/virtune'
-import { createVirtuneTransportConfig, ResponseSchema, VirtuneParams } from './virtune-utils'
+import {
+  createVirtuneTransportConfig,
+  getUrl,
+  ResponseSchema,
+  VirtuneParams,
+} from './virtune-utils'
 
 export type HttpTransportTypes = BaseEndpointTypes & {
   Provider: {
@@ -15,23 +20,23 @@ export type HttpTransportTypes = BaseEndpointTypes & {
 
 type Params = VirtuneParams<HttpTransportTypes>
 
-const getUrl = (params: Params): string => {
-  return params.accountId
-}
-
-const getAddresses = ({ data, params }: { data: ResponseSchema; params: Params }): PoRAddress[] => {
+const getResultFromAddresses = ({
+  addresses,
+  params,
+}: {
+  addresses: string[]
+  params: Params
+}): PoRAddress[] => {
   const { network, chainId } = params
-  return data.result.flatMap((r) =>
-    r.wallets.map((wallet) => ({
-      address: wallet.address,
-      network,
-      chainId,
-    })),
-  )
+  return addresses.map((address) => ({
+    address,
+    network,
+    chainId,
+  }))
 }
 
 const transportConfig: HttpTransportConfig<HttpTransportTypes> =
-  createVirtuneTransportConfig<HttpTransportTypes>(getUrl, getAddresses)
+  createVirtuneTransportConfig<HttpTransportTypes>(getUrl, getResultFromAddresses)
 
 // Exported for testing
 export class VirtuneTransport extends HttpTransport<HttpTransportTypes> {


### PR DESCRIPTION
## Description

This PR cleans up some code in the `virtune` and `virtune-token` endpoints of the `por-address-list` adapter before extending them further in another PR.

Note: ideally it wouldn't be necessary to pass `getUrl` into `createVirtuneTransportConfig` since we always use the same `getUrl`. But `getUrl` requires a parameter which isn't known to be of a required type until the `T` of `createVirtuneTransportConfig<T>` is instantiated to a specific type. Suggestions for how to make this work are welcome.

## Changes

1. Extract parameter definitions common between both endpoints.
2. Define `getUrl` in `virtune-utils.ts` and use from both transports.
3. Remove `accountId` from `VirtuneTransportGenerics` as nothing relies on it being declared there.
4. Instead of extracting wallet address from `data` in both transports, do it in the shared `createVirtuneTransportConfig` and pass just the addresses to the transports to construct the final result.

## Steps to Test

Existing tests continue to pass after the refactoring.

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
