### PR TITLE
Bump framework version of apex + remove axios dep

### DIFF
--- a/.changeset/curly-cars-wash.md
+++ b/.changeset/curly-cars-wash.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/apex-adapter': patch
+---
+
+Bump framework version

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -4996,10 +4996,9 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./packages/sources/apex/",\
         "packageDependencies": [\
           ["@chainlink/apex-adapter", "workspace:packages/sources/apex"],\
-          ["@chainlink/external-adapter-framework", "npm:2.11.6"],\
+          ["@chainlink/external-adapter-framework", "npm:2.16.1"],\
           ["@types/jest", "npm:29.5.14"],\
           ["@types/node", "npm:22.14.1"],\
-          ["axios", "npm:1.13.4"],\
           ["nock", "npm:13.5.6"],\
           ["tslib", "npm:2.4.1"],\
           ["typescript", "patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"]\

--- a/packages/sources/apex/package.json
+++ b/packages/sources/apex/package.json
@@ -34,8 +34,7 @@
     "typescript": "5.8.3"
   },
   "dependencies": {
-    "@chainlink/external-adapter-framework": "2.11.6",
-    "axios": "1.13.4",
+    "@chainlink/external-adapter-framework": "2.16.1",
     "tslib": "2.4.1"
   }
 }

--- a/packages/sources/apex/src/transport/nav.ts
+++ b/packages/sources/apex/src/transport/nav.ts
@@ -1,11 +1,10 @@
-import { TransportDependencies } from '@chainlink/external-adapter-framework/transports'
-import { BaseEndpointTypes, inputParameters } from '../endpoint/nav'
-import { SubscriptionTransport } from '@chainlink/external-adapter-framework/transports/abstract/subscription'
 import { EndpointContext } from '@chainlink/external-adapter-framework/adapter'
-import { makeLogger, AdapterResponse, sleep } from '@chainlink/external-adapter-framework/util'
-import { AdapterError } from '@chainlink/external-adapter-framework/validation/error'
+import { TransportDependencies } from '@chainlink/external-adapter-framework/transports'
+import { SubscriptionTransport } from '@chainlink/external-adapter-framework/transports/abstract/subscription'
+import { AdapterResponse, makeLogger, sleep } from '@chainlink/external-adapter-framework/util'
 import { Requester } from '@chainlink/external-adapter-framework/util/requester'
-import { AxiosResponse } from 'axios'
+import { AdapterError } from '@chainlink/external-adapter-framework/validation/error'
+import { BaseEndpointTypes, inputParameters } from '../endpoint/nav'
 
 const logger = makeLogger('NavTransport')
 
@@ -137,7 +136,7 @@ class NavTransport extends SubscriptionTransport<HttpTransportTypes> {
     return this.latestToken.token
   }
 
-  async requestAuth(): Promise<AxiosResponse<AuthResponseSchema>> {
+  async requestAuth(): Promise<void> {
     const startTimeMs = Date.now()
 
     const baseURL = this.settings.AUTH_API_ENDPOINT
@@ -170,7 +169,6 @@ class NavTransport extends SubscriptionTransport<HttpTransportTypes> {
     }
 
     logger.debug('Successfully fetched token')
-    return a.response
   }
 
   async getNav(accountName: string, token: string): Promise<NavResponseSchema> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2482,10 +2482,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@chainlink/apex-adapter@workspace:packages/sources/apex"
   dependencies:
-    "@chainlink/external-adapter-framework": "npm:2.11.6"
+    "@chainlink/external-adapter-framework": "npm:2.16.1"
     "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:22.14.1"
-    axios: "npm:1.13.4"
     nock: "npm:13.5.6"
     tslib: "npm:2.4.1"
     typescript: "npm:5.8.3"


### PR DESCRIPTION
## Description

Currently, `apex` breaks when you update its framework version.

This is because `requestAuth` returns `AxiosResponse<AuthResponseSchema>` which it gets from `requester.request`.
But the `requester` comes from the framework so if the framework depends on a different version of Axios, the types don't match.

Nothing actually uses the return value of `requestAuth` so we can simply return `Promise<void>` and avoid the Axios dependency in `apex` altogether.

## Changes

1. Change return type of `requestAuth` to `Promise<void>`.
2. Remove Axios dependency.
3. Bump framework version.

## Steps to Test

```
yarn install && yarn tsc -b packages/sources/apex/tsconfig.json --force
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
