### PR TITLE
[OPDATA-6315 Part 2] Mobula-State Cache bug fix

### DIFF
--- a/.changeset/silent-otters-stick.md
+++ b/.changeset/silent-otters-stick.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/mobula-state-adapter': minor
+---
+
+Fixed bug where assets with protocol were causing cache misses

--- a/packages/sources/mobula-state/src/transport/funding-rate.ts
+++ b/packages/sources/mobula-state/src/transport/funding-rate.ts
@@ -1,9 +1,7 @@
 import { WebSocketTransport } from '@chainlink/external-adapter-framework/transports'
-import { makeLogger, ProviderResult } from '@chainlink/external-adapter-framework/util'
+import { ProviderResult } from '@chainlink/external-adapter-framework/util'
 
 import { BaseEndpointTypes } from '../endpoint/funding-rate'
-
-const logger = makeLogger('MobulaFundingRate')
 
 /*
 Example response message:
@@ -71,7 +69,6 @@ export const wsTransport = new WebSocketTransport<WsTransportTypes>({
   },
   handlers: {
     message(message) {
-      logger.info({ msg: 'Received WS message', data: JSON.stringify(message) })
       const results: Array<ProviderResult<WsTransportTypes>> = []
       const queryDetails = message.queryDetails
       Object.entries(message).forEach(([key, value]) => {

--- a/packages/sources/mobula-state/src/transport/funding-rate.ts
+++ b/packages/sources/mobula-state/src/transport/funding-rate.ts
@@ -1,7 +1,9 @@
 import { WebSocketTransport } from '@chainlink/external-adapter-framework/transports'
-import { ProviderResult } from '@chainlink/external-adapter-framework/util'
+import { makeLogger, ProviderResult } from '@chainlink/external-adapter-framework/util'
 
 import { BaseEndpointTypes } from '../endpoint/funding-rate'
+
+const logger = makeLogger('MobulaFundingRate')
 
 /*
 Example response message:
@@ -69,6 +71,7 @@ export const wsTransport = new WebSocketTransport<WsTransportTypes>({
   },
   handlers: {
     message(message) {
+      logger.info({ msg: 'Received WS message', data: JSON.stringify(message) })
       const results: Array<ProviderResult<WsTransportTypes>> = []
       const queryDetails = message.queryDetails
       Object.entries(message).forEach(([key, value]) => {
@@ -82,35 +85,37 @@ export const wsTransport = new WebSocketTransport<WsTransportTypes>({
         }
 
         const exchange = key.slice(0, -'FundingRate'.length).toLowerCase()
-        results.push(getFundingRateResult(exchange, queryDetails, value as FundingRateResponse))
+        results.push(...getFundingRateResults(exchange, queryDetails, value as FundingRateResponse))
       })
       return results
     },
   },
 })
 
-const getFundingRateResult = (
+const getFundingRateResults = (
   exchange: string,
   queryDetails: WSResponse['queryDetails'],
   fundingRate: FundingRateResponse,
-): ProviderResult<WsTransportTypes> => {
+): ProviderResult<WsTransportTypes>[] => {
   // Symbol may contain protocol prefix, e.g. "xyz:SILVER"
   const symbolParts = String(fundingRate.symbol).split(':')
   const protocol = symbolParts.length > 1 ? symbolParts[0] : undefined
-  return {
-    params: {
-      base: queryDetails.base,
-      quote: queryDetails.quote ?? '',
-      exchange,
-      ...(protocol && { protocol }),
-    },
-    response: {
-      result: null,
-      data: {
-        fundingRate: fundingRate.fundingRate,
-        fundingTimestamp: Math.trunc(fundingRate.fundingTime / 1000),
-        epochDuration: Math.trunc(fundingRate.epochDurationMs / 1000),
-      },
+  const response = {
+    result: null,
+    data: {
+      fundingRate: fundingRate.fundingRate,
+      fundingTimestamp: Math.trunc(fundingRate.fundingTime / 1000),
+      epochDuration: Math.trunc(fundingRate.epochDurationMs / 1000),
     },
   }
+  const baseParams = {
+    base: queryDetails.base,
+    quote: queryDetails.quote ?? '',
+    exchange,
+  }
+  const results: ProviderResult<WsTransportTypes>[] = [{ params: baseParams, response }]
+  if (protocol) {
+    results.push({ params: { ...baseParams, protocol }, response })
+  }
+  return results
 }

--- a/packages/sources/mobula-state/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/mobula-state/test/integration/__snapshots__/adapter.test.ts.snap
@@ -32,6 +32,38 @@ exports[`websocket funding rate endpoint have partial data return success 1`] = 
 }
 `;
 
+exports[`websocket funding rate endpoint mixed exchanges: symbol with colon should match protocol request 1`] = `
+{
+  "data": {
+    "epochDuration": 3600,
+    "fundingRate": 0.0000056789,
+    "fundingTimestamp": 1773975600,
+  },
+  "result": null,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 20208,
+    "providerDataStreamEstablishedUnixMs": 16160,
+  },
+}
+`;
+
+exports[`websocket funding rate endpoint mixed exchanges: symbol without colon should match non-protocol request 1`] = `
+{
+  "data": {
+    "epochDuration": 28800,
+    "fundingRate": 0.0001234,
+    "fundingTimestamp": 1773975600,
+  },
+  "result": null,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 20208,
+    "providerDataStreamEstablishedUnixMs": 16160,
+  },
+}
+`;
+
 exports[`websocket funding rate endpoint no data should return failure 1`] = `
 {
   "error": {

--- a/packages/sources/mobula-state/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/mobula-state/test/integration/__snapshots__/adapter.test.ts.snap
@@ -59,6 +59,22 @@ exports[`websocket funding rate endpoint with protocol param should return succe
 }
 `;
 
+exports[`websocket funding rate endpoint without protocol param should return success when response has protocol prefix 1`] = `
+{
+  "data": {
+    "epochDuration": 3600,
+    "fundingRate": 0.0000023431,
+    "fundingTimestamp": 1773975600,
+  },
+  "result": null,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 19198,
+    "providerDataStreamEstablishedUnixMs": 16160,
+  },
+}
+`;
+
 exports[`websocket graceful error handling and case-insensitive requests should continue working after receiving invalid symbol requests 1`] = `
 {
   "data": {

--- a/packages/sources/mobula-state/test/integration/adapter.test.ts
+++ b/packages/sources/mobula-state/test/integration/adapter.test.ts
@@ -50,6 +50,13 @@ describe('websocket', () => {
     endpoint: 'funding-rate',
   }
 
+  const dataFundingRateNoProtocol = {
+    base: 'XYZ100',
+    quote: 'USDC',
+    exchange: 'hyperliquid',
+    endpoint: 'funding-rate',
+  }
+
   beforeAll(async () => {
     oldEnv = JSON.parse(JSON.stringify(process.env))
     process.env['WS_API_ENDPOINT'] = wsEndpoint
@@ -300,6 +307,11 @@ describe('websocket', () => {
 
     it('with protocol param should return success', async () => {
       const response = await testAdapter.request(dataFundingRateProtocol)
+      expect(response.json()).toMatchSnapshot()
+    })
+
+    it('without protocol param should return success when response has protocol prefix', async () => {
+      const response = await testAdapter.request(dataFundingRateNoProtocol)
       expect(response.json()).toMatchSnapshot()
     })
 

--- a/packages/sources/mobula-state/test/integration/adapter.test.ts
+++ b/packages/sources/mobula-state/test/integration/adapter.test.ts
@@ -57,6 +57,22 @@ describe('websocket', () => {
     endpoint: 'funding-rate',
   }
 
+  // Mixed exchange response: binance symbol has no colon, hyperliquid has colon
+  const dataFundingRateMixedProtocol = {
+    base: 'GOLD',
+    quote: 'USDC',
+    exchange: 'hyperliquid',
+    protocol: 'xyz',
+    endpoint: 'funding-rate',
+  }
+
+  const dataFundingRateMixedNoProtocol = {
+    base: 'GOLD',
+    quote: 'USDC',
+    exchange: 'binance',
+    endpoint: 'funding-rate',
+  }
+
   beforeAll(async () => {
     oldEnv = JSON.parse(JSON.stringify(process.env))
     process.env['WS_API_ENDPOINT'] = wsEndpoint
@@ -312,6 +328,18 @@ describe('websocket', () => {
 
     it('without protocol param should return success when response has protocol prefix', async () => {
       const response = await testAdapter.request(dataFundingRateNoProtocol)
+      expect(response.json()).toMatchSnapshot()
+    })
+
+    it('mixed exchanges: symbol with colon should match protocol request', async () => {
+      const response = await testAdapter.request(dataFundingRateMixedProtocol)
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toMatchSnapshot()
+    })
+
+    it('mixed exchanges: symbol without colon should match non-protocol request', async () => {
+      const response = await testAdapter.request(dataFundingRateMixedNoProtocol)
+      expect(response.statusCode).toBe(200)
       expect(response.json()).toMatchSnapshot()
     })
 

--- a/packages/sources/mobula-state/test/integration/fixtures.ts
+++ b/packages/sources/mobula-state/test/integration/fixtures.ts
@@ -277,6 +277,26 @@ export const mockWebsocketServer = (URL: string): MockWebsocketServer => {
               queryDetails: { base: 'XYZ100', quote: 'USDC' },
             }),
           )
+        } else if (symbol === 'GOLD' && parsed.payload.protocol === 'xyz') {
+          // Simulates multiple exchanges where one uses protocol prefix and one does not
+          socket.send(
+            JSON.stringify({
+              binanceFundingRate: {
+                symbol: 'GOLDUSDC',
+                fundingTime: 1773975600000,
+                fundingRate: 0.0001234,
+                marketPrice: '2500.00',
+                epochDurationMs: 28800000,
+              },
+              hyperliquidFundingRate: {
+                symbol: 'xyz:GOLD',
+                fundingTime: 1773975600072,
+                fundingRate: 0.0000056789,
+                epochDurationMs: 3600000,
+              },
+              queryDetails: { base: 'GOLD', quote: 'USDC' },
+            }),
+          )
         }
       }
     })

--- a/packages/sources/mobula-state/test/integration/fixtures.ts
+++ b/packages/sources/mobula-state/test/integration/fixtures.ts
@@ -262,6 +262,21 @@ export const mockWebsocketServer = (URL: string): MockWebsocketServer => {
               queryDetails: { base: 'SILVER', quote: 'USDC' },
             }),
           )
+        } else if (symbol === 'XYZ100') {
+          // Simulates a request without protocol param where the response
+          // includes a protocol prefix in the symbol (backwards compat test)
+          socket.send(
+            JSON.stringify({
+              binanceFundingRate: null,
+              hyperliquidFundingRate: {
+                symbol: 'xyz:XYZ100',
+                fundingTime: 1773975600072,
+                fundingRate: 0.0000023431,
+                epochDurationMs: 3600000,
+              },
+              queryDetails: { base: 'XYZ100', quote: 'USDC' },
+            }),
+          )
         }
       }
     })


### PR DESCRIPTION
## Description
With the latest mobula-state [change](https://github.com/smartcontractkit/external-adapters-js/pull/4745/changes#diff-35f5beff1fc935b84bcc1857b4cc260443fb096908955bc8098426b6983be391R99) we added `protocol` to the Cache key. However in most cases if the protocol is input param is empty it would be fine since WS response would also be undefined. However in some cases with current job specs for example [XYZ100/USDC](https://github.com/smartcontractkit/reference-data-directory/blob/539cabc466b0fd35ca30ba843dfebab68c21df41/data-streams/streams/1000002643.json#L3) the response actually has `symbol\":\"xyz:XYZ100\"` which causes the response to set the `protocol` in the cache key to `xyz` which means the cache will always miss if the input does not have `protocol : xyz`

## Changes
- We have to have two cache keys per input. One with what we have in the queryDetails and one with protocol. So it handles both the cases where in the input has protocol and without

## Steps to Test
**No Protocol**
```
chrayzhang@MB-C3H04RT9WT ~ % curl -X POST http://localhost:8080 \
  -H "Content-Type: application/json" \
  -d '{"data": {
    "endpoint": "funding-rate",
    "from": "XYZ100",
    "to": "USDC",
    "exchange": "hyperliquid"
  }}' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   477  100   360  100   117  87548  28453 --:--:-- --:--:-- --:--:--  116k
{
  "result": null,
  "data": {
    "fundingRate": 0.0000023431,
    "fundingTimestamp": 1773975600,
    "epochDuration": 3600
  },
  "timestamps": {
    "providerDataStreamEstablishedUnixMs": 1773977692065,
    "providerDataReceivedUnixMs": 1773977745206
  },
  "statusCode": 200,
  "meta": {
    "adapterName": "MOBULA_STATE",
    "metrics": {
      "feedId": "{\"base\":\"xyz100\",\"quote\":\"usdc\",\"exchange\":\"hyperliquid\"}"
    }
  }
}
```

**With protocol**
```
chrayzhang@MB-C3H04RT9WT ~ % curl -X POST http://localhost:8080 \
  -H "Content-Type: application/json" \
  -d '{"data": {
    "endpoint": "funding-rate",
    "from": "XYZ100",
    "to": "USDC",
    "exchange": "hyperliquid",
    "protocol": "xyz"
  }}' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   521  100   381  100   140  97218  35723 --:--:-- --:--:-- --:--:--  169k
{
  "result": null,
  "data": {
    "fundingRate": 0.0000023431,
    "fundingTimestamp": 1773975600,
    "epochDuration": 3600
  },
  "timestamps": {
    "providerDataStreamEstablishedUnixMs": 1773977692065,
    "providerDataReceivedUnixMs": 1773977735118
  },
  "statusCode": 200,
  "meta": {
    "adapterName": "MOBULA_STATE",
    "metrics": {
      "feedId": "{\"base\":\"xyz100\",\"quote\":\"usdc\",\"exchange\":\"hyperliquid\",\"protocol\":\"xyz\"}"
    }
  }
}
```

## Quality Assurance

- [ x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [x ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ x] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [x ] This is related to a maximum of one Jira story or GitHub issue.
- [ x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ x] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
