### PR TITLE
Add Coinpaprika State adapter

### DIFF
--- a/.changeset/add-coinpaprika-state.md
+++ b/.changeset/add-coinpaprika-state.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/coinpaprika-state-adapter': minor
+---
+
+feat(coinpaprika-state): add SSE adapter for state_price feeds

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -379,6 +379,10 @@ const RAW_RUNTIME_STATE =
       "reference": "workspace:packages/sources/coinpaprika"\
     },\
     {\
+      "name": "@chainlink/coinpaprika-state-adapter",\
+      "reference": "workspace:packages/sources/coinpaprika-state"\
+    },\
+    {\
       "name": "@chainlink/coinranking-adapter",\
       "reference": "workspace:packages/sources/coinranking"\
     },\
@@ -1041,6 +1045,7 @@ const RAW_RUNTIME_STATE =
     ["@chainlink/coinmetrics-adapter", ["workspace:packages/sources/coinmetrics"]],\
     ["@chainlink/coinmetrics-lwba-adapter", ["workspace:packages/sources/coinmetrics-lwba"]],\
     ["@chainlink/coinpaprika-adapter", ["workspace:packages/sources/coinpaprika"]],\
+    ["@chainlink/coinpaprika-state-adapter", ["workspace:packages/sources/coinpaprika-state"]],\
     ["@chainlink/coinranking-adapter", ["workspace:packages/sources/coinranking"]],\
     ["@chainlink/conflux-adapter", ["workspace:packages/targets/conflux"]],\
     ["@chainlink/covid-tracker-adapter", ["workspace:packages/sources/covid-tracker"]],\
@@ -6096,6 +6101,22 @@ const RAW_RUNTIME_STATE =
           ["@types/sinonjs__fake-timers", "npm:8.1.5"],\
           ["nock", "npm:13.5.6"],\
           ["tslib", "npm:2.8.1"],\
+          ["typescript", "patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"]\
+        ],\
+        "linkType": "SOFT"\
+      }]\
+    ]],\
+    ["@chainlink/coinpaprika-state-adapter", [\
+      ["workspace:packages/sources/coinpaprika-state", {\
+        "packageLocation": "./packages/sources/coinpaprika-state/",\
+        "packageDependencies": [\
+          ["@chainlink/coinpaprika-state-adapter", "workspace:packages/sources/coinpaprika-state"],\
+          ["@chainlink/external-adapter-framework", "npm:2.7.0"],\
+          ["@types/jest", "npm:29.5.14"],\
+          ["@types/node", "npm:22.14.1"],\
+          ["axios", "npm:1.10.0"],\
+          ["nock", "npm:13.5.6"],\
+          ["tslib", "npm:2.4.1"],\
           ["typescript", "patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"]\
         ],\
         "linkType": "SOFT"\

--- a/packages/sources/coinpaprika-state/README.md
+++ b/packages/sources/coinpaprika-state/README.md
@@ -1,0 +1,199 @@
+# COINPAPRIKA_STATE
+
+The Coinpaprika State adapter streams **state_price** for supported pairs via **Server-Sent Events (SSE)** streaming.
+
+---
+
+## Environment Variables
+
+|        Variable         | Description                                          |  Type  | Required |                       Default                       |
+| :---------------------: | ---------------------------------------------------- | :----: | :------: | :-------------------------------------------------: |
+|        `API_KEY`        | Coinpaprika API key (sent as `Authorization` header) | string |    ✅    |                          —                          |
+|     `API_ENDPOINT`      | Coinpaprika streaming endpoint (POST)                | string |          | `https://chainlink-streaming.dexpaprika.com/stream` |
+| `BACKGROUND_EXECUTE_MS` | Background loop interval for pair set evaluation     | number |          |                       `3000`                        |
+
+---
+
+## Endpoint
+
+**Name:** `coinpaprika-state` (alias: `state`)
+
+### Input Parameters
+
+|    Name    | Required | Aliases        | Description        | Type   |            Example            |
+| :--------: | :------: | -------------- | ------------------ | ------ | :---------------------------: |
+|   `base`   |    ✅    | `coin`, `from` | Base asset symbol  | string |   `LUSD`, `ALETH`, `CBETH`    |
+|  `quote`   |    ✅    | `market`, `to` | Quote asset symbol | string |         `USD`, `ETH`          |
+| `endpoint` |          |                | Endpoint selector  | string | `coinpaprika-state` / `state` |
+
+### Example Requests
+
+**Using the primary endpoint `coinpaprika-state`**
+
+```bash
+curl -X POST http://localhost:8080 \
+  -H "Content-Type: application/json" \
+  -d '{"data":{"base":"LUSD","quote":"USD","endpoint":"coinpaprika-state"}}'
+```
+
+**Using the alias `state`**
+
+```bash
+curl -X POST http://localhost:8080 \
+    -H "Content-Type: application/json" \
+    -d '{"data": {"base": "LUSD", "quote": "USD", "endpoint": "state"}}'
+```
+
+**Without endpoint (uses default)**
+
+```bash
+curl -X POST http://localhost:8080 \
+  -H "Content-Type: application/json" \
+  -d '{"data": {"base": "LUSD", "quote": "USD"}}'
+```
+
+### Example Response
+
+```json
+{
+  "data": {
+    "result": 1.000979,
+    "timestamp": 1758888503
+  },
+  "statusCode": 200,
+  "result": 1.000979,
+  "timestamps": {
+    "providerDataRequestedUnixMs": 1758888508939,
+    "providerDataReceivedUnixMs": 1758888508939,
+    "providerIndicatedTimeUnixMs": 1758888503000
+  },
+  "meta": {
+    "adapterName": "COINPAPRIKA_STATE",
+    "metrics": {
+      "feedId": "{\"base\":\"lusd\",\"quote\":\"usd\"}"
+    }
+  }
+}
+```
+
+---
+
+## Streaming Data
+
+### Streaming Method Selection: Multiple Assets via POST (Sessionless)
+
+Per the “EA Requirements – Coinpaprika State” doc, Coinpaprika offers:
+
+1. **Single Asset via GET** — simple but requires one connection per pair
+2. **Multiple Assets via POST (Sessionless)** — ✅ **SELECTED APPROACH**
+3. **Multiple Assets via Session** — requires session management overhead
+
+### Streaming Data Response
+
+> Numeric values may arrive as **strings**; the adapter coerces them to numbers and skips malformed JSON frames.
+
+The adapter receives real-time data from Coinpaprika in the following format:
+
+```text
+data:{
+   "block_time":1758892511,
+   "send_timestamp":1758892514,
+   "base_token_symbol":"ALETH",
+   "quote_symbol":"USD",
+   "volume_7d_usd":190502.190952,
+   "market_depth_plus_1_usd":0.000000,
+   "market_depth_minus_1_usd":0.000000,
+   "state_price":3835.519084
+}
+event:t_s
+
+data:{
+   "block_time":1758892487,
+   "send_timestamp":1758892514,
+   "base_token_symbol":"EURA",
+   "quote_symbol":"USD",
+   "volume_7d_usd":36039.253665,
+   "market_depth_plus_1_usd":0.000000,
+   "market_depth_minus_1_usd":0.000000,
+   "state_price":1.158675
+}
+event:t_s
+
+data:{
+   "block_time":1758892511,
+   "send_timestamp":1758892515,
+   "base_token_symbol":"LUSD",
+   "quote_symbol":"USD",
+   "volume_7d_usd":23434.612065,
+   "market_depth_plus_1_usd":0.000000,
+   "market_depth_minus_1_usd":0.000000,
+   "state_price":1.000883
+}
+event:t_s
+```
+
+---
+
+## Architecture
+
+### Transport
+
+`CoinpaprikaStateTransport` (extends framework `SubscriptionTransport`)
+
+- **Single SSE connection** for all active pairs
+- **Dynamic pair batching**; reconnects when the pair set changes
+- **Malformed event tolerance** (skips bad JSON frames, keeps last good value)
+- **Numeric coercion** for `state_price` & `block_time` (string → number)
+- **Error mapping**: `401/400/429` passthrough, `500 → 502`, **no data → 504**
+- **Graceful shutdown** + reconnect backoff with jitter
+
+### Data Flow
+
+1. **Background Handler** monitors requested pairs and manages SSE connection
+2. **SSE Parser** handles chunked event streams (`src/transport/sse.ts`)
+3. **Processing** (`src/transport/coinpaprika-state.ts`) normalizes symbols, coerces numbers, validates payloads, and writes to the response cache
+4. **Serving requests** returns the latest cached tick for the requested pair
+
+### Error Handling
+
+| Provider Status | Adapter Status | Description                             |
+| :-------------: | :------------: | :-------------------------------------- |
+|      `401`      |     `401`      | Unauthorized                            |
+|      `400`      |     `400`      | Bad Request                             |
+|      `429`      |     `429`      | Rate Limited                            |
+|      `500`      |     `502`      | Bad Gateway - Provider error            |
+|   No data yet   |     `504`      | Foreground fallback when cache is empty |
+
+---
+
+## Development
+
+### Build
+
+```bash
+yarn workspace @chainlink/coinpaprika-state-adapter build
+```
+
+### Start
+
+```bash
+ API_KEY="your-api-key-here" yarn start coinpaprika-state
+```
+
+### Test
+
+```bash
+# Integration
+yarn test packages/sources/coinpaprika-state/test/integration/adapter.test.ts
+
+# Unit
+yarn test packages/sources/coinpaprika-state/test/unit/sse.test.ts
+```
+
+---
+
+## Notes
+
+- **First-tick latency**: Until the first valid tick is cached, foreground requests may return `504`.
+- **Symbol normalization**: `base`/`quote` are uppercased; stick to canonical symbols.
+- **Numeric coercion**: Provider may send numerics as strings; invalid numerics are dropped.

--- a/packages/sources/coinpaprika-state/package.json
+++ b/packages/sources/coinpaprika-state/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@chainlink/coinpaprika-state-adapter",
+  "version": "0.0.0",
+  "description": "Chainlink coinpaprika-state adapter.",
+  "keywords": [
+    "Chainlink",
+    "LINK",
+    "blockchain",
+    "oracle",
+    "coinpaprika-state"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "url": "https://github.com/smartcontractkit/external-adapters-js",
+    "type": "git"
+  },
+  "license": "MIT",
+  "scripts": {
+    "clean": "rm -rf dist && rm -f tsconfig.tsbuildinfo",
+    "prepack": "yarn build",
+    "build": "tsc -b",
+    "server": "node -e 'require(\"./index.js\").server()'",
+    "server:dist": "node -e 'require(\"./dist/index.js\").server()'",
+    "start": "yarn server:dist"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "@types/node": "22.14.1",
+    "nock": "13.5.6",
+    "typescript": "5.8.3"
+  },
+  "dependencies": {
+    "@chainlink/external-adapter-framework": "2.7.0",
+    "axios": "1.10.0",
+    "tslib": "2.4.1"
+  }
+}

--- a/packages/sources/coinpaprika-state/src/config/index.ts
+++ b/packages/sources/coinpaprika-state/src/config/index.ts
@@ -1,0 +1,21 @@
+import { AdapterConfig } from '@chainlink/external-adapter-framework/config'
+
+export const config = new AdapterConfig({
+  API_KEY: {
+    description: 'An API key for Coinpaprika',
+    type: 'string',
+    required: true,
+    sensitive: true,
+  },
+  API_ENDPOINT: {
+    description: 'An API endpoint for Coinpaprika',
+    type: 'string',
+    default: 'https://chainlink-streaming.dexpaprika.com/stream',
+  },
+  BACKGROUND_EXECUTE_MS: {
+    description:
+      'The amount of time the background execute should sleep before performing the next request',
+    type: 'number',
+    default: 3_000,
+  },
+})

--- a/packages/sources/coinpaprika-state/src/config/overrides.json
+++ b/packages/sources/coinpaprika-state/src/config/overrides.json
@@ -1,0 +1,3 @@
+{
+  "coinpaprika-state": {}
+}

--- a/packages/sources/coinpaprika-state/src/endpoint/coinpaprika-state.ts
+++ b/packages/sources/coinpaprika-state/src/endpoint/coinpaprika-state.ts
@@ -1,0 +1,48 @@
+import { AdapterEndpoint } from '@chainlink/external-adapter-framework/adapter'
+import { InputParameters } from '@chainlink/external-adapter-framework/validation'
+import { config } from '../config'
+import overrides from '../config/overrides.json'
+import { CoinpaprikaSubscriptionTransport } from '../transport/coinpaprika-state'
+
+export const inputParameters = new InputParameters(
+  {
+    base: {
+      aliases: ['from', 'coin'],
+      required: true,
+      type: 'string',
+      description: 'The symbol of the currency to query',
+    },
+    quote: {
+      aliases: ['to', 'market'],
+      required: true,
+      type: 'string',
+      description: 'The symbol of the currency to convert to',
+    },
+  },
+  [
+    {
+      base: 'LUSD',
+      quote: 'USD',
+    },
+  ],
+)
+
+export type BaseEndpointTypes = {
+  Parameters: typeof inputParameters.definition
+  Response: {
+    Result: number
+    Data: {
+      result: number
+      timestamp: number
+    }
+  }
+  Settings: typeof config.settings
+}
+
+export const endpoint = new AdapterEndpoint({
+  name: 'coinpaprika-state',
+  aliases: ['state'],
+  transport: CoinpaprikaSubscriptionTransport,
+  inputParameters,
+  overrides: overrides['coinpaprika-state'],
+})

--- a/packages/sources/coinpaprika-state/src/endpoint/index.ts
+++ b/packages/sources/coinpaprika-state/src/endpoint/index.ts
@@ -1,0 +1,1 @@
+export { endpoint as coinpaprikaState } from './coinpaprika-state'

--- a/packages/sources/coinpaprika-state/src/index.ts
+++ b/packages/sources/coinpaprika-state/src/index.ts
@@ -1,0 +1,13 @@
+import { expose, ServerInstance } from '@chainlink/external-adapter-framework'
+import { Adapter } from '@chainlink/external-adapter-framework/adapter'
+import { config } from './config'
+import { coinpaprikaState } from './endpoint'
+
+export const adapter = new Adapter({
+  defaultEndpoint: coinpaprikaState.name,
+  name: 'COINPAPRIKA_STATE',
+  config,
+  endpoints: [coinpaprikaState],
+})
+
+export const server = (): Promise<ServerInstance | undefined> => expose(adapter)

--- a/packages/sources/coinpaprika-state/src/transport/coinpaprika-state.ts
+++ b/packages/sources/coinpaprika-state/src/transport/coinpaprika-state.ts
@@ -1,0 +1,368 @@
+import { EndpointContext } from '@chainlink/external-adapter-framework/adapter'
+import { ResponseCache } from '@chainlink/external-adapter-framework/cache/response'
+import { TransportDependencies } from '@chainlink/external-adapter-framework/transports'
+import { SubscriptionTransport } from '@chainlink/external-adapter-framework/transports/abstract/subscription'
+import { AdapterResponse, makeLogger, sleep } from '@chainlink/external-adapter-framework/util'
+import { Requester } from '@chainlink/external-adapter-framework/util/requester'
+import type { AxiosRequestConfig } from 'axios'
+import { Readable } from 'node:stream'
+import { BaseEndpointTypes, inputParameters } from '../endpoint/coinpaprika-state'
+import { SSEParser } from './sse'
+
+const logger = makeLogger('CoinpaprikaStateTransport')
+
+type RequestParams = typeof inputParameters.validated
+
+// Coinpaprika’s OpenAPI doc says all numeric values are encoded as strings to preserve precision
+interface CoinpaprikaStreamData {
+  block_time: string | number
+  base_token_symbol: string
+  quote_symbol: string
+  volume_7d_usd: string | number
+  market_depth_plus_1_usd: string | number
+  market_depth_minus_1_usd: string | number
+  state_price: string | number
+}
+
+export type TransportTypes = BaseEndpointTypes & {
+  Provider: {
+    RequestBody: Array<{ base: string; quote: string }>
+    ResponseBody: CoinpaprikaStreamData
+  }
+}
+
+const norm = (s: string) => s.trim().toUpperCase()
+const normalizeParams = (p: RequestParams): RequestParams => ({
+  ...p,
+  base: norm(p.base),
+  quote: norm(p.quote),
+})
+
+/**
+ * Single-connection SSE transport that batches all pairs into one POST and streams state_price ticks into the cache.
+ *
+ * */
+export class CoinpaprikaStateTransport extends SubscriptionTransport<TransportTypes> {
+  name!: string
+  responseCache!: ResponseCache<TransportTypes>
+  requester!: Requester
+
+  // single SSE conn for all pairs
+  private activeConnection: AbortController | null = null
+  private activePairs: Map<string, RequestParams> = new Map()
+  // reconnection backoff base (ms); jitter added per attempt //TODO
+  private lastConnectionAttempt: number = 0
+  private reconnectDelay: number = 5000
+  // guard to prevent reconnects during/after shutdown
+  private isShuttingDown = false
+  private sseParser: SSEParser | null = null
+
+  async initialize(
+    dependencies: TransportDependencies<TransportTypes>,
+    adapterSettings: TransportTypes['Settings'],
+    endpointName: string,
+    transportName: string,
+  ): Promise<void> {
+    this.isShuttingDown = false
+    await super.initialize(dependencies, adapterSettings, endpointName, transportName)
+    this.requester = dependencies.requester
+  }
+
+  async backgroundHandler(context: EndpointContext<TransportTypes>, entries: RequestParams[]) {
+    if (this.isShuttingDown) return
+
+    // normalize params once at ingestion
+    const normalized = entries.map(normalizeParams)
+
+    // build current pairs map
+    const currentPairs = new Map<string, RequestParams>()
+    for (const e of normalized) currentPairs.set(`${e.base}/${e.quote}`, e)
+
+    // detect changes in the requested pair set (triggers reconnect if changed)
+    const pairsChanged = this.havePairsChanged(currentPairs)
+
+    if (pairsChanged || !this.activeConnection) {
+      logger.info(`Pairs changed or no connection. Updating stream with ${currentPairs.size} pairs`)
+      logger.debug(`Pairs: ${[...currentPairs.keys()].join(', ')}`)
+
+      await this.updateStream(context, currentPairs)
+    }
+    await sleep(context.adapterSettings.BACKGROUND_EXECUTE_MS)
+  }
+
+  private havePairsChanged(pairs: Map<string, RequestParams>): boolean {
+    if (pairs.size !== this.activePairs.size) return true
+    for (const [key] of pairs) {
+      if (!this.activePairs.has(key)) return true
+    }
+    return false
+  }
+
+  private async updateStream(
+    context: EndpointContext<TransportTypes>,
+    pairs: Map<string, RequestParams>,
+  ) {
+    if (this.isShuttingDown) return
+
+    // close existing connection if any
+    if (this.activeConnection) {
+      logger.info('Closing existing SSE connection')
+      this.activeConnection.abort()
+      this.activeConnection = null
+    }
+    // update active pairs
+    this.activePairs = new Map(pairs)
+
+    if (pairs.size === 0) {
+      logger.debug('No pairs to stream')
+      return
+    }
+
+    await this.createSSEConnection(context)
+  }
+
+  private buildSSERequest(
+    context: EndpointContext<TransportTypes>,
+    pairsArray: Array<{ base: string; quote: string }>,
+    signal: AbortSignal,
+  ): AxiosRequestConfig {
+    return {
+      url: context.adapterSettings.API_ENDPOINT,
+      method: 'POST',
+      headers: {
+        Authorization: context.adapterSettings.API_KEY,
+        'Content-Type': 'application/json',
+        Accept: 'text/event-stream',
+      },
+      data: pairsArray,
+      responseType: 'stream',
+      signal,
+      timeout: 60_000,
+      validateStatus: () => true,
+    }
+  }
+
+  private async createSSEConnection(context: EndpointContext<TransportTypes>) {
+    if (this.isShuttingDown) return
+
+    const pairsArray = Array.from(this.activePairs.values()).map((p) => ({
+      base: p.base,
+      quote: p.quote,
+    }))
+
+    logger.info(`Opening single SSE connection for ${pairsArray.length} pairs`)
+    logger.debug(`Pairs: ${pairsArray.map((p) => `${p.base}/${p.quote}`).join(', ')}`)
+
+    this.lastConnectionAttempt = Date.now()
+    const controller = new AbortController()
+    this.activeConnection = controller
+
+    try {
+      const req = this.buildSSERequest(context, pairsArray, controller.signal)
+      const key = `coinpaprika-state/stream:${[...this.activePairs.keys()].join(',')}`
+      const { response } = await this.requester.request<Readable>(key, req)
+      const axiosResp = response
+
+      if (axiosResp.status !== 200 || !axiosResp.data) {
+        // try to read error body if available
+        let errDetail = `HTTP error! status: ${axiosResp.status}`
+        let rawErrBody = ''
+        try {
+          const text = await new Promise<string>((resolve) => {
+            let buf = ''
+            ;(axiosResp.data as Readable)
+              .on('data', (c: Buffer) => (buf += c.toString('utf8')))
+              .on('end', () => resolve(buf))
+              .on('error', () => resolve(''))
+          })
+          rawErrBody = text
+          try {
+            const j = JSON.parse(text)
+            if (j?.error && j?.details) errDetail = `${j.error}: ${j.details}`
+          } catch {
+            logger.error(`Provider error body (not JSON): ${rawErrBody}`)
+          }
+        } catch {
+          // ignore parse error; keep default errDetail
+        }
+
+        const statusCode =
+          axiosResp.status === 500
+            ? 502
+            : axiosResp.status === 401
+            ? 401
+            : axiosResp.status === 400
+            ? 400
+            : axiosResp.status === 429
+            ? 429
+            : axiosResp.status
+
+        const errorResponse: AdapterResponse<TransportTypes['Response']> = {
+          statusCode,
+          errorMessage: errDetail,
+          timestamps: {
+            providerDataRequestedUnixMs: Date.now(),
+            providerDataReceivedUnixMs: Date.now(),
+            providerIndicatedTimeUnixMs: undefined,
+          },
+        }
+
+        for (const params of this.activePairs.values()) {
+          await this.responseCache.write(this.name, [{ params, response: errorResponse }])
+        }
+
+        if (this.activeConnection === controller) this.activeConnection = null
+        return
+      }
+
+      const stream: Readable = axiosResp.data as Readable
+      let aborted = false
+      this.sseParser = new SSEParser('t_s')
+
+      const handleParsedEvent = async (eventType: string, rawData: string) => {
+        if (this.isShuttingDown) return
+        if (eventType !== 't_s') {
+          logger.debug(`Skipping event type: ${eventType}`)
+          return
+        }
+
+        try {
+          const streamData: CoinpaprikaStreamData = JSON.parse(rawData)
+          const pairKey = `${norm(streamData.base_token_symbol)}/${norm(streamData.quote_symbol)}`
+          const params = this.activePairs.get(pairKey)
+          if (params) {
+            await this.handleStreamData(params, streamData)
+          } else {
+            logger.warn(`Received data for untracked pair: ${pairKey}`)
+          }
+        } catch (err) {
+          logger.debug(`Failed to parse SSE data: ${rawData} | Error: ${(err as Error).message}`)
+        }
+      }
+
+      const onData = async (chunk: Buffer) => {
+        if (this.isShuttingDown) return
+        const raw = chunk.toString('utf8')
+        logger.debug(`Raw price state update message received:\n${raw}`)
+
+        this.sseParser!.push(raw, (evt, data) => {
+          void handleParsedEvent(evt, data)
+        })
+      }
+
+      const onError = (err: Error) => {
+        if (err.name === 'CanceledError' || err.name === 'AbortError') {
+          aborted = true
+        } else {
+          logger.error(`Stream error: ${err}`)
+        }
+      }
+
+      const onEnd = async () => {
+        stream.off('data', onData)
+        stream.off('error', onError)
+        this.sseParser?.reset()
+
+        // mark closed immediately to prevent races
+        if (this.activeConnection === controller) this.activeConnection = null
+
+        if (!this.isShuttingDown && !aborted && this.activePairs.size > 0) {
+          const since = Date.now() - this.lastConnectionAttempt
+          const delay = Math.max(this.reconnectDelay - since, 0) + Math.floor(Math.random() * 1000)
+          logger.info(`SSE ended; reconnecting in ${delay} ms...`)
+          await sleep(delay)
+          if (!this.isShuttingDown) {
+            await this.createSSEConnection(context)
+          }
+        }
+      }
+
+      // wire events
+      stream.on('data', (chunk) => {
+        void onData(chunk as Buffer)
+      })
+      stream.once('error', onError)
+      stream.once('end', onEnd)
+    } catch (error) {
+      this.activeConnection = null
+      if (this.isShuttingDown) return
+      logger.error(`Failed to create SSE connection: ${error}`)
+      return
+    }
+  }
+
+  private async handleStreamData(param: RequestParams, streamData: CoinpaprikaStreamData) {
+    // coerce string -> number
+    const toNum = (value: string | number | undefined | null): number => {
+      if (typeof value === 'number') return value
+      if (typeof value === 'string' && value.trim() !== '') {
+        const n = Number(value)
+        return Number.isFinite(n) ? n : NaN
+      }
+      return NaN
+    }
+    const statePrice = toNum(streamData.state_price)
+    const blockTime = toNum(streamData.block_time)
+
+    // guard against bad payloads
+    if (!Number.isFinite(statePrice) || !Number.isFinite(blockTime) || blockTime <= 0) {
+      logger.warn(
+        `Bad numeric fields for ${param.base}/${param.quote}: ${JSON.stringify(streamData)}`,
+      )
+      return
+    }
+
+    const response: AdapterResponse<TransportTypes['Response']> = {
+      data: {
+        result: statePrice,
+        timestamp: blockTime,
+      },
+      statusCode: 200,
+      result: statePrice,
+      timestamps: {
+        providerDataRequestedUnixMs: Date.now(),
+        providerDataReceivedUnixMs: Date.now(),
+        providerIndicatedTimeUnixMs: blockTime * 1000,
+      },
+    }
+    logger.debug(`tick ${param.base}/${param.quote}=${statePrice} t=${blockTime}`)
+    logger.trace(JSON.stringify(response))
+
+    await this.responseCache.write(this.name, [{ params: param, response }])
+  }
+
+  async _handleRequest(_: RequestParams): Promise<AdapterResponse<TransportTypes['Response']>> {
+    // This fallback shouldn't be called in normal operation - data should come from cache via backgroundHandler
+    logger.debug('Foreground request hit fallback: no cached data yet')
+    return {
+      statusCode: 504,
+      errorMessage:
+        'No cached data available. Streaming transport is initializing or waiting for data.',
+      timestamps: {
+        providerDataRequestedUnixMs: Date.now(),
+        providerDataReceivedUnixMs: Date.now(),
+        providerIndicatedTimeUnixMs: undefined,
+      },
+    }
+  }
+
+  getSubscriptionTtlFromConfig(adapterSettings: TransportTypes['Settings']): number {
+    return adapterSettings.WARMUP_SUBSCRIPTION_TTL
+  }
+
+  async close(): Promise<void> {
+    logger.info('Closing SSE connection')
+    this.isShuttingDown = true
+
+    if (this.activeConnection) {
+      this.activeConnection.abort()
+      this.activeConnection = null
+    }
+    this.activePairs.clear()
+
+    if (this.sseParser) this.sseParser.reset()
+    this.sseParser = null
+  }
+}
+
+export const CoinpaprikaSubscriptionTransport = new CoinpaprikaStateTransport()

--- a/packages/sources/coinpaprika-state/src/transport/sse.ts
+++ b/packages/sources/coinpaprika-state/src/transport/sse.ts
@@ -1,0 +1,56 @@
+/**
+ * Minimal SSE parser that accumulates chunked lines and emits complete events.
+ * - Supports "event:" name (optional; defaults to 't_s')
+ * - Supports multi-line "data:" blocks
+ * - Ignores comment/heartbeat lines starting with ':'
+ */
+export class SSEParser {
+  private buffer = ''
+  private dataLines: string[] = []
+  private currentEvent: string | null = null
+  private readonly defaultEvent: string
+
+  constructor(defaultEvent = 't_s') {
+    this.defaultEvent = defaultEvent
+  }
+
+  /**
+   * Push a chunk and emit parsed events via callback.
+   * The callback is invoked once per complete event frame.
+   */
+  push(chunk: string, onEvent: (eventType: string, data: string) => void): void {
+    this.buffer += chunk
+    const lines = this.buffer.split('\n')
+    this.buffer = lines.pop() || ''
+
+    for (const rawLine of lines) {
+      const line = rawLine.replace(/\r$/, '')
+
+      if (line.startsWith(':')) continue
+
+      if (line.startsWith('event:')) {
+        this.currentEvent = line.slice(6).trim()
+        continue
+      }
+      if (line.startsWith('data:')) {
+        this.dataLines.push(line.slice(5).trim())
+        continue
+      }
+
+      // end of an event
+      if (line.trim() === '' && this.dataLines.length > 0) {
+        const rawData = this.dataLines.join('\n')
+        this.dataLines = []
+        const evt = this.currentEvent ?? this.defaultEvent
+        this.currentEvent = null
+        onEvent(evt, rawData)
+      }
+    }
+  }
+
+  reset(): void {
+    this.buffer = ''
+    this.dataLines = []
+    this.currentEvent = null
+  }
+}

--- a/packages/sources/coinpaprika-state/test-payload.json
+++ b/packages/sources/coinpaprika-state/test-payload.json
@@ -1,0 +1,16 @@
+{
+  "requests": [
+    {
+      "base": "LUSD",
+      "quote": "USD"
+    },
+    {
+      "base": "EURA",
+      "quote": "USD"
+    },
+    {
+      "base": "ALETH",
+      "quote": "USD"
+    }
+  ]
+}

--- a/packages/sources/coinpaprika-state/test/integration/adapter.test.ts
+++ b/packages/sources/coinpaprika-state/test/integration/adapter.test.ts
@@ -1,0 +1,338 @@
+import {
+  TestAdapter,
+  setEnvVariables,
+} from '@chainlink/external-adapter-framework/util/testing-utils'
+import nock from 'nock'
+import {
+  endSSEStream,
+  mockStreamPost,
+  mockStreamPostAnyBody,
+  mockStreamPostRawAnyBody,
+  mockStreamPostRawMatchingBody,
+  sseEventChunk,
+  waitFor,
+} from './fixtures'
+
+jest.setTimeout(10000)
+
+describe('coinpaprika-state adapter', () => {
+  let testAdapter: TestAdapter
+  let oldEnv: NodeJS.ProcessEnv
+  let outSpy: jest.SpyInstance, errSpy: jest.SpyInstance
+
+  beforeAll(async () => {
+    outSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true as any)
+    errSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true as any)
+
+    process.env.LOG_LEVEL = 'silent'
+    process.env.EA_LOG_LEVEL = 'silent'
+    process.env.PINO_LOG_LEVEL = 'silent'
+    process.env.METRICS_ENABLED = 'false'
+    process.env.RETRY = '0'
+
+    nock.disableNetConnect()
+    oldEnv = JSON.parse(JSON.stringify(process.env))
+    process.env.API_KEY = 'TEST-KEY'
+    process.env.API_ENDPOINT = 'http://localhost:1234/stream'
+    process.env.BACKGROUND_EXECUTE_MS = '100'
+
+    const adapter = (await import('../../src')).adapter
+    adapter.rateLimiting = undefined
+    testAdapter = await TestAdapter.startWithMockedCache(adapter, {
+      testAdapter: {} as TestAdapter<never>,
+    })
+    nock.enableNetConnect((host) => host.includes('127.0.0.1') || host.includes('localhost'))
+  })
+
+  afterAll(async () => {
+    await testAdapter.api.close()
+    await new Promise((r) => setTimeout(r, 400))
+    nock.abortPendingRequests()
+    nock.cleanAll()
+    nock.enableNetConnect()
+    setEnvVariables(oldEnv)
+    outSpy.mockRestore()
+    errSpy.mockRestore()
+  })
+
+  beforeEach(() => {
+    nock.cleanAll()
+  })
+
+  it('happy path: streams ticks and serves latest state_price for LUSD/USD', async () => {
+    const { scope, stream } = mockStreamPost({
+      apiBase: 'http://localhost:1234',
+      pairs: [{ base: 'LUSD', quote: 'USD' }],
+      events: [
+        {
+          block_time: 1756224311,
+          base_token_symbol: 'LUSD',
+          quote_symbol: 'USD',
+          state_price: 1.0005,
+          volume_7d_usd: 1234.56,
+          market_depth_plus_1_usd: 0,
+          market_depth_minus_1_usd: 0,
+        },
+        {
+          block_time: 1756224313,
+          base_token_symbol: 'LUSD',
+          quote_symbol: 'USD',
+          state_price: 1.0007,
+          volume_7d_usd: 2222,
+          market_depth_plus_1_usd: 0,
+          market_depth_minus_1_usd: 0,
+        },
+      ],
+    })
+
+    await waitFor(async () => {
+      const r = await testAdapter.request({ base: 'LUSD', quote: 'USD', endpoint: 'state' })
+      expect(r.statusCode).toBe(200)
+      expect(r.json().result).toBeCloseTo(1.0007, 3)
+      expect(r.json().data.timestamp).toBe(1756224313)
+    })
+
+    endSSEStream(stream)
+    scope.done()
+  })
+
+  it('returns 504 when no data available', async () => {
+    const scope = nock('http://localhost:1234')
+      .post('/stream')
+      .matchHeader('authorization', 'TEST-KEY')
+      .reply(200, () => ':heartbeat\n\n', { 'Content-Type': 'text/event-stream' })
+      .persist()
+
+    await new Promise((resolve) => setTimeout(resolve, 300))
+
+    const response = await testAdapter.request({
+      base: 'UNKNOWN_X',
+      quote: 'USD',
+      endpoint: 'state',
+    })
+
+    expect([504, 502]).toContain(response.statusCode)
+    scope.persist(false)
+    nock.cleanAll()
+  })
+
+  it('provider 401 bubbles through', async () => {
+    const scope = nock('http://localhost:1234')
+      .post('/stream')
+      .matchHeader('authorization', 'TEST-KEY')
+      .reply(401, { error: 'Unauthorized', details: 'Invalid API key' })
+      .persist()
+
+    await new Promise((resolve) => setTimeout(resolve, 300))
+
+    const response = await testAdapter.request({
+      base: 'ETH401',
+      quote: 'USD',
+      endpoint: 'state',
+    })
+
+    expect(response.statusCode).toBe(401)
+    scope.persist(false)
+    nock.cleanAll()
+  })
+
+  it('multi-pair batching: caches all pairs independently', async () => {
+    const { scope, stream } = mockStreamPostAnyBody({
+      apiBase: 'http://localhost:1234',
+      events: [
+        { block_time: 10, base_token_symbol: 'LUSD', quote_symbol: 'USD', state_price: '1.01' },
+        { block_time: 12, base_token_symbol: 'EURA', quote_symbol: 'USD', state_price: '1.02' },
+        { block_time: 14, base_token_symbol: 'LUSD', quote_symbol: 'USD', state_price: '1.03' },
+      ],
+    })
+
+    void testAdapter.request({ base: 'LUSD', quote: 'USD', endpoint: 'state' })
+    void testAdapter.request({ base: 'EURA', quote: 'USD', endpoint: 'state' })
+
+    await waitFor(async () => {
+      const r1 = await testAdapter.request({ base: 'LUSD', quote: 'USD', endpoint: 'state' })
+      const r2 = await testAdapter.request({ base: 'EURA', quote: 'USD', endpoint: 'state' })
+      expect(r1.statusCode).toBe(200)
+      expect(r2.statusCode).toBe(200)
+      expect(r1.json().result).toBeCloseTo(1.03)
+      expect(r2.json().result).toBeCloseTo(1.02)
+    })
+
+    endSSEStream(stream)
+    scope.done()
+  })
+
+  it('pair-set change triggers reconnect immediately (first stream kept open)', async () => {
+    const BASE1 = 'LUSD_A'
+    const BASE2 = 'EURA_A'
+
+    const { scope: s1, stream: st1 } = mockStreamPostRawAnyBody({
+      apiBase: 'http://localhost:1234',
+      chunks: [
+        sseEventChunk({
+          block_time: 20,
+          base_token_symbol: BASE1,
+          quote_symbol: 'USD',
+          state_price: 1.0,
+        }),
+      ],
+    })
+
+    void testAdapter.request({ base: BASE1, quote: 'USD', endpoint: 'state' })
+    await waitFor(async () => {
+      const r = await testAdapter.request({ base: BASE1, quote: 'USD', endpoint: 'state' })
+      expect(r.statusCode).toBe(200)
+      expect(r.json().result).toBeCloseTo(1.0, 3)
+    })
+
+    const { scope: s2, stream: st2 } = mockStreamPostAnyBody({
+      apiBase: 'http://localhost:1234',
+      events: [
+        {
+          block_time: 22,
+          base_token_symbol: BASE2,
+          quote_symbol: 'USD',
+          state_price: 1.11,
+        },
+      ],
+    })
+
+    void testAdapter.request({ base: BASE2, quote: 'USD', endpoint: 'state' })
+    await waitFor(async () => {
+      const r = await testAdapter.request({ base: BASE2, quote: 'USD', endpoint: 'state' })
+      expect(r.statusCode).toBe(200)
+      expect(r.json().result).toBeCloseTo(1.11, 3)
+    })
+
+    endSSEStream(st2)
+    endSSEStream(st1)
+    s1.done()
+    s2.done()
+  })
+
+  it('ignores events for unknown pairs and non-t_s event types', async () => {
+    const { scope, stream } = mockStreamPostRawAnyBody({
+      apiBase: 'http://localhost:1234',
+      chunks: [
+        sseEventChunk({
+          block_time: 30,
+          base_token_symbol: 'BTC',
+          quote_symbol: 'JPY',
+          state_price: 9000000,
+        }),
+        sseEventChunk({ ping: true }, 'heartbeat'),
+      ],
+    })
+
+    const r = await testAdapter.request({ base: 'XYZ', quote: 'USD', endpoint: 'state' })
+    expect([504, 502]).toContain(r.statusCode)
+
+    endSSEStream(stream)
+    scope.done()
+  })
+
+  it('malformed JSON is skipped, keeping last good value only', async () => {
+    const BASE = 'LUSD2'
+    const QUOTE = 'USD'
+
+    const { scope, stream } = mockStreamPostRawMatchingBody({
+      apiBase: 'http://localhost:1234',
+      chunks: [
+        sseEventChunk('{not-json}'),
+        sseEventChunk({
+          block_time: 40,
+          base_token_symbol: BASE,
+          quote_symbol: QUOTE,
+          state_price: '1.2',
+        }),
+      ],
+      matchBody: (body) =>
+        Array.isArray(body) && body.some((p: any) => p?.base === BASE && p?.quote === QUOTE),
+    })
+
+    void testAdapter.request({ base: BASE, quote: QUOTE, endpoint: 'state' })
+
+    await waitFor(async () => {
+      expect(scope.isDone()).toBe(true)
+    })
+
+    await waitFor(async () => {
+      const r = await testAdapter.request({ base: BASE, quote: QUOTE, endpoint: 'state' })
+      expect(r.statusCode).toBe(200)
+      expect(r.json().result).toBeCloseTo(1.2)
+    })
+
+    endSSEStream(stream)
+  })
+
+  it('foreground fallback returns 502/504 when no cached data exists yet', async () => {
+    const res = await testAdapter.request({ base: 'ZZZ_NO_CACHE', quote: 'USD', endpoint: 'state' })
+    expect([502, 504]).toContain(res.statusCode)
+  })
+
+  it('error mapping: 500 -> 502', async () => {
+    const scope = nock('http://localhost:1234').post('/stream').reply(500, { error: 'x' }).persist()
+    await new Promise((r) => setTimeout(r, 200))
+    const res = await testAdapter.request({ base: 'ERR500', quote: 'USD', endpoint: 'state' })
+    expect(res.statusCode).toBe(502)
+    scope.persist(false)
+    nock.cleanAll()
+  })
+
+  it('error mapping: 429 preserved', async () => {
+    const scope = nock('http://localhost:1234')
+      .post('/stream')
+      .reply(429, { error: 'too many' })
+      .persist()
+    await new Promise((r) => setTimeout(r, 200))
+    const res = await testAdapter.request({ base: 'ERR429', quote: 'USD', endpoint: 'state' })
+    expect(res.statusCode).toBe(429)
+    scope.persist(false)
+    nock.cleanAll()
+  })
+
+  it('error mapping: 400 preserved', async () => {
+    const scope = nock('http://localhost:1234')
+      .post('/stream')
+      .reply(400, { error: 'bad' })
+      .persist()
+    await new Promise((r) => setTimeout(r, 200))
+    const res = await testAdapter.request({ base: 'ERR400', quote: 'USD', endpoint: 'state' })
+    expect(res.statusCode).toBe(400)
+    scope.persist(false)
+    nock.cleanAll()
+  })
+
+  it('string to number coercion works for state_price and block_time', async () => {
+    const BASE = 'COERCE_B'
+    const { scope, stream } = mockStreamPostAnyBody({
+      apiBase: 'http://localhost:1234',
+      events: [
+        {
+          block_time: '12345',
+          base_token_symbol: BASE,
+          quote_symbol: 'USD',
+          state_price: '1.2345',
+        },
+      ],
+    })
+    scope.persist()
+
+    void testAdapter.request({ base: BASE, quote: 'USD', endpoint: 'state' })
+    await new Promise((r) => setTimeout(r, 200))
+
+    await waitFor(async () => {
+      const r = await testAdapter.request({ base: BASE, quote: 'USD', endpoint: 'state' })
+      expect(r.statusCode).toBe(200)
+      expect(r.json().result).toBeCloseTo(1.2345, 4)
+      expect(r.json().data.timestamp).toBe(12345)
+    }, 10_000)
+
+    await waitFor(async () => {
+      expect(scope.isDone()).toBe(true)
+    })
+
+    endSSEStream(stream)
+    scope.persist(false)
+  })
+})

--- a/packages/sources/coinpaprika-state/test/integration/fixtures.ts
+++ b/packages/sources/coinpaprika-state/test/integration/fixtures.ts
@@ -1,0 +1,179 @@
+import nock from 'nock'
+import { PassThrough } from 'stream'
+
+export const sseEventChunk = (payload: object | string, event = 't_s') => {
+  const dataStr = typeof payload === 'string' ? payload : JSON.stringify(payload)
+  return `event: ${event}\n` + `data: ${dataStr}\n\n`
+}
+
+const makeRawSSEStream = (chunks: string[]) => {
+  const stream = new PassThrough()
+  for (const ch of chunks) stream.write(ch)
+  return stream
+}
+
+const makeSSEStream = (events: object[]) => {
+  return makeRawSSEStream(events.map((ev) => sseEventChunk(ev)))
+}
+
+export const endSSEStream = (stream?: PassThrough) => {
+  if (!stream) return
+  try {
+    stream.end()
+  } catch {}
+  try {
+    stream.destroy()
+  } catch {}
+}
+
+export const mockStreamPost = ({
+  apiBase,
+  pairs,
+  events,
+  authHeader = 'TEST-KEY',
+}: {
+  apiBase: string
+  pairs: Array<{ base: string; quote: string }>
+  events: object[]
+  authHeader?: string
+}) => {
+  const scope = nock(apiBase, {
+    reqheaders: {
+      authorization: (v) => v === authHeader,
+      accept: (v) => (v || '').toLowerCase().includes('text/event-stream'),
+      'content-type': (v) => (v || '').toLowerCase().includes('application/json'),
+    },
+  })
+
+  const stream = makeSSEStream(events)
+
+  scope
+    .post('/stream', (body) => Array.isArray(body) && body.length === pairs.length)
+    .reply(200, () => stream, {
+      'Content-Type': 'text/event-stream',
+      Connection: 'keep-alive',
+      'Cache-Control': 'no-cache',
+      'Transfer-Encoding': 'chunked',
+    })
+
+  return { scope, stream }
+}
+
+export const mockStreamPostAnyBody = ({
+  apiBase,
+  events,
+  authHeader = 'TEST-KEY',
+}: {
+  apiBase: string
+  events: object[]
+  authHeader?: string
+}) => {
+  const scope = nock(apiBase, {
+    reqheaders: {
+      authorization: (v) => v === authHeader,
+      accept: (v) => (v || '').toLowerCase().includes('text/event-stream'),
+      'content-type': (v) => (v || '').toLowerCase().includes('application/json'),
+    },
+  })
+
+  const stream = makeSSEStream(events)
+
+  scope.post('/stream').reply(200, () => stream, {
+    'Content-Type': 'text/event-stream',
+    Connection: 'keep-alive',
+    'Cache-Control': 'no-cache',
+    'Transfer-Encoding': 'chunked',
+  })
+
+  return { scope, stream }
+}
+
+export const mockStreamPostRawAnyBody = ({
+  apiBase,
+  chunks,
+  authHeader = 'TEST-KEY',
+}: {
+  apiBase: string
+  chunks: string[]
+  authHeader?: string
+}) => {
+  const scope = nock(apiBase, {
+    reqheaders: {
+      authorization: (v) => v === authHeader,
+      accept: (v) => (v || '').toLowerCase().includes('text/event-stream'),
+      'content-type': (v) => (v || '').toLowerCase().includes('application/json'),
+    },
+  })
+
+  const stream = makeRawSSEStream(chunks)
+
+  scope.post('/stream').reply(200, () => stream, {
+    'Content-Type': 'text/event-stream',
+    Connection: 'keep-alive',
+    'Cache-Control': 'no-cache',
+    'Transfer-Encoding': 'chunked',
+  })
+
+  return { scope, stream }
+}
+
+export const waitFor = async <T>(
+  fn: () => Promise<T>,
+  timeoutMs = 5000,
+  stepMs = 150,
+): Promise<T> => {
+  const start = Date.now()
+  let lastErr: unknown
+  while (true) {
+    try {
+      return await fn()
+    } catch (e) {
+      lastErr = e
+      if (Date.now() - start > timeoutMs) throw lastErr
+      await new Promise((r) => setTimeout(r, stepMs))
+    }
+  }
+}
+
+export const mockStreamPostRawMatchingBody = ({
+  apiBase,
+  chunks,
+  matchBody,
+  authHeader = 'TEST-KEY',
+  firstDelayMs = 10,
+}: {
+  apiBase: string
+  chunks: string[]
+  matchBody: (body: unknown) => boolean
+  authHeader?: string
+  firstDelayMs?: number
+}) => {
+  const scope = nock(apiBase, {
+    reqheaders: {
+      authorization: (v) => v === authHeader,
+      accept: (v) => (v || '').toLowerCase().includes('text/event-stream'),
+      'content-type': (v) => (v || '').toLowerCase().includes('application/json'),
+    },
+  })
+  const stream = new PassThrough()
+  setTimeout(() => {
+    for (const ch of chunks) stream.write(ch)
+  }, firstDelayMs)
+
+  scope
+    .post('/stream', (body) => {
+      try {
+        return matchBody(body)
+      } catch {
+        return false
+      }
+    })
+    .reply(200, () => stream, {
+      'Content-Type': 'text/event-stream',
+      Connection: 'keep-alive',
+      'Cache-Control': 'no-cache',
+      'Transfer-Encoding': 'chunked',
+    })
+
+  return { scope, stream }
+}

--- a/packages/sources/coinpaprika-state/test/unit/sse.test.ts
+++ b/packages/sources/coinpaprika-state/test/unit/sse.test.ts
@@ -1,0 +1,28 @@
+import { SSEParser } from '../../src/transport/sse'
+
+describe('SSEParser', () => {
+  it('parses single event with default type', () => {
+    const p = new SSEParser('t_s')
+    const events: Array<{ type: string; data: string }> = []
+    p.push('data: {"x":1}\n\n', (t, d) => events.push({ type: t, data: d }))
+    expect(events).toEqual([{ type: 't_s', data: '{"x":1}' }])
+  })
+
+  it('parses multi-line data and explicit event name', () => {
+    const p = new SSEParser()
+    const events: any[] = []
+    p.push('event: t_s\ndata: {"a":1\n', () => {})
+    p.push('data: ,"b":2}\n\n', (t, d) => events.push({ t, d }))
+    expect(events).toEqual([{ t: 't_s', d: '{"a":1\n,"b":2}' }])
+  })
+
+  it('ignores comments and keeps trailing partial line in buffer', () => {
+    const p = new SSEParser()
+    const events: any[] = []
+    p.push(':heartbeat\n', () => {})
+    p.push('data: {"ok":true}\n', () => {})
+    p.push('\n', (t, d) => events.push({ t, d }))
+    expect(events.length).toBe(1)
+    expect(events[0].d).toBe('{"ok":true}')
+  })
+})

--- a/packages/sources/coinpaprika-state/tsconfig.json
+++ b/packages/sources/coinpaprika-state/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*", "src/**/*.json"],
+  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]
+}

--- a/packages/sources/coinpaprika-state/tsconfig.test.json
+++ b/packages/sources/coinpaprika-state/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*", "**/test", "src/**/*.json"],
+  "compilerOptions": {
+    "noEmit": true
+  }
+}

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -264,6 +264,9 @@
       "path": "./sources/coinpaprika"
     },
     {
+      "path": "./sources/coinpaprika-state"
+    },
+    {
       "path": "./sources/coinranking"
     },
     {

--- a/packages/tsconfig.test.json
+++ b/packages/tsconfig.test.json
@@ -264,6 +264,9 @@
       "path": "./sources/coinpaprika/tsconfig.test.json"
     },
     {
+      "path": "./sources/coinpaprika-state/tsconfig.test.json"
+    },
+    {
       "path": "./sources/coinranking/tsconfig.test.json"
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3252,6 +3252,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@chainlink/coinpaprika-state-adapter@workspace:packages/sources/coinpaprika-state":
+  version: 0.0.0-use.local
+  resolution: "@chainlink/coinpaprika-state-adapter@workspace:packages/sources/coinpaprika-state"
+  dependencies:
+    "@chainlink/external-adapter-framework": "npm:2.7.0"
+    "@types/jest": "npm:^29.5.14"
+    "@types/node": "npm:22.14.1"
+    axios: "npm:1.10.0"
+    nock: "npm:13.5.6"
+    tslib: "npm:2.4.1"
+    typescript: "npm:5.8.3"
+  languageName: unknown
+  linkType: soft
+
 "@chainlink/coinranking-adapter@workspace:*, @chainlink/coinranking-adapter@workspace:packages/sources/coinranking":
   version: 0.0.0-use.local
   resolution: "@chainlink/coinranking-adapter@workspace:packages/sources/coinranking"


### PR DESCRIPTION
## Description
Adds a new Coinpaprika State external adapter that streams state_price via Server-Sent Events (SSE).
See package [README](https://github.com/smartcontractkit/external-adapters-js/blob/feat/add-coinpaprika-state-adapter/packages/sources/coinpaprika-state/README.md) for full details

## Changes

- New package: `@chainlink/coinpaprika-state-adapter`
- Endpoint: `coinpaprika-state` (alias: `state`)
- Transport: single-connection SSE with:
  - pair batching & dynamic reconnect on pair-set change
  - JSON parsing with malformed-event tolerance
  - graceful shutdown & reconnection backoff with jitter

## Steps to Test

1. Navigate to the root of the external-adapters-js repo
2. Build the adapter: `yarn workspace @chainlink/coinpaprika-state-adapter build`
3. Run tests:
- Integration test: `yarn test packages/sources/coinpaprika-state/test/integration/adapter.test.ts`
- Unit test: `yarn test packages/sources/coinpaprika-state/test/unit/sse.test.ts`

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [x] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.