### PR TITLE
Add circle endpoint to por-address-list

### DIFF
--- a/.changeset/tiny-tools-smoke.md
+++ b/.changeset/tiny-tools-smoke.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/por-address-list-adapter': minor
+---
+
+Add circle endpoint

--- a/packages/sources/por-address-list/src/config/index.ts
+++ b/packages/sources/por-address-list/src/config/index.ts
@@ -101,4 +101,10 @@ export const config = new AdapterConfig({
     default: 'https://www.okx.com/v2/asset/audit/minted-coin-balances',
     sensitive: false,
   },
+  CIRCLE_API_URL: {
+    description: 'An API endpoint for Circle address list',
+    type: 'string',
+    default: 'https://api.circle.com/v1/reserveAddresses/cirbtc',
+    sensitive: false,
+  },
 })

--- a/packages/sources/por-address-list/src/endpoint/circle.ts
+++ b/packages/sources/por-address-list/src/endpoint/circle.ts
@@ -1,0 +1,24 @@
+import { AdapterEndpoint } from '@chainlink/external-adapter-framework/adapter'
+import { PoRAddress } from '@chainlink/external-adapter-framework/adapter/por'
+import { InputParameters } from '@chainlink/external-adapter-framework/validation'
+import { config } from '../config'
+import { circleTransport } from '../transport/circle'
+
+export const inputParameters = new InputParameters({}, [{}])
+
+export type BaseEndpointTypes = {
+  Parameters: typeof inputParameters.definition
+  Response: {
+    Result: null
+    Data: {
+      result: PoRAddress[]
+    }
+  }
+  Settings: typeof config.settings
+}
+
+export const endpoint = new AdapterEndpoint({
+  name: 'circle',
+  transport: circleTransport,
+  inputParameters,
+})

--- a/packages/sources/por-address-list/src/endpoint/circle.ts
+++ b/packages/sources/por-address-list/src/endpoint/circle.ts
@@ -1,13 +1,11 @@
 import { AdapterEndpoint } from '@chainlink/external-adapter-framework/adapter'
 import { PoRAddress } from '@chainlink/external-adapter-framework/adapter/por'
-import { InputParameters } from '@chainlink/external-adapter-framework/validation'
+import { EmptyInputParameters } from '@chainlink/external-adapter-framework/validation/input-params'
 import { config } from '../config'
 import { circleTransport } from '../transport/circle'
 
-export const inputParameters = new InputParameters({}, [{}])
-
 export type BaseEndpointTypes = {
-  Parameters: typeof inputParameters.definition
+  Parameters: EmptyInputParameters
   Response: {
     Result: null
     Data: {
@@ -20,5 +18,4 @@ export type BaseEndpointTypes = {
 export const endpoint = new AdapterEndpoint({
   name: 'circle',
   transport: circleTransport,
-  inputParameters,
 })

--- a/packages/sources/por-address-list/src/endpoint/index.ts
+++ b/packages/sources/por-address-list/src/endpoint/index.ts
@@ -1,5 +1,6 @@
 export { endpoint as address } from './address'
 export { endpoint as bedrockBTC } from './bedrockBTC'
+export { endpoint as circle } from './circle'
 export { endpoint as coinbaseBTC } from './coinbaseCBBTC'
 export { endpoint as multichainAddress } from './multichainAddress'
 export { endpoint as okxAssetsAddress } from './okxAssetsAddress'

--- a/packages/sources/por-address-list/src/index.ts
+++ b/packages/sources/por-address-list/src/index.ts
@@ -4,6 +4,7 @@ import { config } from './config'
 import {
   address,
   bedrockBTC,
+  circle,
   coinbaseBTC,
   multichainAddress,
   okxAssetsAddress,
@@ -22,6 +23,7 @@ export const adapter = new PoRAdapter({
     address,
     solvBTC,
     bedrockBTC,
+    circle,
     coinbaseBTC,
     multichainAddress,
     openedenAddress,

--- a/packages/sources/por-address-list/src/transport/circle.ts
+++ b/packages/sources/por-address-list/src/transport/circle.ts
@@ -1,0 +1,79 @@
+import { HttpTransport } from '@chainlink/external-adapter-framework/transports'
+import { isValidBitcoinAddress } from '@chainlink/external-adapter-framework/validation/address'
+import { BaseEndpointTypes } from '../endpoint/circle'
+
+export interface ResponseSchema {
+  data: {
+    address: string
+  }[]
+}
+
+export type HttpTransportTypes = BaseEndpointTypes & {
+  Provider: {
+    RequestBody: never
+    ResponseBody: ResponseSchema
+  }
+}
+
+// Exported for testing
+export class CircleTransport extends HttpTransport<HttpTransportTypes> {
+  constructor() {
+    super({
+      prepareRequests: (params, config) => {
+        return params.map((param) => {
+          return {
+            params: [param],
+            request: {
+              baseURL: config.CIRCLE_API_URL,
+            },
+          }
+        })
+      },
+      parseResponse: (params, response) => {
+        if (!response.data) {
+          return params.map((param) => {
+            return {
+              params: param,
+              response: {
+                errorMessage: `The data provider didn't return any value`,
+                statusCode: 502,
+              },
+            }
+          })
+        }
+
+        for (const { address } of response.data.data) {
+          if (!isValidBitcoinAddress(address)) {
+            return params.map((param) => {
+              return {
+                params: param,
+                response: {
+                  errorMessage: `Invalid Bitcoin address returned from data provider: '${address}'`,
+                  statusCode: 502,
+                },
+              }
+            })
+          }
+        }
+
+        return params.map((param) => {
+          return {
+            params: param,
+            response: {
+              result: null,
+              data: {
+                result: response.data.data.map((item) => ({
+                  address: item.address,
+                  network: 'bitcoin',
+                  chainId: 'mainnet',
+                })),
+              },
+            },
+          }
+        })
+      },
+    })
+  }
+}
+
+export const circleTransport = new CircleTransport()

--- a/packages/sources/por-address-list/test/integration/__snapshots__/adapter-circle.test.ts.snap
+++ b/packages/sources/por-address-list/test/integration/__snapshots__/adapter-circle.test.ts.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`execute circle should return success 1`] = `
+{
+  "data": {
+    "result": [
+      {
+        "address": "1FXxhAa9yKCG8WgCTrbSsdGKuC6QzN3Gq9",
+        "chainId": "mainnet",
+        "network": "bitcoin",
+      },
+      {
+        "address": "1HkJ6hcN4h4PtUYHiSi1hrUEUKQJmedM6z",
+        "chainId": "mainnet",
+        "network": "bitcoin",
+      },
+      {
+        "address": "1KVBNjpYfJvASdzeTAwqNbe9WecpKyugM3",
+        "chainId": "mainnet",
+        "network": "bitcoin",
+      },
+    ],
+  },
+  "result": null,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 978347471111,
+    "providerDataRequestedUnixMs": 978347471111,
+  },
+}
+`;

--- a/packages/sources/por-address-list/test/integration/adapter-circle.test.ts
+++ b/packages/sources/por-address-list/test/integration/adapter-circle.test.ts
@@ -1,0 +1,51 @@
+import {
+  TestAdapter,
+  setEnvVariables,
+} from '@chainlink/external-adapter-framework/util/testing-utils'
+import nock from 'nock'
+import { mockCircleResponseSuccess } from './fixtures-api'
+
+describe('execute', () => {
+  let spy: jest.SpyInstance
+  let testAdapter: TestAdapter
+  let oldEnv: NodeJS.ProcessEnv
+
+  beforeAll(async () => {
+    oldEnv = JSON.parse(JSON.stringify(process.env))
+    process.env.RPC_URL = process.env.RPC_URL ?? 'http://localhost:8080'
+    process.env.CIRCLE_API_URL = 'http://circle.api'
+    process.env.BACKGROUND_EXECUTE_MS = '0'
+
+    const mockDate = new Date('2001-01-01T11:11:11.111Z')
+    spy = jest.spyOn(Date, 'now').mockReturnValue(mockDate.getTime())
+
+    const adapter = (await import('./../../src')).adapter
+    adapter.rateLimiting = undefined
+    testAdapter = await TestAdapter.startWithMockedCache(adapter, {
+      testAdapter: {} as TestAdapter<never>,
+    })
+  })
+
+  afterAll(async () => {
+    setEnvVariables(oldEnv)
+    await testAdapter.api.close()
+    nock.restore()
+    nock.cleanAll()
+    spy.mockRestore()
+  })
+
+  describe('circle', () => {
+    it('should return success', async () => {
+      const data = {
+        endpoint: 'circle',
+      }
+
+      mockCircleResponseSuccess()
+
+      const response = await testAdapter.request(data)
+
+      expect(response.json()).toMatchSnapshot()
+      expect(response.statusCode).toBe(200)
+    })
+  })
+})

--- a/packages/sources/por-address-list/test/integration/fixtures-api.ts
+++ b/packages/sources/por-address-list/test/integration/fixtures-api.ts
@@ -533,3 +533,34 @@ export const mockOkxResponseSuccess = (): nock.Scope =>
       detailMsg: '',
     }))
     .persist()
+
+export const mockCircleResponseSuccess = (): nock.Scope =>
+  nock('http://circle.api')
+    .get('/')
+    .reply(
+      200,
+      () => ({
+        data: [
+          {
+            address: '1FXxhAa9yKCG8WgCTrbSsdGKuC6QzN3Gq9',
+          },
+          {
+            address: '1HkJ6hcN4h4PtUYHiSi1hrUEUKQJmedM6z',
+          },
+          {
+            address: '1KVBNjpYfJvASdzeTAwqNbe9WecpKyugM3',
+          },
+        ],
+      }),
+      [
+        'Content-Type',
+        'application/json',
+        'Connection',
+        'close',
+        'Vary',
+        'Accept-Encoding',
+        'Vary',
+        'Origin',
+      ],
+    )
+    .persist()

--- a/packages/sources/por-address-list/test/unit/circle.test.ts
+++ b/packages/sources/por-address-list/test/unit/circle.test.ts
@@ -1,0 +1,199 @@
+import { EndpointContext } from '@chainlink/external-adapter-framework/adapter'
+import { calculateHttpRequestKey } from '@chainlink/external-adapter-framework/cache'
+import { metrics } from '@chainlink/external-adapter-framework/metrics'
+import { TransportDependencies } from '@chainlink/external-adapter-framework/transports'
+import { LoggerFactoryProvider } from '@chainlink/external-adapter-framework/util'
+import { makeStub } from '@chainlink/external-adapter-framework/util/testing-utils'
+import { inputParameters } from '../../src/endpoint/circle'
+import { CircleTransport, HttpTransportTypes } from '../../src/transport/circle'
+
+const log = jest.fn()
+const debugLog = jest.fn()
+const logger = {
+  fatal: log,
+  error: log,
+  warn: log,
+  info: log,
+  debug: debugLog,
+  trace: debugLog,
+  msgPrefix: 'mock-logger',
+}
+
+const loggerFactory = { child: () => logger }
+
+LoggerFactoryProvider.set(loggerFactory)
+metrics.initialize()
+
+describe('CircleTransport', () => {
+  const transportName = 'default_single_transport'
+  const endpointName = 'circle'
+  const apiUrl = 'http://api.example.com'
+
+  const adapterSettings = makeStub('adapterSettings', {
+    CIRCLE_API_URL: apiUrl,
+    CACHE_MAX_AGE: 90_000,
+    MAX_COMMON_KEY_SIZE: 300,
+    WARMUP_SUBSCRIPTION_TTL: 10_000,
+  } as unknown as HttpTransportTypes['Settings'])
+
+  const subscriptionSet = makeStub('subscriptionSet', {
+    getAll: jest.fn(),
+  })
+
+  const subscriptionSetFactory = makeStub('subscriptionSetFactory', {
+    buildSet() {
+      return subscriptionSet
+    },
+  })
+
+  const requester = makeStub('requester', {
+    request: jest.fn(),
+  })
+
+  const responseCache = {
+    write: jest.fn(),
+  }
+  const dependencies = makeStub('dependencies', {
+    requester,
+    responseCache,
+    subscriptionSetFactory,
+  } as unknown as TransportDependencies<HttpTransportTypes>)
+
+  let transport: CircleTransport
+
+  const requestKeyForParams = (params: typeof inputParameters.validated) => {
+    const requestKey = calculateHttpRequestKey<HttpTransportTypes>({
+      context: {
+        adapterSettings,
+        inputParameters,
+        endpointName,
+      },
+      data: [params],
+      transportName,
+    })
+    return requestKey
+  }
+
+  beforeEach(async () => {
+    jest.resetAllMocks()
+    jest.useFakeTimers()
+
+    transport = new CircleTransport()
+
+    await transport.initialize(dependencies, adapterSettings, endpointName, transportName)
+  })
+
+  afterEach(() => {
+    expect(log).not.toHaveBeenCalled()
+  })
+
+  it('should make the request', async () => {
+    const address = '1FXxhAa9yKCG8WgCTrbSsdGKuC6QzN3Gq9'
+    const params = makeStub('params', {})
+    subscriptionSet.getAll.mockReturnValue([params])
+
+    const context = makeStub('context', {
+      adapterSettings,
+      endpointName,
+    } as EndpointContext<HttpTransportTypes>)
+
+    const response = makeStub('response', {
+      response: {
+        data: {
+          data: [{ address }],
+          cost: undefined,
+        },
+      },
+      timestamps: {},
+    })
+
+    requester.request.mockResolvedValue(response)
+
+    await transport.backgroundExecute(context)
+
+    const expectedRequestConfig = {
+      baseURL: adapterSettings.CIRCLE_API_URL,
+    }
+    const expectedRequestKey = requestKeyForParams(params)
+
+    const expectedResponse = {
+      result: null,
+      data: {
+        result: [
+          {
+            address,
+            network: 'bitcoin',
+            chainId: 'mainnet',
+          },
+        ],
+      },
+      timestamps: {},
+    }
+
+    expect(requester.request).toHaveBeenCalledWith(
+      expectedRequestKey,
+      expectedRequestConfig,
+      undefined,
+    )
+    expect(requester.request).toHaveBeenCalledTimes(1)
+
+    expect(responseCache.write).toHaveBeenCalledWith(transportName, [
+      {
+        params,
+        response: expectedResponse,
+      },
+    ])
+    expect(responseCache.write).toHaveBeenCalledTimes(1)
+  })
+
+  it('should return an error for invalid addresses', async () => {
+    const invalidAddress = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+    const params = makeStub('params', {})
+    subscriptionSet.getAll.mockReturnValue([params])
+
+    const context = makeStub('context', {
+      adapterSettings,
+      endpointName,
+    } as EndpointContext<HttpTransportTypes>)
+
+    const response = makeStub('response', {
+      response: {
+        data: {
+          data: [{ address: invalidAddress }],
+          cost: undefined,
+        },
+      },
+      timestamps: {},
+    })
+
+    requester.request.mockResolvedValue(response)
+
+    await transport.backgroundExecute(context)
+
+    const expectedRequestConfig = {
+      baseURL: adapterSettings.CIRCLE_API_URL,
+    }
+    const expectedRequestKey = requestKeyForParams(params)
+
+    const expectedResponse = {
+      errorMessage: `Invalid Bitcoin address returned from data provider: '${invalidAddress}'`,
+      statusCode: 502,
+      timestamps: {},
+    }
+
+    expect(requester.request).toHaveBeenCalledWith(
+      expectedRequestKey,
+      expectedRequestConfig,
+      undefined,
+    )
+    expect(requester.request).toHaveBeenCalledTimes(1)
+
+    expect(responseCache.write).toHaveBeenCalledWith(transportName, [
+      {
+        params,
+        response: expectedResponse,
+      },
+    ])
+    expect(responseCache.write).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/sources/por-address-list/test/unit/circle.test.ts
+++ b/packages/sources/por-address-list/test/unit/circle.test.ts
@@ -4,7 +4,7 @@ import { metrics } from '@chainlink/external-adapter-framework/metrics'
 import { TransportDependencies } from '@chainlink/external-adapter-framework/transports'
 import { LoggerFactoryProvider } from '@chainlink/external-adapter-framework/util'
 import { makeStub } from '@chainlink/external-adapter-framework/util/testing-utils'
-import { inputParameters } from '../../src/endpoint/circle'
+import { InputParameters } from '@chainlink/external-adapter-framework/validation'
 import { CircleTransport, HttpTransportTypes } from '../../src/transport/circle'
 
 const log = jest.fn()
@@ -61,11 +61,11 @@ describe('CircleTransport', () => {
 
   let transport: CircleTransport
 
-  const requestKeyForParams = (params: typeof inputParameters.validated) => {
+  const requestKeyForParams = (params: Record<string, never>) => {
     const requestKey = calculateHttpRequestKey<HttpTransportTypes>({
       context: {
         adapterSettings,
-        inputParameters,
+        inputParameters: new InputParameters({}),
         endpointName,
       },
       data: [params],


### PR DESCRIPTION
## [OPDATA-7629](https://smartcontract-it.atlassian.net/browse/OPDATA-7629)

## Description

Add endpoint to `por-address-list` that reads from API in format:
```
{
  "data": [
    {
      "address": "1FXxhAa9yKCG8WgCTrbSsdGKuC6QzN3Gq9"
    },
...
  ]
}
```
and outputs the format suitable for `por-indexer` via `proof-of-reserves-v2`:
```
{
  "result": null,
  "data": {
    "result": [
      {
        "address": "1FXxhAa9yKCG8WgCTrbSsdGKuC6QzN3Gq9",
        "network": "bitcoin",
        "chainId": "mainnet"
      },
...
    ]
  },
  "timestamps": {
    "providerDataRequestedUnixMs": 1780909748840,
    "providerDataReceivedUnixMs": 1780909749742
  },
  "statusCode": 200,
  "meta": {
    "adapterName": "POR_ADDRESS_LIST",
    "metrics": {
      "feedId": "N/A"
    }
  }
}
```

This will be used for the Circle BTC reservers feed.

## Changes

1. Added `circle` HTTP endpoint with address validation.
2. Added unit tests for success and failure.
3. Added integration tests.

## Steps to Test

```
curl --silent -S -X POST http://localhost:8080 -H 'Content-Type: application/json' -d '{
  "data": {
    "addressLists": [
      {
        "name": "Circle",
        "provider": "por-address-list",
        "params": "{\"endpoint\":\"circle\"}",
        "addressArrayPath": "data.result"
      }
    ],
    "balanceSources": [
      {
        "name": "por-indexer",
        "provider": "por-indexer",
        "params": "{\"minConfirmations\":6}",
        "addressArrayPath": "addresses",
        "balancePath": "result"
      }
    ],
    "components": [
      {
        "name": "Circle BTC",
        "currency": "BTC",
        "addressList": "Circle",
        "balanceSource": "por-indexer",
        "conversions": []
      }
    ],
    "conversions": [],
    "resultDecimals": 8
  }
}'

{
  "data": {
    "result": "119971968",
    "resultAsNumber": 1.19971968,
    "decimals": 8,
    "components": [
      {
        "name": "Circle BTC",
        "currency": "BTC",
        "totalBalance": 1.19971968
      }
    ],
    "conversionRates": []
  },
  "statusCode": 200,
  "result": "119971968",
  "timestamps": {
    "providerDataRequestedUnixMs": 1780912172622,
    "providerDataReceivedUnixMs": 1780912173148
  },
  "meta": {
    "adapterName": "PROOF_OF-RESERVES-2",
    "metrics": {
      "feedId": "yxVDRH8+02X3aKqiIQkxMV+bKNw="
    }
  }
}
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[OPDATA-7629]: https://smartcontract-it.atlassian.net/browse/OPDATA-7629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ