### PR TITLE
[Streams adapter] return 502 if observation success = false

### DIFF
--- a/packages/streams-adapter/server/server.go
+++ b/packages/streams-adapter/server/server.go
@@ -44,6 +44,12 @@ type ErrorResponseData struct {
 	} `json:"error"`
 }
 
+// ObservationErrorResponse is returned when the cached observation has Success=false
+type ObservationErrorResponse struct {
+	ErrorMessage string          `json:"errorMessage"`
+	Timestamps   json.RawMessage `json:"timestamps"`
+}
+
 // Object pools for reducing memory allocations
 var (
 	requestDataPool = sync.Pool{
@@ -312,7 +318,7 @@ func (s *Server) adapterHandler(c *gin.Context) {
 	// Try the mapper: raw key → transformed key → cache lookup by transformed key.
 	if transformedKey, ok := s.keyMapper.Get(rawCacheKey); ok {
 		if item := s.cache.Get(transformedKey); item != nil && item.Observation != nil {
-			c.JSON(http.StatusOK, item.Observation)
+			respondWithObservation(c, item.Observation)
 			return
 		}
 	}
@@ -320,7 +326,7 @@ func (s *Server) adapterHandler(c *gin.Context) {
 	// Fallback: try direct lookup by raw key (handles the common case where
 	// raw key == transformed key, i.e. no adapter-level requestTransform).
 	if item := s.cache.Get(rawCacheKey); item != nil && item.Observation != nil {
-		c.JSON(http.StatusOK, item.Observation)
+		respondWithObservation(c, item.Observation)
 		return
 	}
 
@@ -358,6 +364,19 @@ func (s *Server) adapterHandler(c *gin.Context) {
 	errorResp.Error.Message = "The EA has not received any values from the Data Provider for the requested data yet. Retry after a short delay, and if the problem persists raise this issue in the relevant channels."
 
 	c.JSON(http.StatusGatewayTimeout, errorResp)
+}
+
+// respondWithObservation writes the observation to the response. Returns 200 for
+// successful observations and 502 with an error payload for failed ones.
+func respondWithObservation(c *gin.Context, obs *types.Observation) {
+	if obs.Success {
+		c.JSON(http.StatusOK, obs)
+		return
+	}
+	c.JSON(http.StatusBadGateway, ObservationErrorResponse{
+		ErrorMessage: obs.Error,
+		Timestamps:   obs.Timestamps,
+	})
 }
 
 // subscribeToAsset sends a subscription request to the JS adapter.

--- a/packages/streams-adapter/server/server_test.go
+++ b/packages/streams-adapter/server/server_test.go
@@ -121,6 +121,35 @@ func TestAdapterHandler_CacheHit(t *testing.T) {
 	require.Equal(t, true, resp.Success)
 }
 
+func TestAdapterHandler_CacheHit_FailedObservation(t *testing.T) {
+	params := types.RequestParams{"endpoint": "crypto", "base": "FOO", "quote": "BAR"}
+	obs := &types.Observation{
+		Data:       nil,
+		Timestamps: json.RawMessage(`{"providerDataStreamEstablishedUnixMs":1000,"providerDataReceivedUnixMs":2000}`),
+		Success:    false,
+		Error:      "Bid price: 1.23 or Ask price: 4.56 for FOO is invalid.",
+	}
+	testCache.Set(params, obs, time.Now(), "test-key-fail")
+
+	body := `{"data":{"endpoint":"crypto","base":"FOO","quote":"BAR"}}`
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	testSrv.router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadGateway, w.Code, "body: %s", w.Body.String())
+
+	var resp ObservationErrorResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, "Bid price: 1.23 or Ask price: 4.56 for FOO is invalid.", resp.ErrorMessage)
+	require.NotEmpty(t, resp.Timestamps)
+
+	var ts map[string]interface{}
+	require.NoError(t, json.Unmarshal(resp.Timestamps, &ts))
+	require.Equal(t, float64(1000), ts["providerDataStreamEstablishedUnixMs"])
+	require.Equal(t, float64(2000), ts["providerDataReceivedUnixMs"])
+}
+
 func TestAdapterHandler_CacheMiss(t *testing.T) {
 	// Spin up a fake EA backend so the subscribe POST doesn't fail
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Closes #DS-2892

## Description
Streams adapter should return 502 if observation message has "success": false, like this one:
```
{
  "key": "base=crwv:uslf24:endpoint=stockquotes:isovernight=true:requirevolume=true",
  "adapterKey": "DXFEED-stock_quotes-default_single_transport-{\"base\":\"crwv:uslf24\",\"requireVolume\":true,\"isOvernight\":true}",
  "timestamp": "2026-04-14T16:45:26.219605547Z",
  "observation": {
    "data": null,
    "timestamps": {
      "providerDataStreamEstablishedUnixMs": 1776185047687,
      "providerDataReceivedUnixMs": 1776185126218
    },
    "success": false,
    "error": "Bid price: 116.46 or Ask price: 116.58 for CRWV:USLF24 is invalid."
  }
}
```
