### PR TITLE
Add ea-framework common settings link to generated READMEs

### DIFF
--- a/packages/scripts/src/generate-readme/generator.ts
+++ b/packages/scripts/src/generate-readme/generator.ts
@@ -266,7 +266,10 @@ export class ReadmeGenerator {
       ? buildTable(tableText, paramHeaders)
       : 'There are no environment variables for this adapter.'
 
-    this.readmeText += `## Environment Variables\n\n${envVarTable}\n\n---\n\n`
+    const frameworkSettingsLink =
+      'There are also several [common EA environment variables](https://github.com/smartcontractkit/ea-framework-js/blob/main/docs/reference-tables/ea-settings.md) that apply to all V3 adapters.'
+
+    this.readmeText += `## Environment Variables\n\n${envVarTable}\n\n${frameworkSettingsLink}\n\n---\n\n`
   }
 
   addRateLimitSection(): void {


### PR DESCRIPTION
## Summary
- Adds a link to the [EA Settings reference](https://github.com/smartcontractkit/ea-framework-js/blob/main/docs/reference-tables/ea-settings.md) in the Environment Variables section of every auto-generated EA README
- EA oeprators currently only see adapter-specific env vars in READMEs but miss important framework-level settings they can tune (e.g. cache TTL, rate limiting, logging)
- https://smartcontract-it.atlassian.net/browse/DF-19937