### PR TITLE
OPDATA-7371: Improve lo-tech error handling

### DIFF
--- a/.changeset/heavy-lies-enter.md
+++ b/.changeset/heavy-lies-enter.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/lo-tech-adapter': patch
+---
+
+Improve error handling

--- a/packages/sources/lo-tech/src/transport/stock_quotes.ts
+++ b/packages/sources/lo-tech/src/transport/stock_quotes.ts
@@ -1,18 +1,44 @@
 import { WebSocketTransport } from '@chainlink/external-adapter-framework/transports'
+import { makeLogger } from '@chainlink/external-adapter-framework/util'
 import { BaseEndpointTypes } from '../endpoint/stock_quotes'
 
-export interface WSResponse {
-  egress_ts: number // microseconds
-  data: {
-    type: 'PRICE'
-    symbol: string
-    ingress_ts: number // microseconds
-    publish_ts: null
-    transaction_ts: number // microseconds
-    price: number
-    spread: number
-  }
-}
+const logger = makeLogger('lo-tech - stock_quotes')
+
+export type WSResponse =
+  | {
+      egress_ts: number // microseconds
+      data: {
+        type: 'PRICE'
+        symbol: string
+        ingress_ts: number // microseconds
+        publish_ts: null
+        transaction_ts: number // microseconds
+        price: number
+        spread: number
+      }
+    }
+  | {
+      egress_ts: number // microseconds
+      error: {
+        error: string
+        code: number
+        id: null
+        info: {
+          type: string
+          failures: {
+            symbol: string
+            type: string
+          }[]
+          succeeded: []
+        }
+      }
+    }
+  | {
+      egress_ts: number // microseconds
+      pong: {
+        api_version: string
+      }
+    }
 
 export type WsTransportTypes = BaseEndpointTypes & {
   Provider: {
@@ -42,7 +68,27 @@ export class StockQuotesWebSocketTransport extends WebSocketTransport<WsTranspor
           )
         },
         message(message) {
-          if (message.data.type !== 'PRICE') {
+          if ('error' in message) {
+            logger.error(`Received error message on websocket: ${JSON.stringify(message)}`)
+            return message.error.info.failures.map((failure) => ({
+              params: { base: failure.symbol },
+              response: {
+                statusCode: 502,
+                errorMessage: failure.type,
+                timestamps: {
+                  providerIndicatedTimeUnixMs: Math.floor(message.egress_ts / 1000),
+                },
+              },
+            }))
+          }
+
+          if ('pong' in message) {
+            // Ignore
+            return
+          }
+
+          if (message.data?.type !== 'PRICE') {
+            logger.warn(`Received unsupported message type: ${message.data.type}`)
             return
           }
 

--- a/packages/sources/lo-tech/test/unit/stock_quotes.test.ts
+++ b/packages/sources/lo-tech/test/unit/stock_quotes.test.ts
@@ -16,13 +16,14 @@ import { BaseEndpointTypes } from '../../src/endpoint/stock_quotes'
 import { StockQuotesWebSocketTransport, WsTransportTypes } from '../../src/transport/stock_quotes'
 
 const log = jest.fn()
+const debugLog = jest.fn()
 const logger = {
   fatal: log,
   error: log,
   warn: log,
   info: log,
-  debug: log,
-  trace: log,
+  debug: debugLog,
+  trace: debugLog,
   msgPrefix: 'mock-logger',
 }
 
@@ -113,6 +114,10 @@ describe('stock_quotes', () => {
 
     transport = new StockQuotesWebSocketTransport('asia')
     await transport.initialize(dependencies, adapterSettings, endpointName, transportName)
+  })
+
+  afterEach(() => {
+    expect(log).not.toHaveBeenCalled()
   })
 
   it('should subscribe to the stock price', async () => {
@@ -272,5 +277,125 @@ describe('stock_quotes', () => {
         op: 'PING',
       }),
     )
+  })
+
+  it('should write error to cache', async () => {
+    const symbol = '9988-HKD:SPOT'
+
+    const params = makeStub('params', {
+      base: symbol,
+    })
+    subscriptionSet.getAll.mockReturnValue([params])
+
+    const context = makeStub('context', {
+      adapterSettings,
+      endpointName,
+    } as EndpointContext<WsTransportTypes>)
+
+    const t0 = Date.now()
+    await runAllUntilSettled(clock, transport.backgroundExecute(context))
+    const t1 = Date.now()
+
+    const providerIndicatedTimeUnixMs = 123456789
+
+    const message = JSON.stringify({
+      egress_ts: providerIndicatedTimeUnixMs * 1000,
+      error: {
+        error: 'Some subscriptions failed',
+        code: 14,
+        id: null,
+        info: {
+          type: 'subscription_failure',
+          failures: [
+            {
+              type: 'invalid_permission',
+              symbol,
+            },
+          ],
+          succeeded: [],
+        },
+      },
+    })
+    socket.send(message)
+
+    expect(responseCache.write).toHaveBeenCalledWith(transportName, [
+      {
+        params,
+        response: {
+          errorMessage: 'invalid_permission',
+          statusCode: 502,
+          timestamps: {
+            providerDataStreamEstablishedUnixMs: t0,
+            providerDataReceivedUnixMs: t1,
+            providerIndicatedTimeUnixMs,
+          },
+        },
+      },
+    ])
+    expect(responseCache.write).toHaveBeenCalledTimes(1)
+
+    expect(log).toHaveBeenCalledWith(`Received error message on websocket: ${message}`)
+    log.mockClear()
+  })
+
+  it('should log warning for unknown message type', async () => {
+    const symbol = '9988-HKD:SPOT'
+
+    const params = makeStub('params', {
+      base: symbol,
+    })
+    subscriptionSet.getAll.mockReturnValue([params])
+
+    const context = makeStub('context', {
+      adapterSettings,
+      endpointName,
+    } as EndpointContext<WsTransportTypes>)
+
+    await runAllUntilSettled(clock, transport.backgroundExecute(context))
+
+    const providerIndicatedTimeUnixMs = 123456789
+
+    socket.send(
+      JSON.stringify({
+        egress_ts: providerIndicatedTimeUnixMs * 1000,
+        data: {
+          trades: [],
+          symbol,
+          type: 'TRADE',
+        },
+      }),
+    )
+
+    expect(responseCache.write).toHaveBeenCalledTimes(0)
+    expect(log).toHaveBeenCalledWith(`Received unsupported message type: TRADE`)
+    log.mockClear()
+  })
+
+  it('should ignore pong message', async () => {
+    const symbol = '9988-HKD:SPOT'
+
+    const params = makeStub('params', {
+      base: symbol,
+    })
+    subscriptionSet.getAll.mockReturnValue([params])
+
+    const context = makeStub('context', {
+      adapterSettings,
+      endpointName,
+    } as EndpointContext<WsTransportTypes>)
+
+    await runAllUntilSettled(clock, transport.backgroundExecute(context))
+
+    const providerIndicatedTimeUnixMs = 123456789
+
+    socket.send(
+      JSON.stringify({
+        egress_ts: providerIndicatedTimeUnixMs * 1000,
+        pong: { api_version: '3.0.63' },
+      }),
+    )
+
+    expect(responseCache.write).toHaveBeenCalledTimes(0)
+    expect(log).toHaveBeenCalledTimes(0)
   })
 })


### PR DESCRIPTION
## [OPDATA-7371](https://smartcontract-it.atlassian.net/browse/OPDATA-7371)

## Description

Log unexpected websocket messages and provide an error response if possible.

## Changes

1. Change the message type to include error and pong messages.
2. Add handling for these message types.
3. Add unit tests.

## Steps to Test

When setting a wrong API key:
```
curl --silent -S -X POST http://localhost:8080 -H 'Content-Type: application/json' -d '{
  "data": {
    "symbol": "9988-HKD:SPOT"
  }
}'

{
  "statusCode": 502,
  "errorMessage": "invalid_permission",
  "timestamps": {
    "providerDataStreamEstablishedUnixMs": 1779435624879,
    "providerDataReceivedUnixMs": 1779435626295,
    "providerIndicatedTimeUnixMs": 1779435626179
  },
  "meta": {
    "adapterName": "LO_TECH",
    "metrics": {
      "feedId": "{\"base\":\"9988-hkd:spot\"}"
    }
  }
}
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[OPDATA-7371]: https://smartcontract-it.atlassian.net/browse/OPDATA-7371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ