### PR TITLE
[Streams adapters] Fix finalto and finnhub flatlines

### DIFF
--- a/packages/streams-adapter/README.md
+++ b/packages/streams-adapter/README.md
@@ -51,7 +51,7 @@ The Go runtime waits for the JS adapter `/health` endpoint before starting.
 - `REDCON_PORT` (default: `6379`): Redis-compatible ingestion server port.
 - `METRICS_PORT` (default: `9080`): Prometheus metrics server port.
 - `CACHE_TTL_MINUTES` (default: `5`): in-memory cache TTL.
-- `CACHE_CLEANUP_INTERVAL` (default: `60`): cache cleanup interval in seonds; also used as periodic resubscribe interval.
+- `CACHE_CLEANUP_INTERVAL` (default: `60`): cache cleanup interval in seconds; also used as periodic resubscribe interval.
 - `SUBSCRIPTION_RETRY_DELAY_SECONDS` (default: `10`): delay before allowing re-subscription after a miss.
 - `LOG_LEVEL` (default: `info`): use `debug` to enable Gin request logging and additional debug logs.
 - `PACKAGE_NAME` (required for alias mapping): adapter package name, for example `@chainlink/tiingo-adapter`.

--- a/packages/streams-adapter/README.md
+++ b/packages/streams-adapter/README.md
@@ -51,7 +51,7 @@ The Go runtime waits for the JS adapter `/health` endpoint before starting.
 - `REDCON_PORT` (default: `6379`): Redis-compatible ingestion server port.
 - `METRICS_PORT` (default: `9080`): Prometheus metrics server port.
 - `CACHE_TTL_MINUTES` (default: `5`): in-memory cache TTL.
-- `CACHE_CLEANUP_INTERVAL` (default: `1`): cache cleanup interval; also used as periodic resubscribe interval.
+- `CACHE_CLEANUP_INTERVAL` (default: `60`): cache cleanup interval in seonds; also used as periodic resubscribe interval.
 - `SUBSCRIPTION_RETRY_DELAY_SECONDS` (default: `10`): delay before allowing re-subscription after a miss.
 - `LOG_LEVEL` (default: `info`): use `debug` to enable Gin request logging and additional debug logs.
 - `PACKAGE_NAME` (required for alias mapping): adapter package name, for example `@chainlink/tiingo-adapter`.

--- a/packages/streams-adapter/cache/cache.go
+++ b/packages/streams-adapter/cache/cache.go
@@ -85,15 +85,16 @@ func New(cfg Config) *Cache {
 // SetNew creates a "new" cache item for the given raw key if one does not
 // already exist. Returns true if the item was created (i.e. this is the first
 // caller for this key), false if an item already existed.
-func (c *Cache) SetNew(rawKey string) bool {
+func (c *Cache) SetNew(rawKey string, originalRequestData map[string]interface{}) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if _, exists := c.items[rawKey]; exists {
 		return false
 	}
 	c.items[rawKey] = &types.CacheItem{
-		Status:    types.StatusNew,
-		Timestamp: time.Now(),
+		Status:              types.StatusNew,
+		Timestamp:           time.Now(),
+		OriginalRequestData: originalRequestData,
 	}
 	cacheItemsTotal.Inc()
 	return true

--- a/packages/streams-adapter/cache/cache_test.go
+++ b/packages/streams-adapter/cache/cache_test.go
@@ -24,7 +24,7 @@ func mustKey(t *testing.T, params types.RequestParams) string {
 // (new → learned → active) with the given observation.
 // When there is no parameter transformation rawKey == transformedKey.
 func setActive(c *Cache, rawKey, transformedKey string, obs *types.Observation, timestamp time.Time, originalAdapterKey string) {
-	c.SetNew(rawKey)
+	c.SetNew(rawKey, nil)
 	c.SetTransformedKey(rawKey, transformedKey)
 	c.SetObservation(transformedKey, obs, timestamp, originalAdapterKey)
 }
@@ -178,10 +178,10 @@ func TestCache_SetNew_Idempotent(t *testing.T) {
 	})
 	defer c.Stop()
 
-	created := c.SetNew("some-key")
+	created := c.SetNew("some-key", nil)
 	require.True(t, created, "first SetNew should create the item")
 
-	created = c.SetNew("some-key")
+	created = c.SetNew("some-key", nil)
 	require.False(t, created, "second SetNew should be a no-op")
 
 	require.Len(t, c.Items(), 1)
@@ -191,7 +191,7 @@ func TestCache_SetNew_StatusNew(t *testing.T) {
 	c := New(Config{TTL: time.Minute, CleanupInterval: time.Hour})
 	defer c.Stop()
 
-	c.SetNew("raw-key")
+	c.SetNew("raw-key", nil)
 	item := c.Get("raw-key")
 	require.NotNil(t, item)
 	require.Equal(t, types.StatusNew, item.Status)
@@ -203,7 +203,7 @@ func TestCache_SetTransformedKey_StatusLearned(t *testing.T) {
 	c := New(Config{TTL: time.Minute, CleanupInterval: time.Hour})
 	defer c.Stop()
 
-	c.SetNew("raw-key")
+	c.SetNew("raw-key", nil)
 	c.SetTransformedKey("raw-key", "transformed-key")
 
 	item := c.Get("raw-key")
@@ -218,7 +218,7 @@ func TestCache_SetObservation_StatusActive(t *testing.T) {
 	defer c.Stop()
 
 	obs := &types.Observation{Success: true, Data: json.RawMessage(`{"result":42}`)}
-	c.SetNew("raw-key")
+	c.SetNew("raw-key", nil)
 	c.SetTransformedKey("raw-key", "transformed-key")
 	c.SetObservation("transformed-key", obs, time.Now(), "adapter-key")
 
@@ -291,7 +291,7 @@ func TestCache_CleanupExpired(t *testing.T) {
 
 	// Set item with old timestamp (bypassing the lifecycle for simplicity).
 	oldRawKey := mustKey(t, types.RequestParams{"endpoint": "old"})
-	c.SetNew(oldRawKey)
+	c.SetNew(oldRawKey, nil)
 	c.SetTransformedKey(oldRawKey, "old-transformed")
 	c.SetObservation("old-transformed", obs, time.Now().Add(-ttl*2), "old-adapter")
 	// Force the item's own timestamp back too.
@@ -332,7 +332,7 @@ func TestCache_CleanupLoop(t *testing.T) {
 	obs := &types.Observation{Success: true}
 
 	oldRawKey := mustKey(t, types.RequestParams{"endpoint": "old"})
-	c.SetNew(oldRawKey)
+	c.SetNew(oldRawKey, nil)
 	c.SetTransformedKey(oldRawKey, oldRawKey)
 	c.SetObservation(oldRawKey, obs, time.Now().Add(-ttl*2), "old-adapter")
 	c.mu.Lock()

--- a/packages/streams-adapter/common/types.go
+++ b/packages/streams-adapter/common/types.go
@@ -36,9 +36,10 @@ const (
 
 // CacheItem represents a cached value with metadata
 type CacheItem struct {
-	Status             CacheItemStatus
-	TransformedKey     string       // populated once StatusLearned or StatusActive
-	Observation        *Observation // populated once StatusActive
-	Timestamp          time.Time    // last write time (used for TTL)
-	OriginalAdapterKey string       // JS adapter Redis key; populated once StatusActive
+	Status              CacheItemStatus
+	TransformedKey      string                 // populated once StatusLearned or StatusActive
+	Observation         *Observation           // populated once StatusActive
+	Timestamp           time.Time              // last write time (used for TTL)
+	OriginalAdapterKey  string                 // JS adapter Redis key; populated once StatusActive
+	OriginalRequestData map[string]interface{} // raw request body data from the first subscription request
 }

--- a/packages/streams-adapter/config/config.go
+++ b/packages/streams-adapter/config/config.go
@@ -19,7 +19,7 @@ type Config struct {
 
 	// Cache configuration
 	CacheTTLMinutes      uint // Cache TTL in minutes (0 = default 5 minutes)
-	CacheCleanupInterval uint // Cache cleanup interval in minutes (0 = default 1 minute)
+	CacheCleanupIntervalSeconds uint // Cache cleanup interval in seconds (0 = default 60 seconds)
 
 	// Subscription configuration
 	SubscriptionRetryDelaySeconds uint // Delay before allowing re-subscription (0 = default 10s)
@@ -51,7 +51,7 @@ func Load() *Config {
 
 		// Cache configuration
 		CacheTTLMinutes:      getEnvAsInt("CACHE_TTL_MINUTES", 5),
-		CacheCleanupInterval: getEnvAsInt("CACHE_CLEANUP_INTERVAL", 1),
+		CacheCleanupIntervalSeconds: getEnvAsInt("CACHE_CLEANUP_INTERVAL", 60),
 
 		// Subscription
 		SubscriptionRetryDelaySeconds: getEnvAsInt("SUBSCRIPTION_RETRY_DELAY_SECONDS", 10),

--- a/packages/streams-adapter/config/config.go
+++ b/packages/streams-adapter/config/config.go
@@ -51,7 +51,7 @@ func Load() *Config {
 
 		// Cache configuration
 		CacheTTLMinutes:      getEnvAsInt("CACHE_TTL_MINUTES", 5),
-		CacheCleanupIntervalSeconds: getEnvAsInt("CACHE_CLEANUP_INTERVAL", 60),
+		CacheCleanupIntervalSeconds: getEnvAsInt("CACHE_CLEANUP_INTERVAL", 1),
 
 		// Subscription
 		SubscriptionRetryDelaySeconds: getEnvAsInt("SUBSCRIPTION_RETRY_DELAY_SECONDS", 10),

--- a/packages/streams-adapter/config/config_test.go
+++ b/packages/streams-adapter/config/config_test.go
@@ -32,7 +32,7 @@ func TestLoad_Defaults(t *testing.T) {
 	require.Equal(t, "6379", cfg.RedconPort)
 	require.Equal(t, "9080", cfg.GoMetricsPort)
 	require.Equal(t, uint(5), cfg.CacheTTLMinutes)
-	require.Equal(t, uint(1), cfg.CacheCleanupInterval)
+	require.Equal(t, uint(1), cfg.CacheCleanupIntervalSeconds)
 	require.Equal(t, "info", cfg.LogLevel)
 	require.Equal(t, "", cfg.AdapterName)
 }
@@ -58,7 +58,7 @@ func TestLoad_CustomEnvVars(t *testing.T) {
 	require.Equal(t, "6380", cfg.RedconPort)
 	require.Equal(t, "9090", cfg.GoMetricsPort)
 	require.Equal(t, uint(10), cfg.CacheTTLMinutes)
-	require.Equal(t, uint(3), cfg.CacheCleanupInterval)
+	require.Equal(t, uint(3), cfg.CacheCleanupIntervalSeconds)
 	require.Equal(t, "debug", cfg.LogLevel)
 	require.Equal(t, "tiingo", cfg.AdapterName)
 }

--- a/packages/streams-adapter/helpers/aliases.go
+++ b/packages/streams-adapter/helpers/aliases.go
@@ -172,5 +172,36 @@ func BuildCacheKeyParams(data map[string]interface{}) (types.RequestParams, erro
 		out[strings.ToLower(k)] = strings.ToUpper(value)
 	}
 
+	// Apply adapter-specific symbol overrides so the cache key reflects the
+	// actual symbol the JS adapter will subscribe to. Without this, requests
+	// that map a symbol via overrides (e.g. CRCL → CRCL.xnys) would produce
+	// the same cache key as requests for the raw symbol, causing incorrect
+	// resubscription payloads to be stored and used.
+	if overridesRaw, ok := data["overrides"]; ok {
+		if overridesMap, ok := overridesRaw.(map[string]interface{}); ok {
+			for adapterKey, adapterOverridesRaw := range overridesMap {
+				if !strings.EqualFold(adapterKey, activeAdapter) {
+					continue
+				}
+				adapterOverrides, ok := adapterOverridesRaw.(map[string]interface{})
+				if !ok {
+					break
+				}
+				for paramKey, paramVal := range out {
+					if paramKey == "endpoint" {
+						continue
+					}
+					for overrideKey, overrideVal := range adapterOverrides {
+						if strings.EqualFold(overrideKey, paramVal) {
+							out[paramKey] = strings.ToUpper(toString(overrideVal))
+							break
+						}
+					}
+				}
+				break
+			}
+		}
+	}
+
 	return out, nil
 }

--- a/packages/streams-adapter/helpers/aliases_test.go
+++ b/packages/streams-adapter/helpers/aliases_test.go
@@ -258,10 +258,11 @@ func TestBuildCacheKeyParams_EmptyStringValueSkipped(t *testing.T) {
 	}
 }
 
-func TestBuildCacheKeyParams_OverridesStripped(t *testing.T) {
+func TestBuildCacheKeyParams_OverridesApplied(t *testing.T) {
 	initTestAdapter(t)
 
-	// Overrides are no longer processed, just stripped from output.
+	// Overrides for the active adapter are applied to the cache key params so the
+	// key reflects the actual symbol the JS adapter will subscribe to.
 	result, err := BuildCacheKeyParams(map[string]interface{}{
 		"endpoint": "price",
 		"base":     "WBTC",
@@ -274,8 +275,8 @@ func TestBuildCacheKeyParams_OverridesStripped(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// No override applied — value stays as WBTC
-	assertParam(t, result, "base", "WBTC")
+	// Override applied — base is remapped to BTC
+	assertParam(t, result, "base", "BTC")
 	assertParam(t, result, "quote", "USD")
 	if _, ok := result["overrides"]; ok {
 		t.Error("'overrides' key should not appear in output params")

--- a/packages/streams-adapter/main.go
+++ b/packages/streams-adapter/main.go
@@ -62,7 +62,7 @@ func main() {
 
 	appCache := cache.New(cache.Config{
 		TTL:             time.Duration(cfg.CacheTTLMinutes) * time.Minute,
-		CleanupInterval: time.Duration(cfg.CacheCleanupInterval) * time.Minute,
+		CleanupInterval: time.Duration(cfg.CacheCleanupIntervalSeconds) * time.Second,
 	})
 	defer appCache.Stop()
 

--- a/packages/streams-adapter/server/server.go
+++ b/packages/streams-adapter/server/server.go
@@ -241,23 +241,24 @@ func (s *Server) cacheHandler(c *gin.Context) {
 	items := s.cache.Items()
 
 	type entry struct {
-		Key            string                `json:"key"`
-		Status         types.CacheItemStatus `json:"status"`
-		TransformedKey string                `json:"transformedKey,omitempty"`
-		AdapterKey     string                `json:"adapterKey,omitempty"`
-		Timestamp      time.Time             `json:"timestamp"`
-		Observation    *types.Observation    `json:"observation,omitempty"`
+		Key                 string                 `json:"key"`
+		Status              types.CacheItemStatus  `json:"status"`
+		TransformedKey      string                 `json:"transformedKey,omitempty"`
+		AdapterKey          string                 `json:"adapterKey,omitempty"`
+		Timestamp           time.Time              `json:"timestamp"`
+		Observation         *types.Observation     `json:"observation,omitempty"`
+		OriginalRequestData map[string]interface{} `json:"originalRequestData,omitempty"`
 	}
-
 	entries := make([]entry, 0, len(items))
 	for key, item := range items {
 		entries = append(entries, entry{
-			Key:            key,
-			Status:         item.Status,
-			TransformedKey: item.TransformedKey,
-			AdapterKey:     item.OriginalAdapterKey,
-			Timestamp:      item.Timestamp,
-			Observation:    item.Observation,
+			Key:                 key,
+			Status:              item.Status,
+			TransformedKey:      item.TransformedKey,
+			AdapterKey:          item.OriginalAdapterKey,
+			Timestamp:           item.Timestamp,
+			Observation:         item.Observation,
+			OriginalRequestData: item.OriginalRequestData,
 		})
 	}
 
@@ -329,7 +330,7 @@ func (s *Server) adapterHandler(c *gin.Context) {
 		// Fall through to 504 below.
 	} else {
 		// First request for this key — create the item and start polling.
-		if s.cache.SetNew(rawCacheKey) {
+		if s.cache.SetNew(rawCacheKey, reqData.Data) {
 			s.logger.Debug("Initiating new subscription", "requestParams", rawParams, "rawCacheKey", rawCacheKey)
 			go func(key string, params types.RequestParams, originalData map[string]interface{}) {
 				endpoint := params["endpoint"]
@@ -446,7 +447,7 @@ func (s *Server) queryAdapterForFeedID(data interface{}) (feedID string, ok bool
 
 // resubscribeLoop periodically resubscribes to all assets in the cache.
 func (s *Server) resubscribeLoop() {
-	cleanupInterval := time.Duration(s.config.CacheCleanupInterval) * time.Minute
+	cleanupInterval := time.Duration(s.config.CacheCleanupIntervalSeconds) * time.Second
 	ticker := time.NewTicker(cleanupInterval)
 	defer ticker.Stop()
 
@@ -461,7 +462,10 @@ func (s *Server) resubscribeLoop() {
 }
 
 // resubscribeAllAssets resubscribes to all active assets in the cache.
-// Parses request params from the OriginalAdapterKey stored on each active cache item.
+// Uses OriginalRequestData (stored at first subscription time) when available so
+// that overrides and the exact original params are preserved, avoiding case
+// mismatches that can cause the JS adapter to re-subscribe with a different
+// symbol and have that subscription rejected.
 func (s *Server) resubscribeAllAssets() {
 	items := s.cache.Items()
 
@@ -469,14 +473,13 @@ func (s *Server) resubscribeAllAssets() {
 		if item.Status != types.StatusActive {
 			continue
 		}
-		params, err := helpers.RequestParamsFromKey(item.OriginalAdapterKey)
-		if err != nil {
-			s.logger.Debug("Failed to parse params from adapter key", "key", item.OriginalAdapterKey, "error", err)
+		if item.OriginalRequestData == nil {
+			s.logger.Warn("No original request data for active cache item, skipping resubscribe", "key", item.OriginalAdapterKey)
 			continue
 		}
-		go func(p types.RequestParams) {
+		go func(p interface{}) {
 			s.subscribeToAsset(p)
-		}(params)
+		}(item.OriginalRequestData)
 	}
 }
 

--- a/packages/streams-adapter/server/server_test.go
+++ b/packages/streams-adapter/server/server_test.go
@@ -55,15 +55,15 @@ func TestMain(m *testing.M) {
 	}
 
 	cfg := &config.Config{
-		HTTPPort:             "0",
-		EAPort:               "0",
-		EAHost:               "localhost",
-		RedconPort:           "0",
-		GoMetricsPort:        "0",
-		CacheTTLMinutes:      5,
-		CacheCleanupInterval: 60,
-		LogLevel:             "info",
-		AdapterName:          "test",
+		HTTPPort:                    "0",
+		EAPort:                      "0",
+		EAHost:                      "localhost",
+		RedconPort:                  "0",
+		GoMetricsPort:               "0",
+		CacheTTLMinutes:             5,
+		CacheCleanupIntervalSeconds: 60,
+		LogLevel:                    "info",
+		AdapterName:                 "test",
 	}
 
 	testCache = cache.New(cache.Config{
@@ -83,7 +83,7 @@ func setCache(t *testing.T, params types.RequestParams, obs *types.Observation, 
 	t.Helper()
 	rawKey, err := helpers.CalculateCacheKey(params)
 	require.NoError(t, err)
-	testCache.SetNew(rawKey)
+	testCache.SetNew(rawKey, nil)
 	testCache.SetTransformedKey(rawKey, rawKey)
 	testCache.SetObservation(rawKey, obs, time.Now(), originalAdapterKey)
 }
@@ -195,9 +195,9 @@ func TestAdapterHandler_CacheMiss(t *testing.T) {
 
 func TestBuildMetricsURL_NoBaseUrl(t *testing.T) {
 	cfg := &config.Config{
-		EAHost:              "localhost",
-		EAMetricsPort:       "9081",
-		EABaseUrl:           "",
+		EAHost:            "localhost",
+		EAMetricsPort:     "9081",
+		EABaseUrl:         "",
 		MetricsUseBaseUrl: false,
 	}
 	got := buildMetricsURL(cfg)
@@ -206,9 +206,9 @@ func TestBuildMetricsURL_NoBaseUrl(t *testing.T) {
 
 func TestBuildMetricsURL_WithBaseUrl(t *testing.T) {
 	cfg := &config.Config{
-		EAHost:              "localhost",
-		EAMetricsPort:       "9081",
-		EABaseUrl:           "/blocksize-capital-llo-exp",
+		EAHost:            "localhost",
+		EAMetricsPort:     "9081",
+		EABaseUrl:         "/blocksize-capital-llo-exp",
 		MetricsUseBaseUrl: true,
 	}
 	got := buildMetricsURL(cfg)
@@ -218,9 +218,9 @@ func TestBuildMetricsURL_WithBaseUrl(t *testing.T) {
 func TestBuildMetricsURL_WithBaseUrlTrailingSlash(t *testing.T) {
 	// Config normalizes trailing slashes at load time; EABaseUrl is always stored without one.
 	cfg := &config.Config{
-		EAHost:              "localhost",
-		EAMetricsPort:       "9081",
-		EABaseUrl:           "/blocksize-capital-llo-exp",
+		EAHost:            "localhost",
+		EAMetricsPort:     "9081",
+		EABaseUrl:         "/blocksize-capital-llo-exp",
 		MetricsUseBaseUrl: true,
 	}
 	got := buildMetricsURL(cfg)
@@ -230,9 +230,9 @@ func TestBuildMetricsURL_WithBaseUrlTrailingSlash(t *testing.T) {
 func TestBuildMetricsURL_WithBaseUrlDefault_UseBaseUrl(t *testing.T) {
 	// Config normalizes "/" to "" (empty string) at load time.
 	cfg := &config.Config{
-		EAHost:              "localhost",
-		EAMetricsPort:       "9081",
-		EABaseUrl:           "",
+		EAHost:            "localhost",
+		EAMetricsPort:     "9081",
+		EABaseUrl:         "",
 		MetricsUseBaseUrl: true,
 	}
 	got := buildMetricsURL(cfg)


### PR DESCRIPTION
## Closes #DS-3087

## Description

Finalto and Finnhub data providers are case-sensitive. The resubscribe loop was re-creating the request payload from the adapter key, which resulted in all asset names being uppercased. This caused resubscribes to fail — the JS adapter invalidated the asset pair, and data stopped flowing until the Redcon cache expired.

The fix stores the original request payload in the cache item and uses it when resubscribing.

## Changes

- Cache cleanup interval from minutes to seconds to increase granilarity
- Added `originalRequestData` for cache item, updated `setNew`, and resubscribeAllAssets to use it
- Added overrides to the key items

## Steps to Test

Query Finalto and Finnhub EAs in staging and check that timestamps are no longer than few seconds.
