### PR TITLE
OPDATA-3674: Add optional address filter parameter to virtune endpoints of por-address-list

### DIFF
--- a/.changeset/few-maps-cover.md
+++ b/.changeset/few-maps-cover.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/por-address-list-adapter': minor
+---
+
+Add optional address filter parameter to virtune endpoints

--- a/packages/sources/por-address-list/src/endpoint/virtune.ts
+++ b/packages/sources/por-address-list/src/endpoint/virtune.ts
@@ -21,6 +21,11 @@ export const sharedVirtuneInputParameters = {
     type: 'string',
     required: true,
   },
+  addressPattern: {
+    description: 'Return only addresses matching the given regular expression pattern.',
+    type: 'string',
+    required: false,
+  },
 } as const
 
 export const inputParameters = new InputParameters(
@@ -32,6 +37,7 @@ export const inputParameters = new InputParameters(
       accountId: 'VIRBTC',
       network: 'bitcoin',
       chainId: 'mainnet',
+      addressPattern: '^(?!P-)', // Only addresses that don't start with 'P-'.
     },
   ],
 )

--- a/packages/sources/por-address-list/src/transport/virtune-token.ts
+++ b/packages/sources/por-address-list/src/transport/virtune-token.ts
@@ -6,6 +6,7 @@ import {
 import { BaseEndpointTypes } from '../endpoint/virtune-token'
 import {
   createVirtuneTransportConfig,
+  filterAddresses,
   getUrl,
   ResponseSchema,
   VirtuneParams,
@@ -42,7 +43,7 @@ const getResultFromAddresses = ({
 }
 
 const transportConfig: HttpTransportConfig<HttpTransportTypes> =
-  createVirtuneTransportConfig<HttpTransportTypes>(getUrl, getResultFromAddresses)
+  createVirtuneTransportConfig<HttpTransportTypes>(getUrl, filterAddresses, getResultFromAddresses)
 
 // Exported for testing
 export class VirtuneTokenTransport extends HttpTransport<HttpTransportTypes> {

--- a/packages/sources/por-address-list/src/transport/virtune-utils.ts
+++ b/packages/sources/por-address-list/src/transport/virtune-utils.ts
@@ -7,6 +7,19 @@ export const getUrl = (params: { accountId: string }): string => {
   return params.accountId
 }
 
+export const filterAddresses = ({
+  addresses,
+  params,
+}: {
+  addresses: string[]
+  params: { addressPattern?: string }
+}): string[] => {
+  const { addressPattern } = params
+  if (!addressPattern) return addresses
+  const re = new RegExp(addressPattern)
+  return addresses.filter((address) => re.test(address))
+}
+
 export interface ResponseSchema {
   accountName: string
   result: {
@@ -43,6 +56,16 @@ export const createVirtuneTransportConfig = <T extends VirtuneTransportGenerics>
   // because the compiler doesn't know getUrl satisfies the type until T
   // is instantiated.
   getUrlFromParams: (params: VirtuneParams<T>) => string,
+  // filterAddresses is always assigned to the exported filterAddresses.
+  // It's only a parameter because the compiler doesn't know
+  // filterAddresses satisfies the type until T is instantiated.
+  filterAddresses: ({
+    addresses,
+    params,
+  }: {
+    addresses: string[]
+    params: VirtuneParams<T>
+  }) => string[],
   getResultFromAddresses: (_: {
     params: VirtuneParams<T>
     addresses: string[]
@@ -88,8 +111,10 @@ export const createVirtuneTransportConfig = <T extends VirtuneTransportGenerics>
       ]
     }
 
+    const filteredAddresses = filterAddresses({ addresses, params: param })
+
     const result = getResultFromAddresses({
-      addresses,
+      addresses: filteredAddresses,
       params: param,
     })
 

--- a/packages/sources/por-address-list/src/transport/virtune.ts
+++ b/packages/sources/por-address-list/src/transport/virtune.ts
@@ -6,6 +6,7 @@ import {
 import { BaseEndpointTypes } from '../endpoint/virtune'
 import {
   createVirtuneTransportConfig,
+  filterAddresses,
   getUrl,
   ResponseSchema,
   VirtuneParams,
@@ -36,7 +37,7 @@ const getResultFromAddresses = ({
 }
 
 const transportConfig: HttpTransportConfig<HttpTransportTypes> =
-  createVirtuneTransportConfig<HttpTransportTypes>(getUrl, getResultFromAddresses)
+  createVirtuneTransportConfig<HttpTransportTypes>(getUrl, filterAddresses, getResultFromAddresses)
 
 // Exported for testing
 export class VirtuneTransport extends HttpTransport<HttpTransportTypes> {

--- a/packages/sources/por-address-list/test/unit/virtune-token.test.ts
+++ b/packages/sources/por-address-list/test/unit/virtune-token.test.ts
@@ -136,6 +136,67 @@ describe('VirtuneTokenTransport', () => {
     expect(responseCache.write).toHaveBeenCalledTimes(1)
   }
 
+  it('should filter based on address pattern', async () => {
+    const accountId = 'VIRBTC'
+    const network = 'bitcoin'
+    const chainId = 'mainnet'
+    const contractAddress = '0x514910771af9ca656af840dff83e8264ecf986ca'
+    const address1 = 'x-addr1'
+    const address2 = 'y-addr2'
+
+    const params = makeStub('params', {
+      accountId,
+      network,
+      chainId,
+      contractAddress,
+      addressPattern: '^y-',
+    })
+
+    const expectedRequestConfig = {
+      baseURL: adapterSettings.VIRTUNE_API_URL,
+      params: {
+        key: virtuneApiKey,
+      },
+      url: accountId,
+    }
+
+    const response = makeStub('response', {
+      response: {
+        data: {
+          result: [
+            {
+              wallets: [{ address: address1 }, { address: address2 }],
+            },
+          ],
+          cost: undefined,
+        },
+      },
+      timestamps: {},
+    })
+
+    const expectedResponse = {
+      data: {
+        result: [
+          {
+            network,
+            chainId,
+            contractAddress,
+            wallets: [address2],
+          },
+        ],
+      },
+      result: null,
+      timestamps: {},
+    }
+
+    await testTransport({
+      params,
+      expectedRequestConfig,
+      response,
+      expectedResponse,
+    })
+  })
+
   it('should cache a response for a successful request', async () => {
     const accountId = 'VIRBTC'
     const network = 'bitcoin'
@@ -149,6 +210,7 @@ describe('VirtuneTokenTransport', () => {
       network,
       chainId,
       contractAddress,
+      addressPattern: undefined,
     })
 
     const expectedRequestConfig = {

--- a/packages/sources/por-address-list/test/unit/virtune.test.ts
+++ b/packages/sources/por-address-list/test/unit/virtune.test.ts
@@ -147,6 +147,7 @@ describe('VirtuneTransport', () => {
       accountId,
       network,
       chainId,
+      addressPattern: undefined,
     })
 
     const expectedRequestConfig = {
@@ -177,6 +178,58 @@ describe('VirtuneTransport', () => {
           { address: address1, network, chainId },
           { address: address2, network, chainId },
         ],
+      },
+      result: null,
+      timestamps: {},
+    }
+
+    await testTransport({
+      params,
+      expectedRequestConfig,
+      response,
+      expectedResponse,
+    })
+  })
+
+  it('should filter based on address pattern', async () => {
+    const accountId = 'VIRBTC'
+    const network = 'bitcoin'
+    const chainId = 'mainnet'
+    const address1 = 'x-addr1'
+    const address2 = 'y-addr2'
+
+    const params = makeStub('params', {
+      accountId,
+      network,
+      chainId,
+      addressPattern: '^y-',
+    })
+
+    const expectedRequestConfig = {
+      baseURL: adapterSettings.VIRTUNE_API_URL,
+      params: {
+        key: virtuneApiKey,
+      },
+      url: accountId,
+    }
+
+    const response = makeStub('response', {
+      response: {
+        data: {
+          result: [
+            {
+              wallets: [{ address: address1 }, { address: address2 }],
+            },
+          ],
+          cost: undefined,
+        },
+      },
+      timestamps: {},
+    })
+
+    const expectedResponse = {
+      data: {
+        result: [{ address: address2, network, chainId }],
       },
       result: null,
       timestamps: {},


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/OPDATA-3674

## Description

The address list of Virtune's Avalanche reserves has both P-chain addresses and normal addresses.
The balances of these types of addresses are retrieved with different adapters.
So we need a way to get a list of just one type of address for `proof-of-reserves` to pass to the appropriate indexer.

## Changes

1. Add `addpressPattern` parameter to shared parameters of `virtune` and `virtune-token` endpoints`.
2. Add `filterAddresses` function which keeps the addresses matching pattern, or all addresses if no pattern is specified.
3. Pass the `filterAddresses` function to `createVirtuneTransportConfig`.

## Steps to Test

1. Unit tests added
2.
```
curl --silent -S -X POST http://localhost:8081 -H 'Content-Type: application/json' -d '{
  "data": {
  "endpoint": "virtune",
  "accountId": "VIRAVAX",
  "network": "avalanche",
  "chainId": "43114",
  "addressPattern": "^(?!P-)"
}
}'
{
  "result": null,
  "data": {
    "result": [
      {
        "address": "0xdF8e635E05dAfa055e219B34B37F3bD793C165Cd",
        "network": "avalanche",
        "chainId": "43114"
      },
      {
        "address": "0xF7b2a630d5345d7a86889848ee92FDa4451c6BD4",
        "network": "avalanche",
        "chainId": "43114"
      },
      {
        "address": "0x5fD5Df3e794f0140fE2930440c39098B158A000b",
        "network": "avalanche",
        "chainId": "43114"
      },
      {
        "address": "0xbDa1ABDA39d1b672620688fA46B0B58449F7b4F9",
        "network": "avalanche",
        "chainId": "43114"
      },
      {
        "address": "0x76D203FA71D0DF5cf7Df75b124A1cEeE105a374E",
        "network": "avalanche",
        "chainId": "43114"
      },
      {
        "address": "0x0e43d3D4bFE82Cf706BAbb3fd5e077FE698Bdb0b",
        "network": "avalanche",
        "chainId": "43114"
      },
      {
        "address": "0x94bA68963620B53DEcf06e652eEbb8Bc65137c46",
        "network": "avalanche",
        "chainId": "43114"
      }
    ]
  },
  "timestamps": {
    "providerDataRequestedUnixMs": 1758550117246,
    "providerDataReceivedUnixMs": 1758550117987
  },
  "statusCode": 200,
  "meta": {
    "adapterName": "POR_ADDRESS_LIST",
    "metrics": {
      "feedId": "{\"accountId\":\"viravax\",\"network\":\"avalanche\",\"chainId\":\"43114\",\"addressPattern\":\"^(?!p-)\"}"
    }
  }
}
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
