### PR TITLE
DF-25487 fix request key bug in asseto-finance EA

### DIFF
--- a/.changeset/thick-geese-rush.md
+++ b/.changeset/thick-geese-rush.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/asseto-finance-adapter': patch
+---
+
+Bugfix. Fix request coalescing bug

--- a/packages/sources/asseto-finance/src/transport/nav.ts
+++ b/packages/sources/asseto-finance/src/transport/nav.ts
@@ -136,7 +136,7 @@ class NavTransport extends SubscriptionTransport<HttpTransportTypes> {
         inputParameters,
         endpointName: this.endpointName,
       },
-      data: requestConfig.data || {},
+      data: { fundId },
       transportName: this.name,
     })
 

--- a/packages/sources/asseto-finance/src/transport/reserve.ts
+++ b/packages/sources/asseto-finance/src/transport/reserve.ts
@@ -154,7 +154,7 @@ class ReserveTransport extends SubscriptionTransport<HttpTransportTypes> {
         inputParameters,
         endpointName: this.endpointName,
       },
-      data: requestConfig.data || {},
+      data: { fundId },
       transportName: this.name,
     })
 


### PR DESCRIPTION
Fixes incorrect NAV/reserve responses when multiple fundId values are subscribed concurrently on ea-framework 2.16.1+.

The HTTP request coalesce key was built from requestConfig.data, but Asseto Finance puts fundId in the URL path, not the body. All requests shared DEFAULT_CACHE_KEY, so the Requester returned the same in-flight response for different funds. This was masked on older framework versions by a race in request coalescing; [#805](https://github.com/smartcontractkit/ea-framework-js/pull/805) made coalescing reliable and exposed the bug.

Pass { fundId } into calculateHttpRequestKey so each fund gets a distinct coalesce key.