### PR TITLE
OPDATA-7371: Send ping on Lo-tech websocket

### DIFF
--- a/.changeset/seven-wombats-double.md
+++ b/.changeset/seven-wombats-double.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/lo-tech-adapter': patch
+---
+
+Send keep-alive ping on heartbeat

--- a/packages/sources/lo-tech/src/config/index.ts
+++ b/packages/sources/lo-tech/src/config/index.ts
@@ -1,16 +1,23 @@
 import { AdapterConfig } from '@chainlink/external-adapter-framework/config'
 
-export const config = new AdapterConfig({
-  API_KEY: {
-    description: 'An API key for Data Provider',
-    type: 'string',
-    required: true,
-    sensitive: true,
+export const config = new AdapterConfig(
+  {
+    API_KEY: {
+      description: 'An API key for Data Provider',
+      type: 'string',
+      required: true,
+      sensitive: true,
+    },
+    WS_API_ENDPOINT: {
+      description: 'WS endpoint for Data Provider',
+      type: 'string',
+      default: 'wss://data.lo.tech/ws/v1/rwa-jp',
+      sensitive: false,
+    },
   },
-  WS_API_ENDPOINT: {
-    description: 'WS endpoint for Data Provider',
-    type: 'string',
-    default: 'wss://data.lo.tech/ws/v1/rwa-jp',
-    sensitive: false,
+  {
+    envDefaultOverrides: {
+      WS_HEARTBEAT_INTERVAL_MS: 30_000,
+    },
   },
-})
+)

--- a/packages/sources/lo-tech/src/transport/stock_quotes.ts
+++ b/packages/sources/lo-tech/src/transport/stock_quotes.ts
@@ -32,6 +32,13 @@ export class StockQuotesWebSocketTransport extends WebSocketTransport<WsTranspor
         }
       },
       handlers: {
+        heartbeat(connection) {
+          connection.send(
+            JSON.stringify({
+              op: 'PING',
+            }),
+          )
+        },
         message(message) {
           if (message.data.type !== 'PRICE') {
             return

--- a/packages/sources/lo-tech/test/unit/stock_quotes.test.ts
+++ b/packages/sources/lo-tech/test/unit/stock_quotes.test.ts
@@ -53,6 +53,7 @@ describe('stock_quotes', () => {
     MAX_COMMON_KEY_SIZE: 300,
     WS_CONNECTION_OPEN_TIMEOUT: 10_001,
     BACKGROUND_EXECUTE_MS_WS: 1_002,
+    WS_HEARTBEAT_INTERVAL_MS: 30_000,
   } as unknown as BaseEndpointTypes['Settings'])
 
   const subscriptionSet = makeStub('subscriptionSet', {
@@ -89,6 +90,7 @@ describe('stock_quotes', () => {
 
     mockWebSocketProvider(WebSocketClassProvider)
     receivedMessages.length = 0
+    mockWsServer?.close()
     mockWsServer?.stop()
     mockWsServer = new MockWebsocketServer(adapterSettings.WS_API_ENDPOINT, { mock: false })
 
@@ -218,6 +220,41 @@ describe('stock_quotes', () => {
             type: 'PRICE',
           },
         ],
+      }),
+    )
+  })
+
+  it('should send keep-alive ping', async () => {
+    const symbol = '9988-HKD:SPOT'
+
+    const params = makeStub('params', {
+      base: symbol,
+    })
+
+    const context = makeStub('context', {
+      adapterSettings,
+      endpointName,
+    } as EndpointContext<WsTransportTypes>)
+
+    subscriptionSet.getAll.mockReturnValue([params])
+    await runAllUntilSettled(clock, transport.backgroundExecute(context))
+    expect(receivedMessages.length).toBe(1)
+
+    clock.tick(adapterSettings.WS_HEARTBEAT_INTERVAL_MS)
+    expect(receivedMessages.length).toBe(2)
+
+    await expect(receivedMessages[1]).toBe(
+      JSON.stringify({
+        op: 'PING',
+      }),
+    )
+
+    clock.tick(adapterSettings.WS_HEARTBEAT_INTERVAL_MS)
+    expect(receivedMessages.length).toBe(3)
+
+    await expect(receivedMessages[2]).toBe(
+      JSON.stringify({
+        op: 'PING',
       }),
     )
   })


### PR DESCRIPTION
## [OPDATA-7371](https://smartcontract-it.atlassian.net/browse/OPDATA-7371)

## Description

Send `PING` on heartbeat to keep the websocket connection alive.

## Changes

1. Add `heartbeat` handler and send `PING` message.
2. Set the default heartbeat interval to 30 seconds.
3. Add unit test.
4. Close the mock websocket server in the test cleanup to prevent receiving multiple pings from other tests.

## Steps to Test

1. `yarn test packages/sources/lo-tech`.
2. Manually tested that a `pong` message is received from the server after a `PING` message is sent.

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[OPDATA-7371]: https://smartcontract-it.atlassian.net/browse/OPDATA-7371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ