### PR TITLE
OPDATA-7371: Lo-tech: Use different websockets for different regions

### DIFF
--- a/.changeset/tangy-rules-kiss.md
+++ b/.changeset/tangy-rules-kiss.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/lo-tech-adapter': major
+---
+
+Use different websockets for different regions

--- a/packages/sources/lo-tech/src/config/index.ts
+++ b/packages/sources/lo-tech/src/config/index.ts
@@ -2,16 +2,19 @@ import { AdapterConfig } from '@chainlink/external-adapter-framework/config'
 
 export const config = new AdapterConfig(
   {
-    API_KEY: {
-      description: 'An API key for Data Provider',
+    REGION_API_KEY: {
+      description: 'Lo-Tech API key for the given ${REGION}. Region can be "US" or "ASIA"',
       type: 'string',
       required: true,
+      variablePlaceholder: 'REGION',
       sensitive: true,
     },
-    WS_API_ENDPOINT: {
-      description: 'WS endpoint for Data Provider',
+    REGION_WS_API_ENDPOINT: {
+      description:
+        'Lo-Tech websocket endpoint for the given ${REGION}. Region can be "US" or "ASIA"',
       type: 'string',
-      default: 'wss://data.lo.tech/ws/v1/rwa-jp',
+      required: true,
+      variablePlaceholder: 'REGION',
       sensitive: false,
     },
   },

--- a/packages/sources/lo-tech/src/endpoint/stock_quotes.ts
+++ b/packages/sources/lo-tech/src/endpoint/stock_quotes.ts
@@ -26,6 +26,13 @@ export type BaseEndpointTypes = {
 
 const asianSymbolRegexp = /^\w+-\w\w\w:SPOT$/
 
+const getRegionFromSymbol = (symbol: string): 'asia' | 'us' => {
+  if (asianSymbolRegexp.test(symbol.toUpperCase())) {
+    return 'asia'
+  }
+  return 'us'
+}
+
 export const endpoint = new AdapterEndpoint({
   name: 'stock_quotes',
   aliases: [],
@@ -34,10 +41,18 @@ export const endpoint = new AdapterEndpoint({
     .register('wsus', new StockQuotesWebSocketTransport('us')),
   customRouter: (req, _adapterConfig) => {
     const { base } = req.requestContext.data
-    if (asianSymbolRegexp.test(base.toUpperCase())) {
+    const region = getRegionFromSymbol(base)
+    if (region === 'asia') {
       return 'wsasia'
     }
     return 'wsus'
+  },
+  customInputValidation: (request, settings): undefined => {
+    const params = request.requestContext.data
+    const region = getRegionFromSymbol(params.base)
+    settings.REGION_WS_API_ENDPOINT.get(region)
+    settings.REGION_API_KEY.get(region)
+    return
   },
   inputParameters,
 })

--- a/packages/sources/lo-tech/src/endpoint/stock_quotes.ts
+++ b/packages/sources/lo-tech/src/endpoint/stock_quotes.ts
@@ -1,8 +1,9 @@
 import { AdapterEndpoint } from '@chainlink/external-adapter-framework/adapter'
 import { stockEndpointInputParametersDefinition } from '@chainlink/external-adapter-framework/adapter/stock'
+import { TransportRoutes } from '@chainlink/external-adapter-framework/transports'
 import { InputParameters } from '@chainlink/external-adapter-framework/validation'
 import { config } from '../config'
-import { wsTransport } from '../transport/stock_quotes'
+import { StockQuotesWebSocketTransport } from '../transport/stock_quotes'
 
 export const inputParameters = new InputParameters(stockEndpointInputParametersDefinition, [
   {
@@ -23,9 +24,20 @@ export type BaseEndpointTypes = {
   Settings: typeof config.settings
 }
 
+const asianSymbolRegexp = /^\w+-\w\w\w:SPOT$/
+
 export const endpoint = new AdapterEndpoint({
   name: 'stock_quotes',
   aliases: [],
-  transport: wsTransport,
+  transportRoutes: new TransportRoutes<BaseEndpointTypes>()
+    .register('wsasia', new StockQuotesWebSocketTransport('asia'))
+    .register('wsus', new StockQuotesWebSocketTransport('us')),
+  customRouter: (req, _adapterConfig) => {
+    const { base } = req.requestContext.data
+    if (asianSymbolRegexp.test(base.toUpperCase())) {
+      return 'wsasia'
+    }
+    return 'wsus'
+  },
   inputParameters,
 })

--- a/packages/sources/lo-tech/src/endpoint/stock_quotes.ts
+++ b/packages/sources/lo-tech/src/endpoint/stock_quotes.ts
@@ -37,15 +37,11 @@ export const endpoint = new AdapterEndpoint({
   name: 'stock_quotes',
   aliases: [],
   transportRoutes: new TransportRoutes<BaseEndpointTypes>()
-    .register('wsasia', new StockQuotesWebSocketTransport('asia'))
-    .register('wsus', new StockQuotesWebSocketTransport('us')),
+    .register('asia', new StockQuotesWebSocketTransport('asia'))
+    .register('us', new StockQuotesWebSocketTransport('us')),
   customRouter: (req, _adapterConfig) => {
     const { base } = req.requestContext.data
-    const region = getRegionFromSymbol(base)
-    if (region === 'asia') {
-      return 'wsasia'
-    }
-    return 'wsus'
+    return getRegionFromSymbol(base)
   },
   customInputValidation: (request, settings): undefined => {
     const params = request.requestContext.data

--- a/packages/sources/lo-tech/src/transport/stock_quotes.ts
+++ b/packages/sources/lo-tech/src/transport/stock_quotes.ts
@@ -20,14 +20,16 @@ export type WsTransportTypes = BaseEndpointTypes & {
   }
 }
 
+type Region = 'us' | 'asia'
+
 export class StockQuotesWebSocketTransport extends WebSocketTransport<WsTransportTypes> {
-  constructor() {
+  constructor(region: Region) {
     super({
-      url: (context) => context.adapterSettings.WS_API_ENDPOINT,
+      url: (context) => context.adapterSettings.REGION_WS_API_ENDPOINT.get(region),
       options: (context) => {
         return {
           headers: {
-            'X-API-KEY': context.adapterSettings.API_KEY,
+            'X-API-KEY': context.adapterSettings.REGION_API_KEY.get(region),
           },
         }
       },
@@ -94,5 +96,3 @@ export class StockQuotesWebSocketTransport extends WebSocketTransport<WsTranspor
     })
   }
 }
-
-export const wsTransport = new StockQuotesWebSocketTransport()

--- a/packages/sources/lo-tech/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/lo-tech/test/integration/__snapshots__/adapter.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`websocket stock_quotes endpoint should return success 1`] = `
+exports[`websocket stock_quotes endpoint should return success for Asian stock symbol 1`] = `
 {
   "data": {
     "ask_price": 133.29500000000002,
@@ -13,6 +13,23 @@ exports[`websocket stock_quotes endpoint should return success 1`] = `
     "providerDataReceivedUnixMs": 1018,
     "providerDataStreamEstablishedUnixMs": 1010,
     "providerIndicatedTimeUnixMs": 1018,
+  },
+}
+`;
+
+exports[`websocket stock_quotes endpoint should return success for US stock symbol 1`] = `
+{
+  "data": {
+    "ask_price": 133.29500000000002,
+    "bid_price": 133.305,
+    "mid_price": 133.3,
+  },
+  "result": null,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 2028,
+    "providerDataStreamEstablishedUnixMs": 2020,
+    "providerIndicatedTimeUnixMs": 2028,
   },
 }
 `;

--- a/packages/sources/lo-tech/test/integration/adapter.test.ts
+++ b/packages/sources/lo-tech/test/integration/adapter.test.ts
@@ -9,23 +9,34 @@ import FakeTimers from '@sinonjs/fake-timers'
 import { mockWebsocketServer } from './fixtures'
 
 describe('websocket', () => {
-  let mockWsServer: MockWebsocketServer | undefined
+  let mockWsServerAsia: MockWebsocketServer | undefined
+  let mockWsServerUs: MockWebsocketServer | undefined
   let testAdapter: TestAdapter
-  const wsEndpoint = 'ws://localhost:9090'
+  const wsEndpointAsia = 'ws://localhost:9090/asia'
+  const wsEndpointUs = 'ws://localhost:9090/us'
+  const symbolAsia = '9988-HKD:SPOT'
+  const symbolUs = 'AAPL'
   let oldEnv: NodeJS.ProcessEnv
 
-  const dataStock_quotes = {
-    base: '9988-HKD:SPOT',
+  const dataStockQuotesAsia = {
+    base: symbolAsia,
     endpoint: 'stock_quotes',
-    transport: 'ws',
+  }
+
+  const dataStockQuotesUs = {
+    base: symbolUs,
+    endpoint: 'stock_quotes',
   }
 
   beforeAll(async () => {
     oldEnv = JSON.parse(JSON.stringify(process.env))
-    process.env['WS_API_ENDPOINT'] = wsEndpoint
-    process.env['API_KEY'] = 'fake-api-key'
+    process.env['ASIA_WS_API_ENDPOINT'] = wsEndpointAsia
+    process.env['US_WS_API_ENDPOINT'] = wsEndpointUs
+    process.env['ASIA_API_KEY'] = 'fake-api-key'
+    process.env['US_API_KEY'] = 'fake-api-key'
     mockWebSocketProvider(WebSocketClassProvider)
-    mockWsServer = mockWebsocketServer(wsEndpoint)
+    mockWsServerAsia = mockWebsocketServer(wsEndpointAsia, symbolAsia)
+    mockWsServerUs = mockWebsocketServer(wsEndpointUs, symbolUs)
 
     const adapter = (await import('./../../src')).adapter
     testAdapter = await TestAdapter.startWithMockedCache(adapter, {
@@ -35,20 +46,27 @@ describe('websocket', () => {
 
     // Send initial request to start background execute and wait for cache to be filled with results
 
-    await testAdapter.request(dataStock_quotes)
+    await testAdapter.request(dataStockQuotesAsia)
+    await testAdapter.request(dataStockQuotesUs)
     await testAdapter.waitForCache(1)
   })
 
   afterAll(async () => {
     setEnvVariables(oldEnv)
-    mockWsServer?.close()
+    mockWsServerAsia?.close()
+    mockWsServerUs?.close()
     testAdapter.clock?.uninstall()
     await testAdapter.api.close()
   })
 
   describe('stock_quotes endpoint', () => {
-    it('should return success', async () => {
-      const response = await testAdapter.request(dataStock_quotes)
+    it('should return success for Asian stock symbol', async () => {
+      const response = await testAdapter.request(dataStockQuotesAsia)
+      expect(response.json()).toMatchSnapshot()
+    })
+
+    it('should return success for US stock symbol', async () => {
+      const response = await testAdapter.request(dataStockQuotesUs)
       expect(response.json()).toMatchSnapshot()
     })
   })

--- a/packages/sources/lo-tech/test/integration/fixtures.ts
+++ b/packages/sources/lo-tech/test/integration/fixtures.ts
@@ -1,6 +1,6 @@
 import { MockWebsocketServer } from '@chainlink/external-adapter-framework/util/testing-utils'
 
-export const mockWebsocketServer = (URL: string): MockWebsocketServer => {
+export const mockWebsocketServer = (URL: string, symbol: string): MockWebsocketServer => {
   const mockWsServer = new MockWebsocketServer(URL, { mock: false })
   mockWsServer.on('connection', (socket) => {
     socket.on('message', (_message) => {
@@ -9,7 +9,7 @@ export const mockWebsocketServer = (URL: string): MockWebsocketServer => {
           egress_ts: Date.now() * 1000,
           data: {
             type: 'PRICE',
-            symbol: '9988-HKD:SPOT',
+            symbol,
             ingress_ts: Date.now() * 1000 - 50,
             publish_ts: null,
             transaction_ts: Date.now() * 1000 - 50000,

--- a/packages/sources/lo-tech/test/unit/stock_quotes.test.ts
+++ b/packages/sources/lo-tech/test/unit/stock_quotes.test.ts
@@ -43,8 +43,16 @@ describe('stock_quotes', () => {
   const endpointName = 'stock_quotes'
 
   const adapterSettings = makeStub('adapterSettings', {
-    WS_API_ENDPOINT: 'wss://data.lo.tech/ws/v1/rwa',
-    API_KEY: 'test-api-key',
+    REGION_WS_API_ENDPOINT: {
+      get() {
+        return 'wss://data.lo.tech/ws/v1/rwa'
+      },
+    },
+    REGION_API_KEY: {
+      get() {
+        return 'test-api-key'
+      },
+    },
     WS_SUBSCRIPTION_TTL: 30_000,
     WS_SUBSCRIPTION_UNRESPONSIVE_TTL: 120_001,
     STREAM_HANDLER_RETRY_MIN_MS: 101,
@@ -92,7 +100,9 @@ describe('stock_quotes', () => {
     receivedMessages.length = 0
     mockWsServer?.close()
     mockWsServer?.stop()
-    mockWsServer = new MockWebsocketServer(adapterSettings.WS_API_ENDPOINT, { mock: false })
+    mockWsServer = new MockWebsocketServer(adapterSettings.REGION_WS_API_ENDPOINT.get('asia'), {
+      mock: false,
+    })
 
     mockWsServer.on('connection', (sock) => {
       socket = sock as WebSocket
@@ -101,7 +111,7 @@ describe('stock_quotes', () => {
       })
     })
 
-    transport = new StockQuotesWebSocketTransport()
+    transport = new StockQuotesWebSocketTransport('asia')
     await transport.initialize(dependencies, adapterSettings, endpointName, transportName)
   })
 


### PR DESCRIPTION
## [OPDATA-7371](https://smartcontract-it.atlassian.net/browse/OPDATA-7371)

## Description

The Lo-tech API has different websocket endpoints for different regions but we want to serve them from the same endpoint.

## Changes

1. Create 2 different transports for Asia and US regions.
2. Use a custom router in the `stock_quotes` endpoint to choose a transport based on params. Route as asian equity if the symbol matches `/^\w+-\w\w\w:SPOT$/`.

## Steps to Test

1. `yarn test packages/sources/lo-tech`
2.
    ```
    curl --silent -S -X POST http://localhost:8080 -H 'Content-Type: application/json' -d '{
      "data": {
        "symbol": "9988-HKD:SPOT"
      }
    }'
    
    {
      "result": null,
      "data": {
        "mid_price": 132.207,
        "bid_price": 132.107,
        "ask_price": 132.307
      },
      "timestamps": {
        "providerDataStreamEstablishedUnixMs": 1779291616477,
        "providerDataReceivedUnixMs": 1779291618005,
        "providerIndicatedTimeUnixMs": 1779291371936
      },
      "statusCode": 200,
      "meta": {
        "adapterName": "LO_TECH",
        "metrics": {
          "feedId": "{\"base\":\"9988-hkd:spot\"}"
        }
      }
    }
    ```
    and
    ```
    curl --silent -S -X POST http://localhost:8080 -H 'Content-Type: application/json' -d '{
      "data": {
        "symbol": "AAPL"
      }
    }'
    
    {
      "result": null,
      "data": {
        "mid_price": 299.045,
        "bid_price": 299.03000000000003,
        "ask_price": 299.06
      },
      "timestamps": {
        "providerDataStreamEstablishedUnixMs": 1779291643802,
        "providerDataReceivedUnixMs": 1779291644069,
        "providerIndicatedTimeUnixMs": 1779291644068
      },
      "statusCode": 200,
      "meta": {
        "adapterName": "LO_TECH",
        "metrics": {
          "feedId": "{\"base\":\"aapl\"}"
        }
      }
    }
    ```


## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[OPDATA-7371]: https://smartcontract-it.atlassian.net/browse/OPDATA-7371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ