### PR TITLE
Add asian/energy markets

### DIFF
--- a/.changeset/brave-rabbits-strive.md
+++ b/.changeset/brave-rabbits-strive.md
@@ -1,0 +1,7 @@
+---
+'@chainlink/market-status-adapter': minor
+'@chainlink/tradinghours-adapter': minor
+'@chainlink/finnhub-adapter': minor
+---
+
+Add asian and enery markets

--- a/packages/composites/market-status/src/config/adapters.ts
+++ b/packages/composites/market-status/src/config/adapters.ts
@@ -43,6 +43,30 @@ const marketAdapters: Record<string, { primary: AdapterName; secondary: AdapterN
     primary: 'TRADINGHOURS',
     secondary: 'FINNHUB_SECONDARY',
   },
+  tpex: {
+    primary: 'TRADINGHOURS',
+    secondary: 'FINNHUB_SECONDARY',
+  },
+  twse: {
+    primary: 'TRADINGHOURS',
+    secondary: 'FINNHUB_SECONDARY',
+  },
+  krx: {
+    primary: 'TRADINGHOURS',
+    secondary: 'FINNHUB_SECONDARY',
+  },
+  jpx: {
+    primary: 'TRADINGHOURS',
+    secondary: 'FINNHUB_SECONDARY',
+  },
+  sse: {
+    primary: 'TRADINGHOURS',
+    secondary: 'FINNHUB_SECONDARY',
+  },
+  szse: {
+    primary: 'TRADINGHOURS',
+    secondary: 'FINNHUB_SECONDARY',
+  },
 }
 
 export const getMarketAdapters = (

--- a/packages/sources/finnhub-secondary/test/integration/__snapshots__/adapter-market-status.test.ts.snap
+++ b/packages/sources/finnhub-secondary/test/integration/__snapshots__/adapter-market-status.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Market status endpoint should return error for invalid market 1`] = `
 {
   "error": {
-    "message": "[Param: market] input is not one of valid options (AD,AS,AT,AX,BA,BC,BD,BE,BH,BK,BO,BR,CA,CN,CO,CR,CS,DB,DE,DU,F,HE,HK,HM,IC,IR,IS,JK,JO,KL,KQ,KS,KW,L,LS,MC,ME,MI,MT,MU,MX,NE,NL,NS,NZ,OL,PA,PM,PR,QA,RO,RG,SA,SG,SI,SN,SR,SS,ST,SW,SZ,T,TA,TL,TO,TW,TWO,US,V,VI,VN,VS,WA,HA,SX,TG,SC,NYSE,LSE,TRADEGATE,XETRA,SIX,EURONEXT_MILAN,EURONEXT_PARIS,ad,as,at,ax,ba,bc,bd,be,bh,bk,bo,br,ca,cn,co,cr,cs,db,de,du,f,he,hk,hm,ic,ir,is,jk,jo,kl,kq,ks,kw,l,ls,mc,me,mi,mt,mu,mx,ne,nl,ns,nz,ol,pa,pm,pr,qa,ro,rg,sa,sg,si,sn,sr,ss,st,sw,sz,t,ta,tl,to,tw,two,us,v,vi,vn,vs,wa,ha,sx,tg,sc,nyse,lse,tradegate,xetra,six,euronext_milan,euronext_paris)",
+    "message": "[Param: market] input is not one of valid options (AD,AS,AT,AX,BA,BC,BD,BE,BH,BK,BO,BR,CA,CN,CO,CR,CS,DB,DE,DU,F,HE,HK,HM,IC,IR,IS,JK,JO,KL,KQ,KS,KW,L,LS,MC,ME,MI,MT,MU,MX,NE,NL,NS,NZ,OL,PA,PM,PR,QA,RO,RG,SA,SG,SI,SN,SR,SS,ST,SW,SZ,T,TA,TL,TO,TW,TWO,US,V,VI,VN,VS,WA,HA,SX,TG,SC,NYSE,LSE,TRADEGATE,XETRA,SIX,EURONEXT_MILAN,EURONEXT_PARIS,TPEX,TWSE,KRX,JPX,SSE,SZSE,ad,as,at,ax,ba,bc,bd,be,bh,bk,bo,br,ca,cn,co,cr,cs,db,de,du,f,he,hk,hm,ic,ir,is,jk,jo,kl,kq,ks,kw,l,ls,mc,me,mi,mt,mu,mx,ne,nl,ns,nz,ol,pa,pm,pr,qa,ro,rg,sa,sg,si,sn,sr,ss,st,sw,sz,t,ta,tl,to,tw,two,us,v,vi,vn,vs,wa,ha,sx,tg,sc,nyse,lse,tradegate,xetra,six,euronext_milan,euronext_paris,tpex,twse,krx,jpx,sse,szse)",
     "name": "AdapterError",
   },
   "status": "errored",

--- a/packages/sources/finnhub/src/transport/market-status.ts
+++ b/packages/sources/finnhub/src/transport/market-status.ts
@@ -11,6 +11,12 @@ export const marketAliases = [
   'SIX',
   'EURONEXT_MILAN',
   'EURONEXT_PARIS',
+  'TPEX', // Taipei Exchange
+  'TWSE', // Taiwan Stock Exchange
+  'KRX', // Korea Exchange
+  'JPX', // Japan Exchange Group
+  'SSE', // Shanghai Stock Exchange
+  'SZSE', // Shenzhen Stock Exchange
 ] as const
 
 export type Market = (typeof marketAliases)[number]
@@ -23,6 +29,12 @@ const marketToExchange: Record<Market, string> = {
   SIX: 'SW',
   EURONEXT_MILAN: 'MI',
   EURONEXT_PARIS: 'PA',
+  TPEX: 'TWO',
+  TWSE: 'TW',
+  KRX: 'KS',
+  JPX: 'T',
+  SSE: 'SS',
+  SZSE: 'SZ',
 }
 
 // See: https://finnhub.io/docs/api/market-status

--- a/packages/sources/finnhub/test/integration/__snapshots__/adapter-market-status.test.ts.snap
+++ b/packages/sources/finnhub/test/integration/__snapshots__/adapter-market-status.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Market status endpoint should return error for invalid market 1`] = `
 {
   "error": {
-    "message": "[Param: market] input is not one of valid options (AD,AS,AT,AX,BA,BC,BD,BE,BH,BK,BO,BR,CA,CN,CO,CR,CS,DB,DE,DU,F,HE,HK,HM,IC,IR,IS,JK,JO,KL,KQ,KS,KW,L,LS,MC,ME,MI,MT,MU,MX,NE,NL,NS,NZ,OL,PA,PM,PR,QA,RO,RG,SA,SG,SI,SN,SR,SS,ST,SW,SZ,T,TA,TL,TO,TW,TWO,US,V,VI,VN,VS,WA,HA,SX,TG,SC,NYSE,LSE,TRADEGATE,XETRA,SIX,EURONEXT_MILAN,EURONEXT_PARIS,ad,as,at,ax,ba,bc,bd,be,bh,bk,bo,br,ca,cn,co,cr,cs,db,de,du,f,he,hk,hm,ic,ir,is,jk,jo,kl,kq,ks,kw,l,ls,mc,me,mi,mt,mu,mx,ne,nl,ns,nz,ol,pa,pm,pr,qa,ro,rg,sa,sg,si,sn,sr,ss,st,sw,sz,t,ta,tl,to,tw,two,us,v,vi,vn,vs,wa,ha,sx,tg,sc,nyse,lse,tradegate,xetra,six,euronext_milan,euronext_paris)",
+    "message": "[Param: market] input is not one of valid options (AD,AS,AT,AX,BA,BC,BD,BE,BH,BK,BO,BR,CA,CN,CO,CR,CS,DB,DE,DU,F,HE,HK,HM,IC,IR,IS,JK,JO,KL,KQ,KS,KW,L,LS,MC,ME,MI,MT,MU,MX,NE,NL,NS,NZ,OL,PA,PM,PR,QA,RO,RG,SA,SG,SI,SN,SR,SS,ST,SW,SZ,T,TA,TL,TO,TW,TWO,US,V,VI,VN,VS,WA,HA,SX,TG,SC,NYSE,LSE,TRADEGATE,XETRA,SIX,EURONEXT_MILAN,EURONEXT_PARIS,TPEX,TWSE,KRX,JPX,SSE,SZSE,ad,as,at,ax,ba,bc,bd,be,bh,bk,bo,br,ca,cn,co,cr,cs,db,de,du,f,he,hk,hm,ic,ir,is,jk,jo,kl,kq,ks,kw,l,ls,mc,me,mi,mt,mu,mx,ne,nl,ns,nz,ol,pa,pm,pr,qa,ro,rg,sa,sg,si,sn,sr,ss,st,sw,sz,t,ta,tl,to,tw,two,us,v,vi,vn,vs,wa,ha,sx,tg,sc,nyse,lse,tradegate,xetra,six,euronext_milan,euronext_paris,tpex,twse,krx,jpx,sse,szse)",
     "name": "AdapterError",
   },
   "status": "errored",

--- a/packages/sources/tradinghours/src/transport/utils.ts
+++ b/packages/sources/tradinghours/src/transport/utils.ts
@@ -15,6 +15,14 @@ export const markets = [
   'six',
   'euronext_milan',
   'euronext_paris',
+  'tpex', // Taipei Exchange
+  'twse', // Taiwan Stock Exchange
+  'krx', // Korea Exchange
+  'jpx', // Japan Exchange Group
+  'sse', // Shanghai Stock Exchange
+  'szse', // Shenzhen Stock Exchange
+  'nymex',
+  'ice_europe_energy',
 ] as const
 
 const marketToFinId: Record<Market, string> = {
@@ -28,6 +36,14 @@ const marketToFinId: Record<Market, string> = {
   six: 'CH.SIX',
   euronext_milan: 'IT.EURONEXT',
   euronext_paris: 'FR.EURONEXT',
+  tpex: 'TW.TPEX',
+  twse: 'TW.TWSE',
+  krx: 'KR.KRX',
+  jpx: 'JP.JPX',
+  sse: 'CN.SSE',
+  szse: 'CN.SZSE',
+  nymex: 'US.CHNLNK.WTI',
+  ice_europe_energy: 'US.ICE.ENERGY.GROUP3',
 }
 
 const market245ToFinId: Partial<Record<Market, string>> = {

--- a/packages/sources/tradinghours/test/integration/__snapshots__/adapter-session.test.ts.snap
+++ b/packages/sources/tradinghours/test/integration/__snapshots__/adapter-session.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Market status endpoint should return failure with invalid market 1`] = `
 {
   "error": {
-    "message": "[Param: market] input is not one of valid options (forex,metals,wti,nyse,lse,xetra,tradegate,six,euronext_milan,euronext_paris,FOREX,METALS,WTI,NYSE,LSE,XETRA,TRADEGATE,SIX,EURONEXT_MILAN,EURONEXT_PARIS)",
+    "message": "[Param: market] input is not one of valid options (forex,metals,wti,nyse,lse,xetra,tradegate,six,euronext_milan,euronext_paris,tpex,twse,krx,jpx,sse,szse,nymex,ice_europe_energy,FOREX,METALS,WTI,NYSE,LSE,XETRA,TRADEGATE,SIX,EURONEXT_MILAN,EURONEXT_PARIS,TPEX,TWSE,KRX,JPX,SSE,SZSE,NYMEX,ICE_EUROPE_ENERGY)",
     "name": "AdapterError",
   },
   "status": "errored",


### PR DESCRIPTION
## Closes #OPDATA-6860

## Description

 - Add asian market status
 - Add energy to tradinghours (we are still figuring out the 2nd DP)

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
