### PR TITLE
OPDATA-7115: Include decimals for individual balances of stellar response

### DIFF
--- a/.changeset/wicked-donuts-like.md
+++ b/.changeset/wicked-donuts-like.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/token-balance-adapter': minor
+---
+
+Include decimals for individual balances of stellar response

--- a/packages/sources/token-balance/src/endpoint/stellar.ts
+++ b/packages/sources/token-balance/src/endpoint/stellar.ts
@@ -36,6 +36,7 @@ export const inputParameters = new InputParameters(
 export type AddressWithBalance = {
   address: string
   balance: string
+  decimals: 7
 }
 
 export type BaseEndpointTypes = {

--- a/packages/sources/token-balance/src/transport/stellar.ts
+++ b/packages/sources/token-balance/src/transport/stellar.ts
@@ -130,6 +130,7 @@ export class StellarTransport extends SubscriptionTransport<BaseEndpointTypes> {
       return {
         address: addresses[index].address,
         balance: stroops,
+        decimals: RESULT_DECIMALS,
       }
     })
   }

--- a/packages/sources/token-balance/test/integration/__snapshots__/stellar.test.ts.snap
+++ b/packages/sources/token-balance/test/integration/__snapshots__/stellar.test.ts.snap
@@ -8,10 +8,12 @@ exports[`execute stellar endpoint should return success 1`] = `
       {
         "address": "GBZYS4XMGENS4IQCS2J2R7XUAY2VJST3VM62ZDSC24JONYASS5MAVROB",
         "balance": "64063362344231",
+        "decimals": 7,
       },
       {
         "address": "GB4SJVA7KAFDZJFVTSEV2YWZZA3VEANHHK3WSJRHO2XS2GDYJCGWKDB5",
         "balance": "399999900",
+        "decimals": 7,
       },
     ],
   },

--- a/packages/sources/token-balance/test/unit/stellar.test.ts
+++ b/packages/sources/token-balance/test/unit/stellar.test.ts
@@ -106,10 +106,12 @@ describe('StellarTransport', () => {
     {
       address: address1,
       balance: balance1.toString(),
+      decimals: 7,
     },
     {
       address: address2,
       balance: balance2.toString(),
+      decimals: 7,
     },
   ]
 


### PR DESCRIPTION
## [OPDATA-7115](https://smartcontract-it.atlassian.net/browse/OPDATA-7115)

## Description

All balances returned by the `stellar` endpoint of the `token-balance` adapter are XLM balances, so they all have 7 decimals.
We indicate this with `decimals: 7` directly in the `data` part of the response.

But other endpoints provide decimals for each individual balance so doing the same for this endpoint, makes it more consistent and easier to process the response. In particular in `proof-of-reserves-v2`.

This is analogous to https://github.com/smartcontractkit/external-adapters-js/pull/4947

## Changes

1. Add `decimals: 7` to individual balances in the response.
2. Update tests.

## Steps to Test

```
yarn test packages/sources/token-balance
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.

[OPDATA-7113]: https://smartcontract-it.atlassian.net/browse/OPDATA-7113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[OPDATA-7115]: https://smartcontract-it.atlassian.net/browse/OPDATA-7115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ