### PR TITLE
Bump framework version for scripts package to 2.13.3

### DIFF
--- a/.changeset/green-bars-stop.md
+++ b/.changeset/green-bars-stop.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/ea-scripts': patch
+---
+
+Bump framework version

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -5846,7 +5846,7 @@ const RAW_RUNTIME_STATE =
           ["@apidevtools/json-schema-ref-parser", "npm:9.1.2"],\
           ["@chainlink/ea-bootstrap", "workspace:packages/core/bootstrap"],\
           ["@chainlink/ea-factories", "workspace:packages/core/factories"],\
-          ["@chainlink/external-adapter-framework", "npm:2.11.6"],\
+          ["@chainlink/external-adapter-framework", "npm:2.13.3"],\
           ["@types/command-line-args", "npm:5.2.3"],\
           ["@types/command-line-usage", "npm:5.0.4"],\
           ["@types/jest", "npm:29.5.14"],\
@@ -6121,6 +6121,25 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/@chainlink-external-adapter-framework-npm-2.13.2-5c4174f0f6-43a1f2ee9b.zip/node_modules/@chainlink/external-adapter-framework/",\
         "packageDependencies": [\
           ["@chainlink/external-adapter-framework", "npm:2.13.2"],\
+          ["@date-fns/tz", "npm:1.4.1"],\
+          ["ajv", "npm:8.18.0"],\
+          ["axios", "npm:1.15.0"],\
+          ["eventsource", "npm:4.1.0"],\
+          ["fastify", "npm:5.8.5"],\
+          ["ioredis", "npm:5.10.1"],\
+          ["mock-socket", "npm:9.3.1"],\
+          ["pino", "npm:10.3.1"],\
+          ["pino-pretty", "npm:13.1.3"],\
+          ["prom-client", "npm:15.1.3"],\
+          ["redlock", "npm:5.0.0-beta.2"],\
+          ["ws", "virtual:d1125cad7cf4c8422f5687c530d5c77cd47d0284668bdf40ba159afe1dece93ccff4a39786c83d40b9ae95db12169db693190e9ab277c1a495c58278ba6e6890#npm:8.19.0"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:2.13.3", {\
+        "packageLocation": "./.yarn/cache/@chainlink-external-adapter-framework-npm-2.13.3-ea8ebc6748-bdd5c56e48.zip/node_modules/@chainlink/external-adapter-framework/",\
+        "packageDependencies": [\
+          ["@chainlink/external-adapter-framework", "npm:2.13.3"],\
           ["@date-fns/tz", "npm:1.4.1"],\
           ["ajv", "npm:8.18.0"],\
           ["axios", "npm:1.15.0"],\

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -6,7 +6,7 @@
     "@apidevtools/json-schema-ref-parser": "9.1.2",
     "@chainlink/ea-bootstrap": "workspace:*",
     "@chainlink/ea-factories": "workspace:*",
-    "@chainlink/external-adapter-framework": "2.11.6",
+    "@chainlink/external-adapter-framework": "2.13.3",
     "airtable": "0.11.6",
     "axios": "1.13.4",
     "axios-mock-adapter": "1.20.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3232,7 +3232,7 @@ __metadata:
     "@apidevtools/json-schema-ref-parser": "npm:9.1.2"
     "@chainlink/ea-bootstrap": "workspace:*"
     "@chainlink/ea-factories": "workspace:*"
-    "@chainlink/external-adapter-framework": "npm:2.11.6"
+    "@chainlink/external-adapter-framework": "npm:2.13.3"
     "@types/command-line-args": "npm:5.2.3"
     "@types/command-line-usage": "npm:5.0.4"
     "@types/jest": "npm:^29.5.14"
@@ -3514,6 +3514,28 @@ __metadata:
   bin:
     create-external-adapter: adapter-generator.js
   checksum: 10/43a1f2ee9b85b660c08f1ae57dbcb0b9221c70ae3d18bd213d64932deb2877673aee263abedd3183440234b0ad664c3f9cc45a7e5095db7c32ea89602f5dd372
+  languageName: node
+  linkType: hard
+
+"@chainlink/external-adapter-framework@npm:2.13.3":
+  version: 2.13.3
+  resolution: "@chainlink/external-adapter-framework@npm:2.13.3"
+  dependencies:
+    "@date-fns/tz": "npm:1.4.1"
+    ajv: "npm:8.18.0"
+    axios: "npm:1.15.0"
+    eventsource: "npm:4.1.0"
+    fastify: "npm:5.8.5"
+    ioredis: "npm:5.10.1"
+    mock-socket: "npm:9.3.1"
+    pino: "npm:10.3.1"
+    pino-pretty: "npm:13.1.3"
+    prom-client: "npm:15.1.3"
+    redlock: "npm:5.0.0-beta.2"
+    ws: "npm:8.19.0"
+  bin:
+    create-external-adapter: adapter-generator.js
+  checksum: 10/bdd5c56e48f092107ae3e4b721be3e68dcf585862a1c346ae9e6fe823bc2c4bf382107ec0d9af164e62aaf4bcaf4741020ee731d30a9723f4eff537a42c6f033
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

This will make sure new EAs generated with `yarn new` have the `noUncheckedIndexedAccess ` compiler option enabled.

This options makes sure that the compiler understand that array access can result in `undefined`.

It was implemented in https://github.com/smartcontractkit/ea-framework-js/pull/744.

## Changes

Update framework version in `packages/scripts/package.js` to 2.13.3.

## Steps to Test

1. Run `yarn new` and follow the instructions.
2. Create an adapter with name `abcd`.
3. Inspect the contents of `packages/sources/abcd/tsconfig.json`.
4. Build the generated adapter and run its tests.

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
