### PR TITLE
OPDATA-7107, OPDATA-7307: Make currency conversion optional in solana endpoint of token-balance

### DIFF
--- a/.changeset/dull-horses-jog.md
+++ b/.changeset/dull-horses-jog.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/token-balance-adapter': minor
+---
+
+Make currency conversion optional in solana endpoint

--- a/packages/sources/token-balance/src/endpoint/solana.ts
+++ b/packages/sources/token-balance/src/endpoint/solana.ts
@@ -36,7 +36,7 @@ export const inputParameters = new InputParameters(
       },
     },
     priceOracle: {
-      required: true,
+      required: false,
       description:
         'Configuration of the on-chain price oracle that provides real-time token valuations.',
       type: {

--- a/packages/sources/token-balance/src/transport/solana.ts
+++ b/packages/sources/token-balance/src/transport/solana.ts
@@ -72,10 +72,16 @@ export class SolanaTransport extends SubscriptionTransport<BaseEndpointTypes> {
     const providerDataRequestedUnixMs = Date.now()
 
     // 1. Fetch token price ONCE from oracle contract
-    const tokenPrice = await getTokenPrice({
-      priceOracleAddress: param.priceOracle.contractAddress,
-      priceOracleNetwork: param.priceOracle.network,
-    })
+    // Or use a price of 1 if no oracle provided.
+    const tokenPrice = param.priceOracle
+      ? await getTokenPrice({
+          priceOracleAddress: param.priceOracle.contractAddress,
+          priceOracleNetwork: param.priceOracle.network,
+        })
+      : {
+          value: 1n,
+          decimal: 0,
+        }
 
     // 2. Fetch balances for each Solana wallet and calculate their USD value using the SINGLE tokenPrice
     const totalTokenUSD = await this.calculateTokenAumUSD(addresses, tokenMint, tokenPrice)

--- a/packages/sources/token-balance/test/unit/solana.test.ts
+++ b/packages/sources/token-balance/test/unit/solana.test.ts
@@ -84,6 +84,49 @@ describe('solanaTransport._handleRequest', () => {
     expect(resp.result).toBe(String(BigInt(expectedUsdBalance * 10 ** RESULT_DECIMALS)))
   })
 
+  it('should not convert if priceOracle is not specified', async () => {
+    const tokenBalanceValue = 1000
+    const tokenBalanceDecimals = 6
+    jest.mocked(getToken).mockResolvedValue({
+      result: [
+        {
+          value: BigInt(tokenBalanceValue * 10 ** tokenBalanceDecimals),
+          decimals: tokenBalanceDecimals,
+        },
+      ],
+      formattedResponse: [
+        {
+          token: tokenMintContractAddress,
+          wallet: ownerAddress,
+          value: (tokenBalanceValue * 10 ** tokenBalanceDecimals).toString(),
+          decimals: tokenBalanceDecimals,
+        },
+      ],
+    })
+
+    const resp = await transport._handleRequest({
+      addresses: [{ address: ownerAddress }],
+      tokenMint: {
+        token: token,
+        contractAddress: tokenMintContractAddress,
+      },
+    })
+
+    expect(getToken).toHaveBeenCalledWith(
+      [
+        {
+          token: 'tbill',
+          contractAddress: tokenMintContractAddress,
+          wallets: [ownerAddress],
+        },
+      ],
+      'tbill',
+      transport.connection,
+    )
+    expect(resp.statusCode).toBe(200)
+    expect(resp.result).toBe(String(BigInt(tokenBalanceValue * 10 ** RESULT_DECIMALS)))
+  })
+
   it('test scaling of calculates correct USD result', async () => {
     const tokenBalanceValue = 10
     const tokenBalanceDecimals = 6


### PR DESCRIPTION
## [OPDATA-7107](https://smartcontract-it.atlassian.net/browse/OPDATA-7107), [OPDATA-7307](https://smartcontract-it.atlassian.net/browse/OPDATA-7307)

## Description

The EA `proof-of-reserves-v2` has support for currency conversion built in. This means we no longer need to have currency conversion done in many separate endpoints.

When we migrate from `proof-of-reserves` to `proof-of-reserves-v2`, or create a new PoR feed, we want to be able to query balances on Solana while letting `proof-of-reserves-v2` do the conversion. And eventually when all feeds using the conversion have been migrated, we can remove conversion support.

## Changes

1. Make param `priceOracle` optional.
3. If the price oracle is not specified, use a price of 1.
4. Unit test added.

## Steps to Test

```
yarn test packages/sources/token-balance
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[OPDATA-7107]: https://smartcontract-it.atlassian.net/browse/OPDATA-7107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[OPDATA-7307]: https://smartcontract-it.atlassian.net/browse/OPDATA-7307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ