### PR TITLE
OPDATA-7103: proof-of-reserves-v2: Use decimals.js to handle decimal fractions

### DIFF
--- a/.changeset/strict-melons-make.md
+++ b/.changeset/strict-melons-make.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/proof-of-reserves-v2-adapter': patch
+---
+
+Use decimal.js to handle decimal fractions

--- a/packages/composites/proof-of-reserves-v2/src/utils/fixed-point.ts
+++ b/packages/composites/proof-of-reserves-v2/src/utils/fixed-point.ts
@@ -1,3 +1,4 @@
+import Decimal from 'decimal.js'
 import * as objectPath from 'object-path'
 
 export type FixedPoint = {
@@ -5,13 +6,20 @@ export type FixedPoint = {
   decimals: number
 }
 
-type NumberType = FixedPoint | number
+type NumberType = FixedPoint | number | Decimal
 
 const isFixedPoint = (num: NumberType): num is FixedPoint => {
   return typeof num !== 'number' && 'amount' in num && 'decimals' in num
 }
 
 export const toFixedPointWithDecimals = (num: NumberType, decimals: number): FixedPoint => {
+  if (num instanceof Decimal) {
+    return {
+      amount: BigInt(num.mul(Decimal.pow(10, decimals)).trunc().toFixed(0)),
+      decimals,
+    }
+  }
+
   if (!isFixedPoint(num)) {
     return {
       amount: BigInt(Math.trunc(num * 10 ** decimals)),
@@ -86,5 +94,5 @@ export const getFixedPointFromResult = ({
       decimals: decimals,
     }
   }
-  return toFixedPointWithDecimals(Number(amount), defaultDecimals)
+  return toFixedPointWithDecimals(new Decimal(amount), defaultDecimals)
 }

--- a/packages/composites/proof-of-reserves-v2/src/utils/fixed-point.ts
+++ b/packages/composites/proof-of-reserves-v2/src/utils/fixed-point.ts
@@ -1,6 +1,8 @@
 import Decimal from 'decimal.js'
 import * as objectPath from 'object-path'
 
+Decimal.set({ precision: 50 })
+
 export type FixedPoint = {
   amount: bigint
   decimals: number
@@ -9,7 +11,9 @@ export type FixedPoint = {
 type NumberType = FixedPoint | number | Decimal
 
 const isFixedPoint = (num: NumberType): num is FixedPoint => {
-  return typeof num !== 'number' && 'amount' in num && 'decimals' in num
+  return (
+    typeof num !== 'number' && !(num instanceof Decimal) && 'amount' in num && 'decimals' in num
+  )
 }
 
 export const toFixedPointWithDecimals = (num: NumberType, decimals: number): FixedPoint => {
@@ -22,7 +26,7 @@ export const toFixedPointWithDecimals = (num: NumberType, decimals: number): Fix
 
   if (!isFixedPoint(num)) {
     return {
-      amount: BigInt(Math.trunc(num * 10 ** decimals)),
+      amount: BigInt(new Decimal(num).mul(Decimal.pow(10, decimals)).trunc().toFixed(0)),
       decimals,
     }
   }

--- a/packages/composites/proof-of-reserves-v2/test/unit/fixed-point.test.ts
+++ b/packages/composites/proof-of-reserves-v2/test/unit/fixed-point.test.ts
@@ -1,3 +1,4 @@
+import Decimal from 'decimal.js'
 import {
   add,
   divide,
@@ -6,6 +7,11 @@ import {
   multiply,
   toFixedPointWithDecimals,
 } from '../../src/utils/fixed-point'
+
+// @ts-expect-error - Make errors involving BigInt more readable
+BigInt.prototype.toJSON = function () {
+  return this.toString()
+}
 
 describe('fixed-point', () => {
   describe('toFixedPointWithDecimals', () => {
@@ -87,6 +93,13 @@ describe('fixed-point', () => {
       expect(toFixedPointWithDecimals({ amount: 123n, decimals: 2 }, 2)).toEqual({
         amount: 123n,
         decimals: 2,
+      })
+    })
+
+    it('should work with decimal.js', () => {
+      expect(toFixedPointWithDecimals(new Decimal('76977.62420307'), 8)).toEqual({
+        amount: 7_697_762_420_307n,
+        decimals: 8,
       })
     })
   })
@@ -219,6 +232,26 @@ describe('fixed-point', () => {
       ).toEqual({
         amount: 1_230_000n,
         decimals: 6,
+      })
+    })
+
+    it('should work with precise decimal string', () => {
+      // This specific number gets a rounding error when converted with `Number`.
+      const balance = '76977.62420307'
+      expect(Math.trunc(Number(balance) * 10 ** 8)).toEqual(7697762420306)
+
+      expect(
+        getFixedPointFromResult({
+          result: {
+            balance,
+          },
+          amountPath: 'balance',
+          decimalsPath: undefined,
+          defaultDecimals: 8,
+        }),
+      ).toEqual({
+        amount: 7_697_762_420_307n,
+        decimals: 8,
       })
     })
 


### PR DESCRIPTION
## [OPDATA-7103](https://smartcontract-it.atlassian.net/browse/OPDATA-7103)

## Description

The Bitcoin JSON RPC interface returns amounts as decimals fraction strings, such as `"76977.62420307"`.
Because there are at most `21e14` satoshis, the JavaScript `number` type can represent each possible number of satoshis exactly.
So one might think it's safe to handle Bitcoin amounts with the `number` type.
Unfortunately this is not true when representing amounts as decimal fractions.
For example:
```
> 76977.62420307 * 10 ** 8
7697762420306.999
```

## Changes

When handling a response that contains a decimal fraction string, use `decimal.js`.

## Steps to Test

```
yarn test packages/composites/proof-of-reserves-v2
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[OPDATA-7103]: https://smartcontract-it.atlassian.net/browse/OPDATA-7103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ