### PR TITLE
fix: streams-adapater inverse quote handling

### DIFF
--- a/packages/streams-adapter/cache/cache.go
+++ b/packages/streams-adapter/cache/cache.go
@@ -2,6 +2,8 @@ package cache
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -123,6 +125,7 @@ func (c *Cache) SetTransformedKey(rawKey, transformedKey string) {
 		return
 	}
 	item.TransformedKey = transformedKey
+	item.RequiresInverse = requiresInverse(item.OriginalRequestData, transformedKey)
 	item.Status = types.StatusLearned
 	item.Timestamp = time.Now()
 	c.byTransformedKey[transformedKey] = rawKey
@@ -172,6 +175,50 @@ func (c *Cache) applyObservation(item *types.CacheItem, transformedKey string, o
 		cacheItemsActive.Inc()
 	}
 	cacheObservationsTotal.WithLabelValues(transformedKey).Inc()
+}
+
+func requiresInverse(originalRequestData map[string]interface{}, transformedKey string) bool {
+	if originalRequestData == nil {
+		return false
+	}
+
+	originalBase := getPairValue(originalRequestData, "base", "from")
+	originalQuote := getPairValue(originalRequestData, "quote", "to")
+	if originalBase == "" || originalQuote == "" {
+		return false
+	}
+
+	transformedParams := parseCacheKey(transformedKey)
+	transformedBase := strings.ToUpper(transformedParams["base"])
+	transformedQuote := strings.ToUpper(transformedParams["quote"])
+	if transformedBase == "" || transformedQuote == "" {
+		return false
+	}
+
+	return originalBase == transformedQuote && originalQuote == transformedBase
+}
+
+func getPairValue(data map[string]interface{}, names ...string) string {
+	for _, name := range names {
+		for key, value := range data {
+			if strings.EqualFold(key, name) {
+				return strings.ToUpper(fmt.Sprintf("%v", value))
+			}
+		}
+	}
+	return ""
+}
+
+func parseCacheKey(key string) map[string]string {
+	params := make(map[string]string)
+	for _, part := range strings.Split(key, ":") {
+		pieces := strings.SplitN(part, "=", 2)
+		if len(pieces) != 2 {
+			continue
+		}
+		params[pieces[0]] = pieces[1]
+	}
+	return params
 }
 
 // Get retrieves a cache item by its internal cache key string.

--- a/packages/streams-adapter/common/types.go
+++ b/packages/streams-adapter/common/types.go
@@ -40,6 +40,7 @@ const (
 type CacheItem struct {
 	Status              CacheItemStatus
 	TransformedKey      string                 // populated once StatusLearned or StatusActive
+	RequiresInverse     bool                   // true when the original request is the inverse of TransformedKey
 	Observation         *Observation           // populated once StatusActive
 	Timestamp           time.Time              // last write time (used for TTL)
 	OriginalAdapterKey  string                 // JS adapter Redis key; populated once StatusActive

--- a/packages/streams-adapter/server/server.go
+++ b/packages/streams-adapter/server/server.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
@@ -330,7 +331,7 @@ func (s *Server) adapterHandler(c *gin.Context) {
 	// progress — return 504 without starting another goroutine.
 	if item := s.cache.Get(rawCacheKey); item != nil {
 		if item.Status == types.StatusActive && item.Observation != nil {
-			respondWithObservation(c, item.Observation)
+			respondWithObservation(c, item)
 			return
 		}
 		// Fall through to 504 below.
@@ -376,8 +377,21 @@ func (s *Server) adapterHandler(c *gin.Context) {
 
 // respondWithObservation writes the observation to the response. Returns 200 for
 // successful observations and 502 with an error payload for failed ones.
-func respondWithObservation(c *gin.Context, obs *types.Observation) {
+func respondWithObservation(c *gin.Context, item *types.CacheItem) {
+	obs := item.Observation
 	if obs.Success {
+		if item.RequiresInverse {
+			inverted, err := invertObservation(obs)
+			if err != nil {
+				c.JSON(http.StatusBadGateway, ObservationErrorResponse{
+					ErrorMessage: err.Error(),
+					Timestamps:   obs.Timestamps,
+					StatusCode:   http.StatusBadGateway,
+				})
+				return
+			}
+			obs = inverted
+		}
 		c.JSON(http.StatusOK, obs)
 		return
 	}
@@ -386,6 +400,76 @@ func respondWithObservation(c *gin.Context, obs *types.Observation) {
 		Timestamps:   obs.Timestamps,
 		StatusCode:   http.StatusBadGateway,
 	})
+}
+
+func invertObservation(obs *types.Observation) (*types.Observation, error) {
+	inverted := *obs
+
+	data, err := invertResultInObject(obs.Data)
+	if err != nil {
+		return nil, err
+	}
+	inverted.Data = data
+
+	if len(obs.Result) > 0 {
+		result, err := invertRawNumber(obs.Result)
+		if err != nil {
+			return nil, err
+		}
+		inverted.Result = result
+	}
+
+	return &inverted, nil
+}
+
+func invertResultInObject(raw json.RawMessage) (json.RawMessage, error) {
+	var data map[string]interface{}
+	if err := json.Unmarshal(raw, &data); err != nil {
+		return nil, fmt.Errorf("unable to invert observation result: %w", err)
+	}
+
+	result, ok := data["result"]
+	if !ok {
+		return nil, fmt.Errorf("unable to invert observation result: missing result")
+	}
+	num, err := numberFromInterface(result)
+	if err != nil {
+		return nil, err
+	}
+	if num == 0 {
+		return nil, fmt.Errorf("unable to invert observation result: result is zero")
+	}
+
+	data["result"] = 1 / num
+	return json.Marshal(data)
+}
+
+func invertRawNumber(raw json.RawMessage) (json.RawMessage, error) {
+	var num float64
+	if err := json.Unmarshal(raw, &num); err != nil {
+		return nil, fmt.Errorf("unable to invert top-level result: %w", err)
+	}
+	if num == 0 {
+		return nil, fmt.Errorf("unable to invert top-level result: result is zero")
+	}
+	return json.Marshal(1 / num)
+}
+
+func numberFromInterface(value interface{}) (float64, error) {
+	switch v := value.(type) {
+	case float64:
+		return v, nil
+	case json.Number:
+		return v.Float64()
+	case string:
+		num, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return 0, fmt.Errorf("unable to invert observation result: result is not numeric")
+		}
+		return num, nil
+	default:
+		return 0, fmt.Errorf("unable to invert observation result: result is not numeric")
+	}
 }
 
 // postToAdapter marshals data as {"data": ...} and POSTs it to the JS adapter.

--- a/packages/streams-adapter/server/server_test.go
+++ b/packages/streams-adapter/server/server_test.go
@@ -35,6 +35,13 @@ func TestMain(m *testing.M) {
 							"base": {"aliases": ["from"], "required": true},
 							"quote": {"aliases": ["to"], "required": true}
 						}
+					},
+					"forex": {
+						"aliases": ["forex"],
+						"params": {
+							"base": {"aliases": ["from"], "required": true},
+							"quote": {"aliases": ["to"], "required": true}
+						}
 					}
 				}
 			}
@@ -131,6 +138,78 @@ func TestAdapterHandler_CacheHit(t *testing.T) {
 	var resp types.Observation
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	require.Equal(t, true, resp.Success)
+}
+
+func TestAdapterHandler_CacheHit_InvertsTransformedPairObservation(t *testing.T) {
+	rawParams := types.RequestParams{"endpoint": "forex", "from": "TRY", "to": "USD"}
+	rawKey, err := helpers.CalculateCacheKey(rawParams)
+	require.NoError(t, err)
+	transformedKey, err := helpers.CalculateCacheKey(types.RequestParams{
+		"endpoint": "forex",
+		"base":     "USD",
+		"quote":    "TRY",
+	})
+	require.NoError(t, err)
+	obs := &types.Observation{
+		Data:    json.RawMessage(`{"result":46.4407}`),
+		Result:  json.RawMessage(`46.4407`),
+		Success: true,
+	}
+	testCache.SetNew(rawKey, map[string]interface{}{
+		"endpoint": "forex",
+		"from":     "TRY",
+		"to":       "USD",
+	})
+	testCache.SetTransformedKey(rawKey, transformedKey)
+	testCache.SetObservation(transformedKey, obs, time.Now(), "ncfx-forex-"+`{"base":"usd","quote":"try"}`)
+
+	body := `{"data":{"endpoint":"forex","from":"TRY","to":"USD"}}`
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	testSrv.router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	var resp types.Observation
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	var data map[string]float64
+	require.NoError(t, json.Unmarshal(resp.Data, &data))
+	require.InDelta(t, 1/46.4407, data["result"], 0.0000000001)
+
+	var result float64
+	require.NoError(t, json.Unmarshal(resp.Result, &result))
+	require.InDelta(t, 1/46.4407, result, 0.0000000001)
+
+	item := testCache.Get(rawKey)
+	require.NotNil(t, item)
+	require.JSONEq(t, `{"result":46.4407}`, string(item.Observation.Data))
+}
+
+func TestAdapterHandler_CacheHit_DoesNotInvertDirectTransformedPairObservation(t *testing.T) {
+	params := types.RequestParams{"endpoint": "forex", "base": "USD", "quote": "TRY"}
+	obs := &types.Observation{
+		Data:    json.RawMessage(`{"result":46.4407}`),
+		Result:  json.RawMessage(`46.4407`),
+		Success: true,
+	}
+	setCache(t, params, obs, "ncfx-forex-"+`{"base":"usd","quote":"try"}`)
+
+	body := `{"data":{"endpoint":"forex","base":"USD","quote":"TRY"}}`
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	testSrv.router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	var resp types.Observation
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	var data map[string]float64
+	require.NoError(t, json.Unmarshal(resp.Data, &data))
+	require.Equal(t, 46.4407, data["result"])
 }
 
 func TestAdapterHandler_CacheHit_FailedObservation(t *testing.T) {


### PR DESCRIPTION
Fixes a streams-adapter bug where inverse forex pairs could return the raw provider-side quote, e.g. ncfx TRY/USD would return the value for USD/TRY.

In streams mode, the Go runtime serves observations written by the JS adapter’s websocket cache path. For `includes.json` inverse pairs, that cached observation is keyed by the transformed provider pair (e.g. USD/TRY), but the normal JS PriceAdapter response inversion was bypassed. This caused requests such as ncfx and tiingo TRY/USD to return 46.4407 instead of 1 / 46.4407.

Fix - add inverse-awareness:
- Track whether a raw client request is the inverse of the learned transformed provider key.
- Invert `data.result` and top-level `result` at the Go response boundary for inverse observations.
- Preserve the raw provider observation in cache unchanged.
