### PR TITLE
OPDATA-7109: Include decimals for individual balances of xrp response

### DIFF
--- a/.changeset/tame-worlds-invite.md
+++ b/.changeset/tame-worlds-invite.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/token-balance-adapter': minor
+---
+
+Include decimals for individual balances for xrp response

--- a/packages/sources/token-balance/src/endpoint/xrp.ts
+++ b/packages/sources/token-balance/src/endpoint/xrp.ts
@@ -34,6 +34,7 @@ export const inputParameters = new InputParameters(
 export type AddressWithBalance = {
   address: string
   balance: string
+  decimals: 6
 }
 
 export type BaseEndpointTypes = {

--- a/packages/sources/token-balance/src/transport/xrp.ts
+++ b/packages/sources/token-balance/src/transport/xrp.ts
@@ -126,6 +126,7 @@ export class XrpTransport extends SubscriptionTransport<BaseEndpointTypes> {
         return {
           address,
           balance,
+          decimals: RESULT_DECIMALS,
         }
       },
     )

--- a/packages/sources/token-balance/test/integration/__snapshots__/xrp.test.ts.snap
+++ b/packages/sources/token-balance/test/integration/__snapshots__/xrp.test.ts.snap
@@ -8,6 +8,7 @@ exports[`execute xrpl endpoint should return success 1`] = `
       {
         "address": "rGSA6YCGzywj2hsPA8DArSsLr1DMTBi2LH",
         "balance": "19999926",
+        "decimals": 6,
       },
     ],
   },

--- a/packages/sources/token-balance/test/unit/xrp.test.ts
+++ b/packages/sources/token-balance/test/unit/xrp.test.ts
@@ -172,6 +172,7 @@ describe('XrpTransport', () => {
         {
           address,
           balance: balance.toString(),
+          decimals: 6,
         },
       ]
 
@@ -222,10 +223,12 @@ describe('XrpTransport', () => {
         {
           address: address1,
           balance: balance1.toString(),
+          decimals: 6,
         },
         {
           address: address2,
           balance: balance2.toString(),
+          decimals: 6,
         },
       ]
       expect(response).toEqual({
@@ -277,6 +280,7 @@ describe('XrpTransport', () => {
         {
           address,
           balance: balance.toString(),
+          decimals: 6,
         },
       ]
       expect(await responsePromise).toEqual({
@@ -320,8 +324,8 @@ describe('XrpTransport', () => {
       ])
 
       expect(balances).toEqual([
-        { address: address1, balance: '100.0' },
-        { address: address2, balance: '200.0' },
+        { address: address1, balance: '100.0', decimals: 6 },
+        { address: address2, balance: '200.0', decimals: 6 },
       ])
 
       expect(requester.request).toHaveBeenNthCalledWith(
@@ -389,10 +393,10 @@ describe('XrpTransport', () => {
       resolveLines4('104.0')
 
       expect(await balancePromise).toEqual([
-        { address: address1, balance: '101.0' },
-        { address: address2, balance: '102.0' },
-        { address: address3, balance: '103.0' },
-        { address: address4, balance: '104.0' },
+        { address: address1, balance: '101.0', decimals: 6 },
+        { address: address2, balance: '102.0', decimals: 6 },
+        { address: address3, balance: '103.0', decimals: 6 },
+        { address: address4, balance: '104.0', decimals: 6 },
       ])
 
       expect(log).toHaveBeenNthCalledWith(


### PR DESCRIPTION
## [OPDATA-7109](https://smartcontract-it.atlassian.net/browse/OPDATA-7109)

## Description

All balances returned by the `xrp` endpoint of the `token-balance` adapter are XRP balances, so they all have 6 decimals.
We indicate this with `decimas: 6` directly in the `data` part of the response.

But other endpoints provide decimals for each individual balance so doing the same for this endpoint, makes it more consistent and easier to process the response. In particular in `proof-of-reserves-v2`.

## Changes

1. Add `decimals: 6` to individual balances in the response.
2. Update tests.

## Steps to Test

```
yarn test packages/sources/token-balance
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[OPDATA-7109]: https://smartcontract-it.atlassian.net/browse/OPDATA-7109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ