### PR TITLE
OPDATA-7754: Check adapter names

### DIFF
--- a/.changeset/great-hats-strive.md
+++ b/.changeset/great-hats-strive.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/proof-of-reserves-v2-adapter': patch
+---
+
+Fix adapter name

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -304,3 +304,27 @@ jobs:
             done
             exit 1
           fi
+
+  # Check that adapter names are consistent between directory, package and code.
+  check-adapter-names:
+    name: Check adapter names
+    runs-on: [ubuntu-latest]
+    permissions:
+      pull-requests: read
+    if: needs.install-packages.outputs.changed-packages != '[]'
+    needs:
+      - check-changesets
+      - install-packages
+    env:
+      METRICS_ENABLED: false
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set up and install dependencies
+        uses: ./.github/actions/setup
+      - name: Check adapter names
+        run: |
+          adapters_to_check=($(echo "$CHANGED_ADAPTERS" | jq '.adapter[].location | split("/") | last | "--adapters " + .' -r || true))
+          yarn check-adapter-names "${adapters_to_check[@]}"
+        env:
+          CHANGED_ADAPTERS: ${{ needs.install-packages.outputs.adapter-list }}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "generate:master-list": "METRICS_ENABLED=false ts-node-transpile-only ./packages/scripts/src/generate-master-list",
     "generate:readme": "METRICS_ENABLED=false ts-node-transpile-only ./packages/scripts/src/generate-readme",
     "generate:endpoint-aliases": "METRICS_ENABLED=false ts-node-transpile-only ./packages/scripts/src/generate-endpoint-aliases",
+    "check-adapter-names": "ts-node-transpile-only ./packages/scripts/src/check-adapter-names",
     "get-changeset-arguments": "ts-node-transpile-only ./packages/scripts/src/get-changeset-arguments",
     "postinstall": "husky install",
     "cm": "cz",

--- a/packages/composites/proof-of-reserves-v2/src/index.ts
+++ b/packages/composites/proof-of-reserves-v2/src/index.ts
@@ -5,7 +5,7 @@ import { reserves } from './endpoint'
 
 export const adapter = new Adapter({
   defaultEndpoint: reserves.name,
-  name: 'PROOF_OF-RESERVES-2',
+  name: 'PROOF_OF_RESERVES_V2',
   config,
   endpoints: [reserves],
 })

--- a/packages/scripts/src/check-adapter-names/index.ts
+++ b/packages/scripts/src/check-adapter-names/index.ts
@@ -1,0 +1,131 @@
+import commandLineArgs from 'command-line-args'
+import commandLineUsage from 'command-line-usage'
+import path from 'path'
+import { getWorkspaceAdapters, WorkspaceAdapter } from '../workspace'
+
+const getNameFromLocation = (adapter: WorkspaceAdapter): string => {
+  return adapter.location.split('/').at(-1)!
+}
+
+const getSelfReportedAdapterName = async (adapter: WorkspaceAdapter) => {
+  const adapterPath = path.join(process.cwd(), adapter.location, 'src/index.ts')
+  const adapterModule = await require(adapterPath)
+
+  if ('adapter' in adapterModule) {
+    // V3 framework adapter
+    return adapterModule.adapter.name
+  }
+  // V2 framework adapter
+  return adapterModule.NAME
+}
+
+const getExpectedSelfReportedName = (adapter: WorkspaceAdapter) => {
+  const nameFromLocation = getNameFromLocation(adapter)
+  // Grand-father non-matching adapters:
+  switch (nameFromLocation) {
+    case 'crypto-volatility-index':
+      return 'CVI'
+    case 'nftx':
+      return 'NFTX_VAULT_PRICE'
+    case 'liveart':
+      return 'LIVE_ART'
+    case 'wbtc-address-set':
+      return 'WBTC'
+    case 'bitgo-reserves-test':
+    case 'ix-trust-sync':
+      // Replaces only the first hyphen with an underscore.
+      return nameFromLocation.toUpperCase().replace(/-/, '_')
+    case 'finnhub-secondary':
+    case 'frxeth-exchange-rate':
+    case 'harris-and-trotter':
+    case 'ion.au':
+    case 'moore-hk':
+      // Does not replace special characters with underscores.
+      return nameFromLocation.toUpperCase()
+  }
+  return nameFromLocation.toUpperCase().replace(/\W/g, '_')
+}
+
+export async function main(): Promise<void | string> {
+  try {
+    // Define CLI options
+    const commandLineOptions = [
+      {
+        name: 'adapters',
+        multiple: true,
+        defaultOption: true,
+        description: 'Check names of given adapters. Leave empty to check all adapters.',
+      },
+      { name: 'help', alias: 'h', type: Boolean, description: 'Display usage guide' },
+    ]
+    const options = commandLineArgs(commandLineOptions)
+
+    // Generate usage guide
+    if (options.help) {
+      const usage = commandLineUsage([
+        {
+          header: 'Check that adapter names match package name',
+          content:
+            'This script is run from the root of the external-adapter-js/ repo to check that the self reported name of each adapter matches the name of the package and directory.',
+        },
+        {
+          header: 'Options',
+          optionList: commandLineOptions,
+        },
+        {
+          content:
+            'Source code: {underline https://github.com/smartcontractkit/external-adapters-\njs/packages/scripts/src/check-adapter-names/}',
+        },
+      ])
+      console.log(usage)
+      return
+    }
+
+    let adapters = getWorkspaceAdapters()
+
+    // If specific adapters are passed to the command line, only select those
+    if (options.adapters?.length) {
+      adapters = adapters.filter((a) => {
+        return (options.adapters as string[]).includes(getNameFromLocation(a))
+      })
+
+      for (const adapterOption of options.adapters as string[]) {
+        if (!adapters.find((a) => getNameFromLocation(a) === adapterOption)) {
+          throw new Error(`Unknown adapter: '${adapterOption}'`)
+        }
+      }
+    }
+
+    for (const adapter of adapters) {
+      const expectedPackageName = `@chainlink/${getNameFromLocation(adapter)}-adapter`
+      if (adapter.name !== expectedPackageName) {
+        throw new Error(
+          `Adapter '${adapter.location}' should have package name '${expectedPackageName}' but has package name '${adapter.name}'`,
+        )
+      }
+
+      if (adapter.location.startsWith('packages/non-deployable/')) {
+        continue
+      }
+
+      const selfReportedName = await getSelfReportedAdapterName(adapter)
+      const expectedSelfReportedName = getExpectedSelfReportedName(adapter)
+
+      if (selfReportedName !== expectedSelfReportedName) {
+        throw new Error(
+          `Adapter '${adapter.location}' should self report name '${expectedSelfReportedName}' but self reports name '${selfReportedName}'`,
+        )
+      }
+
+      console.log(`✅ ${getNameFromLocation(adapter)} / ${adapter.name} / ${selfReportedName}`)
+    }
+
+    process.exit(0)
+  } catch (e: unknown) {
+    const error = e as Error
+    console.error({ error: error.message, stack: error.stack })
+    process.exit(1)
+  }
+}
+
+main()


### PR DESCRIPTION
## [OPDATA-7754](https://smartcontract-it.atlassian.net/browse/OPDATA-7754)

## Description

The EA proof-of-reserves-v2 was originally named proof-of-reserves-2 (without v) but was renamed during the code review. But while the package was renamed, the name that the EA [reports of itself](https://github.com/smartcontractkit/external-adapters-js/blob/ee4b9a62ef16f28274f0ef7204c7f2cc17b9483b/packages/composites/proof-of-reserves-v2/src/index.ts#L8) was forgotten.

This hasn’t prevented us from deploying and using the EA. But now that I’m trying to reconfigure an existing feed to use this EA, it’s confusing clops which now thinks there is no telemetry for the new EA as it expects telemetry for PROOF_OF_RESERVES_V2 but there is only telemetry for PROOF_OF_RESERVES_2.

This PR fixes the name of `proof-of-reserves-v2` and also adds a CI check to make sure future adapters have the correct name.

## Changes

1. Set adapter name to `PROOF_OF_RESERVES_V2`.
2. Add script `packages/scripts/src/check-adapter-names/index.ts` to check adapters names are as expected.
3. Grand-father some existing incorrect adapter names.
4. Add to `package.json` scripts.

## Steps to Test

```
yarn check-adapter-names 
```
This run shows it failing on `proof-of-reserves-v2`: https://github.com/smartcontractkit/external-adapters-js/actions/runs/27547241171/job/81424267263
This run shows it passing: https://github.com/smartcontractkit/external-adapters-js/actions/runs/27548783823/job/81429757098

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[OPDATA-7754]: https://smartcontract-it.atlassian.net/browse/OPDATA-7754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ