### PR TITLE
OPDATA-7078: Handle different kinds of error in proof-of-reserves-v2

### DIFF
--- a/.changeset/nice-trains-learn.md
+++ b/.changeset/nice-trains-learn.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/proof-of-reserves-v2-adapter': patch
+---
+
+Handle different kinds of errors from providers

--- a/packages/composites/proof-of-reserves-v2/src/transport/utils.ts
+++ b/packages/composites/proof-of-reserves-v2/src/transport/utils.ts
@@ -28,8 +28,17 @@ export const fetchFromProvider = async (
     return result.response.data as Record<string, unknown>
   } catch (error: unknown) {
     // Try to forward the error message from another adapter.
-    let providerErrorMessage = (error as { errorResponse: { error: { message: string } } })
-      .errorResponse?.error?.message
+    let providerErrorMessage =
+      // Error format of framework v3 adapters
+      (error as { errorResponse: { error: { message: string } } }).errorResponse?.error?.message ??
+      // Error format of framework v2 adapters
+      (error as { errorResponse: { errorMessage: string } }).errorResponse?.errorMessage ??
+      // Error format from fastify server
+      (error as { errorResponse: { message: string } }).errorResponse?.message ??
+      // Error format from ethereum-cl-indexer
+      (error as { errorResponse: { error: string } }).errorResponse?.error ??
+      // Error format when Axios can't connect
+      (error as { cause: { code: string } }).cause?.code
     if (!providerErrorMessage) {
       if (error instanceof Error) {
         providerErrorMessage = error.message

--- a/packages/composites/proof-of-reserves-v2/test/unit/reserves.test.ts
+++ b/packages/composites/proof-of-reserves-v2/test/unit/reserves.test.ts
@@ -31,6 +31,7 @@ describe('ReservesTransport', () => {
   const PROVIDER_URLS = {
     'por-address-list': 'https://por.address.list',
     'token-balance': 'https://token.balance',
+    'ethereum-cl-indexer': 'https://ethereum.cl.indexer',
     'view-function-multi-chain': 'https://view.function.multi.chain',
   }
 
@@ -308,6 +309,471 @@ describe('ReservesTransport', () => {
       await transport.handleRequest(context, param)
 
       const expectedErrorMessage = `Error processing component 'component1': Error fetching data from provider 'token-balance' at 'https://token.balance': The EA has not received any values from the Data Provider`
+
+      const expectedResponse = {
+        statusCode: 502,
+        errorMessage: expectedErrorMessage,
+        timestamps: {
+          providerDataRequestedUnixMs: 0,
+          providerDataReceivedUnixMs: 0,
+          providerIndicatedTimeUnixMs: undefined,
+        },
+      }
+
+      expect(responseCache.write).toBeCalledWith(transportName, [
+        {
+          params: param,
+          response: expectedResponse,
+        },
+      ])
+      expect(responseCache.write).toBeCalledTimes(1)
+
+      expect(requester.request).toBeCalledTimes(2)
+
+      expect(log).toBeCalledWith(
+        new AdapterError({
+          statusCode: 502,
+          message: expectedErrorMessage,
+        }),
+        expectedErrorMessage,
+      )
+      expect(log).toBeCalledTimes(1)
+      log.mockClear()
+    })
+
+    it('should cache an error if balance provider returns a v3 framework error', async () => {
+      const addressListParams = { endpoint: 'multiAddressList' }
+      const balanceParams = { endpoint: 'evm' }
+      const addressArray = [{ address: '0x123' }]
+      const providerError = {
+        errorResponse: {
+          status: 'errored',
+          statusCode: 504,
+          error: {
+            name: 'AdapterError',
+            message: 'The EA has not received any values from the Data Provider',
+          },
+        },
+      }
+
+      mockFetchData('por-address-list', addressListParams, {
+        data: {
+          result: addressArray,
+        },
+      })
+
+      mockFetchData(
+        'token-balance',
+        { ...balanceParams, addresses: addressArray },
+        Promise.reject(providerError),
+      )
+
+      const param = makeStub('param', {
+        addressLists: [
+          {
+            name: 'list1',
+            fixed: undefined,
+            provider: 'por-address-list',
+            params: JSON.stringify(addressListParams),
+            addressArrayPath: 'data.result',
+            ripcord: undefined,
+          },
+        ],
+        balanceSources: [
+          {
+            name: 'source1',
+            provider: 'token-balance',
+            params: JSON.stringify(balanceParams),
+            addressArrayPath: 'addresses',
+            balancesArrayPath: 'data.wallets',
+            balancePath: 'balance',
+            decimalsPath: 'decimals',
+          },
+        ],
+        components: [
+          {
+            name: 'component1',
+            currency: 'USDC',
+            addressList: 'list1',
+            balanceSource: 'source1',
+            conversions: [],
+          },
+        ],
+        conversions: [],
+        resultDecimals: 6,
+      } as unknown as RequestParams)
+
+      await transport.handleRequest(context, param)
+
+      const expectedErrorMessage = `Error processing component 'component1': Error fetching data from provider 'token-balance' at 'https://token.balance': The EA has not received any values from the Data Provider`
+
+      const expectedResponse = {
+        statusCode: 502,
+        errorMessage: expectedErrorMessage,
+        timestamps: {
+          providerDataRequestedUnixMs: 0,
+          providerDataReceivedUnixMs: 0,
+          providerIndicatedTimeUnixMs: undefined,
+        },
+      }
+
+      expect(responseCache.write).toBeCalledWith(transportName, [
+        {
+          params: param,
+          response: expectedResponse,
+        },
+      ])
+      expect(responseCache.write).toBeCalledTimes(1)
+
+      expect(requester.request).toBeCalledTimes(2)
+
+      expect(log).toBeCalledWith(
+        new AdapterError({
+          statusCode: 502,
+          message: expectedErrorMessage,
+        }),
+        expectedErrorMessage,
+      )
+      expect(log).toBeCalledTimes(1)
+      log.mockClear()
+    })
+
+    it('should cache an error if balance provider returns a v2 framework error', async () => {
+      const addressListParams = { endpoint: 'multiAddressList' }
+      const balanceParams = { endpoint: 'evm' }
+      const addressArray = [{ address: '0x123' }]
+      const providerError = {
+        errorResponse: {
+          errorMessage: 'The EA has not received any values from the Data Provider',
+        },
+      }
+
+      mockFetchData('por-address-list', addressListParams, {
+        data: {
+          result: addressArray,
+        },
+      })
+
+      mockFetchData(
+        'token-balance',
+        { ...balanceParams, addresses: addressArray },
+        Promise.reject(providerError),
+      )
+
+      const param = makeStub('param', {
+        addressLists: [
+          {
+            name: 'list1',
+            fixed: undefined,
+            provider: 'por-address-list',
+            params: JSON.stringify(addressListParams),
+            addressArrayPath: 'data.result',
+            ripcord: undefined,
+          },
+        ],
+        balanceSources: [
+          {
+            name: 'source1',
+            provider: 'token-balance',
+            params: JSON.stringify(balanceParams),
+            addressArrayPath: 'addresses',
+            balancesArrayPath: 'data.wallets',
+            balancePath: 'balance',
+            decimalsPath: 'decimals',
+          },
+        ],
+        components: [
+          {
+            name: 'component1',
+            currency: 'USDC',
+            addressList: 'list1',
+            balanceSource: 'source1',
+            conversions: [],
+          },
+        ],
+        conversions: [],
+        resultDecimals: 6,
+      } as unknown as RequestParams)
+
+      await transport.handleRequest(context, param)
+
+      const expectedErrorMessage = `Error processing component 'component1': Error fetching data from provider 'token-balance' at 'https://token.balance': The EA has not received any values from the Data Provider`
+
+      const expectedResponse = {
+        statusCode: 502,
+        errorMessage: expectedErrorMessage,
+        timestamps: {
+          providerDataRequestedUnixMs: 0,
+          providerDataReceivedUnixMs: 0,
+          providerIndicatedTimeUnixMs: undefined,
+        },
+      }
+
+      expect(responseCache.write).toBeCalledWith(transportName, [
+        {
+          params: param,
+          response: expectedResponse,
+        },
+      ])
+      expect(responseCache.write).toBeCalledTimes(1)
+
+      expect(requester.request).toBeCalledTimes(2)
+
+      expect(log).toBeCalledWith(
+        new AdapterError({
+          statusCode: 502,
+          message: expectedErrorMessage,
+        }),
+        expectedErrorMessage,
+      )
+      expect(log).toBeCalledTimes(1)
+      log.mockClear()
+    })
+
+    it('should cache an error if balance provider returns a fastify error', async () => {
+      const addressListParams = { endpoint: 'multiAddressList' }
+      const balanceParams = { endpoint: 'evm' }
+      const addressArray = [{ address: '0x123' }]
+      const providerError = {
+        errorResponse: {
+          message: 'Service unavailable',
+        },
+      }
+
+      mockFetchData('por-address-list', addressListParams, {
+        data: {
+          result: addressArray,
+        },
+      })
+
+      mockFetchData(
+        'token-balance',
+        { ...balanceParams, addresses: addressArray },
+        Promise.reject(providerError),
+      )
+
+      const param = makeStub('param', {
+        addressLists: [
+          {
+            name: 'list1',
+            fixed: undefined,
+            provider: 'por-address-list',
+            params: JSON.stringify(addressListParams),
+            addressArrayPath: 'data.result',
+            ripcord: undefined,
+          },
+        ],
+        balanceSources: [
+          {
+            name: 'source1',
+            provider: 'token-balance',
+            params: JSON.stringify(balanceParams),
+            addressArrayPath: 'addresses',
+            balancesArrayPath: 'data.wallets',
+            balancePath: 'balance',
+            decimalsPath: 'decimals',
+          },
+        ],
+        components: [
+          {
+            name: 'component1',
+            currency: 'USDC',
+            addressList: 'list1',
+            balanceSource: 'source1',
+            conversions: [],
+          },
+        ],
+        conversions: [],
+        resultDecimals: 6,
+      } as unknown as RequestParams)
+
+      await transport.handleRequest(context, param)
+
+      const expectedErrorMessage = `Error processing component 'component1': Error fetching data from provider 'token-balance' at 'https://token.balance': Service unavailable`
+
+      const expectedResponse = {
+        statusCode: 502,
+        errorMessage: expectedErrorMessage,
+        timestamps: {
+          providerDataRequestedUnixMs: 0,
+          providerDataReceivedUnixMs: 0,
+          providerIndicatedTimeUnixMs: undefined,
+        },
+      }
+
+      expect(responseCache.write).toBeCalledWith(transportName, [
+        {
+          params: param,
+          response: expectedResponse,
+        },
+      ])
+      expect(responseCache.write).toBeCalledTimes(1)
+
+      expect(requester.request).toBeCalledTimes(2)
+
+      expect(log).toBeCalledWith(
+        new AdapterError({
+          statusCode: 502,
+          message: expectedErrorMessage,
+        }),
+        expectedErrorMessage,
+      )
+      expect(log).toBeCalledTimes(1)
+      log.mockClear()
+    })
+
+    it('should cache an error if balance provider returns a ethereum-cl-indexer error', async () => {
+      const addressListParams = { endpoint: 'multiAddressList' }
+      const balanceParams = { endpoint: 'evm' }
+      const addressArray = [{ address: '0x123' }]
+      const providerError = {
+        errorResponse: {
+          error: 'Invalid validator credential',
+        },
+      }
+
+      mockFetchData('por-address-list', addressListParams, {
+        data: {
+          result: addressArray,
+        },
+      })
+
+      mockFetchData(
+        'ethereum-cl-indexer',
+        { ...balanceParams, addresses: addressArray },
+        Promise.reject(providerError),
+      )
+
+      const param = makeStub('param', {
+        addressLists: [
+          {
+            name: 'list1',
+            fixed: undefined,
+            provider: 'por-address-list',
+            params: JSON.stringify(addressListParams),
+            addressArrayPath: 'data.result',
+            ripcord: undefined,
+          },
+        ],
+        balanceSources: [
+          {
+            name: 'source1',
+            provider: 'ethereum-cl-indexer',
+            params: JSON.stringify(balanceParams),
+            addressArrayPath: 'addresses',
+            balancesArrayPath: 'data.wallets',
+            balancePath: 'balance',
+            decimalsPath: 'decimals',
+          },
+        ],
+        components: [
+          {
+            name: 'component1',
+            currency: 'USDC',
+            addressList: 'list1',
+            balanceSource: 'source1',
+            conversions: [],
+          },
+        ],
+        conversions: [],
+        resultDecimals: 6,
+      } as unknown as RequestParams)
+
+      await transport.handleRequest(context, param)
+
+      const expectedErrorMessage = `Error processing component 'component1': Error fetching data from provider 'ethereum-cl-indexer' at 'https://ethereum.cl.indexer': Invalid validator credential`
+
+      const expectedResponse = {
+        statusCode: 502,
+        errorMessage: expectedErrorMessage,
+        timestamps: {
+          providerDataRequestedUnixMs: 0,
+          providerDataReceivedUnixMs: 0,
+          providerIndicatedTimeUnixMs: undefined,
+        },
+      }
+
+      expect(responseCache.write).toBeCalledWith(transportName, [
+        {
+          params: param,
+          response: expectedResponse,
+        },
+      ])
+      expect(responseCache.write).toBeCalledTimes(1)
+
+      expect(requester.request).toBeCalledTimes(2)
+
+      expect(log).toBeCalledWith(
+        new AdapterError({
+          statusCode: 502,
+          message: expectedErrorMessage,
+        }),
+        expectedErrorMessage,
+      )
+      expect(log).toBeCalledTimes(1)
+      log.mockClear()
+    })
+
+    it('should cache an error if balance provider returns an Axios error', async () => {
+      const addressListParams = { endpoint: 'multiAddressList' }
+      const balanceParams = { endpoint: 'evm' }
+      const addressArray = [{ address: '0x123' }]
+      const providerError = {
+        cause: {
+          code: 'E_ADDRESS_NOT_FOUND',
+        },
+      }
+
+      mockFetchData('por-address-list', addressListParams, {
+        data: {
+          result: addressArray,
+        },
+      })
+
+      mockFetchData(
+        'ethereum-cl-indexer',
+        { ...balanceParams, addresses: addressArray },
+        Promise.reject(providerError),
+      )
+
+      const param = makeStub('param', {
+        addressLists: [
+          {
+            name: 'list1',
+            fixed: undefined,
+            provider: 'por-address-list',
+            params: JSON.stringify(addressListParams),
+            addressArrayPath: 'data.result',
+            ripcord: undefined,
+          },
+        ],
+        balanceSources: [
+          {
+            name: 'source1',
+            provider: 'ethereum-cl-indexer',
+            params: JSON.stringify(balanceParams),
+            addressArrayPath: 'addresses',
+            balancesArrayPath: 'data.wallets',
+            balancePath: 'balance',
+            decimalsPath: 'decimals',
+          },
+        ],
+        components: [
+          {
+            name: 'component1',
+            currency: 'USDC',
+            addressList: 'list1',
+            balanceSource: 'source1',
+            conversions: [],
+          },
+        ],
+        conversions: [],
+        resultDecimals: 6,
+      } as unknown as RequestParams)
+
+      await transport.handleRequest(context, param)
+
+      const expectedErrorMessage = `Error processing component 'component1': Error fetching data from provider 'ethereum-cl-indexer' at 'https://ethereum.cl.indexer': E_ADDRESS_NOT_FOUND`
 
       const expectedResponse = {
         statusCode: 502,


### PR DESCRIPTION
## [OPDATA-7078](https://smartcontract-it.atlassian.net/browse/OPDATA-7078)

## Description

While creating the params for all the existing PoR feeds, I ran into several kinds of errors.
I added handling for them locally and just realized I still had it sitting in my local branch.
I think it could be useful for trouble shooting in the future so would be good to include.

## Changes

1. Handle different kinds of error shapes from providers.
2. Added unit tests.

## Steps to Test

```
yarn test packages/composites/proof-of-reserves-v2/test/unit/reserves.test.ts
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[OPDATA-7078]: https://smartcontract-it.atlassian.net/browse/OPDATA-7078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ