### PR TITLE
Bump framework on ix-trust-sync + remove axios dep

### DIFF
--- a/.changeset/fruity-maps-appear.md
+++ b/.changeset/fruity-maps-appear.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/ix-trust-sync-adapter': patch
+---
+
+Bump framework version

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -6962,11 +6962,10 @@ const RAW_RUNTIME_STATE =
       ["workspace:packages/sources/ix-trust-sync", {\
         "packageLocation": "./packages/sources/ix-trust-sync/",\
         "packageDependencies": [\
-          ["@chainlink/external-adapter-framework", "npm:2.13.1"],\
+          ["@chainlink/external-adapter-framework", "npm:2.16.1"],\
           ["@chainlink/ix-trust-sync-adapter", "workspace:packages/sources/ix-trust-sync"],\
           ["@types/jest", "npm:29.5.14"],\
           ["@types/node", "npm:22.14.1"],\
-          ["axios", "npm:1.13.5"],\
           ["ethers", "npm:6.15.0"],\
           ["nock", "npm:13.5.6"],\
           ["tslib", "npm:2.4.1"],\

--- a/packages/sources/ix-trust-sync/package.json
+++ b/packages/sources/ix-trust-sync/package.json
@@ -34,8 +34,7 @@
     "typescript": "5.8.3"
   },
   "dependencies": {
-    "@chainlink/external-adapter-framework": "2.13.1",
-    "axios": "1.13.5",
+    "@chainlink/external-adapter-framework": "2.16.1",
     "ethers": "^6.15.0",
     "tslib": "2.4.1"
   }

--- a/packages/sources/ix-trust-sync/src/transport/cumulativeAmount.ts
+++ b/packages/sources/ix-trust-sync/src/transport/cumulativeAmount.ts
@@ -5,7 +5,6 @@ import {
 import { makeLogger, ProviderResult } from '@chainlink/external-adapter-framework/util'
 import { AdapterError } from '@chainlink/external-adapter-framework/validation/error'
 import { TypeFromDefinition } from '@chainlink/external-adapter-framework/validation/input-params'
-import { AxiosResponse } from 'axios'
 import { TypedDataDomain, TypedDataField, verifyTypedData } from 'ethers'
 import { BaseEndpointTypes } from '../endpoint/cumulativeAmount'
 
@@ -280,10 +279,7 @@ const transportConfig: HttpTransportConfig<HttpTransportTypes> = {
       }
     })
   },
-  parseResponse: (
-    params: Params[],
-    response: AxiosResponse<ResponseSchema>,
-  ): ProviderResult<HttpTransportTypes>[] => {
+  parseResponse: (params, response): ProviderResult<HttpTransportTypes>[] => {
     if (!response.data) {
       return params.map((param) => {
         return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4278,10 +4278,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@chainlink/ix-trust-sync-adapter@workspace:packages/sources/ix-trust-sync"
   dependencies:
-    "@chainlink/external-adapter-framework": "npm:2.13.1"
+    "@chainlink/external-adapter-framework": "npm:2.16.1"
     "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:22.14.1"
-    axios: "npm:1.13.5"
     ethers: "npm:^6.15.0"
     nock: "npm:13.5.6"
     tslib: "npm:2.4.1"


### PR DESCRIPTION
## Description

Currently, `ix-trust-sync` breaks when you update its framework version.

This is because the response param of `parseResponse` is declared as `AxiosResponse` imported in the package.
But it has to match the `AxiosResponse` from the framework.

We should just rely on type inference instead of declaring it explicitly.

## Changes

1. Remove type declarations of `parseResponse` params.
2. Remove Axios dependency.
3. Bump framework version.

## Steps to Test

```
yarn install && yarn tsc -b packages/sources/ix-trust-sync/tsconfig.json --force
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
