### PR TITLE
Ondo Tokenized Equity Regular Hours Only EA

### DIFF
--- a/.changeset/stale-groups-rule.md
+++ b/.changeset/stale-groups-rule.md
@@ -2,4 +2,4 @@
 '@chainlink/tokenized-equity-adapter': patch
 ---
 
-Skip smoothing
+Allow no smoothing as well as only 1 streams

--- a/.changeset/stale-groups-rule.md
+++ b/.changeset/stale-groups-rule.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/tokenized-equity-adapter': patch
+---
+
+Skip smoothing

--- a/packages/composites/tokenized-equity/src/endpoint/common.ts
+++ b/packages/composites/tokenized-equity/src/endpoint/common.ts
@@ -47,33 +47,29 @@ export const inputDefinition = new InputParameters(
         'Ignore report if the streams report is older than current time by more than this value in seconds. If not provided, all reports will be processed regardless of age.',
     },
     sessionMarket: {
-      required: true,
       type: 'string',
       description:
         'The name of the market for session times, for example nyse. This is passed to the tradinghours adapter as the `market` parameter.',
     },
     sessionMarketType: {
-      required: true,
       type: 'string',
       description:
         'The type of the market for session times, for example 24/5. This is passed to the tradinghours adapter as the `type` parameter.',
     },
     sessionBoundaries: {
-      required: true,
       type: 'string',
       array: true,
       description:
         '(backup) A list of time where market trasition from 1 session to the next in the format of HH:MM. This is only used when the adapter is unable to fetch session times from the tradinghours EA',
     },
     sessionBoundariesTimeZone: {
-      required: true,
       type: 'string',
       description: 'ANA Time Zone Database format',
     },
     smoother: {
       type: 'string',
       description: 'Smoothing algorithm to apply to the price',
-      options: ['kalman', 'ema'],
+      options: ['kalman', 'ema', 'none'],
       default: 'kalman',
     },
     decimals: {
@@ -87,7 +83,17 @@ export const inputDefinition = new InputParameters(
 
 export type Smoother = TypeFromDefinition<typeof inputDefinition.definition>['smoother']
 
-export const validateSession = (sessionBoundaries: string[], sessionBoundariesTimeZone: string) => {
+export const validateSmoother = (
+  smoother: string,
+  sessionBoundaries: string[],
+  sessionBoundariesTimeZone?: string,
+  sessionMarket?: string,
+  sessionMarketType?: string,
+) => {
+  if (smoother === 'none') {
+    return
+  }
+
   sessionBoundaries.forEach((s) => {
     if (!s.match(/^(?:[01]\d|2[0-3]):[0-5]\d$/)) {
       throw new AdapterInputError({
@@ -97,6 +103,12 @@ export const validateSession = (sessionBoundaries: string[], sessionBoundariesTi
     }
   })
 
+  if (!sessionBoundariesTimeZone) {
+    throw new AdapterInputError({
+      statusCode: 400,
+      message: `Missing required parameter sessionBoundariesTimeZone when smoother is ${smoother}`,
+    })
+  }
   try {
     // eslint-disable-next-line new-cap
     Intl.DateTimeFormat(undefined, { timeZone: sessionBoundariesTimeZone })
@@ -106,6 +118,21 @@ export const validateSession = (sessionBoundaries: string[], sessionBoundariesTi
       message: `[Param: sessionBoundariesTimeZone] is not valid timezone: ${error}`,
     })
   }
+
+  if (!sessionMarket) {
+    throw new AdapterInputError({
+      statusCode: 400,
+      message: `Missing required parameter sessionMarket when smoother is ${smoother}`,
+    })
+  }
+
+  if (!sessionMarketType) {
+    throw new AdapterInputError({
+      statusCode: 400,
+      message: `Missing required parameter sessionMarketType when smoother is ${smoother}`,
+    })
+  }
+
   return
 }
 
@@ -122,7 +149,7 @@ export type output = {
     price: string
     x: string
     p: string
-    secondsFromTransition: number
+    secondsFromTransition?: number
   }
-  sessionSource: 'TRADINGHOURS' | 'FALLBACK'
+  sessionSource?: 'TRADINGHOURS' | 'FALLBACK'
 }

--- a/packages/composites/tokenized-equity/src/endpoint/common.ts
+++ b/packages/composites/tokenized-equity/src/endpoint/common.ts
@@ -80,11 +80,15 @@ export const inputDefinition = new InputParameters(
 
 export type Smoother = TypeFromDefinition<typeof inputDefinition.definition>['smoother']
 
-export const validateStreamIds = (
-  regularStreamId?: string,
-  extendedStreamId?: string,
-  overnightStreamId?: string,
-) => {
+export const validateStreamIds = ({
+  regularStreamId,
+  extendedStreamId,
+  overnightStreamId,
+}: {
+  regularStreamId?: string
+  extendedStreamId?: string
+  overnightStreamId?: string
+}) => {
   if (!regularStreamId && !extendedStreamId && !overnightStreamId) {
     throw new AdapterInputError({
       statusCode: 400,
@@ -93,14 +97,31 @@ export const validateStreamIds = (
   }
 }
 
-export const validateSmoother = (
-  smoother: string,
-  sessionBoundaries: string[],
-  sessionBoundariesTimeZone?: string,
-  sessionMarket?: string,
-  sessionMarketType?: string,
-) => {
+export const validateSmoother = ({
+  smoother,
+  sessionBoundaries,
+  sessionBoundariesTimeZone,
+  sessionMarket,
+  sessionMarketType,
+}: {
+  smoother: string
+  sessionBoundaries: string[]
+  sessionBoundariesTimeZone?: string
+  sessionMarket?: string
+  sessionMarketType?: string
+}) => {
   if (smoother === 'none') {
+    if (
+      sessionBoundaries.length > 0 ||
+      sessionBoundariesTimeZone ||
+      sessionMarket ||
+      sessionMarketType
+    ) {
+      throw new AdapterInputError({
+        statusCode: 400,
+        message: `Parameters sessionBoundaries, sessionBoundariesTimeZone, sessionMarket, and sessionMarketType should not be provided when smoother is 'none'`,
+      })
+    }
     return
   }
 

--- a/packages/composites/tokenized-equity/src/endpoint/common.ts
+++ b/packages/composites/tokenized-equity/src/endpoint/common.ts
@@ -26,17 +26,14 @@ export const inputDefinition = new InputParameters(
         'Unique identifier of the underlying asset. Used to maintain smoother internal state.',
     },
     regularStreamId: {
-      required: true,
       type: 'string',
       description: 'Data Streams regular hour feed ID for the underlying asset',
     },
     extendedStreamId: {
-      required: true,
       type: 'string',
       description: 'Data Streams extended hour feed ID for the underlying asset',
     },
     overnightStreamId: {
-      required: true,
       type: 'string',
       description: 'Data Streams overnight hour feed ID for the underlying asset',
     },
@@ -82,6 +79,19 @@ export const inputDefinition = new InputParameters(
 )
 
 export type Smoother = TypeFromDefinition<typeof inputDefinition.definition>['smoother']
+
+export const validateStreamIds = (
+  regularStreamId?: string,
+  extendedStreamId?: string,
+  overnightStreamId?: string,
+) => {
+  if (!regularStreamId && !extendedStreamId && !overnightStreamId) {
+    throw new AdapterInputError({
+      statusCode: 400,
+      message: `At least one of regularStreamId, extendedStreamId or overnightStreamId must be provided`,
+    })
+  }
+}
 
 export const validateSmoother = (
   smoother: string,

--- a/packages/composites/tokenized-equity/src/endpoint/ondo.ts
+++ b/packages/composites/tokenized-equity/src/endpoint/ondo.ts
@@ -4,7 +4,7 @@ import { AdapterInputError } from '@chainlink/external-adapter-framework/validat
 import { config } from '../config'
 import { ondoTransport } from '../transport/ondoTransport'
 import type { output } from './common'
-import { inputDefinition, inputExample, validateSession } from './common'
+import { inputDefinition, inputExample, validateSmoother } from './common'
 
 export const inputParameters = new InputParameters(
   {
@@ -50,9 +50,12 @@ export const endpoint = new AdapterEndpoint({
       })
     }
 
-    validateSession(
+    validateSmoother(
+      req.requestContext.data.smoother,
       req.requestContext.data.sessionBoundaries,
       req.requestContext.data.sessionBoundariesTimeZone,
+      req.requestContext.data.sessionMarket,
+      req.requestContext.data.sessionMarketType,
     )
 
     return

--- a/packages/composites/tokenized-equity/src/endpoint/ondo.ts
+++ b/packages/composites/tokenized-equity/src/endpoint/ondo.ts
@@ -50,19 +50,8 @@ export const endpoint = new AdapterEndpoint({
       })
     }
 
-    validateStreamIds(
-      req.requestContext.data.regularStreamId,
-      req.requestContext.data.extendedStreamId,
-      req.requestContext.data.overnightStreamId,
-    )
-
-    validateSmoother(
-      req.requestContext.data.smoother,
-      req.requestContext.data.sessionBoundaries,
-      req.requestContext.data.sessionBoundariesTimeZone,
-      req.requestContext.data.sessionMarket,
-      req.requestContext.data.sessionMarketType,
-    )
+    validateStreamIds(req.requestContext.data)
+    validateSmoother(req.requestContext.data)
 
     return
   },

--- a/packages/composites/tokenized-equity/src/endpoint/ondo.ts
+++ b/packages/composites/tokenized-equity/src/endpoint/ondo.ts
@@ -4,7 +4,7 @@ import { AdapterInputError } from '@chainlink/external-adapter-framework/validat
 import { config } from '../config'
 import { ondoTransport } from '../transport/ondoTransport'
 import type { output } from './common'
-import { inputDefinition, inputExample, validateSmoother } from './common'
+import { inputDefinition, inputExample, validateSmoother, validateStreamIds } from './common'
 
 export const inputParameters = new InputParameters(
   {
@@ -49,6 +49,12 @@ export const endpoint = new AdapterEndpoint({
         statusCode: 400,
       })
     }
+
+    validateStreamIds(
+      req.requestContext.data.regularStreamId,
+      req.requestContext.data.extendedStreamId,
+      req.requestContext.data.overnightStreamId,
+    )
 
     validateSmoother(
       req.requestContext.data.smoother,

--- a/packages/composites/tokenized-equity/src/endpoint/price.ts
+++ b/packages/composites/tokenized-equity/src/endpoint/price.ts
@@ -22,19 +22,8 @@ export const endpoint = new AdapterEndpoint({
   transport,
   inputParameters,
   customInputValidation: (req): AdapterInputError | undefined => {
-    validateStreamIds(
-      req.requestContext.data.regularStreamId,
-      req.requestContext.data.extendedStreamId,
-      req.requestContext.data.overnightStreamId,
-    )
-
-    validateSmoother(
-      req.requestContext.data.smoother,
-      req.requestContext.data.sessionBoundaries,
-      req.requestContext.data.sessionBoundariesTimeZone,
-      req.requestContext.data.sessionMarket,
-      req.requestContext.data.sessionMarketType,
-    )
+    validateStreamIds(req.requestContext.data)
+    validateSmoother(req.requestContext.data)
 
     return
   },

--- a/packages/composites/tokenized-equity/src/endpoint/price.ts
+++ b/packages/composites/tokenized-equity/src/endpoint/price.ts
@@ -3,7 +3,7 @@ import { AdapterInputError } from '@chainlink/external-adapter-framework/validat
 import { config } from '../config'
 import { transport } from '../transport/priceTransport'
 import type { output } from './common'
-import { inputDefinition, validateSmoother } from './common'
+import { inputDefinition, validateSmoother, validateStreamIds } from './common'
 
 export const inputParameters = inputDefinition
 
@@ -21,7 +21,13 @@ export const endpoint = new AdapterEndpoint({
   aliases: [],
   transport,
   inputParameters,
-  customInputValidation: (req, _): AdapterInputError | undefined => {
+  customInputValidation: (req): AdapterInputError | undefined => {
+    validateStreamIds(
+      req.requestContext.data.regularStreamId,
+      req.requestContext.data.extendedStreamId,
+      req.requestContext.data.overnightStreamId,
+    )
+
     validateSmoother(
       req.requestContext.data.smoother,
       req.requestContext.data.sessionBoundaries,

--- a/packages/composites/tokenized-equity/src/endpoint/price.ts
+++ b/packages/composites/tokenized-equity/src/endpoint/price.ts
@@ -3,7 +3,7 @@ import { AdapterInputError } from '@chainlink/external-adapter-framework/validat
 import { config } from '../config'
 import { transport } from '../transport/priceTransport'
 import type { output } from './common'
-import { inputDefinition, validateSession } from './common'
+import { inputDefinition, validateSmoother } from './common'
 
 export const inputParameters = inputDefinition
 
@@ -22,9 +22,12 @@ export const endpoint = new AdapterEndpoint({
   transport,
   inputParameters,
   customInputValidation: (req, _): AdapterInputError | undefined => {
-    validateSession(
+    validateSmoother(
+      req.requestContext.data.smoother,
       req.requestContext.data.sessionBoundaries,
       req.requestContext.data.sessionBoundariesTimeZone,
+      req.requestContext.data.sessionMarket,
+      req.requestContext.data.sessionMarketType,
     )
 
     return

--- a/packages/composites/tokenized-equity/src/lib/session/session.ts
+++ b/packages/composites/tokenized-equity/src/lib/session/session.ts
@@ -11,10 +11,14 @@ export const calculateSecondsFromTransition = async (
   tradingHoursUrl: string,
   requester: Requester,
   sessionBoundaries: string[],
-  sessionBoundariesTimeZone: string,
-  sessionMarket: string,
-  sessionMarketType: string,
+  sessionBoundariesTimeZone?: string,
+  sessionMarket?: string,
+  sessionMarketType?: string,
 ) => {
+  if (!sessionBoundariesTimeZone || !sessionMarket || !sessionMarketType) {
+    return
+  }
+
   const now = new TZDate(new Date().getTime(), sessionBoundariesTimeZone)
 
   let sessions: number[]

--- a/packages/composites/tokenized-equity/src/lib/streams.ts
+++ b/packages/composites/tokenized-equity/src/lib/streams.ts
@@ -10,19 +10,23 @@ type DataEngineResponse = BaseEndpointTypes['Response']['Data']
 export const getPrice = async (
   url: string,
   requester: Requester,
-  regularStreamId: string,
-  extendedStreamId: string,
-  overnightStreamId: string,
+  regularStreamId?: string,
+  extendedStreamId?: string,
+  overnightStreamId?: string,
   overnightStreamMaxAgeInSeconds?: number,
 ) => {
   const [regular, extended, overnight] = await Promise.allSettled(
     [regularStreamId, extendedStreamId, overnightStreamId].map((streamId) =>
-      getDeutscheBoersePrice(
-        streamId,
-        url,
-        requester,
-        streamId === overnightStreamId ? { maxAgeInSeconds: overnightStreamMaxAgeInSeconds } : {},
-      ),
+      streamId
+        ? getDeutscheBoersePrice(
+            streamId,
+            url,
+            requester,
+            streamId === overnightStreamId
+              ? { maxAgeInSeconds: overnightStreamMaxAgeInSeconds }
+              : {},
+          )
+        : Promise.reject(new Error('streamId not provided')),
     ),
   )
 

--- a/packages/composites/tokenized-equity/src/transport/ondoPrice.ts
+++ b/packages/composites/tokenized-equity/src/transport/ondoPrice.ts
@@ -20,10 +20,10 @@ export const calculatePrice = async (param: {
   url: string
   tradingHoursUrl: string
   requester: Requester
-  sessionMarket: string
-  sessionMarketType: string
+  sessionMarket?: string
+  sessionMarketType?: string
   sessionBoundaries: string[]
-  sessionBoundariesTimeZone: string
+  sessionBoundariesTimeZone?: string
   smoother: Smoother
   decimals: number
 }) => {

--- a/packages/composites/tokenized-equity/src/transport/ondoPrice.ts
+++ b/packages/composites/tokenized-equity/src/transport/ondoPrice.ts
@@ -13,9 +13,9 @@ export const calculatePrice = async (param: {
   asset: string
   registry: string
   provider: JsonRpcProvider
-  regularStreamId: string
-  extendedStreamId: string
-  overnightStreamId: string
+  regularStreamId?: string
+  extendedStreamId?: string
+  overnightStreamId?: string
   overnightStreamMaxAgeInSeconds?: number
   url: string
   tradingHoursUrl: string

--- a/packages/composites/tokenized-equity/src/transport/ondoTransport.ts
+++ b/packages/composites/tokenized-equity/src/transport/ondoTransport.ts
@@ -41,7 +41,7 @@ export class OndoTransport extends SubscriptionTransport<BaseEndpointTypes> {
   }
 
   async handleRequest(param: RequestParams) {
-    let responses: Record<Smoother, AdapterResponse<BaseEndpointTypes['Response']>>
+    let responses: Partial<Record<Smoother, AdapterResponse<BaseEndpointTypes['Response']>>>
     try {
       responses = await this._handleRequest(param)
     } catch (e) {

--- a/packages/composites/tokenized-equity/src/transport/ondoTransport.ts
+++ b/packages/composites/tokenized-equity/src/transport/ondoTransport.ts
@@ -57,10 +57,13 @@ export class OndoTransport extends SubscriptionTransport<BaseEndpointTypes> {
           providerIndicatedTimeUnixMs: undefined,
         },
       }
-      responses = {
-        ema: errorResponse,
-        kalman: errorResponse,
-      }
+      responses =
+        param.smoother === 'none'
+          ? { none: errorResponse }
+          : {
+              ema: errorResponse,
+              kalman: errorResponse,
+            }
     }
 
     await this.responseCache.write(

--- a/packages/composites/tokenized-equity/src/transport/priceTransport.ts
+++ b/packages/composites/tokenized-equity/src/transport/priceTransport.ts
@@ -51,10 +51,13 @@ export class PriceTransport extends SubscriptionTransport<BaseEndpointTypes> {
           providerIndicatedTimeUnixMs: undefined,
         },
       }
-      responses = {
-        ema: errorResponse,
-        kalman: errorResponse,
-      }
+      responses =
+        param.smoother === 'none'
+          ? { none: errorResponse }
+          : {
+              ema: errorResponse,
+              kalman: errorResponse,
+            }
     }
 
     await this.responseCache.write(

--- a/packages/composites/tokenized-equity/src/transport/priceTransport.ts
+++ b/packages/composites/tokenized-equity/src/transport/priceTransport.ts
@@ -35,7 +35,7 @@ export class PriceTransport extends SubscriptionTransport<BaseEndpointTypes> {
   }
 
   async handleRequest(param: RequestParams) {
-    let responses: Record<Smoother, AdapterResponse<BaseEndpointTypes['Response']>>
+    let responses: Partial<Record<Smoother, AdapterResponse<BaseEndpointTypes['Response']>>>
     try {
       responses = await this._handleRequest(param)
     } catch (e) {

--- a/packages/composites/tokenized-equity/src/transport/smoothedPrice.ts
+++ b/packages/composites/tokenized-equity/src/transport/smoothedPrice.ts
@@ -6,9 +6,9 @@ import { getPrice } from '../lib/streams'
 
 export const smoothedStreamPrice = async (param: {
   asset: string
-  regularStreamId: string
-  extendedStreamId: string
-  overnightStreamId: string
+  regularStreamId?: string
+  extendedStreamId?: string
+  overnightStreamId?: string
   overnightStreamMaxAgeInSeconds?: number
   url: string
   tradingHoursUrl: string

--- a/packages/composites/tokenized-equity/src/transport/smoothedPrice.ts
+++ b/packages/composites/tokenized-equity/src/transport/smoothedPrice.ts
@@ -13,10 +13,10 @@ export const smoothedStreamPrice = async (param: {
   url: string
   tradingHoursUrl: string
   requester: Requester
-  sessionMarket: string
-  sessionMarketType: string
+  sessionMarket?: string
+  sessionMarketType?: string
   sessionBoundaries: string[]
-  sessionBoundariesTimeZone: string
+  sessionBoundariesTimeZone?: string
   smoother: Smoother
   decimals: number
 }) => {
@@ -45,41 +45,36 @@ export const smoothedStreamPrice = async (param: {
     stream: price.data,
   }
 
-  return ['ema', 'kalman'].map((smoother) => {
-    const smoothed = smooth(smoother as Smoother, param, price, secondsFromTransition.value)
+  const smoothers = secondsFromTransition ? ['ema', 'kalman'] : ['none']
+
+  return smoothers.map((smoother) => {
+    const smoothed = secondsFromTransition
+      ? processUpdate(
+          smoother as Smoother,
+          param.asset,
+          BigInt(price.price),
+          price.spread,
+          secondsFromTransition.value,
+        )
+      : {
+          price: BigInt(price.price),
+          x: 0n,
+          p: 0n,
+        }
+
+    const result = (smoothed.price * 10n ** BigInt(param.decimals)) / 10n ** BigInt(price.decimals)
+
     return {
-      result: smoothed.result,
+      result,
       ...common,
-      smoother: smoothed.smoother,
-      sessionSource: secondsFromTransition.source,
+      smoother: {
+        smoother,
+        price: smoothed.price.toString(),
+        x: smoothed.x.toString(),
+        p: smoothed.p.toString(),
+        secondsFromTransition: secondsFromTransition?.value,
+      },
+      sessionSource: secondsFromTransition?.source,
     }
   })
-}
-
-const smooth = (
-  smoother: Smoother,
-  param: { asset: string; decimals: number },
-  price: { price: string; spread: bigint; decimals: number },
-  secondsFromTransition: number,
-) => {
-  const smoothed = processUpdate(
-    smoother,
-    param.asset,
-    BigInt(price.price),
-    price.spread,
-    secondsFromTransition,
-  )
-
-  const result = (smoothed.price * 10n ** BigInt(param.decimals)) / 10n ** BigInt(price.decimals)
-
-  return {
-    result: result,
-    smoother: {
-      smoother,
-      price: smoothed.price.toString(),
-      x: smoothed.x.toString(),
-      p: smoothed.p.toString(),
-      secondsFromTransition,
-    },
-  }
 }

--- a/packages/composites/tokenized-equity/test/integration/__snapshots__/adapter-ondo.test.ts.snap
+++ b/packages/composites/tokenized-equity/test/integration/__snapshots__/adapter-ondo.test.ts.snap
@@ -22,6 +22,17 @@ exports[`execute price endpoint bad sessionBoundariesTimeZone 1`] = `
 }
 `;
 
+exports[`execute price endpoint missing sessionMarket 1`] = `
+{
+  "error": {
+    "message": "Missing required parameter sessionMarket when smoother is ema",
+    "name": "AdapterError",
+  },
+  "status": "errored",
+  "statusCode": 400,
+}
+`;
+
 exports[`execute price endpoint should return success - ema 1`] = `
 {
   "data": {

--- a/packages/composites/tokenized-equity/test/integration/__snapshots__/adapter-price.test.ts.snap
+++ b/packages/composites/tokenized-equity/test/integration/__snapshots__/adapter-price.test.ts.snap
@@ -22,6 +22,17 @@ exports[`execute price endpoint bad sessionBoundariesTimeZone 1`] = `
 }
 `;
 
+exports[`execute price endpoint error when no smoother with session parameters 1`] = `
+{
+  "error": {
+    "message": "Parameters sessionBoundaries, sessionBoundariesTimeZone, sessionMarket, and sessionMarketType should not be provided when smoother is 'none'",
+    "name": "AdapterError",
+  },
+  "status": "errored",
+  "statusCode": 400,
+}
+`;
+
 exports[`execute price endpoint missing sessionMarketType 1`] = `
 {
   "error": {

--- a/packages/composites/tokenized-equity/test/integration/__snapshots__/adapter-price.test.ts.snap
+++ b/packages/composites/tokenized-equity/test/integration/__snapshots__/adapter-price.test.ts.snap
@@ -33,6 +33,17 @@ exports[`execute price endpoint missing sessionMarketType 1`] = `
 }
 `;
 
+exports[`execute price endpoint missing stream ids 1`] = `
+{
+  "error": {
+    "message": "At least one of regularStreamId, extendedStreamId or overnightStreamId must be provided",
+    "name": "AdapterError",
+  },
+  "status": "errored",
+  "statusCode": 400,
+}
+`;
+
 exports[`execute price endpoint should return success - ema 1`] = `
 {
   "data": {
@@ -130,6 +141,41 @@ exports[`execute price endpoint should return success - kalman 1`] = `
         "mid": "1",
       },
       "regular": {
+        "ask": "5",
+        "askVolume": 6,
+        "bid": "3",
+        "bidVolume": 4,
+        "decimals": 1,
+        "lastSeenTimestampNs": "2",
+        "lastTradedPrice": "7",
+        "marketStatus": 1,
+        "mid": "1",
+      },
+    },
+  },
+  "result": "10000000",
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 978347471111,
+    "providerDataRequestedUnixMs": 978347471111,
+  },
+}
+`;
+
+exports[`execute price endpoint should return success - no smoother - extended stream only 1`] = `
+{
+  "data": {
+    "decimals": 8,
+    "rawPrice": "1",
+    "result": "10000000",
+    "smoother": {
+      "p": "0",
+      "price": "1",
+      "smoother": "none",
+      "x": "0",
+    },
+    "stream": {
+      "extended": {
         "ask": "5",
         "askVolume": 6,
         "bid": "3",

--- a/packages/composites/tokenized-equity/test/integration/__snapshots__/adapter-price.test.ts.snap
+++ b/packages/composites/tokenized-equity/test/integration/__snapshots__/adapter-price.test.ts.snap
@@ -22,6 +22,17 @@ exports[`execute price endpoint bad sessionBoundariesTimeZone 1`] = `
 }
 `;
 
+exports[`execute price endpoint missing sessionMarketType 1`] = `
+{
+  "error": {
+    "message": "Missing required parameter sessionMarketType when smoother is ema",
+    "name": "AdapterError",
+  },
+  "status": "errored",
+  "statusCode": 400,
+}
+`;
+
 exports[`execute price endpoint should return success - ema 1`] = `
 {
   "data": {
@@ -94,6 +105,63 @@ exports[`execute price endpoint should return success - kalman 1`] = `
       "secondsFromTransition": 9007199254740991,
       "smoother": "kalman",
       "x": "-1",
+    },
+    "stream": {
+      "extended": {
+        "ask": "5",
+        "askVolume": 6,
+        "bid": "3",
+        "bidVolume": 4,
+        "decimals": 1,
+        "lastSeenTimestampNs": "2",
+        "lastTradedPrice": "7",
+        "marketStatus": 1,
+        "mid": "1",
+      },
+      "overnight": {
+        "ask": "5",
+        "askVolume": 6,
+        "bid": "3",
+        "bidVolume": 4,
+        "decimals": 1,
+        "lastSeenTimestampNs": "2",
+        "lastTradedPrice": "7",
+        "marketStatus": 1,
+        "mid": "1",
+      },
+      "regular": {
+        "ask": "5",
+        "askVolume": 6,
+        "bid": "3",
+        "bidVolume": 4,
+        "decimals": 1,
+        "lastSeenTimestampNs": "2",
+        "lastTradedPrice": "7",
+        "marketStatus": 1,
+        "mid": "1",
+      },
+    },
+  },
+  "result": "10000000",
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 978347471111,
+    "providerDataRequestedUnixMs": 978347471111,
+  },
+}
+`;
+
+exports[`execute price endpoint should return success - no smoother 1`] = `
+{
+  "data": {
+    "decimals": 8,
+    "rawPrice": "1",
+    "result": "10000000",
+    "smoother": {
+      "p": "0",
+      "price": "1",
+      "smoother": "none",
+      "x": "0",
     },
     "stream": {
       "extended": {

--- a/packages/composites/tokenized-equity/test/integration/adapter-ondo.test.ts
+++ b/packages/composites/tokenized-equity/test/integration/adapter-ondo.test.ts
@@ -105,6 +105,27 @@ describe('execute', () => {
       expect(response.json()).toMatchSnapshot()
     })
 
+    it('missing sessionMarket', async () => {
+      const data = {
+        endpoint: 'ondo',
+        registry: validContract,
+        asset: '0x0',
+        regularStreamId: '0x000b5',
+        extendedStreamId: '0x000b6',
+        overnightStreamId: '0x000b7',
+        sessionMarketType: '24/5',
+        sessionBoundaries: [],
+        sessionBoundariesTimeZone: 'UTC',
+        smoother: 'ema',
+        decimals: 8,
+      }
+
+      const response = await testAdapter.request(data)
+
+      expect(response.statusCode).toBe(400)
+      expect(response.json()).toMatchSnapshot()
+    })
+
     it('bad sessionBoundariesTimeZone', async () => {
       const data = {
         endpoint: 'ondo',

--- a/packages/composites/tokenized-equity/test/integration/adapter-price.test.ts
+++ b/packages/composites/tokenized-equity/test/integration/adapter-price.test.ts
@@ -34,6 +34,23 @@ describe('execute', () => {
   })
 
   describe('price endpoint', () => {
+    it('should return success - no smoother', async () => {
+      const data = {
+        asset: '0x0',
+        regularStreamId: '0x000b5',
+        extendedStreamId: '0x000b6',
+        overnightStreamId: '0x000b7',
+        smoother: 'none',
+        decimals: 8,
+      }
+      mockResponseSuccess()
+
+      const response = await testAdapter.request(data)
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toMatchSnapshot()
+    })
+
     it('should return success - kalman', async () => {
       const data = {
         asset: '0x0',
@@ -74,6 +91,25 @@ describe('execute', () => {
       const response = await testAdapter.request(data)
 
       expect(response.statusCode).toBe(200)
+      expect(response.json()).toMatchSnapshot()
+    })
+
+    it('missing sessionMarketType', async () => {
+      const data = {
+        asset: '0x0',
+        regularStreamId: '0x000b5',
+        extendedStreamId: '0x000b6',
+        overnightStreamId: '0x000b7',
+        sessionMarket: 'nyse',
+        sessionBoundaries: [],
+        sessionBoundariesTimeZone: 'UTC',
+        smoother: 'ema',
+        decimals: 8,
+      }
+
+      const response = await testAdapter.request(data)
+
+      expect(response.statusCode).toBe(400)
       expect(response.json()).toMatchSnapshot()
     })
 

--- a/packages/composites/tokenized-equity/test/integration/adapter-price.test.ts
+++ b/packages/composites/tokenized-equity/test/integration/adapter-price.test.ts
@@ -51,6 +51,21 @@ describe('execute', () => {
       expect(response.json()).toMatchSnapshot()
     })
 
+    it('should return success - no smoother - extended stream only', async () => {
+      const data = {
+        asset: '0x0',
+        extendedStreamId: '0x000b6',
+        smoother: 'none',
+        decimals: 8,
+      }
+      mockResponseSuccess()
+
+      const response = await testAdapter.request(data)
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toMatchSnapshot()
+    })
+
     it('should return success - kalman', async () => {
       const data = {
         asset: '0x0',
@@ -91,6 +106,23 @@ describe('execute', () => {
       const response = await testAdapter.request(data)
 
       expect(response.statusCode).toBe(200)
+      expect(response.json()).toMatchSnapshot()
+    })
+
+    it('missing stream ids', async () => {
+      const data = {
+        asset: '0x0',
+        sessionMarket: 'nyse',
+        sessionMarketType: '24/5',
+        sessionBoundaries: [],
+        sessionBoundariesTimeZone: 'UTC',
+        smoother: 'ema',
+        decimals: 8,
+      }
+
+      const response = await testAdapter.request(data)
+
+      expect(response.statusCode).toBe(400)
       expect(response.json()).toMatchSnapshot()
     })
 

--- a/packages/composites/tokenized-equity/test/integration/adapter-price.test.ts
+++ b/packages/composites/tokenized-equity/test/integration/adapter-price.test.ts
@@ -145,6 +145,22 @@ describe('execute', () => {
       expect(response.json()).toMatchSnapshot()
     })
 
+    it('error when no smoother with session parameters', async () => {
+      const data = {
+        asset: '0x0',
+        extendedStreamId: '0x000b6',
+        sessionMarket: 'nyse',
+        smoother: 'none',
+        decimals: 8,
+      }
+      mockResponseSuccess()
+
+      const response = await testAdapter.request(data)
+
+      expect(response.statusCode).toBe(400)
+      expect(response.json()).toMatchSnapshot()
+    })
+
     it('bad sessionBoundariesTimeZone', async () => {
       const data = {
         asset: '0x0',

--- a/packages/composites/tokenized-equity/test/unit/lib/session.test.ts
+++ b/packages/composites/tokenized-equity/test/unit/lib/session.test.ts
@@ -401,4 +401,16 @@ describe('calculateSecondsFromTransition', () => {
       }
     })
   })
+
+  describe('Missing sesson', () => {
+    it('returns null', async () => {
+      const result = await calculateSecondsFromTransition(
+        'https://tradinghours.example.com',
+        {} as Requester,
+        [],
+      )
+
+      expect(result).toBeUndefined()
+    })
+  })
 })

--- a/packages/composites/tokenized-equity/test/unit/lib/streams.test.ts
+++ b/packages/composites/tokenized-equity/test/unit/lib/streams.test.ts
@@ -87,6 +87,23 @@ describe('getPrice', () => {
     })
   })
 
+  it('regular stream only', async () => {
+    const regularData = createStreamData('100.5', TwentyfourFiveMarketStatus.REGULAR, 2)
+
+    setupMock(regularData, null, null)
+
+    const result = await getPrice('', requester, regularStreamId)
+
+    expect(result).toEqual({
+      price: regularData.mid,
+      spread: 1n,
+      decimals: regularData.decimals,
+      data: {
+        regular: regularData,
+      },
+    })
+  })
+
   it('PRE_MARKET', async () => {
     const regularData = createStreamData('100.5', TwentyfourFiveMarketStatus.UNKNOWN, 2)
     const extendedData = createStreamData('99.5', TwentyfourFiveMarketStatus.PRE_MARKET, 3)
@@ -267,7 +284,7 @@ describe('getPrice', () => {
     expect(error.message).toContain('Market is not open')
   })
 
-  it('error', async () => {
+  it('error - market not open', async () => {
     const regularData = createStreamData('100.5', TwentyfourFiveMarketStatus.UNKNOWN, 2)
     const extendedData = createStreamData('99.5', TwentyfourFiveMarketStatus.WEEKEND, 3)
     const overnightData = createStreamData('98.5', TwentyfourFiveMarketStatus.UNKNOWN, 4)
@@ -284,5 +301,16 @@ describe('getPrice', () => {
 
     expect(error).toBeInstanceOf(AdapterError)
     expect(error.message).toContain('Market is not open')
+  })
+
+  it('error - missing stream', async () => {
+    setupMock(null, null, null)
+
+    const error = await getPrice('', requester).catch((e) => e)
+
+    expect(error).toBeInstanceOf(AdapterError)
+    expect(error.message).toBe(
+      'Market is not open: regular  Error: streamId not provided, extended  Error: streamId not provided, overnight  Error: streamId not provided',
+    )
   })
 })

--- a/packages/composites/tokenized-equity/test/unit/transport/smoothedPrice.test.ts
+++ b/packages/composites/tokenized-equity/test/unit/transport/smoothedPrice.test.ts
@@ -182,5 +182,83 @@ describe('smoothedStreamPrice', () => {
       expect(result[0].result.toString()).toEqual('10')
       expect(result[0].decimals).toEqual(7)
     })
+
+    it('no smoother', async () => {
+      const streams = {
+        regular: {
+          mid: '1',
+          lastSeenTimestampNs: '2',
+          bid: '0.99',
+          bidVolume: 100,
+          ask: '1.01',
+          askVolume: 100,
+          lastTradedPrice: '1.00',
+          marketStatus: 1,
+          decimals: 18,
+        },
+        extended: {
+          mid: '10',
+          lastSeenTimestampNs: '20',
+          bid: '9.9',
+          bidVolume: 1000,
+          ask: '10.1',
+          askVolume: 1000,
+          lastTradedPrice: '10.0',
+          marketStatus: 2,
+          decimals: 18,
+        },
+        overnight: {
+          mid: '100',
+          lastSeenTimestampNs: '200',
+          bid: '99',
+          bidVolume: 10000,
+          ask: '101',
+          askVolume: 10000,
+          lastTradedPrice: '100',
+          marketStatus: 3,
+          decimals: 18,
+        },
+      }
+      mockGetPrice.mockResolvedValue({
+        price: '1',
+        spread: 2n,
+        decimals: 6,
+        data: {
+          regular: streams.regular,
+          extended: streams.extended,
+          overnight: streams.overnight,
+        },
+      })
+
+      mockCalculateSecondsFromTransition.mockReturnValue(Promise.resolve(undefined))
+
+      const result = (
+        await smoothedStreamPrice({
+          ...defaultParams,
+          smoother: 'none',
+          decimals: 6,
+        })
+      ).map((r) => ({
+        ...r,
+        result: r.result.toString(),
+      }))
+
+      expect(result.length).toEqual(1)
+      expect(result[0]).toStrictEqual({
+        result: '1',
+
+        rawPrice: '1',
+        decimals: 6,
+        stream: streams,
+        smoother: {
+          price: '1',
+          x: '0',
+          p: '0',
+          smoother: 'none',
+          secondsFromTransition: undefined,
+        },
+        sessionSource: undefined,
+      })
+    })
   })
 })


### PR DESCRIPTION
## Closes #OPDATA-6833

 - Commit 1: Add a new smoother type "none" which skips smoothing logic
 - Commit 2: Allow providing 1 stream only, the EA will only fetch during that stream's open hours


## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
