### PR TITLE
itick use 1 input param

### DIFF
--- a/.changeset/five-bobcats-lick.md
+++ b/.changeset/five-bobcats-lick.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/itick-adapter': minor
+---
+
+Use 1 input param instead of 2

--- a/packages/sources/itick/src/endpoint/quotes.ts
+++ b/packages/sources/itick/src/endpoint/quotes.ts
@@ -1,10 +1,11 @@
 import { AdapterEndpoint } from '@chainlink/external-adapter-framework/adapter'
 import { TransportRoutes } from '@chainlink/external-adapter-framework/transports'
+import { AdapterInputError } from '@chainlink/external-adapter-framework/validation/error'
 import { config } from '../config'
 import { createAdapterResponseFromMessage } from '../transport/quotes'
 import { createHttpTransport } from '../transport/shared-http'
 import { createWsTransport } from '../transport/shared-ws'
-import { inputParameters } from './shared'
+import { getBaseRegion, inputParameters } from './shared'
 
 export type BaseEndpointTypes = {
   Parameters: typeof inputParameters.definition
@@ -38,5 +39,9 @@ export const endpoints = QUOTES_ENDPOINT_CONFIGS.map(({ apiPath, name }) => {
       .register('rest', createHttpTransport({ type, apiPath, messageHandler }))
       .register('ws', createWsTransport({ type, apiPath, messageHandler })),
     inputParameters,
+    customInputValidation: (req): AdapterInputError | undefined => {
+      getBaseRegion(req.requestContext.data.base)
+      return
+    },
   })
 })

--- a/packages/sources/itick/src/endpoint/shared.ts
+++ b/packages/sources/itick/src/endpoint/shared.ts
@@ -1,19 +1,24 @@
 import { stockEndpointInputParametersDefinition } from '@chainlink/external-adapter-framework/adapter/stock'
 import { InputParameters } from '@chainlink/external-adapter-framework/validation'
+import { AdapterInputError } from '@chainlink/external-adapter-framework/validation/error'
 
-export const inputParameters = new InputParameters(
+export const inputParameters = new InputParameters(stockEndpointInputParametersDefinition, [
   {
-    ...stockEndpointInputParametersDefinition,
-    region: {
-      required: true,
-      type: 'string',
-      description: 'The code of the stock exchange region (e.g. "hk", "kr", "jq")',
-    },
+    base: '700$hk',
   },
-  [
-    {
-      base: '700',
-      region: 'hk',
-    },
-  ],
-)
+])
+
+export const getBaseRegion = (input: string) => {
+  const parts = input.split('$')
+
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    throw new AdapterInputError({
+      statusCode: 400,
+      message: 'Symbol must be in the format of "${ticker}$${region}" for example "700$hk"',
+    })
+  }
+  return {
+    base: parts[0],
+    region: parts[1],
+  }
+}

--- a/packages/sources/itick/src/endpoint/stock.ts
+++ b/packages/sources/itick/src/endpoint/stock.ts
@@ -1,11 +1,12 @@
 import { StockEndpoint } from '@chainlink/external-adapter-framework/adapter/stock'
 import { TransportRoutes } from '@chainlink/external-adapter-framework/transports'
 import { SingleNumberResultResponse } from '@chainlink/external-adapter-framework/util'
+import { AdapterInputError } from '@chainlink/external-adapter-framework/validation/error'
 import { config } from '../config'
 import { createHttpTransport } from '../transport/shared-http'
 import { createWsTransport } from '../transport/shared-ws'
 import { createAdapterResponseFromMessage } from '../transport/stock'
-import { inputParameters } from './shared'
+import { getBaseRegion, inputParameters } from './shared'
 
 export type BaseEndpointTypes = {
   Parameters: typeof inputParameters.definition
@@ -30,5 +31,9 @@ export const endpoints = QUOTE_ENDPOINT_CONFIGS.map(({ apiPath, name }) => {
       .register('rest', createHttpTransport({ type, apiPath, messageHandler }))
       .register('ws', createWsTransport({ type, apiPath, messageHandler })),
     inputParameters,
+    customInputValidation: (req): AdapterInputError | undefined => {
+      getBaseRegion(req.requestContext.data.base)
+      return
+    },
   })
 })

--- a/packages/sources/itick/src/transport/quotes.ts
+++ b/packages/sources/itick/src/transport/quotes.ts
@@ -48,7 +48,7 @@ export const createAdapterResponseFromMessage = (
 
   return [
     {
-      params: { base: symbol, region },
+      params: { base: `${symbol}$${region}` },
       response: {
         result: null,
         data: {

--- a/packages/sources/itick/src/transport/shared-http.ts
+++ b/packages/sources/itick/src/transport/shared-http.ts
@@ -1,7 +1,7 @@
 import { HttpTransport } from '@chainlink/external-adapter-framework/transports'
 import { ProviderResult, ResponseGenerics } from '@chainlink/external-adapter-framework/util'
 import { config } from '../config'
-import { inputParameters } from '../endpoint/shared'
+import { getBaseRegion, inputParameters } from '../endpoint/shared'
 
 type HttpTransportTypes<ResponseSchema, Response extends ResponseGenerics> = {
   Parameters: typeof inputParameters.definition
@@ -28,7 +28,7 @@ export const createHttpTransport = <ResponseSchema, Response extends ResponseGen
   return new HttpTransport<HttpTransportTypes<ResponseSchema, Response>>({
     prepareRequests: (params, config) => {
       return params.map((param) => {
-        const { base: symbol, region } = param
+        const { base: symbol, region } = getBaseRegion(param.base)
         return {
           method: 'GET',
           params: [param],
@@ -49,7 +49,7 @@ export const createHttpTransport = <ResponseSchema, Response extends ResponseGen
     parseResponse: (params, response) => {
       if (!response.data) {
         return params.map((param) => {
-          const { base: symbol, region } = param
+          const { base: symbol, region } = getBaseRegion(param.base)
           return {
             params: param,
             response: {
@@ -60,7 +60,7 @@ export const createHttpTransport = <ResponseSchema, Response extends ResponseGen
         })
       }
 
-      return params.flatMap(({ region }) => messageHandler(response.data, region))
+      return params.flatMap(({ base }) => messageHandler(response.data, getBaseRegion(base).region))
     },
   })
 }

--- a/packages/sources/itick/src/transport/shared-ws.ts
+++ b/packages/sources/itick/src/transport/shared-ws.ts
@@ -30,7 +30,7 @@ export const createWsTransport = <Message, Response extends ResponseGenerics>({
 }) => {
   return new WebSocketTransport<WsTransportTypes<Message, Response>>({
     url: (context) => `${context.adapterSettings.WS_API_ENDPOINT}/${apiPath}`,
-    options: (context, _desiredSubs) => {
+    options: (context) => {
       return {
         headers: {
           token: context.adapterSettings.API_KEY,
@@ -39,7 +39,7 @@ export const createWsTransport = <Message, Response extends ResponseGenerics>({
     },
     handlers: {
       // changed via WS_HEARTBEAT_INTERVAL_MS.
-      heartbeat: (connection, _context) => {
+      heartbeat: (connection) => {
         connection.send(
           JSON.stringify({
             ac: 'ping',
@@ -58,11 +58,11 @@ export const createWsTransport = <Message, Response extends ResponseGenerics>({
       subscribeMessage: (params) => {
         return {
           ac: 'subscribe',
-          params: [params.base, params.region.toLowerCase()].join('$'),
+          params: params.base,
           types: type,
         }
       },
-      unsubscribeMessage: (_params) => {
+      unsubscribeMessage: () => {
         // iTick doesn't support unsubscribing.
         // Return a ping message instead.
         return {

--- a/packages/sources/itick/src/transport/stock.ts
+++ b/packages/sources/itick/src/transport/stock.ts
@@ -31,7 +31,7 @@ export const createAdapterResponseFromMessage = (
   const region = message.data.r ?? defaultRegion
   return [
     {
-      params: { base: symbol, region },
+      params: { base: `${symbol}$${region}` },
       response: {
         result: lastPrice,
         data: {

--- a/packages/sources/itick/test/integration/adapter-ws.test.ts
+++ b/packages/sources/itick/test/integration/adapter-ws.test.ts
@@ -18,37 +18,32 @@ describe('websocket', () => {
 
   const requests = [
     {
-      symbol: '100',
-      region: 'hk',
+      symbol: '100$hk',
       endpoint: 'stock_quotes',
       transport: 'ws',
     },
     {
-      symbol: '100',
-      region: 'hk',
+      symbol: '100$hk',
       endpoint: 'indices_quotes',
       transport: 'ws',
     },
     {
-      symbol: '100',
-      region: 'hk',
+      symbol: '100$hk',
       endpoint: 'price',
       transport: 'ws',
     },
     {
-      symbol: '100',
-      region: 'hk',
+      symbol: '100$hk',
       endpoint: 'indices_price',
       transport: 'ws',
     },
     {
-      symbol: 'X700',
-      region: 'hk',
+      symbol: 'X700$hk',
       endpoint: 'stock_quotes',
       transport: 'ws',
       overrides: {
         itick: {
-          X700: '700',
+          X700$hk: '700$hk',
         },
       },
     },

--- a/packages/sources/itick/test/integration/adapter.test.ts
+++ b/packages/sources/itick/test/integration/adapter.test.ts
@@ -13,10 +13,10 @@ describe('execute', () => {
   let oldEnv: NodeJS.ProcessEnv
 
   const requests = [
-    { symbol: '100', region: 'hk', endpoint: 'stock_quotes', transport: 'rest' },
-    { symbol: '100', region: 'gb', endpoint: 'indices_quotes', transport: 'rest' },
-    { symbol: '100', region: 'hk', endpoint: 'price', transport: 'rest' },
-    { symbol: '100', region: 'gb', endpoint: 'indices_price', transport: 'rest' },
+    { symbol: '100$hk', endpoint: 'stock_quotes', transport: 'rest' },
+    { symbol: '100$gb', endpoint: 'indices_quotes', transport: 'rest' },
+    { symbol: '100$hk', endpoint: 'price', transport: 'rest' },
+    { symbol: '100$gb', endpoint: 'indices_price', transport: 'rest' },
   ]
 
   beforeAll(async () => {

--- a/packages/sources/itick/test/unit/quotes.test.ts
+++ b/packages/sources/itick/test/unit/quotes.test.ts
@@ -37,7 +37,7 @@ describe('quotes', () => {
       }
 
       const expectedResponse = {
-        params: { base: symbol, region },
+        params: { base: `${symbol}$${region}` },
         response: {
           result: null,
           data: {
@@ -94,7 +94,7 @@ describe('quotes', () => {
       }
 
       const expectedResponse = {
-        params: { base: symbol, region },
+        params: { base: `${symbol}$${region}` },
         response: {
           result: null,
           data: {


### PR DESCRIPTION
## Closes #OPDATA-7275

## Description

Use only 1 input param that looks like this `"symbol": "GER30$GB"`

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
