### PR TITLE
Bump framework on gmci + test fix

### DIFF
--- a/.changeset/slick-oranges-enter.md
+++ b/.changeset/slick-oranges-enter.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/gmci-adapter': patch
+---
+
+Bump framework version

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -6667,7 +6667,7 @@ const RAW_RUNTIME_STATE =
       ["workspace:packages/sources/gmci", {\
         "packageLocation": "./packages/sources/gmci/",\
         "packageDependencies": [\
-          ["@chainlink/external-adapter-framework", "npm:2.11.6"],\
+          ["@chainlink/external-adapter-framework", "npm:2.16.1"],\
           ["@chainlink/gmci-adapter", "workspace:packages/sources/gmci"],\
           ["@sinonjs/fake-timers", "npm:9.1.2"],\
           ["@types/jest", "npm:29.5.14"],\

--- a/packages/sources/gmci/package.json
+++ b/packages/sources/gmci/package.json
@@ -36,7 +36,7 @@
     "typescript": "5.8.3"
   },
   "dependencies": {
-    "@chainlink/external-adapter-framework": "2.11.6",
+    "@chainlink/external-adapter-framework": "2.16.1",
     "tslib": "2.4.1"
   }
 }

--- a/packages/sources/gmci/src/transport/price.ts
+++ b/packages/sources/gmci/src/transport/price.ts
@@ -42,7 +42,7 @@ export type WsTransportTypes = BaseEndpointTypes & {
 
 const logger = makeLogger('GmciTransport')
 
-export const options: WebSocketTransportConfig<WsTransportTypes> = {
+export const options = {
   url: (context: EndpointContext<WsTransportTypes>) => context.adapterSettings.WS_API_ENDPOINT,
   options: async (context: EndpointContext<WsTransportTypes>) => ({
     headers: {
@@ -95,6 +95,6 @@ export const options: WebSocketTransportConfig<WsTransportTypes> = {
       }
     },
   },
-}
+} satisfies WebSocketTransportConfig<WsTransportTypes>
 
 export const transport = new WebSocketTransport(options)

--- a/packages/sources/gmci/test/unit/price.test.ts
+++ b/packages/sources/gmci/test/unit/price.test.ts
@@ -1,6 +1,5 @@
-import { EndpointContext } from '@chainlink/external-adapter-framework/adapter'
 import { LoggerFactoryProvider } from '@chainlink/external-adapter-framework/util'
-import { options, WsResponse, WsTransportTypes } from '../../src/transport/price'
+import { options, WsResponse } from '../../src/transport/price'
 import { convertTimetoUnixMs } from '../../src/transport/util'
 
 // Initialize logger to avoid errors during test
@@ -20,10 +19,9 @@ describe('convertTimetoUnixMs', () => {
 
 describe('builders.subscribeMessage', () => {
   const builders = options.builders!
-  const context = {} as EndpointContext<WsTransportTypes>
 
   it('builds correct subscribe message for a symbol', () => {
-    const message = builders.subscribeMessage!({ symbol: 'GMCI30' }, context) as any
+    const message = builders.subscribeMessage!({ symbol: 'GMCI30' }) as any
     expect(message.op).toBe('subscribe')
     expect(message.args).toContain('price.gmci30')
     expect(message.args.length).toBe(1)
@@ -32,10 +30,9 @@ describe('builders.subscribeMessage', () => {
 
 describe('builders.unsubscribeMessage', () => {
   const builders = options.builders!
-  const context = {} as EndpointContext<WsTransportTypes>
 
   it('builds correct unsubscribe message for a symbol', () => {
-    const message = builders.unsubscribeMessage!({ symbol: 'GMCI30' }, context) as any
+    const message = builders.unsubscribeMessage!({ symbol: 'GMCI30' }) as any
     expect(message.op).toBe('unsubscribe')
     expect(message.args).toContain('price.gmci30')
     expect(message.args.length).toBe(1)
@@ -44,7 +41,6 @@ describe('builders.unsubscribeMessage', () => {
 
 describe('message handler', () => {
   const handlers = options.handlers!
-  const context = {} as EndpointContext<WsTransportTypes>
 
   it('parses a valid price message', () => {
     const mockpriceMessage: WsResponse = {
@@ -59,7 +55,7 @@ describe('message handler', () => {
       ],
     }
 
-    const results = handlers.message(mockpriceMessage, context)
+    const results = handlers.message(mockpriceMessage)
 
     expect(results).toEqual([
       {
@@ -85,7 +81,7 @@ describe('message handler', () => {
       data: [],
     }
 
-    const result = handlers.message(mockUnsuccessfulMessage, context)
+    const result = handlers.message(mockUnsuccessfulMessage)
     expect(result).toBeUndefined()
   })
 
@@ -107,7 +103,7 @@ describe('message handler', () => {
       ],
     }
 
-    const results = handlers.message(mockMessage, context)
+    const results = handlers.message(mockMessage)
 
     expect(results).toHaveLength(2)
     expect(results?.[0].params.symbol).toBe('GMCI30')
@@ -128,7 +124,7 @@ describe('message handler', () => {
       ],
     }
 
-    const result = handlers.message(mockMessage, context)
+    const result = handlers.message(mockMessage)
     expect(result).toEqual([])
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -4017,7 +4017,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@chainlink/gmci-adapter@workspace:packages/sources/gmci"
   dependencies:
-    "@chainlink/external-adapter-framework": "npm:2.11.6"
+    "@chainlink/external-adapter-framework": "npm:2.16.1"
     "@sinonjs/fake-timers": "npm:9.1.2"
     "@types/jest": "npm:29.5.14"
     "@types/node": "npm:22.14.1"


### PR DESCRIPTION
## Description

Same as https://github.com/smartcontractkit/external-adapters-js/pull/5038 but for `gmci`.

## Changes

1. Change declaration of options.
2. Stop passing stub context in the test as it's no longer necessary or allowed.
3. Bump framework version.

## Steps to Test

```
yarn install && yarn tsc -b --noEmit packages/sources/gmci/tsconfig.test.json --force
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
