### PR TITLE
Bump framework for hashnote + remove axios dep

### DIFF
--- a/.changeset/forty-ravens-knock.md
+++ b/.changeset/forty-ravens-knock.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/hashnote-adapter': patch
+---
+
+Bump framework version

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -6793,11 +6793,10 @@ const RAW_RUNTIME_STATE =
       ["workspace:packages/sources/hashnote", {\
         "packageLocation": "./packages/sources/hashnote/",\
         "packageDependencies": [\
-          ["@chainlink/external-adapter-framework", "npm:2.11.6"],\
+          ["@chainlink/external-adapter-framework", "npm:2.16.1"],\
           ["@chainlink/hashnote-adapter", "workspace:packages/sources/hashnote"],\
           ["@types/jest", "npm:29.5.14"],\
           ["@types/node", "npm:22.14.1"],\
-          ["axios", "npm:1.13.4"],\
           ["nock", "npm:13.5.6"],\
           ["tslib", "npm:2.4.1"],\
           ["typescript", "patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"]\

--- a/packages/sources/hashnote/package.json
+++ b/packages/sources/hashnote/package.json
@@ -34,8 +34,7 @@
     "typescript": "5.8.3"
   },
   "dependencies": {
-    "@chainlink/external-adapter-framework": "2.11.6",
-    "axios": "1.13.4",
+    "@chainlink/external-adapter-framework": "2.16.1",
     "tslib": "2.4.1"
   }
 }

--- a/packages/sources/hashnote/src/transport/price.ts
+++ b/packages/sources/hashnote/src/transport/price.ts
@@ -1,5 +1,7 @@
-import { HttpTransport } from '@chainlink/external-adapter-framework/transports'
-import { AxiosResponse } from 'axios'
+import {
+  HttpTransport,
+  HttpTransportConfig,
+} from '@chainlink/external-adapter-framework/transports'
 import { BaseEndpointTypes, inputParameters } from '../endpoint/price'
 
 export interface PriceReport {
@@ -72,7 +74,10 @@ export const prepareRequests = (params: RequestParams[], config: Config) => {
 }
 
 // Exported for testing
-export const parseResponse = (params: RequestParams[], response: AxiosResponse<ResponseSchema>) => {
+export const parseResponse: HttpTransportConfig<HttpTransportTypes>['parseResponse'] = (
+  params,
+  response,
+) => {
   if (!response.data) {
     return params.map((param) => {
       return {

--- a/packages/sources/hashnote/test/unit/price.test.ts
+++ b/packages/sources/hashnote/test/unit/price.test.ts
@@ -1,14 +1,18 @@
+import { HttpTransportConfig } from '@chainlink/external-adapter-framework/transports'
 import { LoggerFactoryProvider } from '@chainlink/external-adapter-framework/util'
 import { makeStub } from '@chainlink/external-adapter-framework/util/testing-utils'
-import { AxiosResponse } from 'axios'
 import { BaseEndpointTypes } from '../../src/endpoint/price'
 import {
+  HttpTransportTypes,
   PriceReport,
   RequestParams,
-  ResponseSchema,
   parseResponse,
   prepareRequests,
 } from '../../src/transport/price'
+
+// Derived from framework type instead of using AxiosResponse<ResponseSchema>
+// to avoid having to keep our axios dependency in sync with the framework's.
+type Response = Parameters<HttpTransportConfig<HttpTransportTypes>['parseResponse']>[1]
 
 LoggerFactoryProvider.set()
 
@@ -90,9 +94,9 @@ describe('price transport', () => {
           entity: 'usyc_price_report',
           data: [newestReport],
         },
-      } as AxiosResponse<ResponseSchema>)
+      } as Response)
 
-      const parsedResponse = parseResponse([param], response)
+      const parsedResponse = parseResponse([param], response, config)
 
       expect(parsedResponse).toEqual([
         {
@@ -112,9 +116,9 @@ describe('price transport', () => {
           entity: 'usyc_price_report',
           data: [newestReport, olderReport],
         },
-      } as AxiosResponse<ResponseSchema>)
+      } as Response)
 
-      const parsedResponse = parseResponse([param], response)
+      const parsedResponse = parseResponse([param], response, config)
 
       expect(parsedResponse).toEqual([
         {
@@ -134,9 +138,9 @@ describe('price transport', () => {
           entity: 'usyc_price_report',
           data: [olderReport, newestReport],
         },
-      } as AxiosResponse<ResponseSchema>)
+      } as Response)
 
-      const parsedResponse = parseResponse([param], response)
+      const parsedResponse = parseResponse([param], response, config)
 
       expect(parsedResponse).toEqual([
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4129,10 +4129,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@chainlink/hashnote-adapter@workspace:packages/sources/hashnote"
   dependencies:
-    "@chainlink/external-adapter-framework": "npm:2.11.6"
+    "@chainlink/external-adapter-framework": "npm:2.16.1"
     "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:22.14.1"
-    axios: "npm:1.13.4"
     nock: "npm:13.5.6"
     tslib: "npm:2.4.1"
     typescript: "npm:5.8.3"


### PR DESCRIPTION
## Description

Currently, `hashnote` breaks when you update its framework version.

This is because `parseResponse` is declared with a response parameter of type `AxiosResponse<ResponseSchema>` with axios imported in the package.
But it has to match the `AxiosResponse` from the framework.

Instead of updating the axios dependency each time we update the framework dependency, we can derive the type from the framework type.

## Changes

1. Derive the type of `parseResponse` from the framework.
2. Pass `config` as third parameter in the test as the real type of `parseResponse` expects it (even though we don't use it).
3. Remove `axios` dependency.
4. Bump framework dependency.

## Steps to Test

```
yarn install && yarn tsc -b packages/sources/hashnote/tsconfig.test.json --force
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
