### PR TITLE
Remove outdated comment in GHA workflow

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -109,8 +109,6 @@ jobs:
   # ---------- Adapter checks (only for changed EAs) ----------
 
   # Check that there are no compilation errors in test.
-  # There are many existing tests with compilation errors, so we skip them
-  # until we can fix them.
   compile-tests:
     name: Compile tests for changed packages
     runs-on: [ubuntu-latest]


### PR DESCRIPTION
## Description

The last package with test compilation errors was deleted in https://github.com/smartcontractkit/external-adapters-js/pull/4278

## Changes

Remove outdated comment in GHA workflow.

## Steps to Test

N/A

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
