### PR TITLE
Remove direct axios dependency from por-address-list

### DIFF
--- a/.changeset/honest-moose-push.md
+++ b/.changeset/honest-moose-push.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/por-address-list-adapter': patch
+---
+
+Remove dependency on axios

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -6958,7 +6958,6 @@ const RAW_RUNTIME_STATE =
           ["@chainlink/por-address-list-adapter", "workspace:packages/sources/por-address-list"],\
           ["@types/jest", "npm:29.5.14"],\
           ["@types/node", "npm:22.14.1"],\
-          ["axios", "npm:1.16.1"],\
           ["ethers", "npm:5.8.0"],\
           ["nock", "npm:13.5.6"],\
           ["tslib", "npm:2.4.1"],\

--- a/packages/sources/por-address-list/package.json
+++ b/packages/sources/por-address-list/package.json
@@ -35,7 +35,6 @@
   },
   "dependencies": {
     "@chainlink/external-adapter-framework": "2.16.1",
-    "axios": "1.16.1",
     "ethers": "^5.5.1",
     "tslib": "2.4.1"
   }

--- a/packages/sources/por-address-list/src/transport/virtune-utils.ts
+++ b/packages/sources/por-address-list/src/transport/virtune-utils.ts
@@ -1,6 +1,8 @@
-import { TransportGenerics } from '@chainlink/external-adapter-framework/transports'
+import {
+  HttpTransportConfig,
+  TransportGenerics,
+} from '@chainlink/external-adapter-framework/transports'
 import { TypeFromDefinition } from '@chainlink/external-adapter-framework/validation/input-params'
-import { AxiosResponse } from 'axios'
 import { config } from '../config'
 
 export const getUrl = (params: { accountId: string }): string => {
@@ -39,10 +41,15 @@ export interface ResponseSchema {
 }
 
 type VirtuneTransportGenerics = TransportGenerics & {
+  Settings: typeof config.settings
   Response: {
     Data: {
       result: unknown[]
     }
+  }
+  Provider: {
+    RequestBody: never
+    ResponseBody: ResponseSchema
   }
 }
 
@@ -70,7 +77,7 @@ export const createVirtuneTransportConfig = <T extends VirtuneTransportGenerics>
     params: VirtuneParams<T>
     addresses: string[]
   }) => VirtuneResult<T>,
-) => ({
+): HttpTransportConfig<T> => ({
   prepareRequests: (params: VirtuneParams<T>[], config: Config) => {
     return params.map((param) => ({
       params: [param],
@@ -83,7 +90,7 @@ export const createVirtuneTransportConfig = <T extends VirtuneTransportGenerics>
       },
     }))
   },
-  parseResponse: (params: VirtuneParams<T>[], response: AxiosResponse<ResponseSchema>) => {
+  parseResponse: (params, response) => {
     const [param] = params
     if (!response.data) {
       return [

--- a/yarn.lock
+++ b/yarn.lock
@@ -4342,7 +4342,6 @@ __metadata:
     "@chainlink/external-adapter-framework": "npm:2.16.1"
     "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:22.14.1"
-    axios: "npm:1.16.1"
     ethers: "npm:^5.5.1"
     nock: "npm:13.5.6"
     tslib: "npm:2.4.1"


### PR DESCRIPTION
## Description

When adapters depend on `axios` directly, this version they depend on needs to be the same as the version used by the framework version used by the EA. This makes it difficult to update the framework or the axios dependency.

## Changes

1. Change type declarations in `por-address-list` to avoid depending on `axios` directly.
2. Remove `axios` dependency from `por-address-list`.

## Steps to Test

```
yarn tsc -b --noEmit packages/sources/por-address-list/tsconfig.test.json
yarn test packages/sources/por-address-list
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
