### PR TITLE
Remove six from market-status

### DIFF
--- a/.changeset/true-teeth-care.md
+++ b/.changeset/true-teeth-care.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/market-status-adapter': minor
+---
+
+Remove six

--- a/packages/composites/market-status/src/source/sources.ts
+++ b/packages/composites/market-status/src/source/sources.ts
@@ -3,7 +3,7 @@ import { TypeFromDefinition } from '@chainlink/external-adapter-framework/valida
 
 import type { StaticSourceName } from './static'
 
-export const ADAPTER_NAMES = ['NCFX', 'TRADINGHOURS', 'FINNHUB_SECONDARY', 'SIX'] as const
+export const ADAPTER_NAMES = ['NCFX', 'TRADINGHOURS', 'FINNHUB_SECONDARY'] as const
 export type AdapterName = (typeof ADAPTER_NAMES)[number]
 
 export type SourceName = AdapterName | StaticSourceName
@@ -35,8 +35,8 @@ const marketSources: Record<string, { primary: SourceName; secondary: SourceName
     secondary: 'FINNHUB_SECONDARY',
   },
   six: {
-    primary: 'SIX',
-    secondary: 'TRADINGHOURS',
+    primary: 'TRADINGHOURS',
+    secondary: 'FINNHUB_SECONDARY',
   },
   euronext_milan: {
     primary: 'TRADINGHOURS',
@@ -77,10 +77,6 @@ const marketSources: Record<string, { primary: SourceName; secondary: SourceName
   ice_europe_energy: {
     primary: 'TRADINGHOURS',
     secondary: 'STATIC_ICE_EUROPE_ENERGY',
-  },
-  bme: {
-    primary: 'SIX',
-    secondary: 'TRADINGHOURS',
   },
 }
 

--- a/packages/composites/market-status/test/integration/adapter.test.ts
+++ b/packages/composites/market-status/test/integration/adapter.test.ts
@@ -523,18 +523,4 @@ describe('execute', () => {
       })
     })
   })
-
-  describe('missing env var', () => {
-    it('throws error', async () => {
-      let response
-      for (let i = 0; i < 10; i++) {
-        response = await testAdapter.request({
-          market: 'six',
-        })
-      }
-      expect(response.json().errorMessage).toEqual(
-        'Missing required environment variable: SIX_ADAPTER_URL',
-      )
-    })
-  })
 })


### PR DESCRIPTION
Revert the six changes from: https://github.com/smartcontractkit/external-adapters-js/commit/c0c0ecee59b8bbf4c429e048b1558a0b8cbbfa47

Because six is not deployed yet