### PR TITLE
OPDATA-7107, OPDATA-7308: Support token filtering in evm endpoint of token-balance

### DIFF
--- a/.changeset/better-places-shine.md
+++ b/.changeset/better-places-shine.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/token-balance-adapter': minor
+---
+
+Support token filtering in evm endpoint of token-balance

--- a/packages/sources/token-balance/src/endpoint/evm.ts
+++ b/packages/sources/token-balance/src/endpoint/evm.ts
@@ -1,15 +1,20 @@
 import { AdapterEndpoint } from '@chainlink/external-adapter-framework/adapter'
+import { AdapterRequest } from '@chainlink/external-adapter-framework/util'
 import { InputParameters } from '@chainlink/external-adapter-framework/validation'
+import { AdapterInputError } from '@chainlink/external-adapter-framework/validation/error'
 import { config } from '../config'
 import { erc20TokenBalanceTransport } from '../transport/evm'
-import { AdapterRequest } from '@chainlink/external-adapter-framework/util'
-import { AdapterInputError } from '@chainlink/external-adapter-framework/validation/error'
 
 export const inputParameters = new InputParameters(
   {
     addresses: {
       required: true,
       type: {
+        token: {
+          required: false,
+          type: 'string',
+          description: 'Token symbol of the token of the contract address.',
+        },
         network: {
           aliases: ['chain'],
           required: false,
@@ -50,11 +55,17 @@ export const inputParameters = new InputParameters(
       array: true,
       description: 'List of addresses to read',
     },
+    token: {
+      required: false,
+      description: 'Token symbol used to filter addresses',
+      type: 'string',
+    },
   },
   [
     {
       addresses: [
         {
+          token: 'LINK',
           network: 'ethereum',
           chainId: '1',
           contractAddress: '0x514910771af9ca656af840dff83e8264ecf986ca',
@@ -66,6 +77,7 @@ export const inputParameters = new InputParameters(
           decimalsSignature: 'function decimals() external pure returns (uint8)',
         },
       ],
+      token: 'LINK',
     },
   ],
 )
@@ -106,6 +118,18 @@ export const endpoint = new AdapterEndpoint({
           statusCode: 400,
           message: "One or more addresses is missing one of ['chainId', 'network'].",
         })
+      }
+    }
+    // If filtering by token symbol, ensure each address has a token specified
+    if (req.requestContext.data.token) {
+      for (const address of addresses) {
+        if (!address.token) {
+          throw new AdapterInputError({
+            statusCode: 400,
+            message:
+              'When top-level token is specified, each address must have a token specified as well.',
+          })
+        }
       }
     }
     return

--- a/packages/sources/token-balance/src/transport/evm.ts
+++ b/packages/sources/token-balance/src/transport/evm.ts
@@ -1,9 +1,9 @@
-import { TransportDependencies } from '@chainlink/external-adapter-framework/transports'
-import { AdapterResponse, makeLogger, sleep } from '@chainlink/external-adapter-framework/util'
-import { SubscriptionTransport } from '@chainlink/external-adapter-framework/transports/abstract/subscription'
 import { EndpointContext } from '@chainlink/external-adapter-framework/adapter'
-import { ethers } from 'ethers'
+import { TransportDependencies } from '@chainlink/external-adapter-framework/transports'
+import { SubscriptionTransport } from '@chainlink/external-adapter-framework/transports/abstract/subscription'
+import { AdapterResponse, makeLogger, sleep } from '@chainlink/external-adapter-framework/util'
 import { AdapterInputError } from '@chainlink/external-adapter-framework/validation/error'
+import { ethers } from 'ethers'
 import { BaseEndpointTypes, inputParameters } from '../endpoint/evm'
 
 const logger = makeLogger('Token Balances')
@@ -103,7 +103,11 @@ export class ERC20TokenBalanceTransport extends SubscriptionTransport<BaseEndpoi
   async _handleRequest(
     param: RequestParams,
   ): Promise<AdapterResponse<BaseEndpointTypes['Response']>> {
-    const addresses = param.addresses.filter((a) => a.chainId != '0')
+    const addresses = param.addresses
+      .filter((a) => a.chainId != '0')
+      .filter(
+        (a) => param.token === undefined || a.token?.toLowerCase() === param.token.toLowerCase(),
+      )
 
     // verify providers exist for this request
     const normalizedAddresses = this.verifyProviders(addresses)

--- a/packages/sources/token-balance/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/token-balance/test/integration/__snapshots__/adapter.test.ts.snap
@@ -22,6 +22,30 @@ exports[`execute evm endpoint missing env var network RPC should fail 400 1`] = 
 }
 `;
 
+exports[`execute evm endpoint should filter by token 1`] = `
+{
+  "data": {
+    "decimals": 18,
+    "result": "741008730000000000",
+    "wallets": [
+      {
+        "balance": "74100873",
+        "contractAddress": "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf",
+        "decimals": 8,
+        "network": "base",
+        "walletAddress": "0x1fCca65fb6Ae3b2758b9b2B394CB227eAE404e1E",
+      },
+    ],
+  },
+  "result": "741008730000000000",
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 978347471111,
+    "providerDataRequestedUnixMs": 978347471111,
+  },
+}
+`;
+
 exports[`execute evm endpoint should return success with chainId 1`] = `
 {
   "data": {

--- a/packages/sources/token-balance/test/integration/adapter.test.ts
+++ b/packages/sources/token-balance/test/integration/adapter.test.ts
@@ -117,5 +117,35 @@ describe('execute', () => {
       expect(response.statusCode).toBe(200)
       expect(response.json()).toMatchSnapshot()
     })
+
+    it('should filter by token', async () => {
+      const data = {
+        endpoint: 'evm',
+        addresses: [
+          {
+            token: 'FBTC',
+            network: 'ethereum',
+            contractAddress: '0xC96dE26018A54D51c097160568752c4E3BD6C364',
+            wallets: [
+              '0x3A29CD3052774224E7C2CF001254211C986967B2',
+              '0x3d9bCcA8Bc7D438a4c5171435f41a0AF5d5E6083',
+            ],
+          },
+          {
+            token: 'cbBTC',
+            network: 'base',
+            contractAddress: '0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf',
+            wallets: ['0x1fCca65fb6Ae3b2758b9b2B394CB227eAE404e1E'],
+          },
+        ],
+        token: 'cbbtc',
+      }
+      mockETHMainnetContractCallResponseSuccess()
+      mockBASEMainnetContractCallResponseSuccess()
+
+      const response = await testAdapter.request(data)
+      expect(response.json()).toMatchSnapshot()
+      expect(response.statusCode).toBe(200)
+    })
   })
 })


### PR DESCRIPTION
## [OPDATA-7107](https://smartcontract-it.atlassian.net/browse/OPDATA-7107), [OPDATA-7308](https://smartcontract-it.atlassian.net/browse/OPDATA-7308)

## Description

The EA proof-of-reserves-v2 has support for currency conversion built in. This means we no longer need to have currency conversion done in many separate endpoints.

But in order to do currency conversion in `proof-of-reserves-v2` each component needs to have balances for a single currency. By adding a `token` param to filter on to the `evm` endpoint of `token-balance` we can separate balances for different currencies into different components.

This allows feeds to stop using the `tbill` endpoint which can then eventually be removed.

The used pattern is similar to what is used in the [solanaMulti endpoint](https://github.com/smartcontractkit/external-adapters-js/blob/main/packages/sources/token-balance/src/endpoint/solanaMulti.ts).

## Changes

1. Add optional `token` field in the `addresses` param.
2. Add optional `token` param.
3. Validate that all addresses specify the `token` field when the `token` param is set.
4. Filter addresses when the `token` param is set.
5. Integration test added.

## Steps to Test

1. `yarn test packages/sources/token-balance`
2.
    ```
    curl --silent -S -X POST http://localhost:8083 -H 'Content-Type: application/json' -d '{
      "data": {
        "addressLists": [
          {
            "name": "openEdenAddress tbill",
            "provider": "por-address-list",
            "params": "{\"endpoint\":\"openedenAddress\",\"abiName\":\"MultiEVMPoRAddressList\",\"contractAddress\":\"0x440139321A15d14ce0729E004e91D66BaF1A08B0\",\"contractAddressNetwork\":\"BASE\",\"endUTC\":\"0800\",\"startUTC\":\"0000\",\"type\":\"tbill\"}",
            "addressArrayPath": "data.result"
          }
        ],
        "balanceSources": [
          {
            "name": "token-balance/evm:TBILL",
            "provider": "token-balance",
            "params": "{\"endpoint\":\"evm\",\"token\":\"TBILL\"}",
            "addressArrayPath": "addresses",
            "balancesArrayPath": "data.wallets",
            "balancePath": "balance",
            "decimalsPath": "decimals"
          }
        ],
        "components": [
          {
            "name": "openEdenAddress tbill + token-balance/evm:TBILL",
            "currency": "TBILL",
            "addressList": "openEdenAddress tbill",
            "balanceSource": "token-balance/evm:TBILL",
            "conversions": []
          }
        ],
        "conversions": [],
        "resultDecimals": 18
      }
    }'
    
    {
      "data": {
        "result": "3537161988423000000000000",
        "resultAsNumber": 3537161.988423,
        "decimals": 18,
        "components": [
          {
            "name": "openEdenAddress tbill + token-balance/evm:TBILL",
            "currency": "TBILL",
            "totalBalance": 3537161.988423,
            "addressCount": 5
          }
        ],
        "conversionRates": []
      },
      "statusCode": 200,
      "result": "3537161988423000000000000",
      "timestamps": {
        "providerDataRequestedUnixMs": 1778495330204,
        "providerDataReceivedUnixMs": 1778495330887
      },
      "meta": {
        "adapterName": "PROOF_OF-RESERVES-2",
        "metrics": {
          "feedId": "F2cVrrL62+oSgYvtNrtLuzK/tfs="
        }
      }
    }
    ```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[OPDATA-7107]: https://smartcontract-it.atlassian.net/browse/OPDATA-7107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OPDATA-7308]: https://smartcontract-it.atlassian.net/browse/OPDATA-7308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ