### PR TITLE
Fix ripcord bug in generic-api

### DIFF
--- a/.changeset/petite-parents-win.md
+++ b/.changeset/petite-parents-win.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/generic-api-adapter': patch
+---
+
+Require ripcord field to be present when configured

--- a/packages/sources/generic-api/src/transport/utils.ts
+++ b/packages/sources/generic-api/src/transport/utils.ts
@@ -60,8 +60,7 @@ const createMultiResponse = (
   // Check ripcord
   if (
     param.ripcordPath !== undefined &&
-    objectPath.has(response.data, param.ripcordPath) &&
-    objectPath.get(response.data, param.ripcordPath).toString() !== param.ripcordDisabledValue
+    String(objectPath.get(response.data, param.ripcordPath)) !== param.ripcordDisabledValue
   ) {
     // Look for ripcordDetails as sibling field
     const ripcordDetailsPath = `${param.ripcordPath}Details`

--- a/packages/sources/generic-api/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/generic-api/test/integration/__snapshots__/adapter.test.ts.snap
@@ -4,8 +4,6 @@ exports[`execute http endpoint should return success 1`] = `
 {
   "data": {
     "result": "123000",
-    "ripcord": false,
-    "ripcordAsInt": 0,
   },
   "result": "123000",
   "statusCode": 200,

--- a/packages/sources/generic-api/test/integration/adapter.test.ts
+++ b/packages/sources/generic-api/test/integration/adapter.test.ts
@@ -53,7 +53,6 @@ describe('execute', () => {
         endpoint: 'http',
         apiName: 'test',
         dataPath: 'PoR',
-        ripcordPath: 'ripcord',
       }
       mockResponseSuccess()
       const response = await testAdapter.request(data)

--- a/packages/sources/generic-api/test/unit/http.test.ts
+++ b/packages/sources/generic-api/test/unit/http.test.ts
@@ -179,7 +179,7 @@ describe('GenericApiHttpTransport', () => {
     const params = makeStub('params', {
       apiName,
       dataPath,
-      ripcordPath,
+      ripcordPath: undefined,
       ripcordDisabledValue: 'false',
       providerIndicatedTimePath: undefined,
     })
@@ -199,8 +199,6 @@ describe('GenericApiHttpTransport', () => {
     const expectedResponse = {
       data: {
         result: expectedValue,
-        ripcord: false,
-        ripcordAsInt: 0,
       },
       result: expectedValue,
       timestamps: {
@@ -333,7 +331,7 @@ describe('GenericApiHttpTransport', () => {
     const params = makeStub('params', {
       apiName,
       dataPath,
-      ripcordPath,
+      ripcordPath: undefined,
       ripcordDisabledValue: 'false',
       providerIndicatedTimePath: undefined,
     })
@@ -353,8 +351,6 @@ describe('GenericApiHttpTransport', () => {
     const expectedResponse = {
       data: {
         result: expectedValue,
-        ripcord: false,
-        ripcordAsInt: 0,
       },
       result: expectedValue,
       timestamps: {
@@ -380,7 +376,7 @@ describe('GenericApiHttpTransport', () => {
     const params = makeStub('params', {
       apiName,
       dataPath,
-      ripcordPath,
+      ripcordPath: undefined,
       ripcordDisabledValue: 'false',
       providerIndicatedTimePath: undefined,
     })
@@ -736,6 +732,44 @@ describe('GenericApiHttpTransport', () => {
     })
   })
 
+  it('should treat missing ripcord as success with undefined disabledValue', async () => {
+    process.env.TEST_API_URL = apiUrl
+
+    const params = {
+      apiName,
+      dataPath: 'net_asset_value',
+      ripcordPath: 'ripcord',
+      ripcordDisabledValue: 'undefined',
+    }
+
+    const response = {
+      response: {
+        data: {
+          net_asset_value: 1.004373,
+        },
+        cost: undefined,
+      },
+      timestamps: {},
+    }
+
+    const expectedResponse = {
+      data: {
+        result: '1.004373',
+        ripcord: false,
+        ripcordAsInt: 0,
+      },
+      result: '1.004373',
+      timestamps: { providerIndicatedTimeUnixMs: undefined },
+    }
+
+    await doTransportTest({
+      params,
+      expectedRequestConfig: requestConfigWithoutAuthHeader,
+      response,
+      expectedResponse,
+    })
+  })
+
   it('should not include ripcord status when ripcord path is absent', async () => {
     process.env.TEST_API_URL = apiUrl
 
@@ -762,6 +796,42 @@ describe('GenericApiHttpTransport', () => {
       },
       result: '1.004373',
       timestamps: { providerIndicatedTimeUnixMs: undefined },
+    }
+
+    await doTransportTest({
+      params,
+      expectedRequestConfig: requestConfigWithoutAuthHeader,
+      response,
+      expectedResponse,
+    })
+  })
+
+  it('should treat ripcord as enabled if ripcord field is expected but missing', async () => {
+    process.env.TEST_API_URL = apiUrl
+
+    const params = {
+      apiName,
+      dataPath: 'net_asset_value',
+      ripcordPath,
+      ripcordDisabledValue: 'false',
+    }
+
+    const response = {
+      response: {
+        data: {
+          net_asset_value: 1.004373,
+        },
+        cost: undefined,
+      },
+      timestamps: {},
+    }
+
+    const expectedResponse = {
+      errorMessage: `Ripcord activated for 'test'`,
+      ripcord: true,
+      ripcordAsInt: 1,
+      statusCode: 503,
+      timestamps: {},
     }
 
     await doTransportTest({


### PR DESCRIPTION
## Description

Currently, when the ripcord field is absent in the response, this does not cause an error even when the ripcord path is configured in the params.

The ripcord path is optional so when it's configured, it should be interpreted as expected in the response.

## Changes

1. Don't skip ripcord check if ripcord is absent in the response but present in the params.

## Steps to Test

1. `yarn test packages/sources/generic-api`
2. I tested it with all 18 existing feeds and streams that use `generic-api` with `ripcord`.

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
