### PR TITLE
OPDATA-7121: Include decimals in polkadot-balance response

### DIFF
--- a/.changeset/wide-snails-trade.md
+++ b/.changeset/wide-snails-trade.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/polkadot-balance-adapter': minor
+---
+
+Include decimals in response

--- a/packages/sources/polkadot-balance/src/endpoint/balance.ts
+++ b/packages/sources/polkadot-balance/src/endpoint/balance.ts
@@ -26,6 +26,7 @@ export type PolkadotBalance = {
   free: string
   reserved: string
   balance: string // sum of free and reserved
+  decimals: 10
 }
 
 export type BaseEndpointTypes = {

--- a/packages/sources/polkadot-balance/src/transport/balance.ts
+++ b/packages/sources/polkadot-balance/src/transport/balance.ts
@@ -10,6 +10,8 @@ export type BalanceTransportTypes = BaseEndpointTypes
 
 type RequestParams = typeof inputParameters.validated
 
+const RESULT_DECIMALS = 10
+
 export class BalanceTransport extends SubscriptionTransport<BalanceTransportTypes> {
   api!: ApiPromise
   config!: BalanceTransportTypes['Settings']
@@ -77,6 +79,7 @@ export class BalanceTransport extends SubscriptionTransport<BalanceTransportType
         free: free.toString(),
         reserved: reserved.toString(),
         balance: balance.toString(),
+        decimals: RESULT_DECIMALS,
       })
     })
 

--- a/packages/sources/polkadot-balance/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/polkadot-balance/test/integration/__snapshots__/adapter.test.ts.snap
@@ -18,18 +18,21 @@ exports[`Balance Endpoint should return success 1`] = `
       {
         "address": "13nogjgyJcGQduHt8RtZiKKbt7Uy6py9hv1WMDZWueEcsHdh",
         "balance": "554312742041197",
+        "decimals": 10,
         "free": "10249387394",
         "reserved": "554302492653803",
       },
       {
         "address": "126rjyDQEJm6V6YPDcN85hJDYraqB6hL9bFsvWLDnM8rLc3J",
         "balance": "10164493645506991",
+        "decimals": 10,
         "free": "536730221406",
         "reserved": "10163956915285585",
       },
       {
         "address": "15vJFD1Y8nButjmgjbK5x6SYU2cQnbihM4GgkR5enkwyTVLq",
         "balance": "10577378450377986",
+        "decimals": 10,
         "free": "10577378450377986",
         "reserved": "0",
       },


### PR DESCRIPTION
## [OPDATA-7121](https://smartcontract-it.atlassian.net/browse/OPDATA-7121)

## Description

All balances returned by the `polkadot-balance` adapter are DOT balances, so they all have 10 decimals.
This is currently not indicated in the response.

Providing decimals for each individual balance makes it more consistent and easier to process the response. In particular in `proof-of-reserves-v2`.

This is analogous to https://github.com/smartcontractkit/external-adapters-js/pull/4947

## Changes

1. Add `decimals: 10` to individual balances in the response.
2. Update tests.

## Steps to Test

```
yarn test packages/sources/polkadot-balance
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[OPDATA-7121]: https://smartcontract-it.atlassian.net/browse/OPDATA-7121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ