### PR TITLE
Support for BASE_URL, and payload without endpoint

### DIFF
--- a/.changeset/swift-horses-shop.md
+++ b/.changeset/swift-horses-shop.md
@@ -1,0 +1,16 @@
+---
+'@chainlink/blocksize-capital-adapter': patch
+'@chainlink/cfbenchmarks-adapter': patch
+'@chainlink/coinmetrics-adapter': patch
+'@chainlink/dxfeed-adapter': patch
+'@chainlink/elwood-adapter': patch
+'@chainlink/finage-adapter': patch
+'@chainlink/finalto-adapter': patch
+'@chainlink/finnhub-adapter': patch
+'@chainlink/gsr-adapter': patch
+'@chainlink/ncfx-adapter': patch
+'@chainlink/tiingo-adapter': patch
+'@chainlink/tiingo-state-adapter': patch
+---
+
+Support for BASE_URL, and payload without endpoint


### PR DESCRIPTION
## Closes 
- DS-3047
- DS-3048 

## Changes

- Streams adapter now supports BASE_URL and METRICS_USE_BASE_URL
- Fallback for requests without `endpoint` in the payload to the default adapter endpoint. 