### PR TITLE
Address AI feedback

### DIFF
--- a/.changeset/clever-brooms-agree.md
+++ b/.changeset/clever-brooms-agree.md
@@ -1,0 +1,6 @@
+---
+'@chainlink/tokenized-equity-adapter': patch
+'@chainlink/itick-adapter': patch
+---
+
+Code refactoring

--- a/packages/composites/tokenized-equity/src/transport/smoothedPrice.ts
+++ b/packages/composites/tokenized-equity/src/transport/smoothedPrice.ts
@@ -45,7 +45,7 @@ export const smoothedStreamPrice = async (param: {
     stream: price.data,
   }
 
-  const smoothers = secondsFromTransition ? ['ema', 'kalman'] : ['none']
+  const smoothers = param.smoother === 'none' ? ['none'] : ['ema', 'kalman']
 
   return smoothers.map((smoother) => {
     const smoothed = secondsFromTransition

--- a/packages/sources/itick/src/endpoint/quotes.ts
+++ b/packages/sources/itick/src/endpoint/quotes.ts
@@ -1,6 +1,5 @@
 import { AdapterEndpoint } from '@chainlink/external-adapter-framework/adapter'
 import { TransportRoutes } from '@chainlink/external-adapter-framework/transports'
-import { AdapterInputError } from '@chainlink/external-adapter-framework/validation/error'
 import { config } from '../config'
 import { createAdapterResponseFromMessage } from '../transport/quotes'
 import { createHttpTransport } from '../transport/shared-http'
@@ -39,9 +38,11 @@ export const endpoints = QUOTES_ENDPOINT_CONFIGS.map(({ apiPath, name }) => {
       .register('rest', createHttpTransport({ type, apiPath, messageHandler }))
       .register('ws', createWsTransport({ type, apiPath, messageHandler })),
     inputParameters,
-    customInputValidation: (req): AdapterInputError | undefined => {
-      getBaseRegion(req.requestContext.data.base)
-      return
-    },
+    // Not using customInputValidation because we want to validate after overrides are applied
+    requestTransforms: [
+      (request) => {
+        getBaseRegion(request.requestContext.data.base)
+      },
+    ],
   })
 })

--- a/packages/sources/itick/src/endpoint/stock.ts
+++ b/packages/sources/itick/src/endpoint/stock.ts
@@ -1,7 +1,6 @@
 import { StockEndpoint } from '@chainlink/external-adapter-framework/adapter/stock'
 import { TransportRoutes } from '@chainlink/external-adapter-framework/transports'
 import { SingleNumberResultResponse } from '@chainlink/external-adapter-framework/util'
-import { AdapterInputError } from '@chainlink/external-adapter-framework/validation/error'
 import { config } from '../config'
 import { createHttpTransport } from '../transport/shared-http'
 import { createWsTransport } from '../transport/shared-ws'
@@ -31,9 +30,11 @@ export const endpoints = QUOTE_ENDPOINT_CONFIGS.map(({ apiPath, name }) => {
       .register('rest', createHttpTransport({ type, apiPath, messageHandler }))
       .register('ws', createWsTransport({ type, apiPath, messageHandler })),
     inputParameters,
-    customInputValidation: (req): AdapterInputError | undefined => {
-      getBaseRegion(req.requestContext.data.base)
-      return
-    },
+    // Not using customInputValidation because we want to validate after overrides are applied
+    requestTransforms: [
+      (request) => {
+        getBaseRegion(request.requestContext.data.base)
+      },
+    ],
   })
 })

--- a/packages/sources/itick/src/transport/shared-http.ts
+++ b/packages/sources/itick/src/transport/shared-http.ts
@@ -47,20 +47,20 @@ export const createHttpTransport = <ResponseSchema, Response extends ResponseGen
       })
     },
     parseResponse: (params, response) => {
+      const mappedParams = params.map((param) => getBaseRegion(param.base))
       if (!response.data) {
-        return params.map((param) => {
-          const { base: symbol, region } = getBaseRegion(param.base)
+        return mappedParams.map((param) => {
           return {
             params: param,
             response: {
-              errorMessage: `The data provider didn't return any value for symbol '${symbol}' and region '${region}'.`,
+              errorMessage: `The data provider didn't return any value for symbol '${param.base}' and region '${param.region}'.`,
               statusCode: 502,
             },
           }
         })
       }
 
-      return params.flatMap(({ base }) => messageHandler(response.data, getBaseRegion(base).region))
+      return mappedParams.flatMap(({ region }) => messageHandler(response.data, region))
     },
   })
 }

--- a/packages/sources/itick/test/integration/adapter-ws.test.ts
+++ b/packages/sources/itick/test/integration/adapter-ws.test.ts
@@ -38,12 +38,12 @@ describe('websocket', () => {
       transport: 'ws',
     },
     {
-      symbol: 'X700$hk',
+      symbol: 'lol',
       endpoint: 'stock_quotes',
       transport: 'ws',
       overrides: {
         itick: {
-          X700$hk: '700$hk',
+          lol: '700$hk',
         },
       },
     },


### PR DESCRIPTION
## Commit 1
Address the following two feedback from change request approval


Minor: getBaseRegion is called 2–3 times per HTTP request (in prepareRequests, parseResponse error path, and parseResponse success path in shared-http.ts). The string is validated at input time so there's no correctness risk, but redundant parsing adds noise. Could be extracted once at the transport entry point.


Important: smoothedPrice.ts:404 uses secondsFromTransition truthiness as a proxy for whether the none smoother was requested (const smoothers = secondsFromTransition ? ['ema', 'kalman'] : ['none']). Today this invariant holds because validateSmoother requires session params for kalman/ema (guaranteeing calculateSecondsFromTransition returns a value) and rejects them for none (guaranteeing undefined). But the coupling is implicit — if calculateSecondsFromTransition returns undefined due to a future bug or timeout in the kalman/ema path, the function silently falls back to none behavior for a smoother that was supposed to apply a filter. A guard at this branch (smoother === 'none' ? ['none'] : ['ema', 'kalman']) would make the intent explicit and protect against future divergence.

## Commit 2

Apply input validation after override is applied so that we can do 
```
{
    "data": {
        "endpoint": "stock_quotes",
        "symbol": "3037.TW",
        "overrides": { "itick": { "3037.TW": "3037$TW"}}
    }
}
```