### PR TITLE
Add noUncheckedIndexedAccess to compiler options where possible

### DIFF
--- a/packages/core/factories/tsconfig.json
+++ b/packages/core/factories/tsconfig.json
@@ -2,9 +2,17 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
-  "references": [{ "path": "../../core/test-helpers" }, { "path": "../bootstrap" }]
+  "references": [
+    {
+      "path": "../../core/test-helpers"
+    },
+    {
+      "path": "../bootstrap"
+    }
+  ]
 }

--- a/packages/sources/aleno/tsconfig.json
+++ b/packages/sources/aleno/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/allium-state/tsconfig.json
+++ b/packages/sources/allium-state/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/anchorage/tsconfig.json
+++ b/packages/sources/anchorage/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/apex/tsconfig.json
+++ b/packages/sources/apex/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/backed-fi/tsconfig.json
+++ b/packages/sources/backed-fi/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/binance/tsconfig.json
+++ b/packages/sources/binance/tsconfig.json
@@ -2,13 +2,20 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
   "references": [
-    { "path": "../../core/test-helpers" },
-    { "path": "../../core/bootstrap" },
-    { "path": "../../core/test-helpers" }
+    {
+      "path": "../../core/test-helpers"
+    },
+    {
+      "path": "../../core/bootstrap"
+    },
+    {
+      "path": "../../core/test-helpers"
+    }
   ]
 }

--- a/packages/sources/bitgo/tsconfig.json
+++ b/packages/sources/bitgo/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/blocksize-capital-state/tsconfig.json
+++ b/packages/sources/blocksize-capital-state/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/blocksize-capital/tsconfig.json
+++ b/packages/sources/blocksize-capital/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/bob/tsconfig.json
+++ b/packages/sources/bob/tsconfig.json
@@ -2,9 +2,17 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
-  "references": [{ "path": "../../core/test-helpers" }, { "path": "../../core/bootstrap" }]
+  "references": [
+    {
+      "path": "../../core/test-helpers"
+    },
+    {
+      "path": "../../core/bootstrap"
+    }
+  ]
 }

--- a/packages/sources/cache.gold/tsconfig.json
+++ b/packages/sources/cache.gold/tsconfig.json
@@ -2,13 +2,20 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
   "references": [
-    { "path": "../../core/test-helpers" },
-    { "path": "../../core/bootstrap" },
-    { "path": "../../core/test-helpers" }
+    {
+      "path": "../../core/test-helpers"
+    },
+    {
+      "path": "../../core/bootstrap"
+    },
+    {
+      "path": "../../core/test-helpers"
+    }
   ]
 }

--- a/packages/sources/chain-reserve-wallet/tsconfig.json
+++ b/packages/sources/chain-reserve-wallet/tsconfig.json
@@ -2,13 +2,20 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
   "references": [
-    { "path": "../../core/test-helpers" },
-    { "path": "../../core/bootstrap" },
-    { "path": "../../core/test-helpers" }
+    {
+      "path": "../../core/test-helpers"
+    },
+    {
+      "path": "../../core/bootstrap"
+    },
+    {
+      "path": "../../core/test-helpers"
+    }
   ]
 }

--- a/packages/sources/coinapi/tsconfig.json
+++ b/packages/sources/coinapi/tsconfig.json
@@ -2,9 +2,17 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
-  "references": [{ "path": "../../core/test-helpers" }, { "path": "../../core/bootstrap" }]
+  "references": [
+    {
+      "path": "../../core/test-helpers"
+    },
+    {
+      "path": "../../core/bootstrap"
+    }
+  ]
 }

--- a/packages/sources/coinbase/tsconfig.json
+++ b/packages/sources/coinbase/tsconfig.json
@@ -2,9 +2,17 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
-  "references": [{ "path": "../../core/test-helpers" }, { "path": "../../core/bootstrap" }]
+  "references": [
+    {
+      "path": "../../core/test-helpers"
+    },
+    {
+      "path": "../../core/bootstrap"
+    }
+  ]
 }

--- a/packages/sources/coinlore/tsconfig.json
+++ b/packages/sources/coinlore/tsconfig.json
@@ -2,9 +2,17 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
-  "references": [{ "path": "../../core/test-helpers" }, { "path": "../../core/bootstrap" }]
+  "references": [
+    {
+      "path": "../../core/test-helpers"
+    },
+    {
+      "path": "../../core/bootstrap"
+    }
+  ]
 }

--- a/packages/sources/coinpaprika-state/tsconfig.json
+++ b/packages/sources/coinpaprika-state/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/coinranking/tsconfig.json
+++ b/packages/sources/coinranking/tsconfig.json
@@ -2,9 +2,17 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
-  "references": [{ "path": "../../core/test-helpers" }, { "path": "../../core/bootstrap" }]
+  "references": [
+    {
+      "path": "../../core/test-helpers"
+    },
+    {
+      "path": "../../core/bootstrap"
+    }
+  ]
 }

--- a/packages/sources/data-engine/tsconfig.json
+++ b/packages/sources/data-engine/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/exchange-copter/tsconfig.json
+++ b/packages/sources/exchange-copter/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/expand-network/tsconfig.json
+++ b/packages/sources/expand-network/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/finalto/tsconfig.json
+++ b/packages/sources/finalto/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/frxeth-exchange-rate/tsconfig.json
+++ b/packages/sources/frxeth-exchange-rate/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/gemini/tsconfig.json
+++ b/packages/sources/gemini/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/generic-api/tsconfig.json
+++ b/packages/sources/generic-api/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/gmci/tsconfig.json
+++ b/packages/sources/gmci/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/graphql/tsconfig.json
+++ b/packages/sources/graphql/tsconfig.json
@@ -2,13 +2,20 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
   "references": [
-    { "path": "../../core/test-helpers" },
-    { "path": "../../core/bootstrap" },
-    { "path": "../../core/test-helpers" }
+    {
+      "path": "../../core/test-helpers"
+    },
+    {
+      "path": "../../core/bootstrap"
+    },
+    {
+      "path": "../../core/test-helpers"
+    }
   ]
 }

--- a/packages/sources/hastra/tsconfig.json
+++ b/packages/sources/hastra/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/ice/tsconfig.json
+++ b/packages/sources/ice/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",
-    "exactOptionalPropertyTypes": true
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/ignition-address-list/tsconfig.json
+++ b/packages/sources/ignition-address-list/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/ion.au/tsconfig.json
+++ b/packages/sources/ion.au/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/kaiko-state/tsconfig.json
+++ b/packages/sources/kaiko-state/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/layer2-sequencer-health/tsconfig.json
+++ b/packages/sources/layer2-sequencer-health/tsconfig.json
@@ -2,13 +2,20 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
   "references": [
-    { "path": "../../core/test-helpers" },
-    { "path": "../../core/bootstrap" },
-    { "path": "../../core/test-helpers" }
+    {
+      "path": "../../core/test-helpers"
+    },
+    {
+      "path": "../../core/bootstrap"
+    },
+    {
+      "path": "../../core/test-helpers"
+    }
   ]
 }

--- a/packages/sources/lcx/tsconfig.json
+++ b/packages/sources/lcx/tsconfig.json
@@ -2,9 +2,17 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
-  "references": [{ "path": "../../core/test-helpers" }, { "path": "../../core/bootstrap" }]
+  "references": [
+    {
+      "path": "../../core/test-helpers"
+    },
+    {
+      "path": "../../core/bootstrap"
+    }
+  ]
 }

--- a/packages/sources/lido-por/tsconfig.json
+++ b/packages/sources/lido-por/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/lido/tsconfig.json
+++ b/packages/sources/lido/tsconfig.json
@@ -2,13 +2,20 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
   "references": [
-    { "path": "../../core/test-helpers" },
-    { "path": "../../core/bootstrap" },
-    { "path": "../../core/test-helpers" }
+    {
+      "path": "../../core/test-helpers"
+    },
+    {
+      "path": "../../core/bootstrap"
+    },
+    {
+      "path": "../../core/test-helpers"
+    }
   ]
 }

--- a/packages/sources/liveart/tsconfig.json
+++ b/packages/sources/liveart/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/lotus/tsconfig.json
+++ b/packages/sources/lotus/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/m0/tsconfig.json
+++ b/packages/sources/m0/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/matrixdock/tsconfig.json
+++ b/packages/sources/matrixdock/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/mobula-state/tsconfig.json
+++ b/packages/sources/mobula-state/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/mock-ea/tsconfig.json
+++ b/packages/sources/mock-ea/tsconfig.json
@@ -2,13 +2,20 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
   "references": [
-    { "path": "../../core/test-helpers" },
-    { "path": "../../core/bootstrap" },
-    { "path": "../../core/test-helpers" }
+    {
+      "path": "../../core/test-helpers"
+    },
+    {
+      "path": "../../core/bootstrap"
+    },
+    {
+      "path": "../../core/test-helpers"
+    }
   ]
 }

--- a/packages/sources/moore-hk/tsconfig.json
+++ b/packages/sources/moore-hk/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/mycryptoapi/tsconfig.json
+++ b/packages/sources/mycryptoapi/tsconfig.json
@@ -2,13 +2,20 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
   "references": [
-    { "path": "../../core/test-helpers" },
-    { "path": "../../core/bootstrap" },
-    { "path": "../../core/test-helpers" }
+    {
+      "path": "../../core/test-helpers"
+    },
+    {
+      "path": "../../core/bootstrap"
+    },
+    {
+      "path": "../../core/test-helpers"
+    }
   ]
 }

--- a/packages/sources/nav-generic/tsconfig.json
+++ b/packages/sources/nav-generic/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/nomia2/tsconfig.json
+++ b/packages/sources/nomia2/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/nyfed/tsconfig.json
+++ b/packages/sources/nyfed/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/ondo/tsconfig.json
+++ b/packages/sources/ondo/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/openexchangerates/tsconfig.json
+++ b/packages/sources/openexchangerates/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/polygon/tsconfig.json
+++ b/packages/sources/polygon/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/r25/tsconfig.json
+++ b/packages/sources/r25/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/securitize/tsconfig.json
+++ b/packages/sources/securitize/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/snowflake/tsconfig.json
+++ b/packages/sources/snowflake/tsconfig.json
@@ -2,13 +2,20 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
   "references": [
-    { "path": "../../core/test-helpers" },
-    { "path": "../../core/bootstrap" },
-    { "path": "../../core/test-helpers" }
+    {
+      "path": "../../core/test-helpers"
+    },
+    {
+      "path": "../../core/bootstrap"
+    },
+    {
+      "path": "../../core/test-helpers"
+    }
   ]
 }

--- a/packages/sources/solactive/tsconfig.json
+++ b/packages/sources/solactive/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/solana-functions/tsconfig.json
+++ b/packages/sources/solana-functions/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/solana-view-function/tsconfig.json
+++ b/packages/sources/solana-view-function/tsconfig.json
@@ -2,13 +2,20 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
   "references": [
-    { "path": "../../core/test-helpers" },
-    { "path": "../../core/bootstrap" },
-    { "path": "../../core/test-helpers" }
+    {
+      "path": "../../core/test-helpers"
+    },
+    {
+      "path": "../../core/bootstrap"
+    },
+    {
+      "path": "../../core/test-helpers"
+    }
   ]
 }

--- a/packages/sources/sportsdataio/tsconfig.json
+++ b/packages/sources/sportsdataio/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],

--- a/packages/sources/starknet-gas-price/tsconfig.json
+++ b/packages/sources/starknet-gas-price/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/streamex/tsconfig.json
+++ b/packages/sources/streamex/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/synthetix-feeds/tsconfig.json
+++ b/packages/sources/synthetix-feeds/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/therundown/tsconfig.json
+++ b/packages/sources/therundown/tsconfig.json
@@ -2,9 +2,17 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
-  "references": [{ "path": "../../core/test-helpers" }, { "path": "../../core/bootstrap" }]
+  "references": [
+    {
+      "path": "../../core/test-helpers"
+    },
+    {
+      "path": "../../core/bootstrap"
+    }
+  ]
 }

--- a/packages/sources/tradermade/tsconfig.json
+++ b/packages/sources/tradermade/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/trueusd/tsconfig.json
+++ b/packages/sources/trueusd/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/twelvedata/tsconfig.json
+++ b/packages/sources/twelvedata/tsconfig.json
@@ -2,9 +2,17 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
-  "references": [{ "path": "../../core/test-helpers" }, { "path": "../../core/bootstrap" }]
+  "references": [
+    {
+      "path": "../../core/test-helpers"
+    },
+    {
+      "path": "../../core/bootstrap"
+    }
+  ]
 }

--- a/packages/sources/upvest/tsconfig.json
+++ b/packages/sources/upvest/tsconfig.json
@@ -2,13 +2,20 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
   "references": [
-    { "path": "../../core/test-helpers" },
-    { "path": "../../core/bootstrap" },
-    { "path": "../../core/test-helpers" }
+    {
+      "path": "../../core/test-helpers"
+    },
+    {
+      "path": "../../core/bootstrap"
+    },
+    {
+      "path": "../../core/test-helpers"
+    }
   ]
 }

--- a/packages/sources/uscpi-one/tsconfig.json
+++ b/packages/sources/uscpi-one/tsconfig.json
@@ -2,13 +2,20 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"],
   "references": [
-    { "path": "../../core/test-helpers" },
-    { "path": "../../core/bootstrap" },
-    { "path": "../../core/test-helpers" }
+    {
+      "path": "../../core/test-helpers"
+    },
+    {
+      "path": "../../core/bootstrap"
+    },
+    {
+      "path": "../../core/test-helpers"
+    }
   ]
 }

--- a/packages/sources/view-function/tsconfig.json
+++ b/packages/sources/view-function/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/wintermute/tsconfig.json
+++ b/packages/sources/wintermute/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/sources/wisdomtree/tsconfig.json
+++ b/packages/sources/wisdomtree/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]

--- a/packages/targets/dydx-stark/tsconfig.json
+++ b/packages/targets/dydx-stark/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]


### PR DESCRIPTION
## Description

This PR adds `noUncheckedIndexedAccess` to the compiler options of packages where this doesn't cause compilation errors.

This options makes sure that the compiler understand that array access can result in undefined.

## Changes

1. Enable the option in all `tsconfig.json` files:
    ```
    for file in packages/*/*/tsconfig.json; do
      jq '.compilerOptions.noUncheckedIndexedAccess = true' "$file" | sponge "$file"
    done
    ```
2. Revert where it causes errors:
    ```
    for x in packages/*/*/tsconfig.json; do
      if ! yarn tsc -b $x; then
        git checkout $x
      fi
    done`
    ```

## Steps to Test

`yarn setup`

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
