### PR TITLE
Split changeset to allow individual releases

### DIFF
--- a/.changeset/soft-symbols-behave-2.md
+++ b/.changeset/soft-symbols-behave-2.md
@@ -1,5 +1,5 @@
 ---
-'@chainlink/view-function-multi-chain-adapter': minor
+'@chainlink/the-network-firm-adapter': minor
 ---
 
 Update ea framework to support json only feed id


### PR DESCRIPTION
## Description

I want to create a release for `the-network-firm` but it's in a changeset together with `view-function-multi-chain` which I don't want to be responsible for releasing.

## Changes

Split the changeset.

## Steps to Test

```
$ .github/scripts/get-changeset-arguments.sh the-network-firm
Not ignoring the following transitive dependencies:
@chainlink/the-network-firm-adapter

Expecting the following packages to be released:
@chainlink/the-network-firm-adapter

...
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
