### PR TITLE
OPDATA-7091: Include decimals: 18 in eth-balance response

### DIFF
--- a/.changeset/slick-kids-hug.md
+++ b/.changeset/slick-kids-hug.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/eth-balance-adapter': minor
+---
+
+Include 'decimals: 18' in response

--- a/packages/sources/eth-balance/src/endpoint/balance.ts
+++ b/packages/sources/eth-balance/src/endpoint/balance.ts
@@ -38,6 +38,7 @@ export const inputParameters: InputParameters<TInputParameters> = {
 interface AddressWithBalance {
   address: string
   balance: string
+  decimals: 18
 }
 
 type Address = {
@@ -162,4 +163,5 @@ const getBalance = async (
 ): Promise<AddressWithBalance> => ({
   address,
   balance: (await provider.getBalance(address, targetBlockTag)).toString(),
+  decimals: 18,
 })

--- a/packages/sources/eth-balance/test/integration/__snapshots__/balance.test.ts.snap
+++ b/packages/sources/eth-balance/test/integration/__snapshots__/balance.test.ts.snap
@@ -7,10 +7,12 @@ exports[`execute with address.chainId should return success 1`] = `
       {
         "address": "0xEF9FFcFbeCB6213E5903529c8457b6F61141140d",
         "balance": "842796652117371",
+        "decimals": 18,
       },
       {
         "address": "0x6a1544F72A2A275715e8d5924e6D8A017F0e41ed",
         "balance": "1604497408893139674",
+        "decimals": 18,
       },
     ],
   },
@@ -20,10 +22,12 @@ exports[`execute with address.chainId should return success 1`] = `
     {
       "address": "0xEF9FFcFbeCB6213E5903529c8457b6F61141140d",
       "balance": "842796652117371",
+      "decimals": 18,
     },
     {
       "address": "0x6a1544F72A2A275715e8d5924e6D8A017F0e41ed",
       "balance": "1604497408893139674",
+      "decimals": 18,
     },
   ],
   "statusCode": 200,
@@ -37,6 +41,7 @@ exports[`execute with address.chainId should use default provider when string ch
       {
         "address": "0x6a1544F72A2A275715e8d5924e6D8A017F0e41ed",
         "balance": "1604497408893139674",
+        "decimals": 18,
       },
     ],
   },
@@ -46,6 +51,7 @@ exports[`execute with address.chainId should use default provider when string ch
     {
       "address": "0x6a1544F72A2A275715e8d5924e6D8A017F0e41ed",
       "balance": "1604497408893139674",
+      "decimals": 18,
     },
   ],
   "statusCode": 200,
@@ -59,6 +65,7 @@ exports[`execute with explicit minConfirmations should return success 1`] = `
       {
         "address": "0x6a1544F72A2A275715e8d5924e6D8A017F0e41ed",
         "balance": "15671674977708000",
+        "decimals": 18,
       },
     ],
   },
@@ -68,6 +75,7 @@ exports[`execute with explicit minConfirmations should return success 1`] = `
     {
       "address": "0x6a1544F72A2A275715e8d5924e6D8A017F0e41ed",
       "balance": "15671674977708000",
+      "decimals": 18,
     },
   ],
   "statusCode": 200,
@@ -81,10 +89,12 @@ exports[`execute with multiple addresses should return success 1`] = `
       {
         "address": "0xEF9FFcFbeCB6213E5903529c8457b6F61141140d",
         "balance": "842796652117371",
+        "decimals": 18,
       },
       {
         "address": "0x6a1544F72A2A275715e8d5924e6D8A017F0e41ed",
         "balance": "1604497408893139674",
+        "decimals": 18,
       },
     ],
   },
@@ -94,10 +104,12 @@ exports[`execute with multiple addresses should return success 1`] = `
     {
       "address": "0xEF9FFcFbeCB6213E5903529c8457b6F61141140d",
       "balance": "842796652117371",
+      "decimals": 18,
     },
     {
       "address": "0x6a1544F72A2A275715e8d5924e6D8A017F0e41ed",
       "balance": "1604497408893139674",
+      "decimals": 18,
     },
   ],
   "statusCode": 200,
@@ -111,6 +123,7 @@ exports[`execute with single address should return success 1`] = `
       {
         "address": "0xEF9FFcFbeCB6213E5903529c8457b6F61141140d",
         "balance": "842796652117371",
+        "decimals": 18,
       },
     ],
   },
@@ -120,6 +133,7 @@ exports[`execute with single address should return success 1`] = `
     {
       "address": "0xEF9FFcFbeCB6213E5903529c8457b6F61141140d",
       "balance": "842796652117371",
+      "decimals": 18,
     },
   ],
   "statusCode": 200,


### PR DESCRIPTION
## [OPDATA-7091](https://smartcontract-it.atlassian.net/browse/OPDATA-7091)

## Description

`proof-of-reserves-v2` expects `decimals` in balance responses.
And it's also just convenient for human readability.

## Changes

Add `decimals: 18` in the response.

## Steps to Test

```
yarn test packages/sources/eth-balance/test/{integration,unit}
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[OPDATA-7091]: https://smartcontract-it.atlassian.net/browse/OPDATA-7091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ