### PR TITLE
OPDATA-7113: Include decimals for individual balances of cardano response

### DIFF
--- a/.changeset/loud-days-walk.md
+++ b/.changeset/loud-days-walk.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/token-balance-adapter': minor
+---
+
+Include decimals for individual balances of cardano response

--- a/packages/sources/token-balance/src/endpoint/cardano.ts
+++ b/packages/sources/token-balance/src/endpoint/cardano.ts
@@ -34,6 +34,7 @@ export const inputParameters = new InputParameters(
 export type AddressWithBalance = {
   address: string
   balance: string
+  decimals: 6
 }
 
 export type BaseEndpointTypes = {

--- a/packages/sources/token-balance/src/transport/cardano.ts
+++ b/packages/sources/token-balance/src/transport/cardano.ts
@@ -95,6 +95,7 @@ export class CardanoTransport extends SubscriptionTransport<BaseEndpointTypes> {
         return {
           address,
           balance,
+          decimals: RESULT_DECIMALS,
         }
       },
     )

--- a/packages/sources/token-balance/test/integration/__snapshots__/cardano.test.ts.snap
+++ b/packages/sources/token-balance/test/integration/__snapshots__/cardano.test.ts.snap
@@ -8,6 +8,7 @@ exports[`execute cardano endpoint should return success 1`] = `
       {
         "address": "addr1w8z0xlftcx54tn7uxdvhk0qgj9u7hmlaccjthnc9kvu4pmcyemglm",
         "balance": "19999926",
+        "decimals": 6,
       },
     ],
   },

--- a/packages/sources/token-balance/test/unit/cardano.test.ts
+++ b/packages/sources/token-balance/test/unit/cardano.test.ts
@@ -164,6 +164,7 @@ describe('CardanoTransport', () => {
         {
           address,
           balance: balance.toString(),
+          decimals: 6,
         },
       ]
 
@@ -214,10 +215,12 @@ describe('CardanoTransport', () => {
         {
           address: address1,
           balance: balance1.toString(),
+          decimals: 6,
         },
         {
           address: address2,
           balance: balance2.toString(),
+          decimals: 6,
         },
       ]
       expect(response).toEqual({
@@ -269,6 +272,7 @@ describe('CardanoTransport', () => {
         {
           address,
           balance: balance.toString(),
+          decimals: 6,
         },
       ]
       expect(await responsePromise).toEqual({
@@ -312,8 +316,8 @@ describe('CardanoTransport', () => {
       ])
 
       expect(balances).toEqual([
-        { address: address1, balance: '100' },
-        { address: address2, balance: '200' },
+        { address: address1, balance: '100', decimals: 6 },
+        { address: address2, balance: '200', decimals: 6 },
       ])
 
       expect(requester.request).toHaveBeenNthCalledWith(
@@ -381,10 +385,10 @@ describe('CardanoTransport', () => {
       resolveLines4('104')
 
       expect(await balancePromise).toEqual([
-        { address: address1, balance: '101' },
-        { address: address2, balance: '102' },
-        { address: address3, balance: '103' },
-        { address: address4, balance: '104' },
+        { address: address1, balance: '101', decimals: 6 },
+        { address: address2, balance: '102', decimals: 6 },
+        { address: address3, balance: '103', decimals: 6 },
+        { address: address4, balance: '104', decimals: 6 },
       ])
 
       expect(log).toHaveBeenNthCalledWith(


### PR DESCRIPTION
## [OPDATA-7113](https://smartcontract-it.atlassian.net/browse/OPDATA-7113)

## Description

All balances returned by the `cardano` endpoint of the `token-balance` adapter are ADA balances, so they all have 6 decimals.
We indicate this with `decimals: 6` directly in the `data` part of the response.

But other endpoints provide decimals for each individual balance so doing the same for this endpoint, makes it more consistent and easier to process the response. In particular in `proof-of-reserves-v2`.

This is analogous to https://github.com/smartcontractkit/external-adapters-js/pull/4947

## Changes

1. Add `decimals: 6` to individual balances in the response.
2. Update tests.

## Steps to Test

```
yarn test packages/sources/token-balance
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.

[OPDATA-7113]: https://smartcontract-it.atlassian.net/browse/OPDATA-7113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ