### PR TITLE
Remove asian markets from finnhub

### DIFF
--- a/.changeset/modern-loops-hug.md
+++ b/.changeset/modern-loops-hug.md
@@ -1,0 +1,6 @@
+---
+'@chainlink/finnhub-secondary-adapter': minor
+'@chainlink/finnhub-adapter': minor
+---
+
+Remove asian markets

--- a/packages/sources/finnhub-secondary/test/integration/__snapshots__/adapter-market-status.test.ts.snap
+++ b/packages/sources/finnhub-secondary/test/integration/__snapshots__/adapter-market-status.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Market status endpoint should return error for invalid market 1`] = `
 {
   "error": {
-    "message": "[Param: market] input is not one of valid options (AD,AS,AT,AX,BA,BC,BD,BE,BH,BK,BO,BR,CA,CN,CO,CR,CS,DB,DE,DU,F,HE,HK,HM,IC,IR,IS,JK,JO,KL,KQ,KS,KW,L,LS,MC,ME,MI,MT,MU,MX,NE,NL,NS,NZ,OL,PA,PM,PR,QA,RO,RG,SA,SG,SI,SN,SR,SS,ST,SW,SZ,T,TA,TL,TO,TW,TWO,US,V,VI,VN,VS,WA,HA,SX,TG,SC,NYSE,LSE,TRADEGATE,XETRA,SIX,EURONEXT_MILAN,EURONEXT_PARIS,TPEX,TWSE,KRX,JPX,SSE,SZSE,ad,as,at,ax,ba,bc,bd,be,bh,bk,bo,br,ca,cn,co,cr,cs,db,de,du,f,he,hk,hm,ic,ir,is,jk,jo,kl,kq,ks,kw,l,ls,mc,me,mi,mt,mu,mx,ne,nl,ns,nz,ol,pa,pm,pr,qa,ro,rg,sa,sg,si,sn,sr,ss,st,sw,sz,t,ta,tl,to,tw,two,us,v,vi,vn,vs,wa,ha,sx,tg,sc,nyse,lse,tradegate,xetra,six,euronext_milan,euronext_paris,tpex,twse,krx,jpx,sse,szse)",
+    "message": "[Param: market] input is not one of valid options (AD,AS,AT,AX,BA,BC,BD,BE,BH,BK,BO,BR,CA,CN,CO,CR,CS,DB,DE,DU,F,HE,HK,HM,IC,IR,IS,JK,JO,KL,KQ,KS,KW,L,LS,MC,ME,MI,MT,MU,MX,NE,NL,NS,NZ,OL,PA,PM,PR,QA,RO,RG,SA,SG,SI,SN,SR,SS,ST,SW,SZ,T,TA,TL,TO,TW,TWO,US,V,VI,VN,VS,WA,HA,SX,TG,SC,NYSE,LSE,TRADEGATE,XETRA,SIX,EURONEXT_MILAN,EURONEXT_PARIS,ad,as,at,ax,ba,bc,bd,be,bh,bk,bo,br,ca,cn,co,cr,cs,db,de,du,f,he,hk,hm,ic,ir,is,jk,jo,kl,kq,ks,kw,l,ls,mc,me,mi,mt,mu,mx,ne,nl,ns,nz,ol,pa,pm,pr,qa,ro,rg,sa,sg,si,sn,sr,ss,st,sw,sz,t,ta,tl,to,tw,two,us,v,vi,vn,vs,wa,ha,sx,tg,sc,nyse,lse,tradegate,xetra,six,euronext_milan,euronext_paris)",
     "name": "AdapterError",
   },
   "status": "errored",

--- a/packages/sources/finnhub/src/transport/market-status.ts
+++ b/packages/sources/finnhub/src/transport/market-status.ts
@@ -11,12 +11,6 @@ export const marketAliases = [
   'SIX',
   'EURONEXT_MILAN',
   'EURONEXT_PARIS',
-  'TPEX', // Taipei Exchange
-  'TWSE', // Taiwan Stock Exchange
-  'KRX', // Korea Exchange
-  'JPX', // Japan Exchange Group
-  'SSE', // Shanghai Stock Exchange
-  'SZSE', // Shenzhen Stock Exchange
 ] as const
 
 export type Market = (typeof marketAliases)[number]
@@ -29,12 +23,6 @@ const marketToExchange: Record<Market, string> = {
   SIX: 'SW',
   EURONEXT_MILAN: 'MI',
   EURONEXT_PARIS: 'PA',
-  TPEX: 'TWO',
-  TWSE: 'TW',
-  KRX: 'KS',
-  JPX: 'T',
-  SSE: 'SS',
-  SZSE: 'SZ',
 }
 
 // See: https://finnhub.io/docs/api/market-status

--- a/packages/sources/finnhub/test/integration/__snapshots__/adapter-market-status.test.ts.snap
+++ b/packages/sources/finnhub/test/integration/__snapshots__/adapter-market-status.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Market status endpoint should return error for invalid market 1`] = `
 {
   "error": {
-    "message": "[Param: market] input is not one of valid options (AD,AS,AT,AX,BA,BC,BD,BE,BH,BK,BO,BR,CA,CN,CO,CR,CS,DB,DE,DU,F,HE,HK,HM,IC,IR,IS,JK,JO,KL,KQ,KS,KW,L,LS,MC,ME,MI,MT,MU,MX,NE,NL,NS,NZ,OL,PA,PM,PR,QA,RO,RG,SA,SG,SI,SN,SR,SS,ST,SW,SZ,T,TA,TL,TO,TW,TWO,US,V,VI,VN,VS,WA,HA,SX,TG,SC,NYSE,LSE,TRADEGATE,XETRA,SIX,EURONEXT_MILAN,EURONEXT_PARIS,TPEX,TWSE,KRX,JPX,SSE,SZSE,ad,as,at,ax,ba,bc,bd,be,bh,bk,bo,br,ca,cn,co,cr,cs,db,de,du,f,he,hk,hm,ic,ir,is,jk,jo,kl,kq,ks,kw,l,ls,mc,me,mi,mt,mu,mx,ne,nl,ns,nz,ol,pa,pm,pr,qa,ro,rg,sa,sg,si,sn,sr,ss,st,sw,sz,t,ta,tl,to,tw,two,us,v,vi,vn,vs,wa,ha,sx,tg,sc,nyse,lse,tradegate,xetra,six,euronext_milan,euronext_paris,tpex,twse,krx,jpx,sse,szse)",
+    "message": "[Param: market] input is not one of valid options (AD,AS,AT,AX,BA,BC,BD,BE,BH,BK,BO,BR,CA,CN,CO,CR,CS,DB,DE,DU,F,HE,HK,HM,IC,IR,IS,JK,JO,KL,KQ,KS,KW,L,LS,MC,ME,MI,MT,MU,MX,NE,NL,NS,NZ,OL,PA,PM,PR,QA,RO,RG,SA,SG,SI,SN,SR,SS,ST,SW,SZ,T,TA,TL,TO,TW,TWO,US,V,VI,VN,VS,WA,HA,SX,TG,SC,NYSE,LSE,TRADEGATE,XETRA,SIX,EURONEXT_MILAN,EURONEXT_PARIS,ad,as,at,ax,ba,bc,bd,be,bh,bk,bo,br,ca,cn,co,cr,cs,db,de,du,f,he,hk,hm,ic,ir,is,jk,jo,kl,kq,ks,kw,l,ls,mc,me,mi,mt,mu,mx,ne,nl,ns,nz,ol,pa,pm,pr,qa,ro,rg,sa,sg,si,sn,sr,ss,st,sw,sz,t,ta,tl,to,tw,two,us,v,vi,vn,vs,wa,ha,sx,tg,sc,nyse,lse,tradegate,xetra,six,euronext_milan,euronext_paris)",
     "name": "AdapterError",
   },
   "status": "errored",


### PR DESCRIPTION
## Closes #OPDATA-6860

## Description

Finnhub does not have accurate information on asian markets

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
