### PR TITLE
OPDATA-7111: Include decimals for individual balances of solana-balance response

### DIFF
--- a/.changeset/late-kiwis-see.md
+++ b/.changeset/late-kiwis-see.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/token-balance-adapter': minor
+---
+
+Include decimals for individual balances of solana-balance response

--- a/packages/sources/token-balance/src/endpoint/solana-balance.ts
+++ b/packages/sources/token-balance/src/endpoint/solana-balance.ts
@@ -34,6 +34,7 @@ export const inputParameters = new InputParameters(
 export type AddressWithBalance = {
   address: string
   balance: string
+  decimals: 9
 }
 
 export type BaseEndpointTypes = {

--- a/packages/sources/token-balance/src/transport/solana-balance.ts
+++ b/packages/sources/token-balance/src/transport/solana-balance.ts
@@ -89,6 +89,7 @@ export class SolanaBalanceTransport extends SubscriptionTransport<BaseEndpointTy
         return {
           address,
           balance: balance.toString(),
+          decimals: RESULT_DECIMALS,
         }
       },
     )

--- a/packages/sources/token-balance/test/integration/__snapshots__/solana-balance.test.ts.snap
+++ b/packages/sources/token-balance/test/integration/__snapshots__/solana-balance.test.ts.snap
@@ -8,6 +8,7 @@ exports[`execute SolanaBalanceTransport endpoint returns success 1`] = `
       {
         "address": "G7v3P9yPtBj1e3JN7B6dq4zbkrrW3e2ovdwAkSTKuUFG",
         "balance": "123000000000",
+        "decimals": 9,
       },
     ],
   },

--- a/packages/sources/token-balance/test/unit/solana-balance.test.ts
+++ b/packages/sources/token-balance/test/unit/solana-balance.test.ts
@@ -140,6 +140,7 @@ describe('SolanaBalanceTransport', () => {
         {
           address,
           balance: balance.toString(),
+          decimals: RESULT_DECIMALS,
         },
       ]
 
@@ -186,10 +187,12 @@ describe('SolanaBalanceTransport', () => {
         {
           address: address1,
           balance: balance1.toString(),
+          decimals: RESULT_DECIMALS,
         },
         {
           address: address2,
           balance: balance2.toString(),
+          decimals: RESULT_DECIMALS,
         },
       ]
       expect(response).toEqual({
@@ -230,6 +233,7 @@ describe('SolanaBalanceTransport', () => {
         {
           address,
           balance: balance.toString(),
+          decimals: RESULT_DECIMALS,
         },
       ]
       expect(await responsePromise).toEqual({
@@ -263,8 +267,8 @@ describe('SolanaBalanceTransport', () => {
       ])
 
       expect(balances).toEqual([
-        { address: address1, balance: '100' },
-        { address: address2, balance: '200' },
+        { address: address1, balance: '100', decimals: RESULT_DECIMALS },
+        { address: address2, balance: '200', decimals: RESULT_DECIMALS },
       ])
 
       expect(connectionGetAccountInfo).toHaveBeenNthCalledWith(1, createFakePublicKey(address1))
@@ -313,10 +317,10 @@ describe('SolanaBalanceTransport', () => {
       resolveLines4(104.0)
 
       expect(await balancePromise).toEqual([
-        { address: address1, balance: '101' },
-        { address: address2, balance: '102' },
-        { address: address3, balance: '103' },
-        { address: address4, balance: '104' },
+        { address: address1, balance: '101', decimals: RESULT_DECIMALS },
+        { address: address2, balance: '102', decimals: RESULT_DECIMALS },
+        { address: address3, balance: '103', decimals: RESULT_DECIMALS },
+        { address: address4, balance: '104', decimals: RESULT_DECIMALS },
       ])
     })
   })


### PR DESCRIPTION
## [OPDATA-7111](https://smartcontract-it.atlassian.net/browse/OPDATA-7111)

## Description

All balances returned by the `solana-balance` endpoint of the `token-balance` adapter are SOL balances, so they all have 9 decimals.
We indicate this with `decimas: 9` directly in the `data` part of the response.

But other endpoints provide decimals for each individual balance so doing the same for this endpoint, makes it more consistent and easier to process the response. In particular in `proof-of-reserves-v2`.

This is analogous to https://github.com/smartcontractkit/external-adapters-js/pull/4947

## Changes

1. Add `decimals: 9` to individual balances in the response.
2. Update tests.

## Steps to Test

```
yarn test packages/sources/token-balance
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[OPDATA-7109]: https://smartcontract-it.atlassian.net/browse/OPDATA-7109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[OPDATA-7111]: https://smartcontract-it.atlassian.net/browse/OPDATA-7111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ