### PR TITLE
[Streams Adapter] BASE_URL, and METRICS_USE_BASE_URL support

### DIFF
--- a/packages/streams-adapter/config/config.go
+++ b/packages/streams-adapter/config/config.go
@@ -8,12 +8,14 @@ import (
 
 // Config holds all configuration for the adapter
 type Config struct {
-	HTTPPort      string
-	EAPort        string
-	EAHost        string
-	EAMetricsPort string
-	RedconPort    string
-	GoMetricsPort string
+	HTTPPort          string
+	EAPort            string
+	EAHost            string
+	EABaseUrl         string
+	EAMetricsPort     string
+	MetricsUseBaseUrl bool
+	RedconPort        string
+	GoMetricsPort     string
 
 	// Cache configuration
 	CacheTTLMinutes      uint // Cache TTL in minutes (0 = default 5 minutes)
@@ -38,12 +40,14 @@ func Load() *Config {
 	adapterName := extractAdapterName(packageName)
 
 	cfg := &Config{
-		HTTPPort:      getEnv("HTTP_PORT", "8080"),
-		EAPort:        getEnv("EA_PORT", "8070"),
-		EAHost:        getEnv("EA_INTERNAL_HOST", "localhost"),
-		EAMetricsPort: getEnv("EA_METRICS_PORT", "9081"),
-		RedconPort:    getEnv("REDCON_PORT", "6379"),
-		GoMetricsPort: getEnv("METRICS_PORT", "9080"),
+		HTTPPort:          getEnv("HTTP_PORT", "8080"),
+		EAPort:            getEnv("EA_PORT", "8070"),
+		EAHost:            getEnv("EA_INTERNAL_HOST", "localhost"),
+		EABaseUrl:         strings.TrimRight(getEnv("BASE_URL", "/"), "/"),
+		EAMetricsPort:     getEnv("EA_METRICS_PORT", "9081"),
+		MetricsUseBaseUrl: getEnvAsBool("METRICS_USE_BASE_URL", false),
+		RedconPort:        getEnv("REDCON_PORT", "6379"),
+		GoMetricsPort:     getEnv("METRICS_PORT", "9080"),
 
 		// Cache configuration
 		CacheTTLMinutes:      getEnvAsInt("CACHE_TTL_MINUTES", 5),
@@ -90,6 +94,15 @@ func getEnvAsInt(key string, defaultValue uint) uint {
 			return defaultValue
 		}
 		return uint(value)
+	}
+	return defaultValue
+}
+
+// getEnvAsBool gets an environment variable as boolean with a default value
+func getEnvAsBool(key string, defaultValue bool) bool {
+	valueStr := getEnv(key, "")
+	if value, err := strconv.ParseBool(valueStr); err == nil {
+		return value
 	}
 	return defaultValue
 }

--- a/packages/streams-adapter/main.go
+++ b/packages/streams-adapter/main.go
@@ -17,7 +17,7 @@ import (
 
 // waitForEAServer waits for the EA server to be ready before proceeding
 func waitForEAServer(cfg *config.Config, logger *slog.Logger) {
-	eaURL := fmt.Sprintf("http://%s:%s/health", cfg.EAHost, cfg.EAPort)
+	eaURL := fmt.Sprintf("http://%s:%s%s/health", cfg.EAHost, cfg.EAPort, cfg.EABaseUrl)
 	maxWaitTime := 60 * time.Second
 	checkInterval := 500 * time.Millisecond
 	startTime := time.Now()

--- a/packages/streams-adapter/server/server.go
+++ b/packages/streams-adapter/server/server.go
@@ -125,7 +125,7 @@ func New(cfg *config.Config, cache *cache.Cache, logger *slog.Logger) *Server {
 		},
 	}
 
-	jsMetricsURL := fmt.Sprintf("http://%s:%s/metrics", cfg.EAHost, cfg.EAMetricsPort)
+	jsMetricsURL := buildMetricsURL(cfg)
 	metricsForwarder := appMetrics.NewForwarder(jsMetricsURL, time.Duration(cfg.MetricsForwardTimeoutSeconds)*time.Second)
 
 	server := &Server{
@@ -147,12 +147,13 @@ func New(cfg *config.Config, cache *cache.Cache, logger *slog.Logger) *Server {
 
 // setupRoutes configures the HTTP routes
 func (s *Server) setupRoutes() {
+	group := s.router.Group(s.config.EABaseUrl)
 	// Health check endpoint
-	s.router.GET("/health", s.healthHandler)
+	group.GET("/health", s.healthHandler)
 	// Cache debug endpoint
-	s.router.GET("/cache", s.cacheHandler)
+	group.GET("/cache", s.cacheHandler)
 	// Main adapter endpoint
-	s.router.POST("/", s.adapterHandler)
+	group.POST("/", s.adapterHandler)
 }
 
 // Start starts the HTTP server
@@ -162,7 +163,7 @@ func (s *Server) Start() error {
 	// adapter metrics (excluding families already tracked in Go).
 	gatherer := appMetrics.CombinedGatherer(s.metricsForwarder)
 	metricsMux := http.NewServeMux()
-	metricsMux.Handle("/metrics", promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{}))
+	metricsMux.Handle(s.config.EABaseUrl+"/metrics", promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{}))
 
 	s.metricsServer = &http.Server{
 		Addr:    ":" + s.config.GoMetricsPort,
@@ -378,33 +379,31 @@ func respondWithObservation(c *gin.Context, obs *types.Observation) {
 	})
 }
 
+// postToAdapter marshals data as {"data": ...} and POSTs it to the JS adapter.
+// The caller is responsible for closing resp.Body.
+func (s *Server) postToAdapter(data interface{}) (*http.Response, error) {
+	body, err := json.Marshal(map[string]interface{}{"data": data})
+	if err != nil {
+		return nil, fmt.Errorf("marshal: %w", err)
+	}
+	url := fmt.Sprintf("http://%s:%s%s", s.config.EAHost, s.config.EAPort, s.config.EABaseUrl)
+	return s.httpClient.Post(url, "application/json", bytes.NewBuffer(body))
+}
+
 // subscribeToAsset sends a subscription request to the JS adapter.
 // The data parameter is sent as the "data" field in the POST body.
 // It accepts either the original client request data (map[string]interface{},
 // preserving overrides) or stripped RequestParams (map[string]string).
 func (s *Server) subscribeToAsset(data interface{}) {
-	subscribeBody := map[string]interface{}{
-		"data": data,
-	}
-
-	jsonBody, err := json.Marshal(subscribeBody)
+	resp, err := s.postToAdapter(data)
 	if err != nil {
-		s.logger.Error("Failed to marshal subscribe request", "error", err)
-		return
-	}
-
-	internalUrl := fmt.Sprintf("http://%s:%s", s.config.EAHost, s.config.EAPort)
-
-	// Use the reusable HTTP client to avoid port exhaustion
-	resp, err := s.httpClient.Post(internalUrl, "application/json", bytes.NewBuffer(jsonBody))
-	if err != nil {
-		s.logger.Error("Failed to send subscribe request", "error", err, "url", internalUrl)
+		s.logger.Error("Failed to send subscribe request", "error", err)
 		return
 	}
 	defer resp.Body.Close()
 
 	if s.config.LogLevel == "debug" {
-		s.logger.Debug("Subscribe request sent successfully", "status", resp.StatusCode, "url", internalUrl)
+		s.logger.Debug("Subscribe request sent successfully", "status", resp.StatusCode)
 	}
 }
 
@@ -412,21 +411,9 @@ func (s *Server) subscribeToAsset(data interface{}) {
 // feedId from meta.metrics.feedId on a 200 response. Returns empty string and
 // false if the adapter returns a non-200 status or feedId is absent.
 func (s *Server) queryAdapterForFeedID(data interface{}) (feedID string, ok bool) {
-	subscribeBody := map[string]interface{}{
-		"data": data,
-	}
-
-	jsonBody, err := json.Marshal(subscribeBody)
+	resp, err := s.postToAdapter(data)
 	if err != nil {
-		s.logger.Error("Failed to marshal feedId query request", "error", err)
-		return "", false
-	}
-
-	internalUrl := fmt.Sprintf("http://%s:%s", s.config.EAHost, s.config.EAPort)
-
-	resp, err := s.httpClient.Post(internalUrl, "application/json", bytes.NewBuffer(jsonBody))
-	if err != nil {
-		s.logger.Error("Failed to query JS adapter for feedId", "error", err, "url", internalUrl)
+		s.logger.Error("Failed to query JS adapter for feedId", "error", err)
 		return "", false
 	}
 	defer resp.Body.Close()
@@ -491,4 +478,14 @@ func (s *Server) resubscribeAllAssets() {
 			s.subscribeToAsset(p)
 		}(params)
 	}
+}
+
+// buildMetricsURL constructs the JS adapter metrics scrape URL.
+// When MetricsUseBaseUrl is true, EABaseUrl is prepended to /metrics.
+func buildMetricsURL(cfg *config.Config) string {
+	metricsPath := "/metrics"
+	if cfg.MetricsUseBaseUrl {
+		metricsPath = cfg.EABaseUrl + "/metrics"
+	}
+	return fmt.Sprintf("http://%s:%s%s", cfg.EAHost, cfg.EAMetricsPort, metricsPath)
 }

--- a/packages/streams-adapter/server/server_test.go
+++ b/packages/streams-adapter/server/server_test.go
@@ -15,6 +15,7 @@ import (
 	config "streams-adapter/config"
 	"streams-adapter/helpers"
 
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
 
@@ -190,4 +191,92 @@ func TestAdapterHandler_CacheMiss(t *testing.T) {
 	var errResp ErrorResponseData
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &errResp))
 	require.Equal(t, "AdapterError", errResp.Error.Name)
+}
+
+func TestBuildMetricsURL_NoBaseUrl(t *testing.T) {
+	cfg := &config.Config{
+		EAHost:              "localhost",
+		EAMetricsPort:       "9081",
+		EABaseUrl:           "",
+		MetricsUseBaseUrl: false,
+	}
+	got := buildMetricsURL(cfg)
+	require.Equal(t, "http://localhost:9081/metrics", got)
+}
+
+func TestBuildMetricsURL_WithBaseUrl(t *testing.T) {
+	cfg := &config.Config{
+		EAHost:              "localhost",
+		EAMetricsPort:       "9081",
+		EABaseUrl:           "/blocksize-capital-llo-exp",
+		MetricsUseBaseUrl: true,
+	}
+	got := buildMetricsURL(cfg)
+	require.Equal(t, "http://localhost:9081/blocksize-capital-llo-exp/metrics", got)
+}
+
+func TestBuildMetricsURL_WithBaseUrlTrailingSlash(t *testing.T) {
+	// Config normalizes trailing slashes at load time; EABaseUrl is always stored without one.
+	cfg := &config.Config{
+		EAHost:              "localhost",
+		EAMetricsPort:       "9081",
+		EABaseUrl:           "/blocksize-capital-llo-exp",
+		MetricsUseBaseUrl: true,
+	}
+	got := buildMetricsURL(cfg)
+	require.Equal(t, "http://localhost:9081/blocksize-capital-llo-exp/metrics", got)
+}
+
+func TestBuildMetricsURL_WithBaseUrlDefault_UseBaseUrl(t *testing.T) {
+	// Config normalizes "/" to "" (empty string) at load time.
+	cfg := &config.Config{
+		EAHost:              "localhost",
+		EAMetricsPort:       "9081",
+		EABaseUrl:           "",
+		MetricsUseBaseUrl: true,
+	}
+	got := buildMetricsURL(cfg)
+	require.Equal(t, "http://localhost:9081/metrics", got)
+}
+
+func newServerWithBaseURL(t *testing.T, baseURL string) *Server {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(gin.Recovery())
+	srv := &Server{
+		config: &config.Config{EABaseUrl: baseURL, LogLevel: "info"},
+		router: router,
+	}
+	srv.setupRoutes()
+	return srv
+}
+
+func TestSetupRoutes_DefaultBaseUrl_RoutesAccessible(t *testing.T) {
+	srv := newServerWithBaseURL(t, "/")
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	srv.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestSetupRoutes_CustomBaseUrl_RoutesAccessible(t *testing.T) {
+	srv := newServerWithBaseURL(t, "/blocksize-capital-llo-exp")
+
+	req := httptest.NewRequest(http.MethodGet, "/blocksize-capital-llo-exp/health", nil)
+	w := httptest.NewRecorder()
+	srv.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestSetupRoutes_CustomBaseUrl_OldPathsReturn404(t *testing.T) {
+	srv := newServerWithBaseURL(t, "/blocksize-capital-llo-exp")
+
+	for _, path := range []string{"/health", "/cache"} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		w := httptest.NewRecorder()
+		srv.router.ServeHTTP(w, req)
+		require.Equal(t, http.StatusNotFound, w.Code, "expected 404 at %s with custom base URL", path)
+	}
 }


### PR DESCRIPTION
## Closes #DS-3047

## Changes
- New config values for BASE_URL, and METRICS_USE_BASE_URL environment variables
- Server honors base url
- metrics server honors base url
- Asset subscribe uses base url for JS adapter
- Unit tests