### PR TITLE
OPDATA-6745: Bump framework version on the-network-firm

### DIFF
--- a/.changeset/light-pumas-post.md
+++ b/.changeset/light-pumas-post.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/the-network-firm-adapter': patch
+---
+
+Bumped framework version

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -6377,6 +6377,27 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
+      ["npm:2.16.1", {\
+        "packageLocation": "./.yarn/cache/@chainlink-external-adapter-framework-npm-2.16.1-bebc600dc0-4eaa996fbf.zip/node_modules/@chainlink/external-adapter-framework/",\
+        "packageDependencies": [\
+          ["@chainlink/external-adapter-framework", "npm:2.16.1"],\
+          ["@date-fns/tz", "npm:1.5.0"],\
+          ["@solana/kit", "virtual:e164854d300ea35b7fa3cd6a156e91619b18483c375f0e19e840c2407b9c2b3cb28559dd82b52bd774a11ef6eda89d1c73e1df84aa088be71b59fe686bdc8d15#npm:6.9.0"],\
+          ["ajv", "npm:8.20.0"],\
+          ["axios", "npm:1.16.1"],\
+          ["ethers", "npm:6.16.0"],\
+          ["eventsource", "npm:4.1.0"],\
+          ["fastify", "npm:5.8.5"],\
+          ["ioredis", "npm:5.11.0"],\
+          ["mock-socket", "npm:9.3.1"],\
+          ["pino", "npm:10.3.1"],\
+          ["pino-pretty", "npm:13.1.3"],\
+          ["prom-client", "npm:15.1.3"],\
+          ["redlock", "npm:5.0.0-beta.2"],\
+          ["ws", "virtual:e164854d300ea35b7fa3cd6a156e91619b18483c375f0e19e840c2407b9c2b3cb28559dd82b52bd774a11ef6eda89d1c73e1df84aa088be71b59fe686bdc8d15#npm:8.21.0"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["npm:2.8.0", {\
         "packageLocation": "./.yarn/cache/@chainlink-external-adapter-framework-npm-2.8.0-2b0ebd2740-5eee866738.zip/node_modules/@chainlink/external-adapter-framework/",\
         "packageDependencies": [\
@@ -8231,7 +8252,7 @@ const RAW_RUNTIME_STATE =
       ["workspace:packages/sources/the-network-firm", {\
         "packageLocation": "./packages/sources/the-network-firm/",\
         "packageDependencies": [\
-          ["@chainlink/external-adapter-framework", "npm:2.11.6"],\
+          ["@chainlink/external-adapter-framework", "npm:2.16.1"],\
           ["@chainlink/the-network-firm-adapter", "workspace:packages/sources/the-network-firm"],\
           ["@types/jest", "npm:29.5.14"],\
           ["@types/node", "npm:22.14.1"],\

--- a/packages/sources/the-network-firm/package.json
+++ b/packages/sources/the-network-firm/package.json
@@ -34,7 +34,7 @@
     "typescript": "5.8.3"
   },
   "dependencies": {
-    "@chainlink/external-adapter-framework": "2.11.6",
+    "@chainlink/external-adapter-framework": "2.16.1",
     "tslib": "2.4.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3753,6 +3753,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@chainlink/external-adapter-framework@npm:2.16.1":
+  version: 2.16.1
+  resolution: "@chainlink/external-adapter-framework@npm:2.16.1"
+  dependencies:
+    "@date-fns/tz": "npm:1.5.0"
+    "@solana/kit": "npm:6.9.0"
+    ajv: "npm:8.20.0"
+    axios: "npm:1.16.1"
+    ethers: "npm:6.16.0"
+    eventsource: "npm:4.1.0"
+    fastify: "npm:5.8.5"
+    ioredis: "npm:5.11.0"
+    mock-socket: "npm:9.3.1"
+    pino: "npm:10.3.1"
+    pino-pretty: "npm:13.1.3"
+    prom-client: "npm:15.1.3"
+    redlock: "npm:5.0.0-beta.2"
+    ws: "npm:8.21.0"
+  bin:
+    create-external-adapter: adapter-generator.js
+  checksum: 10/4eaa996fbf82b315aca9221478e2db8840f2fe3a814aa0245b8a6285bb3d192bcf7a5d4e83f08da0853138d2800f5460fba697230b91669742ee05abed2895e5
+  languageName: node
+  linkType: hard
+
 "@chainlink/external-adapter-framework@npm:2.8.0":
   version: 2.8.0
   resolution: "@chainlink/external-adapter-framework@npm:2.8.0"
@@ -5405,7 +5429,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@chainlink/the-network-firm-adapter@workspace:packages/sources/the-network-firm"
   dependencies:
-    "@chainlink/external-adapter-framework": "npm:2.11.6"
+    "@chainlink/external-adapter-framework": "npm:2.16.1"
     "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:22.14.1"
     nock: "npm:13.5.6"


### PR DESCRIPTION
## [OPDATA-6745](https://smartcontract-it.atlassian.net/browse/OPDATA-6745)

## Description

This framework version includes a fix to remove a memory leak.
I want to test it on staging over the weekend before bumping all other EAs.

## Changes

Update framework dependency of `the-network-firm` to 2.16.1.

## Steps to Test

Will run on staging over the weekend.

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[OPDATA-6745]: https://smartcontract-it.atlassian.net/browse/OPDATA-6745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ