### PR TITLE
OPDATA-7371: Add zero volume and human readable ingress time

### DIFF
--- a/.changeset/clean-stars-arrive.md
+++ b/.changeset/clean-stars-arrive.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/lo-tech-adapter': patch
+---
+
+Add zero volume and human readable ingress time

--- a/packages/sources/lo-tech/src/endpoint/stock_quotes.ts
+++ b/packages/sources/lo-tech/src/endpoint/stock_quotes.ts
@@ -19,6 +19,9 @@ export type BaseEndpointTypes = {
       mid_price: number
       bid_price: number
       ask_price: number
+      bid_volume: 0
+      ask_volume: 0
+      ingress_ts_iso: string
     }
   }
   Settings: typeof config.settings

--- a/packages/sources/lo-tech/src/transport/stock_quotes.ts
+++ b/packages/sources/lo-tech/src/transport/stock_quotes.ts
@@ -60,6 +60,9 @@ export class StockQuotesWebSocketTransport extends WebSocketTransport<WsTranspor
                   mid_price,
                   bid_price,
                   ask_price,
+                  bid_volume: 0,
+                  ask_volume: 0,
+                  ingress_ts_iso: new Date(message.data.ingress_ts / 1000).toISOString(),
                 },
                 timestamps: {
                   providerIndicatedTimeUnixMs: Math.floor(message.egress_ts / 1000),

--- a/packages/sources/lo-tech/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/lo-tech/test/integration/__snapshots__/adapter.test.ts.snap
@@ -4,7 +4,10 @@ exports[`websocket stock_quotes endpoint should return success for Asian stock s
 {
   "data": {
     "ask_price": 133.29500000000002,
+    "ask_volume": 0,
     "bid_price": 133.305,
+    "bid_volume": 0,
+    "ingress_ts_iso": "1970-01-01T00:00:01.017Z",
     "mid_price": 133.3,
   },
   "result": null,
@@ -21,7 +24,10 @@ exports[`websocket stock_quotes endpoint should return success for US stock symb
 {
   "data": {
     "ask_price": 133.29500000000002,
+    "ask_volume": 0,
     "bid_price": 133.305,
+    "bid_volume": 0,
+    "ingress_ts_iso": "1970-01-01T00:00:02.027Z",
     "mid_price": 133.3,
   },
   "result": null,

--- a/packages/sources/lo-tech/test/unit/stock_quotes.test.ts
+++ b/packages/sources/lo-tech/test/unit/stock_quotes.test.ts
@@ -167,6 +167,7 @@ describe('stock_quotes', () => {
     const spread = ask_price - bid_price
 
     const providerIndicatedTimeUnixMs = 123456789
+    const ingressTimestamp = providerIndicatedTimeUnixMs - 555
 
     socket.send(
       JSON.stringify({
@@ -176,6 +177,7 @@ describe('stock_quotes', () => {
           symbol,
           spread,
           type: 'PRICE',
+          ingress_ts: ingressTimestamp * 1000,
         },
       }),
     )
@@ -189,6 +191,9 @@ describe('stock_quotes', () => {
             mid_price,
             bid_price,
             ask_price,
+            bid_volume: 0,
+            ask_volume: 0,
+            ingress_ts_iso: new Date(ingressTimestamp).toISOString(),
           },
           timestamps: {
             providerDataStreamEstablishedUnixMs: t0,


### PR DESCRIPTION
## [OPDATA-7371](https://smartcontract-it.atlassian.net/browse/OPDATA-7371)

## Description

Schema 11 of Streams requires bid volume and ask volume.
The bid and ask provided by `lo-tech` are fictitious so there is not specific volume.
So we return volume 0.

The PRD also asks for an ISO8601 timestamp in the response.

## Changes

1. Add `bid_volume: 0` and `ask_volume: 0` in the response.
2. Add ISO8601 timestamp in response.
3. Update unit test.

## Steps to Test

1. `yarn test packages/sources/lo-tech`
2.
    ```
    curl --silent -S -X POST http://localhost:8080 -H 'Content-Type: application/json' -d '{
      "data": {
        "symbol": "AAPL"
      }
    }'
    
    {
      "result": null,
      "data": {
        "mid_price": 301.474,
        "bid_price": 301.394,
        "ask_price": 301.554,
        "bid_volume": 0,
        "ask_volume": 0,
        "ingress_ts_iso": "2026-05-21T10:07:27.666Z"
      },
      "timestamps": {
        "providerDataStreamEstablishedUnixMs": 1779358156546,
        "providerDataReceivedUnixMs": 1779358156833,
        "providerIndicatedTimeUnixMs": 1779358047666
      },
      "statusCode": 200,
      "meta": {
        "adapterName": "LO_TECH",
        "metrics": {
          "feedId": "{\"base\":\"aapl\"}"
        }
      }
    }
    ```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[OPDATA-7371]: https://smartcontract-it.atlassian.net/browse/OPDATA-7371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ