### PR TITLE
Bump framework on wintermute + test fix

### DIFF
--- a/.changeset/cozy-turtles-prove.md
+++ b/.changeset/cozy-turtles-prove.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/wintermute-adapter': patch
+---
+
+Bump framework version

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -8629,7 +8629,7 @@ const RAW_RUNTIME_STATE =
       ["workspace:packages/sources/wintermute", {\
         "packageLocation": "./packages/sources/wintermute/",\
         "packageDependencies": [\
-          ["@chainlink/external-adapter-framework", "npm:2.11.6"],\
+          ["@chainlink/external-adapter-framework", "npm:2.16.1"],\
           ["@chainlink/wintermute-adapter", "workspace:packages/sources/wintermute"],\
           ["@sinonjs/fake-timers", "npm:9.1.2"],\
           ["@types/jest", "npm:29.5.14"],\

--- a/packages/sources/wintermute/package.json
+++ b/packages/sources/wintermute/package.json
@@ -36,7 +36,7 @@
     "typescript": "5.8.3"
   },
   "dependencies": {
-    "@chainlink/external-adapter-framework": "2.11.6",
+    "@chainlink/external-adapter-framework": "2.16.1",
     "tslib": "2.4.1"
   }
 }

--- a/packages/sources/wintermute/src/transport/price.ts
+++ b/packages/sources/wintermute/src/transport/price.ts
@@ -23,7 +23,7 @@ export type WsTransportTypes = BaseEndpointTypes & {
   }
 }
 
-export const options: WebSocketTransportConfig<WsTransportTypes> = {
+export const options = {
   url: (context: EndpointContext<WsTransportTypes>) => context.adapterSettings.WS_API_ENDPOINT,
   options: async (context: EndpointContext<WsTransportTypes>) => ({
     headers: {
@@ -75,6 +75,6 @@ export const options: WebSocketTransportConfig<WsTransportTypes> = {
       }
     },
   },
-}
+} satisfies WebSocketTransportConfig<WsTransportTypes>
 
 export const transport = new WebSocketTransport(options)

--- a/packages/sources/wintermute/test/unit/adapter.test.ts
+++ b/packages/sources/wintermute/test/unit/adapter.test.ts
@@ -1,15 +1,12 @@
-import { EndpointContext } from '@chainlink/external-adapter-framework/adapter'
-import { options, WSResponse, WsTransportTypes } from '../../src/transport/price'
+import { options, WSResponse } from '../../src/transport/price'
 describe('Wintermute WebSocketTransport - Unit', () => {
   describe('builders', () => {
-    const context = {} as EndpointContext<WsTransportTypes>
-
     it('should build subscribe message correctly', () => {
       if (!options || !options.builders || !options.builders.subscribeMessage) {
         throw new Error('subscribeMessage is undefined, cannot run test')
       }
 
-      const message = options.builders.subscribeMessage!({ symbol: 'GMCI30' }, context) as any
+      const message = options.builders.subscribeMessage!({ symbol: 'GMCI30' }) as any
       expect(message).toEqual({
         op: 'subscribe',
         args: ['price.gmci30'],
@@ -21,7 +18,7 @@ describe('Wintermute WebSocketTransport - Unit', () => {
         throw new Error('subscribeMessage is undefined, cannot run test')
       }
 
-      const msg = options.builders.unsubscribeMessage({ symbol: 'GMCI30' }, context)
+      const msg = options.builders.unsubscribeMessage({ symbol: 'GMCI30' })
       expect(msg).toEqual({
         op: 'unsubscribe',
         args: ['price.gmci30'],
@@ -31,11 +28,10 @@ describe('Wintermute WebSocketTransport - Unit', () => {
 
   describe('handlers.message', () => {
     const messageHandler = options.handlers.message!
-    const context = {} as EndpointContext<WsTransportTypes>
 
     it('should return undefined for unsuccessful message', () => {
       const msg: WSResponse = { success: false, data: [], topic: 'price' }
-      const result = messageHandler(msg, context)
+      const result = messageHandler(msg)
       expect(result).toBeUndefined()
     })
 
@@ -45,7 +41,7 @@ describe('Wintermute WebSocketTransport - Unit', () => {
         topic: 'price',
         data: [{ last_updated: '2025-10-21T21:27:11.498199Z', price: 202.22, symbol: 'GMCI30' }],
       }
-      const result = messageHandler(msg, context)
+      const result = messageHandler(msg)
       expect(result).toHaveLength(1)
       const item = result![0]
       expect(item.params).toEqual({ symbol: 'GMCI30' })
@@ -59,7 +55,7 @@ describe('Wintermute WebSocketTransport - Unit', () => {
         topic: 'rebalance_status',
         data: [],
       }
-      const result = messageHandler(msg, context)
+      const result = messageHandler(msg)
       expect(result).toEqual([])
     })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -5759,7 +5759,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@chainlink/wintermute-adapter@workspace:packages/sources/wintermute"
   dependencies:
-    "@chainlink/external-adapter-framework": "npm:2.11.6"
+    "@chainlink/external-adapter-framework": "npm:2.16.1"
     "@sinonjs/fake-timers": "npm:9.1.2"
     "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:22.14.1"


### PR DESCRIPTION
## Description

The type of `WebSocketTransportConfig.builders` changed in https://github.com/smartcontractkit/ea-framework-js/pull/801. It can now have `batchSubscribeMessage` and `batchUnsubscribeMessage` instead of `subscribeMessage` and `unsubscribeMessage`.

So when `options` in `packages/sources/wintermute/src/transport/price.ts` is declared as `WebSocketTransportConfig<WsTransportTypes>`, this no longer implies that it has those fields. And this causes test compilation errors when we bump the framework version on `wintermute`.

```
packages/sources/wintermute/test/unit/adapter.test.ts:8:62 - error TS2339: Property 'subscribeMessage' does not exist on type 'WebSocketIndividualBuilders<WsTransportTypes> | WebSocketBatchBuilders<WsTransportTypes>'.
  Property 'subscribeMessage' does not exist on type 'WebSocketBatchBuilders<WsTransportTypes>'.

8       if (!options || !options.builders || !options.builders.subscribeMessage) {
                                                               ~~~~~~~~~~~~~~~~

packages/sources/wintermute/test/unit/adapter.test.ts:12:40 - error TS2339: Property 'subscribeMessage' does not exist on type 'WebSocketIndividualBuilders<WsTransportTypes> | WebSocketBatchBuilders<WsTransportTypes>'.
  Property 'subscribeMessage' does not exist on type 'WebSocketBatchBuilders<WsTransportTypes>'.

12       const message = options.builders.subscribeMessage!({ symbol: 'GMCI30' }, context) as any
                                          ~~~~~~~~~~~~~~~~

packages/sources/wintermute/test/unit/adapter.test.ts:20:62 - error TS2339: Property 'unsubscribeMessage' does not exist on type 'WebSocketIndividualBuilders<WsTransportTypes> | WebSocketBatchBuilders<WsTransportTypes>'.
  Property 'unsubscribeMessage' does not exist on type 'WebSocketBatchBuilders<WsTransportTypes>'.

20       if (!options || !options.builders || !options.builders.unsubscribeMessage) {
                                                                ~~~~~~~~~~~~~~~~~~

packages/sources/wintermute/test/unit/adapter.test.ts:24:36 - error TS2339: Property 'unsubscribeMessage' does not exist on type 'WebSocketIndividualBuilders<WsTransportTypes> | WebSocketBatchBuilders<WsTransportTypes>'.
  Property 'unsubscribeMessage' does not exist on type 'WebSocketBatchBuilders<WsTransportTypes>'.

24       const msg = options.builders.unsubscribeMessage({ symbol: 'GMCI30' }, context)
                                      ~~~~~~~~~~~~~~~~~~


Found 4 errors.
```

If instead, we declare it just to satisfy `WebSocketTransportConfig<WsTransportTypes>`, it has the intended effect but a more explicit type to use in the test.

## Changes

1. Change declaration of `options`.
2. Stop passing stub `context` in the test as it's no longer necessary or allowed.
3. Bump framework version.

## Steps to Test

```
yarn install && yarn tsc -b --noEmit packages/sources/wintermute/tsconfig.test.json --force
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
