### PR TITLE
Feature extend reserve endpoint for lax ripcording

### DIFF
--- a/.changeset/odd-lions-eat.md
+++ b/.changeset/odd-lions-eat.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/the-network-firm-adapter': patch
+---
+
+Update the reserve endpoint to take an additional parameter for laxRipcord

--- a/.changeset/odd-lions-eat.md
+++ b/.changeset/odd-lions-eat.md
@@ -2,4 +2,4 @@
 '@chainlink/the-network-firm-adapter': patch
 ---
 
-Update the reserve endpoint to take an additional parameter for laxRipcord
+Update the reserve endpoint to take an additional parameter for noErrorOnRipcord

--- a/packages/sources/the-network-firm/src/endpoint/reserve.ts
+++ b/packages/sources/the-network-firm/src/endpoint/reserve.ts
@@ -32,7 +32,11 @@ export const inputParameters = new InputParameters(
 
 export type BaseEndpointTypes = {
   Parameters: typeof inputParameters.definition
-  Response: PoRProviderResponse
+  Response: PoRProviderResponse & {
+    ripcordAsInt?: number
+    totalReserve?: number
+    totalToken?: number
+  }
   Settings: typeof config.settings
 }
 

--- a/packages/sources/the-network-firm/src/endpoint/reserve.ts
+++ b/packages/sources/the-network-firm/src/endpoint/reserve.ts
@@ -14,18 +14,18 @@ export const inputParameters = new InputParameters(
       required: true,
       description: 'The name of the TNF client to consume from',
     },
-    laxRipcord: {
+    noErrorOnRipcord: {
       type: 'boolean',
       required: false,
       default: false,
       description:
-        'Lax ripcord handling, return 200 on ripcord when laxRipcord is true, return 502 with ripcord details if laxRipcord is false or unset',
+        'Lax ripcord handling, return 200 on ripcord when noErrorOnRipcord is true, return 502 with ripcord details if noErrorOnRipcord is false or unset',
     },
   },
   [
     {
       client: 'acme',
-      laxRipcord: false,
+      noErrorOnRipcord: false,
     },
   ],
 )

--- a/packages/sources/the-network-firm/src/endpoint/reserve.ts
+++ b/packages/sources/the-network-firm/src/endpoint/reserve.ts
@@ -18,7 +18,8 @@ export const inputParameters = new InputParameters(
       type: 'boolean',
       required: false,
       default: false,
-      description: 'Lax ripcord handling, return 200 on ripcord when laxRipcord is true, return 502 with ripcord details if laxRipcord is false or unset',
+      description:
+        'Lax ripcord handling, return 200 on ripcord when laxRipcord is true, return 502 with ripcord details if laxRipcord is false or unset',
     },
   },
   [

--- a/packages/sources/the-network-firm/src/endpoint/reserve.ts
+++ b/packages/sources/the-network-firm/src/endpoint/reserve.ts
@@ -14,10 +14,17 @@ export const inputParameters = new InputParameters(
       required: true,
       description: 'The name of the TNF client to consume from',
     },
+    laxRipcord: {
+      type: 'boolean',
+      required: false,
+      default: false,
+      description: 'Lax ripcord handling, return 200 on ripcord when laxRipcord is true, return 502 with ripcord details if laxRipcord is false or unset',
+    },
   },
   [
     {
       client: 'acme',
+      laxRipcord: false,
     },
   ],
 )

--- a/packages/sources/the-network-firm/src/transport/reserve.ts
+++ b/packages/sources/the-network-firm/src/transport/reserve.ts
@@ -53,7 +53,7 @@ export const httpTransport = new HttpTransport<HttpTransportTypes>({
   },
   parseResponse: (params, response) => {
     return params.map((param) => {
-      const laxRipcord = param.laxRipcord
+      const noErrorOnRipcord = param.noErrorOnRipcord
 
       const ripcord =
         response.data.ripcord || response.data.ripcord.toString().toLowerCase() === 'true'
@@ -63,8 +63,8 @@ export const httpTransport = new HttpTransport<HttpTransportTypes>({
       if (ripcord) {
         const ripcordDetails = response.data.ripcordDetails.join(', ')
 
-        // If laxRipcord is false and ripcord is true return 502
-        if (!laxRipcord) {
+        // If noErrorOnRipcord is false and ripcord is true return 502
+        if (!noErrorOnRipcord) {
           const message = `Ripcord indicator true. Details: ${ripcordDetails}`
           return {
             params: param,

--- a/packages/sources/the-network-firm/src/transport/reserve.ts
+++ b/packages/sources/the-network-firm/src/transport/reserve.ts
@@ -62,15 +62,15 @@ export const httpTransport = new HttpTransport<HttpTransportTypes>({
       // Populate ripcord details if ripcord is true
       if (ripcord) {
         const ripcordDetails = response.data.ripcordDetails.join(', ')
+        const message = `Ripcord indicator true. Details: ${ripcordDetails}`
 
         // If noErrorOnRipcord is false and ripcord is true return 502
         if (!noErrorOnRipcord) {
-          const message = `Ripcord indicator true. Details: ${ripcordDetails}`
           return {
             params: param,
             response: {
               errorMessage: message,
-              ripcord: response.data.ripcord,
+              ripcord,
               ripcordAsInt,
               ripcordDetails,
               statusCode: 502,
@@ -79,9 +79,9 @@ export const httpTransport = new HttpTransport<HttpTransportTypes>({
               },
             },
           }
+        } else {
+          logger.debug(message)
         }
-
-        logger.debug(`Ripcord indicator true. Details: ${ripcordDetails}`)
       }
 
       // Ensure totalReserve and totalToken are numbers, keep result as is for backwards compatibility
@@ -94,7 +94,7 @@ export const httpTransport = new HttpTransport<HttpTransportTypes>({
           result,
           data: {
             result,
-            ripcord: response.data.ripcord,
+            ripcord,
             ripcordAsInt,
             totalReserve,
             totalToken,

--- a/packages/sources/the-network-firm/src/transport/reserve.ts
+++ b/packages/sources/the-network-firm/src/transport/reserve.ts
@@ -19,7 +19,7 @@ export type HttpTransportTypes = BaseEndpointTypes & {
   }
 }
 
-const logger = makeLogger('ReserveStreamsHTTPTransport')
+const logger = makeLogger('ReserveHTTPTransport')
 
 export const getApiKey = (client: string) => {
   const apiKeyName = `${client.replace(/-/g, '_').toUpperCase()}_API_KEY`

--- a/packages/sources/the-network-firm/test/integration/__snapshots__/reserve.test.ts.snap
+++ b/packages/sources/the-network-firm/test/integration/__snapshots__/reserve.test.ts.snap
@@ -16,6 +16,9 @@ exports[`execute reserve endpoint should return success for emgemx 1`] = `
   "data": {
     "result": "5100005",
     "ripcord": false,
+    "ripcordAsInt": 0,
+    "totalReserve": 5100005,
+    "totalToken": 100000,
   },
   "result": "5100005",
   "statusCode": 200,
@@ -32,6 +35,9 @@ exports[`execute reserve endpoint should return success for m0 1`] = `
   "data": {
     "result": "2344889.68",
     "ripcord": false,
+    "ripcordAsInt": 0,
+    "totalReserve": 2344889.68,
+    "totalToken": 100000,
   },
   "result": "2344889.68",
   "statusCode": 200,
@@ -48,6 +54,9 @@ exports[`execute reserve endpoint should return success for re 1`] = `
   "data": {
     "result": "333.99882",
     "ripcord": false,
+    "ripcordAsInt": 0,
+    "totalReserve": 333.99882,
+    "totalToken": 100000,
   },
   "result": "333.99882",
   "statusCode": 200,
@@ -64,6 +73,9 @@ exports[`execute reserve endpoint should return success for uranium 1`] = `
   "data": {
     "result": "75000000",
     "ripcord": false,
+    "ripcordAsInt": 0,
+    "totalReserve": 75000000,
+    "totalToken": 100000,
   },
   "result": "75000000",
   "statusCode": 200,

--- a/packages/sources/the-network-firm/test/integration/__snapshots__/ripcord.test.ts.snap
+++ b/packages/sources/the-network-firm/test/integration/__snapshots__/ripcord.test.ts.snap
@@ -71,7 +71,7 @@ exports[`execute reserve endpoint when ripcord true should fail 1`] = `
 }
 `;
 
-exports[`execute reserve endpoint when ripcord true should succeed with lax ripcord 1`] = `
+exports[`execute reserve endpoint when ripcord true should succeed with noErrorOnRipcord 1`] = `
 {
   "data": {
     "result": "1000000",

--- a/packages/sources/the-network-firm/test/integration/__snapshots__/ripcord.test.ts.snap
+++ b/packages/sources/the-network-firm/test/integration/__snapshots__/ripcord.test.ts.snap
@@ -56,6 +56,40 @@ exports[`execute gift endpoint when ripcord true should return error 1`] = `
 }
 `;
 
+exports[`execute reserve endpoint when ripcord true should fail 1`] = `
+{
+  "errorMessage": "Ripcord indicator true. Details: Balances",
+  "ripcord": true,
+  "ripcordAsInt": 1,
+  "ripcordDetails": "Balances",
+  "statusCode": 502,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 978347471111,
+    "providerDataRequestedUnixMs": 978347471111,
+    "providerIndicatedTimeUnixMs": 1748007917250,
+  },
+}
+`;
+
+exports[`execute reserve endpoint when ripcord true should succeed with lax ripcord 1`] = `
+{
+  "data": {
+    "result": "1000000",
+    "ripcord": true,
+    "ripcordAsInt": 1,
+    "totalReserve": 1000000,
+    "totalToken": 100000,
+  },
+  "result": "1000000",
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 978347471111,
+    "providerDataRequestedUnixMs": 978347471111,
+    "providerIndicatedTimeUnixMs": 1748007917250,
+  },
+}
+`;
+
 exports[`execute stbt endpoint when ripcord true should return error 1`] = `
 {
   "errorMessage": "Ripcord indicator true. Details: Balances",

--- a/packages/sources/the-network-firm/test/integration/reserve.test.ts
+++ b/packages/sources/the-network-firm/test/integration/reserve.test.ts
@@ -8,6 +8,7 @@ import {
   mockReResponseSuccess,
   mockReserveEmgemxResponseSuccess,
   mockReserveUraniumResponseSuccess,
+
 } from './fixtures'
 
 describe('execute', () => {

--- a/packages/sources/the-network-firm/test/integration/reserve.test.ts
+++ b/packages/sources/the-network-firm/test/integration/reserve.test.ts
@@ -8,7 +8,6 @@ import {
   mockReResponseSuccess,
   mockReserveEmgemxResponseSuccess,
   mockReserveUraniumResponseSuccess,
-
 } from './fixtures'
 
 describe('execute', () => {

--- a/packages/sources/the-network-firm/test/integration/ripcord.test.ts
+++ b/packages/sources/the-network-firm/test/integration/ripcord.test.ts
@@ -28,6 +28,7 @@ describe('execute', () => {
     process.env.ALT_API_ENDPOINT = 'http://test-endpoint-new'
     process.env.EMGEMX_API_KEY = 'api-key'
     process.env.URANIUM_API_KEY = 'api-key'
+    process.env.EMGEMX_TDFKF3_API_KEY = 'emgemx-api-key'
 
     const adapter = (await import('../../src')).adapter
     adapter.rateLimiting = undefined
@@ -123,6 +124,32 @@ describe('execute', () => {
         endpoint: 'uranium',
       }
       mockUraniumResponseRipcordSuccess()
+      const response = await testAdapter.request(data)
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toMatchSnapshot()
+    })
+  })
+
+  describe('reserve endpoint when ripcord true', () => {
+    it('should fail', async () => {
+      const data = {
+        endpoint: 'reserve',
+        client: 'emgemx-tdfkf3',
+      }
+      mockEmgemxResponseRipcordFailure()
+      const response = await testAdapter.request(data)
+      expect(response.statusCode).toBe(502)
+      expect(response.json()).toMatchSnapshot()
+    })
+
+    it('should succeed with lax ripcord', async () => {
+      const data = {
+        endpoint: 'reserve',
+        client: 'emgemx-tdfkf3',
+        laxRipcord: true,
+      }
+
+      mockEmgemxResponseRipcordFailure()
       const response = await testAdapter.request(data)
       expect(response.statusCode).toBe(200)
       expect(response.json()).toMatchSnapshot()

--- a/packages/sources/the-network-firm/test/integration/ripcord.test.ts
+++ b/packages/sources/the-network-firm/test/integration/ripcord.test.ts
@@ -142,11 +142,11 @@ describe('execute', () => {
       expect(response.json()).toMatchSnapshot()
     })
 
-    it('should succeed with lax ripcord', async () => {
+    it('should succeed with noErrorOnRipcord', async () => {
       const data = {
         endpoint: 'reserve',
         client: 'emgemx-tdfkf3',
-        laxRipcord: true,
+        noErrorOnRipcord: true,
       }
 
       mockEmgemxResponseRipcordFailure()


### PR DESCRIPTION
## Closes [#OPDATA-4443](https://smartcontract-it.atlassian.net/issues/?selectedIssue=OPDATA-4443)

## Description

......

## Changes

- Updates the the reserve endpoint to take a laxRipcord option for data streams and always return ripcordAsInt also 

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

```
curl -s --header "Content-Type: application/json" --request POST --data '{ "data": {"endpoint": "reserve", "client": "backed-tslax-kyln3p"} }' localhost:8080  | jq 
{
  "result": 47327,
  "data": {
    "result": 47327,
    "ripcord": false,
    "ripcordAsInt": 0,
    "totalReserve": 47327,
    "totalToken": 46366.19985541
  },
  "timestamps": {
    "providerDataRequestedUnixMs": 1758915236519,
    "providerDataReceivedUnixMs": 1758915236960,
    "providerIndicatedTimeUnixMs": 1758913525602
  },
  "statusCode": 200,
  "meta": {
    "adapterName": "THE_NETWORK_FIRM",
    "metrics": {
      "feedId": "{\"client\":\"backed-tslax-kyln3p\",\"laxRipcord\":false}"
    }
  }
```

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file or update the [soak testing blacklist](/packages/scripts/src/get-changed-adapters/soakTestBlacklist.ts).
- [x] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [x] This is related to a maximum of one Jira story or GitHub issue.
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
