### PR TITLE
OPDATA-7131: Include decimals in individual balance responses of avalanche-platform

### DIFF
--- a/.changeset/brown-lions-cry.md
+++ b/.changeset/brown-lions-cry.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/avalanche-platform-adapter': minor
+---
+
+Include decimals in individual balance responses

--- a/packages/sources/avalanche-platform/src/transport/totalBalance.ts
+++ b/packages/sources/avalanche-platform/src/transport/totalBalance.ts
@@ -45,6 +45,7 @@ type BalanceResult = {
   lockedStakeable: string
   lockedNotStakeable: string
   staked: string
+  decimals: 18
 }
 
 const RESULT_DECIMALS = 18
@@ -165,6 +166,7 @@ export class TotalBalanceTransport extends SubscriptionTransport<BaseEndpointTyp
           lockedStakeable,
           lockedNotStakeable,
           staked,
+          decimals: RESULT_DECIMALS,
         }
       }),
     )

--- a/packages/sources/avalanche-platform/test/integration/__snapshots__/totalBalance.test.ts.snap
+++ b/packages/sources/avalanche-platform/test/integration/__snapshots__/totalBalance.test.ts.snap
@@ -8,6 +8,7 @@ exports[`execute totalBalance endpoint should return success 1`] = `
       {
         "address": "P-fuji1vd9sddlllrlk9fvj9lhntpw8t00lmvtnqkl2jt",
         "balance": "5000000000000000000000",
+        "decimals": 18,
         "lockedNotStakeable": "0",
         "lockedStakeable": "0",
         "staked": "2000000000000000000000",

--- a/packages/sources/avalanche-platform/test/unit/totalBalance.test.ts
+++ b/packages/sources/avalanche-platform/test/unit/totalBalance.test.ts
@@ -211,6 +211,7 @@ describe('TotalBalanceTransport', () => {
           unlocked: (123_000_000_000).toString(),
           lockedStakeable: '0',
           lockedNotStakeable: '0',
+          decimals: RESULT_DECIMALS,
         },
       ]
 
@@ -264,6 +265,7 @@ describe('TotalBalanceTransport', () => {
           unlocked: '100000000000',
           lockedStakeable: '0',
           lockedNotStakeable: '0',
+          decimals: RESULT_DECIMALS,
         },
         {
           address: address2,
@@ -272,6 +274,7 @@ describe('TotalBalanceTransport', () => {
           unlocked: '200000000000',
           lockedStakeable: '0',
           lockedNotStakeable: '0',
+          decimals: RESULT_DECIMALS,
         },
       ]
 
@@ -314,6 +317,7 @@ describe('TotalBalanceTransport', () => {
           unlocked: '101000000000',
           lockedStakeable: '201000000000',
           lockedNotStakeable: '301000000000',
+          decimals: RESULT_DECIMALS,
         },
       ]
 
@@ -361,6 +365,7 @@ describe('TotalBalanceTransport', () => {
           unlocked: '1000000000',
           lockedStakeable: '0',
           lockedNotStakeable: '0',
+          decimals: RESULT_DECIMALS,
         },
       ]
       expect(await responsePromise).toEqual({


### PR DESCRIPTION
## [OPDATA-7131](https://smartcontract-it.atlassian.net/browse/OPDATA-7131)

## Description

All balances returned by the `totalBalance` endpoint of the `avalanche-platform` adapter are AVAX balances, so they all have 18 decimals.
We indicate this with `decimals: 18` directly in the `data` part of the response.

But other endpoints provide decimals for each individual balance so doing the same for this endpoint, makes it more consistent and easier to process the response. In particular in `proof-of-reserves-v2`.

This is analogous to https://github.com/smartcontractkit/external-adapters-js/pull/4947

## Changes

1. Add `decimals: 18` to individual balances in the response.
2. Update tests.

## Steps to Test

```
yarn test packages/sources/avalanche-platform
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.

[OPDATA-7113]: https://smartcontract-it.atlassian.net/browse/OPDATA-7113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[OPDATA-7115]: https://smartcontract-it.atlassian.net/browse/OPDATA-7115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[OPDATA-7117]: https://smartcontract-it.atlassian.net/browse/OPDATA-7117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[OPDATA-7131]: https://smartcontract-it.atlassian.net/browse/OPDATA-7131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ