### PR TITLE
Bump framework on tradinghours + test fix

### DIFF
--- a/.changeset/strict-bobcats-greet.md
+++ b/.changeset/strict-bobcats-greet.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/tradinghours-adapter': patch
+---
+
+Bump framework version

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -8423,7 +8423,7 @@ const RAW_RUNTIME_STATE =
       ["workspace:packages/sources/tradinghours", {\
         "packageLocation": "./packages/sources/tradinghours/",\
         "packageDependencies": [\
-          ["@chainlink/external-adapter-framework", "npm:2.11.6"],\
+          ["@chainlink/external-adapter-framework", "npm:2.16.1"],\
           ["@chainlink/tradinghours-adapter", "workspace:packages/sources/tradinghours"],\
           ["@date-fns/tz", "npm:1.4.1"],\
           ["@sinonjs/fake-timers", "npm:9.1.2"],\

--- a/packages/sources/tradinghours/package.json
+++ b/packages/sources/tradinghours/package.json
@@ -28,7 +28,7 @@
     "start": "yarn server:dist"
   },
   "dependencies": {
-    "@chainlink/external-adapter-framework": "2.11.6",
+    "@chainlink/external-adapter-framework": "2.16.1",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/packages/sources/tradinghours/test/unit/market-status.test.ts
+++ b/packages/sources/tradinghours/test/unit/market-status.test.ts
@@ -26,6 +26,7 @@ describe('parseMarketStatus', () => {
     const param = {
       market: 'NYSE',
       type: 'regular' as const,
+      force245MarketStatus: false,
     }
 
     it('return OPEN when status is Open', () => {
@@ -60,6 +61,7 @@ describe('parseMarketStatus', () => {
       market: 'BTC',
       type: '24/5' as const,
       weekend: '520-020:America/New_York',
+      force245MarketStatus: false,
     }
 
     it('return WEEKEND when isWeekend returns true', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5577,7 +5577,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@chainlink/tradinghours-adapter@workspace:packages/sources/tradinghours"
   dependencies:
-    "@chainlink/external-adapter-framework": "npm:2.11.6"
+    "@chainlink/external-adapter-framework": "npm:2.16.1"
     "@date-fns/tz": "npm:1.4.1"
     "@sinonjs/fake-timers": "npm:9.1.2"
     "@types/jest": "npm:^29.5.14"


### PR DESCRIPTION
## Description

https://github.com/smartcontractkit/ea-framework-js/pull/743 (released with version 2.13.2 of the framework) added an extra field, `force245MarketStatus` to `marketStatusEndpointInputParametersDefinition`.

The `market-status` endpoint of the `tradinghours` EA includes all those parameters.

The extra parameter defaults to `false` in production, but needs to be included when passed explicitly, as it is in the test.

## Changes

1. Bump framework version.
2. Pass `force245MarketStatus: false` in test params.

## Steps to Test

```
yarn install && yarn tsc -b --noEmit packages/sources/tradinghours/tsconfig.test.json --force
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
