### PR TITLE
Create a changeset file per package on framework bump

### DIFF
--- a/packages/scripts/src/framework/version-bump.sh
+++ b/packages/scripts/src/framework/version-bump.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 
 LATEST_VERSION=$(npm view @chainlink/external-adapter-framework version)''
 
@@ -56,13 +56,22 @@ echo "Running yarn..."
 yarn > /dev/null
 
 if [ -s changed_eas.tmp ]; then
-  # Generate changeset (manually for now, since the changesets CLI has no options to automate this part)
-  changeset_name="$(cd packages/scripts && yarn node -e 'console.log(require("human-id").humanId({ separator: "-", capitalize: false }))').md"
-  echo "Creating changeset ($changeset_name)..."
-  touch .changeset/$changeset_name
-  echo "---" >> .changeset/$changeset_name
-  cat changed_eas.tmp >> .changeset/$changeset_name
-  printf -- '---\n\nBumped framework version\n' >> .changeset/$changeset_name
+  # We create a separate changeset file for each package so we don't enforce
+  # releasing all packages at the same time.
+  mapfile -t changeset_lines < changed_eas.tmp
+  count=${#changeset_lines[@]}
+  # Create changeset names with a single call to yarn node as calling it 100+
+  # times is quite slow.
+  mapfile -t changeset_names < <(cd packages/scripts && yarn node -e "
+    const { humanId } = require('human-id')
+    for (let i = 0; i < $count; i++) console.log(humanId({ separator: '-', capitalize: false }))
+  ")
+  for i in "${!changeset_lines[@]}"; do
+    # Generate changeset (manually for now, since the changesets CLI has no options to automate this part)
+    changeset_filename="${changeset_names[$i]}.md"
+    echo "Creating changeset ($changeset_filename)..."
+    printf '%s\n%s\n%s\n\nBumped framework version\n' "---" "${changeset_lines[$i]}" "---" > ".changeset/$changeset_filename"
+  done
 else
   echo "No adapters were changed, no need to create a changeset."
 fi


### PR DESCRIPTION
## Description

Currently the `packages/scripts/src/framework/version-bump.sh` script creates a single changeset file for all the packages.
This means that we have to release all those packages at the same time.
But creating a separate changeset file per package we can release individual packages when we want.

## Changes

1. Create changeset file names with a single call to `yarn node` to avoid the script being very slow.
2. Generate a changeset file per changed package.
3. Run with `/usr/bin/env bash` instead of `/bin/bash` as `mapfile` requires `bash` 4+ and Mac installs version 3 in `/bin/`.

## Steps to Test

Created https://github.com/smartcontractkit/external-adapters-js/pull/5030

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
