### PR TITLE
Support Solana functions in calculated-price

### DIFF
--- a/.changeset/stale-coins-wonder.md
+++ b/.changeset/stale-coins-wonder.md
@@ -1,0 +1,6 @@
+---
+'@chainlink/calculated-price-adapter': minor
+'@chainlink/solana-functions-adapter': minor
+---
+
+Support Solana functions in calculated-price

--- a/packages/composites/calculated-price/src/transport/computePrice.ts
+++ b/packages/composites/calculated-price/src/transport/computePrice.ts
@@ -239,7 +239,7 @@ export class ComputedPriceTransport extends SubscriptionTransport<ComputedPriceT
       // Extract decimals from all successful responses and verify consistency
       const allDecimals = successfulResults
         .map((r) => r?.response?.data?.data?.[decimalsField])
-        .filter((d): d is number => typeof d === 'number')
+        .filter((d): d is number => d !== undefined && !Number.isNaN(d))
 
       const uniqueDecimals = new Set(allDecimals)
       if (uniqueDecimals.size !== 1) {

--- a/packages/sources/solana-functions/src/endpoint/buffer-layout.ts
+++ b/packages/sources/solana-functions/src/endpoint/buffer-layout.ts
@@ -15,11 +15,18 @@ export const inputParameters = new InputParameters(
       type: 'string',
       required: true,
     },
+    extraFields: {
+      description: 'The names of other fields to retrieve from the state account',
+      type: 'string',
+      required: false,
+      array: true,
+    },
   },
   [
     {
       stateAccountAddress: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
       field: 'supply',
+      extraFields: [],
     },
   ],
 )

--- a/packages/sources/solana-functions/src/endpoint/extension.ts
+++ b/packages/sources/solana-functions/src/endpoint/extension.ts
@@ -77,6 +77,16 @@ export const inputParameters = new InputParameters(
       required: false,
       array: true,
     },
+    resultName: {
+      description: 'Name of the field to be on result response field',
+      type: 'string',
+      required: false,
+    },
+    resultDecimals: {
+      description: 'decimals of the result response field',
+      type: 'number',
+      required: false,
+    },
   },
   [
     {
@@ -126,7 +136,7 @@ export type BaseEndpointTypes = {
     Data: {
       [fieldName: string]: number | string
     }
-    Result: null
+    Result: number | string | null
   }
   Settings: typeof config.settings
 }

--- a/packages/sources/solana-functions/src/shared/buffer-layout-accounts.ts
+++ b/packages/sources/solana-functions/src/shared/buffer-layout-accounts.ts
@@ -101,12 +101,14 @@ export const fetchDataFromBufferLayoutStateAccount = async ({
 export const fetchFieldFromBufferLayoutStateAccount = async ({
   stateAccountAddress,
   field,
+  extraFields,
   rpc,
 }: {
   stateAccountAddress: string
   field: string
+  extraFields?: string[]
   rpc: Rpc<SolanaRpcApi>
-}): Promise<string> => {
+}) => {
   const { programAddress, data: dataDecoded } = await fetchDataFromBufferLayoutStateAccount({
     stateAccountAddress,
     rpc,
@@ -122,5 +124,10 @@ export const fetchFieldFromBufferLayoutStateAccount = async ({
     })
   }
 
-  return resultValue.toString()
+  return {
+    result: resultValue.toString(),
+    extraFields: Object.fromEntries(
+      (extraFields ?? []).map((f) => [f, dataDecoded[f]?.toString()]),
+    ),
+  }
 }

--- a/packages/sources/solana-functions/src/transport/buffer-layout.ts
+++ b/packages/sources/solana-functions/src/transport/buffer-layout.ts
@@ -59,15 +59,17 @@ export class BufferLayoutTransport extends SubscriptionTransport<BaseEndpointTyp
     const result = await fetchFieldFromBufferLayoutStateAccount({
       stateAccountAddress: params.stateAccountAddress,
       field: params.field,
+      extraFields: params.extraFields,
       rpc: this.rpc,
     })
 
     return {
       data: {
-        result,
+        result: result.result,
+        ...result.extraFields,
       },
       statusCode: 200,
-      result,
+      result: result.result,
       timestamps: {
         providerDataRequestedUnixMs,
         providerDataReceivedUnixMs: Date.now(),

--- a/packages/sources/solana-functions/src/transport/extension.ts
+++ b/packages/sources/solana-functions/src/transport/extension.ts
@@ -128,10 +128,14 @@ export class ExtensionTransport extends SubscriptionTransport<BaseEndpointTypes>
       }
     }
 
+    if (params.resultDecimals !== undefined) {
+      resultData['decimals'] = params.resultDecimals
+    }
+
     return {
       data: resultData,
       statusCode: 200,
-      result: null,
+      result: resultData[params.resultName ?? ''] ?? null,
       timestamps: {
         providerDataRequestedUnixMs,
         providerDataReceivedUnixMs: Date.now(),

--- a/packages/sources/solana-functions/src/transport/sanctum-infinity.ts
+++ b/packages/sources/solana-functions/src/transport/sanctum-infinity.ts
@@ -73,7 +73,7 @@ export class SanctumInfinityTransport extends SubscriptionTransport<BaseEndpoint
       }),
     ])
 
-    const result = Number(totalPoolValueString) / Number(totalPoolTokenSupplyString)
+    const result = Number(totalPoolValueString.result) / Number(totalPoolTokenSupplyString.result)
 
     return {
       data: {

--- a/packages/sources/solana-functions/test/unit/buffer-layout-accounts.test.ts
+++ b/packages/sources/solana-functions/test/unit/buffer-layout-accounts.test.ts
@@ -28,9 +28,13 @@ describe('buffer-layout-accounts', () => {
       const poolTotalSolValue = await fetchFieldFromBufferLayoutStateAccount({
         stateAccountAddress,
         field: 'supply',
+        extraFields: ['decimals'],
         rpc,
       })
-      expect(poolTotalSolValue).toBe('1116792619507830')
+      expect(poolTotalSolValue).toEqual({
+        result: '1116792619507830',
+        extraFields: { decimals: '9' },
+      })
 
       expect(getAccountInfoMock).toHaveBeenCalledWith(stateAccountAddress, { encoding: 'base64' })
       expect(getAccountInfoMock).toHaveBeenCalledTimes(1)
@@ -48,7 +52,7 @@ describe('buffer-layout-accounts', () => {
         field: 'amount',
         rpc,
       })
-      expect(amount).toBe('34228590128')
+      expect(amount).toEqual({ result: '34228590128', extraFields: {} })
 
       expect(getAccountInfoMock).toHaveBeenCalledWith(stateAccountAddress, { encoding: 'base64' })
       expect(getAccountInfoMock).toHaveBeenCalledTimes(1)
@@ -65,7 +69,7 @@ describe('buffer-layout-accounts', () => {
         field: 'total_sol_value',
         rpc,
       })
-      expect(poolTotalSolValue).toBe('1526932937260359')
+      expect(poolTotalSolValue).toEqual({ result: '1526932937260359', extraFields: {} })
 
       expect(getAccountInfoMock).toHaveBeenCalledWith(stateAccountAddress, { encoding: 'base64' })
       expect(getAccountInfoMock).toHaveBeenCalledTimes(1)

--- a/packages/sources/solana-functions/test/unit/buffer-layout.test.ts
+++ b/packages/sources/solana-functions/test/unit/buffer-layout.test.ts
@@ -120,6 +120,7 @@ describe('BufferLayoutTransport', () => {
         endpoint: 'buffer-layout',
         stateAccountAddress: usdcMinterAccountAddress,
         field: 'supply',
+        extraFields: [],
       })
       await transport.handleRequest(param)
 
@@ -154,6 +155,7 @@ describe('BufferLayoutTransport', () => {
         endpoint: 'buffer-layout',
         stateAccountAddress: usdcMinterAccountAddress,
         field: 'supply',
+        extraFields: ['decimals'],
       })
 
       const response = await transport._handleRequest(param)
@@ -163,6 +165,7 @@ describe('BufferLayoutTransport', () => {
         result: expectedTokenSupply,
         data: {
           result: expectedTokenSupply,
+          decimals: '6',
         },
         timestamps: {
           providerDataRequestedUnixMs: Date.now(),
@@ -182,6 +185,7 @@ describe('BufferLayoutTransport', () => {
         endpoint: 'buffer-layout',
         stateAccountAddress: usdcMinterAccountAddress,
         field: 'supply',
+        extraFields: [],
       })
 
       const requestTimestamp = Date.now()

--- a/packages/sources/solana-functions/test/unit/extension.test.ts
+++ b/packages/sources/solana-functions/test/unit/extension.test.ts
@@ -129,14 +129,17 @@ describe('ExtensionTransport', () => {
         ],
         extensionDataOffset,
         extensionFields: [],
+        resultName: 'supply',
+        resultDecimals: 8,
       })
       await transport.handleRequest(param)
 
       const expectedResponse = {
         statusCode: 200,
-        result: null,
+        result: expectedTokenSupply,
         data: {
           supply: expectedTokenSupply,
+          decimals: 8,
         },
         timestamps: {
           providerDataRequestedUnixMs: Date.now(),
@@ -171,6 +174,8 @@ describe('ExtensionTransport', () => {
         ],
         extensionDataOffset,
         extensionFields: [],
+        resultName: undefined,
+        resultDecimals: undefined,
       })
 
       const response = await transport._handleRequest(param)
@@ -205,6 +210,8 @@ describe('ExtensionTransport', () => {
             type: 'float64' as const,
           },
         ],
+        resultName: undefined,
+        resultDecimals: undefined,
       })
 
       const response = await transport._handleRequest(param)
@@ -257,6 +264,8 @@ describe('ExtensionTransport', () => {
             type: 'int64' as const,
           },
         ],
+        resultName: undefined,
+        resultDecimals: undefined,
       })
 
       const response = await transport._handleRequest(param)
@@ -296,6 +305,8 @@ describe('ExtensionTransport', () => {
         ],
         extensionDataOffset,
         extensionFields: [],
+        resultName: undefined,
+        resultDecimals: undefined,
       })
 
       const requestTimestamp = Date.now()


### PR DESCRIPTION
## Closes #OPDATA-7373

calculated-price-adapter - Allow decimals in format of string
solana-functions-adapter - buffer-layout - Allow fetching other fields on the same program
solana-functions-adapter - extension - Allow setting result field as well as hard-coded decimals

```
{
    "data": {
        "endpoint": "computedprice",
        "operand1Sources": [
            "solana_functions"
        ],
        "operand1MinAnswers": 1,
        "operand1Input": "{\"endpoint\":\"extension\",\"stateAccountAddress\":\"iFgP2EbzHUZzMjqbjaagJQ8zmn6as3Hw95aVUKm67od\",\"baseFields\":[{\"name\":\"assets\",\"offset\":30,\"type\":\"uint64\"}],\"resultName\":\"assets\",\"resultDecimals\":6}",
        "operand1DecimalsField": "decimals",
        "operand2Sources": [
            "solana_functions"
        ],
        "operand2MinAnswers": 1,
        "operand2Input": "{\"endpoint\":\"buffer-layout\",\"stateAccountAddress\":\"59obFNBzyTBGowrkif5uK7ojS58vsuWz3ZCvg6tfZAGw\",\"field\":\"supply\",\"extraFields\": [\"decimals\"]}",
        "operand2DecimalsField": "decimals",
        "operation": "divide",
        "outputDecimals": 18
    }
}
```

```
{
    "data": {
        "result": "1104187251051202678.9",
        "operand1Result": "153265518636957",
        "operand2Result": "138803919798065",
        "operand1Decimals": 6,
        "operand2Decimals": "6",
        "resultDecimals": 18
    },
    "statusCode": 200,
    "result": "1104187251051202678.9",
    "timestamps": {
        "providerDataRequestedUnixMs": 1779214096546,
        "providerDataReceivedUnixMs": 1779214097987
    },
    "meta": {
        "adapterName": "CALCULATED_PRICE",
        "metrics": {
            "feedId": "lWtnYQ5SMY67CH8ZhhUZaJOMMCw="
        }
    }
}
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
