### PR TITLE
New streams adapter release

### DIFF
--- a/.changeset/eager-squids-invite.md
+++ b/.changeset/eager-squids-invite.md
@@ -1,0 +1,16 @@
+---
+'@chainlink/blocksize-capital-adapter': patch
+'@chainlink/cfbenchmarks-adapter': patch
+'@chainlink/coinmetrics-adapter': patch
+'@chainlink/dxfeed-adapter': patch
+'@chainlink/elwood-adapter': patch
+'@chainlink/finage-adapter': patch
+'@chainlink/finalto-adapter': patch
+'@chainlink/finnhub-adapter': patch
+'@chainlink/gsr-adapter': patch
+'@chainlink/ncfx-adapter': patch
+'@chainlink/tiingo-adapter': patch
+'@chainlink/tiingo-state-adapter': patch
+---
+
+Streams adapter code - race conditions fix


### PR DESCRIPTION
## Closes #DS-2939
## Description
 New image for the following streams adapters: blocksize-capital, cfbenchmarks2, coinmetrics, dxfeed, elwood, finage, finalto, finnhub, gsr, ncfx, tiingo, tiingo-state
Contains this bug fix: https://github.com/smartcontractkit/external-adapters-js/pull/4890
