### PR TITLE
unified streams adapter image

### DIFF
--- a/.changeset/hot-tables-clean.md
+++ b/.changeset/hot-tables-clean.md
@@ -1,0 +1,14 @@
+---
+'@chainlink/cfbenchmarks-adapter': minor
+'@chainlink/coinmetrics-adapter': minor
+'@chainlink/dxfeed-adapter': minor
+'@chainlink/elwood-adapter': minor
+'@chainlink/finage-adapter': minor
+'@chainlink/finalto-adapter': minor
+'@chainlink/gsr-adapter': minor
+'@chainlink/ncfx-adapter': minor
+'@chainlink/tiingo-adapter': minor
+'@chainlink/tiingo-state-adapter': minor
+---
+
+Unified streams adapter image


### PR DESCRIPTION
## Closes #[CHANGE-1076](https://smartcontract-it.atlassian.net/browse/CHANGE-1076)

## Changes
No code change, new images for:
- cfbenchmarks2
- coinmetrics
- dxfeed
- elwood
- finage
- finalto
- gsr
- ncfx
- tiingo
- tiingo-state

[CHANGE-1076]: https://smartcontract-it.atlassian.net/browse/CHANGE-1076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ