### PR TITLE
OPDATA-5390: Gold: Change deviation cap

### DIFF
--- a/.changeset/great-apes-float.md
+++ b/.changeset/great-apes-float.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/gold-adapter': minor
+---
+
+Change default deviation cap

--- a/packages/composites/gold/src/config/index.ts
+++ b/packages/composites/gold/src/config/index.ts
@@ -38,11 +38,18 @@ export const config = new AdapterConfig({
     default: 500_000,
     sensitive: false,
   },
-  DEVIATION_CAP: {
+  DEVIATION_CAP_LOW: {
     description:
-      'Maximum deviation allowed from the closing price. Used deviation is clamped between this and minus this value.',
+      'Maximum downward deviation allowed from the closing price. Used deviation is clamped between this value and DEVIATION_CAP_HIGH.',
     type: 'number',
-    default: 0.02,
+    default: -0.05,
+    sensitive: false,
+  },
+  DEVIATION_CAP_HIGH: {
+    description:
+      'Maximum upward deviation allowed from the closing price. Used deviation is clamped between DEVIATION_CAP_LOW and this value.',
+    type: 'number',
+    default: 0.025,
     sensitive: false,
   },
   TOKENIZED_PRICE_WEIGHT: {

--- a/packages/composites/gold/src/transport/price.ts
+++ b/packages/composites/gold/src/transport/price.ts
@@ -59,7 +59,8 @@ export class PriceTransport extends SubscriptionTransport<BaseEndpointTypes> {
   requester!: Requester
   tokenizedPriceStreamsConfig!: Record<string, string>
   tokenizedPriceWeight!: bigint
-  maxDeviation!: bigint
+  maxDeviationDown!: bigint
+  maxDeviationUp!: bigint
   state!: State
   stateCache!: Cache<State>
   stateCacheKey!: string
@@ -86,8 +87,12 @@ export class PriceTransport extends SubscriptionTransport<BaseEndpointTypes> {
       new Decimal(this.config.TOKENIZED_PRICE_WEIGHT).mul(10 ** RESULT_DECIMALS).toFixed(),
     )
 
-    this.maxDeviation = BigInt(
-      new Decimal(this.config.DEVIATION_CAP).mul(10 ** RESULT_DECIMALS).toFixed(),
+    this.maxDeviationDown = BigInt(
+      new Decimal(this.config.DEVIATION_CAP_LOW).mul(10 ** RESULT_DECIMALS).toFixed(),
+    )
+
+    this.maxDeviationUp = BigInt(
+      new Decimal(this.config.DEVIATION_CAP_HIGH).mul(10 ** RESULT_DECIMALS).toFixed(),
     )
 
     this.stateCache = dependencies.cache as Cache<State>
@@ -343,10 +348,10 @@ export class PriceTransport extends SubscriptionTransport<BaseEndpointTypes> {
   }
 
   capDeviation(deviation: bigint): bigint {
-    if (deviation > this.maxDeviation) {
-      return this.maxDeviation
-    } else if (deviation < -this.maxDeviation) {
-      return -this.maxDeviation
+    if (deviation > this.maxDeviationUp) {
+      return this.maxDeviationUp
+    } else if (deviation < this.maxDeviationDown) {
+      return this.maxDeviationDown
     }
     return deviation
   }

--- a/packages/composites/gold/test/unit/price.test.ts
+++ b/packages/composites/gold/test/unit/price.test.ts
@@ -48,7 +48,8 @@ describe('PriceTransport', () => {
   const PRICE_STALE_TIMEOUT_MS = 5 * 60 * 1000 // 5 minutes
   const PREMIUM_EMA_TAU_MS = 1_000_000
   const DEVIATION_EMA_TAU_MS = 500_000
-  const DEVIATION_CAP = 0.02
+  const DEVIATION_CAP_LOW = -0.05
+  const DEVIATION_CAP_HIGH = 0.025
   const TOKENIZED_PRICE_WEIGHT = 0.7
   const CACHE_TTL_MS = 604800000
   const CACHE_PREFIX = 'cache-prefix'
@@ -62,7 +63,8 @@ describe('PriceTransport', () => {
     PRICE_STALE_TIMEOUT_MS,
     PREMIUM_EMA_TAU_MS,
     DEVIATION_EMA_TAU_MS,
-    DEVIATION_CAP,
+    DEVIATION_CAP_LOW,
+    DEVIATION_CAP_HIGH,
     TOKENIZED_PRICE_WEIGHT,
     CACHE_TTL_MS,
     CACHE_PREFIX,
@@ -916,13 +918,13 @@ describe('PriceTransport', () => {
     })
 
     it('should cap increase to 1.4%', async () => {
-      // The deviation is capped to 2% but is only applied with a weight of 70%
-      // so the maximum increase is 70% of 2% which is 1.4%.
+      // The deviation is capped to 2.5% but is only applied with a weight of 70%
+      // so the maximum increase is 70% of 2.5% which is 1.75%.
       const goldPrice = '4000000000000000000000'
       const xautPrice = '5100000000000000000000'
       const paxgPrice = '5300000000000000000000'
       const averagePrice = '5200000000000000000000'
-      const cappedExpectedResult = '4056000000000000000000' // 1.4% higher than goldPrice
+      const cappedExpectedResult = '4070000000000000000000' // 1.75% higher than goldPrice
 
       // Start out with all prices the same to have a premium factor if 1.
       mockXauPriceResponse(goldPrice, MarketStatus.OPEN)
@@ -994,14 +996,14 @@ describe('PriceTransport', () => {
       log.mockClear()
     })
 
-    it('should cap decrease to 1.4%', async () => {
-      // The deviation is capped to 2% but is only applied with a weight of 70%
-      // so the maximum decrease is 70% of 2% which is 1.4%.
+    it('should cap decrease to 3.5%', async () => {
+      // The deviation is capped to 5% but is only applied with a weight of 70%
+      // so the maximum decrease is 70% of 5% which is 3.5%.
       const goldPrice = '4000000000000000000000'
       const xautPrice = '2900000000000000000000'
       const paxgPrice = '2700000000000000000000'
       const averagePrice = '2800000000000000000000'
-      const cappedExpectedResult = '3944000000000000000000' // 1.4% lower than goldPrice
+      const cappedExpectedResult = '3860000000000000000000' // 3.5% lower than goldPrice
 
       // Start out with all prices the same to have a premium factor if 1.
       mockXauPriceResponse(goldPrice, MarketStatus.OPEN)


### PR DESCRIPTION
## [OPDATA-5390](https://smartcontract-it.atlassian.net/browse/)

## Description

New requirements state that the deviation should be capped between 5% down and 2.5% up instead of 2% in both directions.

## Changes

1. Remove config `DEVIATION_CAP` and add `DEVIATION_CAP_LOW` and `DEVIATION_CAP_HIGH`.
2. Update the logic to use the new config.
3. Update the tests.

## Steps to Test

1. `yarn test packages/composites/gold`

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[OPDATA-5390]: https://smartcontract-it.atlassian.net/browse/OPDATA-5390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ