### PR TITLE
Adds NCFX 24x7 ncfx-continuous endpoint

### DIFF
--- a/.changeset/friendly-parents-draw.md
+++ b/.changeset/friendly-parents-draw.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/ncfx-adapter': minor
+---
+
+Adds NCFX 24x7 ncfx-continuous endpoint

--- a/packages/sources/ncfx/src/config/index.ts
+++ b/packages/sources/ncfx/src/config/index.ts
@@ -35,4 +35,9 @@ export const config = new AdapterConfig({
     description: 'The WS API key to use for the market status endpoint',
     sensitive: true,
   },
+  FOREX_CONTINUOUS_WS_API_ENDPOINT: {
+    type: 'string',
+    description: 'The WS API endpoint to use for the forex-continuous (24/7) endpoint',
+    default: 'wss://cryptofeed.ws.newchangefx.com/fiat_v1',
+  },
 })

--- a/packages/sources/ncfx/src/endpoint/forex-continuous.ts
+++ b/packages/sources/ncfx/src/endpoint/forex-continuous.ts
@@ -1,0 +1,46 @@
+import {
+  AdapterEndpoint,
+  LwbaResponseDataFields,
+  lwbaEndpointInputParametersDefinition,
+  validateLwbaResponse,
+} from '@chainlink/external-adapter-framework/adapter'
+import { InputParameters } from '@chainlink/external-adapter-framework/validation'
+import { AdapterLWBAError } from '@chainlink/external-adapter-framework/validation/error'
+import { config } from '../config'
+import { transport } from '../transport/forex-continuous'
+import { customInputValidation } from './crypto'
+
+export const inputParameters = new InputParameters(lwbaEndpointInputParametersDefinition, [
+  {
+    base: 'ARS',
+    quote: 'USD',
+  },
+])
+
+export type BaseEndpointTypesForexContinuous = {
+  Parameters: typeof inputParameters.definition
+  Settings: typeof config.settings
+  Response: LwbaResponseDataFields
+}
+
+export const forexContinuousEndpoint = new AdapterEndpoint({
+  name: 'forex-continuous',
+  aliases: ['forex_continuous', 'forexcontinuous'],
+  customInputValidation,
+  transport,
+  inputParameters,
+  requestTransforms: [
+    (req) => {
+      req.requestContext.data.base = req.requestContext.data.base.toUpperCase()
+      req.requestContext.data.quote = req.requestContext.data.quote.toUpperCase()
+    },
+  ],
+  customOutputValidation: (output) => {
+    const data = output.data as { bid: number; mid: number; ask: number }
+    const error = validateLwbaResponse(data.bid, data.mid, data.ask)
+    if (error) {
+      throw new AdapterLWBAError({ statusCode: 500, message: error })
+    }
+    return undefined
+  },
+})

--- a/packages/sources/ncfx/src/endpoint/index.ts
+++ b/packages/sources/ncfx/src/endpoint/index.ts
@@ -1,4 +1,5 @@
 export { cryptoEndpoint as crypto } from './crypto'
 export { cryptoLwbaEndpoint as lwba } from './crypto-lwba'
 export { forexEndpoint as forex } from './forex'
+export { forexContinuousEndpoint as forexContinuous } from './forex-continuous'
 export { marketStatusEndpoint as marketStatus } from './market-status'

--- a/packages/sources/ncfx/src/index.ts
+++ b/packages/sources/ncfx/src/index.ts
@@ -2,11 +2,11 @@ import { expose, ServerInstance } from '@chainlink/external-adapter-framework'
 import { PriceAdapter } from '@chainlink/external-adapter-framework/adapter'
 import { config } from './config'
 import includes from './config/includes.json'
-import { crypto, forex, lwba, marketStatus } from './endpoint'
+import { crypto, forex, forexContinuous, lwba, marketStatus } from './endpoint'
 
 export const adapter = new PriceAdapter({
   name: 'NCFX',
-  endpoints: [crypto, forex, lwba, marketStatus],
+  endpoints: [crypto, forex, forexContinuous, lwba, marketStatus],
   defaultEndpoint: crypto.name,
   config,
   includes,

--- a/packages/sources/ncfx/src/transport/crypto.ts
+++ b/packages/sources/ncfx/src/transport/crypto.ts
@@ -1,124 +1,59 @@
 import { WebSocketTransport } from '@chainlink/external-adapter-framework/transports'
 import { BaseEndpointTypes } from '../endpoint/crypto'
-import { makeLogger } from '@chainlink/external-adapter-framework/util'
+import {
+  WsMessage,
+  WsPriceMessage,
+  createSubscriptionBuilders,
+  handleInfoMessage,
+  parseProviderTime,
+  wsOpenHandler,
+} from './utils'
 
-const logger = makeLogger('NcfxCryptoEndpoint')
-
-type WsMessage = WsInfoMessage | WsPriceMessage
-
-type WsInfoMessage = {
-  Type: string
-  Message: string
-}
-
-type WsPriceMessage = {
-  timestamp: string // e.g. 2023-01-31T20:10:41
-  currencyPair: string // e.g. ETH/USD
-  bid?: number // e.g. 1595.4999
-  offer?: number // e.g. 1595.5694
-  mid?: number // e.g. 1595.5346
-}
+// Crypto uses '/' separator (e.g., "ETH/USD") and 'offer' field for ask price
+const PAIR_SEPARATOR = '/'
 
 type WsTransportTypes = BaseEndpointTypes & {
   Provider: {
     WsMessage: WsMessage
   }
 }
+
 export const transport = new WebSocketTransport<WsTransportTypes>({
   url: (context) => context.adapterSettings.WS_API_ENDPOINT,
   handlers: {
-    open(connection, context) {
-      return new Promise<void>((resolve, reject) => {
-        // Set up listener
-        connection.addEventListener('message', (event: MessageEvent) => {
-          const parsed = JSON.parse(event.data.toString())
-          if (parsed.Message === 'Successfully Authenticated') {
-            logger.debug('Got logged in response, connection is ready')
-            resolve()
-          } else {
-            reject(
-              new Error(`Unexpected message after WS connection open: ${event.data.toString()}`),
-            )
-          }
-        })
-        // Send login payload
-        logger.debug('Logging in WS connection')
-        connection.send(
-          JSON.stringify({
-            request: 'login',
-            username: context.adapterSettings.API_USERNAME,
-            password: context.adapterSettings.API_PASSWORD,
-          }),
-        )
-      }).catch((error) => {
-        if (
-          error.message ===
-          'Unexpected message after WS connection open: {"Type":"Error","Message":"Login failed, Invalid login"}'
-        ) {
-          logger.error(`Login failed, Invalid login`)
-          logger.error(`Possible Solutions:
-            1. Doublecheck your supplied credentials.
-            2. Contact Data Provider to ensure your subscription is active
-            3. If credentials are supplied under the node licensing agreement with Chainlink Labs, please make contact with us and we will look into it.`)
-        }
-        throw error
-      })
-    },
+    open: wsOpenHandler,
 
     message(message: WsMessage) {
-      if (isInfoMessage(message)) {
-        logger.debug(`Received message ${message.Type}: ${message.Message}`)
-        if (
-          message.Message ===
-          "Request contains pairs you don't have access to, please check the request"
-        ) {
-          logger.error(`Request contains pairs you don't have access to`)
-          logger.error(`Possible Solutions:
-            1. Confirm you are using the same symbol found in the job spec with the correct case.
-            2. There maybe an issue with the job spec or the Data Provider may have delisted the asset. Reach out to Chainlink Labs.`)
-        }
+      if (handleInfoMessage(message)) {
         return
       }
 
-      if (!message.currencyPair || !message.mid || !message.bid || !message.offer) {
-        logger.debug('WS message does not contain valid data, skipping')
+      const priceMessage = message as WsPriceMessage
+      if (
+        !priceMessage.currencyPair ||
+        !priceMessage.mid ||
+        !priceMessage.bid ||
+        !priceMessage.offer
+      ) {
         return
       }
 
-      // Expected timestamp in datetime format from NCFX API is missing timezone
-      // Documented as UTC eg: "2023-06-06 16:03:47.750"
-      const providerTime = message.timestamp.includes('Z')
-        ? message.timestamp
-        : `${message.timestamp}Z`
-      const [base, quote] = message.currencyPair.split('/')
+      const [base, quote] = priceMessage.currencyPair.split(PAIR_SEPARATOR)
       return [
         {
           params: { base, quote },
           response: {
-            result: message.mid || 0, // Already validated in the filter above
+            result: priceMessage.mid,
             data: {
-              result: message.mid || 0, // Already validated in the filter above
+              result: priceMessage.mid,
             },
             timestamps: {
-              providerIndicatedTimeUnixMs: new Date(providerTime).getTime(),
+              providerIndicatedTimeUnixMs: parseProviderTime(priceMessage.timestamp),
             },
           },
         },
       ]
     },
   },
-  builders: {
-    subscribeMessage: (params) => ({
-      request: 'subscribe',
-      ccy: `${params.base}/${params.quote}`,
-    }),
-    unsubscribeMessage: (params) => ({
-      request: 'unsubscribe',
-      ccy: `${params.base}/${params.quote}`,
-    }),
-  },
+  builders: createSubscriptionBuilders(PAIR_SEPARATOR),
 })
-
-const isInfoMessage = (message: WsMessage): message is WsInfoMessage => {
-  return (message as WsInfoMessage).Type !== undefined
-}

--- a/packages/sources/ncfx/src/transport/forex-continuous.ts
+++ b/packages/sources/ncfx/src/transport/forex-continuous.ts
@@ -1,5 +1,5 @@
 import { WebSocketTransport } from '@chainlink/external-adapter-framework/transports'
-import { BaseEndpointTypesLwba } from '../endpoint/crypto-lwba'
+import { BaseEndpointTypesForexContinuous } from '../endpoint/forex-continuous'
 import {
   WsMessage,
   WsPriceMessage,
@@ -9,17 +9,17 @@ import {
   wsOpenHandler,
 } from './utils'
 
-// Crypto LWBA uses '/' separator (e.g., "ETH/USD") and 'offer' field for ask price
-const PAIR_SEPARATOR = '/'
+// Forex continuous uses '-' separator (e.g., "ARS-USD") and 'ask' field
+const PAIR_SEPARATOR = '-'
 
-type WsTransportTypes = BaseEndpointTypesLwba & {
+type WsTransportTypes = BaseEndpointTypesForexContinuous & {
   Provider: {
     WsMessage: WsMessage
   }
 }
 
 export const transport = new WebSocketTransport<WsTransportTypes>({
-  url: (context) => context.adapterSettings.WS_API_ENDPOINT,
+  url: (context) => context.adapterSettings.FOREX_CONTINUOUS_WS_API_ENDPOINT,
   handlers: {
     open: wsOpenHandler,
 
@@ -29,12 +29,11 @@ export const transport = new WebSocketTransport<WsTransportTypes>({
       }
 
       const priceMessage = message as WsPriceMessage
-      // Crypto feed uses 'offer' field instead of 'ask'
       if (
         !priceMessage.currencyPair ||
         !priceMessage.mid ||
         !priceMessage.bid ||
-        !priceMessage.offer
+        !priceMessage.ask
       ) {
         return
       }
@@ -48,7 +47,7 @@ export const transport = new WebSocketTransport<WsTransportTypes>({
             data: {
               bid: priceMessage.bid,
               mid: priceMessage.mid,
-              ask: priceMessage.offer, // Map 'offer' to 'ask' in response
+              ask: priceMessage.ask,
             },
             timestamps: {
               providerIndicatedTimeUnixMs: parseProviderTime(priceMessage.timestamp),

--- a/packages/sources/ncfx/src/transport/utils.ts
+++ b/packages/sources/ncfx/src/transport/utils.ts
@@ -1,0 +1,130 @@
+import { makeLogger } from '@chainlink/external-adapter-framework/util'
+
+const logger = makeLogger('NcfxTransport')
+
+/**
+ * Common WebSocket message types for NCFX feeds
+ */
+export type WsInfoMessage = {
+  Type: string
+  Message: string
+}
+
+export type WsPriceMessage = {
+  timestamp: string // e.g. "2023-01-31T20:10:41" or "2026-01-15 17:09:38.501"
+  currencyPair: string // e.g. "ETH/USD" or "ARS-USD"
+  bid?: number
+  offer?: number // Used by crypto feeds
+  ask?: number // Used by forex-continuous feed
+  mid?: number
+}
+
+export type WsMessage = WsInfoMessage | WsPriceMessage
+
+/**
+ * Type guard to check if a message is an info message
+ */
+export const isInfoMessage = (message: WsMessage): message is WsInfoMessage => {
+  return (message as WsInfoMessage).Type !== undefined
+}
+
+/**
+ * Parses the provider timestamp and ensures it has timezone info
+ * NCFX timestamps are UTC but often missing the 'Z' suffix
+ */
+export const parseProviderTime = (timestamp: string): number => {
+  const providerTime = timestamp.includes('Z') ? timestamp : `${timestamp}Z`
+  return new Date(providerTime).getTime()
+}
+
+/**
+ * Handles info messages with appropriate logging
+ * Returns true if message was an info message (caller should return early)
+ */
+export const handleInfoMessage = (message: WsMessage): boolean => {
+  console.log(`Received message ${JSON.stringify(message)}`)
+  if (!isInfoMessage(message)) {
+    return false
+  }
+
+  logger.debug(`Received message ${message.Type}: ${message.Message}`)
+
+  if (
+    message.Message === "Request contains pairs you don't have access to, please check the request"
+  ) {
+    logger.error(`Request contains pairs you don't have access to`)
+    logger.error(`Possible Solutions:
+      1. Confirm you are using the same symbol found in the job spec with the correct case.
+      2. There maybe an issue with the job spec or the Data Provider may have delisted the asset. Reach out to Chainlink Labs.`)
+  }
+
+  return true
+}
+
+/**
+ * Context type for the open handler - matches what the framework provides
+ */
+type OpenHandlerContext = {
+  adapterSettings: {
+    API_USERNAME?: string
+    API_PASSWORD?: string
+  }
+}
+
+/**
+ * Creates the WebSocket open handler for NCFX authentication
+ * This is shared across all NCFX WebSocket transports
+ */
+export const wsOpenHandler = (
+  connection: WebSocket,
+  context: OpenHandlerContext,
+): Promise<void> => {
+  return new Promise<void>((resolve, reject) => {
+    // Set up listener for auth response
+    connection.addEventListener('message', (event: MessageEvent) => {
+      const parsed = JSON.parse(event.data.toString())
+      if (parsed.Message === 'Successfully Authenticated') {
+        logger.debug('Got logged in response, connection is ready')
+        resolve()
+      } else {
+        reject(new Error(`Unexpected message after WS connection open: ${event.data.toString()}`))
+      }
+    })
+
+    // Send login payload
+    logger.debug('Logging in WS connection')
+    connection.send(
+      JSON.stringify({
+        request: 'login',
+        username: context.adapterSettings.API_USERNAME,
+        password: context.adapterSettings.API_PASSWORD,
+      }),
+    )
+  }).catch((error) => {
+    if (
+      error.message ===
+      'Unexpected message after WS connection open: {"Type":"Error","Message":"Login failed, Invalid login"}'
+    ) {
+      logger.error(`Login failed, Invalid login`)
+      logger.error(`Possible Solutions:
+        1. Doublecheck your supplied credentials.
+        2. Contact Data Provider to ensure your subscription is active
+        3. If credentials are supplied under the node licensing agreement with Chainlink Labs, please make contact with us and we will look into it.`)
+    }
+    throw error
+  })
+}
+
+/**
+ * Creates subscription message builders for a given pair separator
+ */
+export const createSubscriptionBuilders = (pairSeparator: string) => ({
+  subscribeMessage: (params: { base: string; quote: string }) => ({
+    request: 'subscribe',
+    ccy: `${params.base}${pairSeparator}${params.quote}`,
+  }),
+  unsubscribeMessage: (params: { base: string; quote: string }) => ({
+    request: 'unsubscribe',
+    ccy: `${params.base}${pairSeparator}${params.quote}`,
+  }),
+})

--- a/packages/sources/ncfx/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/ncfx/test/integration/__snapshots__/adapter.test.ts.snap
@@ -30,6 +30,23 @@ exports[`websocket forex endpoint should return success 1`] = `
 }
 `;
 
+exports[`websocket forex-continuous endpoint should return success 1`] = `
+{
+  "data": {
+    "ask": 0.000659234,
+    "bid": 0.000659191,
+    "mid": 0.000659222,
+  },
+  "result": null,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 1018,
+    "providerDataStreamEstablishedUnixMs": 1010,
+    "providerIndicatedTimeUnixMs": 1768496978501,
+  },
+}
+`;
+
 exports[`websocket lwba endpoint should return error (LWBA invariant violation) 1`] = `
 {
   "error": {

--- a/packages/sources/ncfx/test/integration/fixtures.ts
+++ b/packages/sources/ncfx/test/integration/fixtures.ts
@@ -135,6 +135,19 @@ export const mockMarketStatusResponse = {
   timestamp: '2024-06-20T20:44:09.594Z',
 }
 
+export const mockForexContinuousSubscribeResponse = {
+  Type: 'Info',
+  Message: 'Subscribed to currency pair(s) ARS-USD',
+}
+
+export const mockForexContinuousResponse = {
+  timestamp: '2026-01-15 17:09:38.501',
+  currencyPair: 'ARS-USD',
+  mid: 0.000659222,
+  bid: 0.000659191,
+  ask: 0.000659234,
+}
+
 export const mockCryptoWebSocketServer = (URL: string): MockWebsocketServer => {
   const mockWsServer = new MockWebsocketServer(URL, { mock: false })
   mockWsServer.on('connection', (socket) => {
@@ -165,6 +178,18 @@ export const mockMarketStatusWebSocketServer = (URL: string): MockWebsocketServe
     setTimeout(() => {
       socket.send(JSON.stringify(mockMarketStatusResponse))
     }, 0)
+  })
+  return mockWsServer
+}
+
+export const mockForexContinuousWebSocketServer = (URL: string): MockWebsocketServer => {
+  const mockWsServer = new MockWebsocketServer(URL, { mock: false })
+  mockWsServer.on('connection', (socket) => {
+    socket.send(JSON.stringify(loginResponse))
+    socket.on('message', () => {
+      socket.send(JSON.stringify(mockForexContinuousSubscribeResponse))
+      socket.send(JSON.stringify(mockForexContinuousResponse))
+    })
   })
   return mockWsServer
 }


### PR DESCRIPTION
## Closes [OPDATA-5753](https://smartcontract-it.atlassian.net/browse/OPDATA-5753)

## Description

This PR adds a new endpoint [forex-continuous] that consumes a new 24x7 NCFX forex price feed. 

## Changes

- Adds a new endpoint [forex-continuous] that consumes a new 24x7 NCFX forex price feed.

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. Integration tests
2. Local curl server tests

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[OPDATA-5753]: https://smartcontract-it.atlassian.net/browse/OPDATA-5753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ