### PR TITLE
Remove direct axios dependency from implied-price

### DIFF
--- a/.changeset/eleven-monkeys-notice.md
+++ b/.changeset/eleven-monkeys-notice.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/implied-price-adapter': patch
+---
+
+Remove direct axios dependency

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -6324,7 +6324,6 @@ const RAW_RUNTIME_STATE =
           ["@types/jest", "npm:29.5.14"],\
           ["@types/node", "npm:22.14.1"],\
           ["@types/supertest", "npm:2.0.16"],\
-          ["axios", "npm:1.13.4"],\
           ["decimal.js", "npm:10.5.0"],\
           ["nock", "npm:13.5.6"],\
           ["supertest", "npm:6.2.4"],\

--- a/packages/composites/implied-price/package.json
+++ b/packages/composites/implied-price/package.json
@@ -32,7 +32,6 @@
   "dependencies": {
     "@chainlink/ea-bootstrap": "workspace:*",
     "@chainlink/ea-test-helpers": "workspace:*",
-    "axios": "1.13.4",
     "decimal.js": "^10.3.1",
     "tslib": "^2.3.1"
   },

--- a/packages/composites/implied-price/src/endpoint/computedPrice.ts
+++ b/packages/composites/implied-price/src/endpoint/computedPrice.ts
@@ -3,7 +3,6 @@ import {
   AdapterInputError,
   AdapterRequest,
   AdapterResponseInvalidError,
-  AxiosRequestConfig,
   Config,
   ExecuteWithConfig,
   InputParameters,
@@ -11,12 +10,9 @@ import {
   util,
   Validator,
 } from '@chainlink/ea-bootstrap'
-import { AxiosResponse } from 'axios'
 import Decimal from 'decimal.js'
 
 export const supportedEndpoints = ['computedPrice']
-
-export type SourceRequestOptions = { [source: string]: AxiosRequestConfig }
 
 export type TInputParameters = {
   operand1Sources: string | string[]
@@ -194,7 +190,7 @@ const getExecuteMedian = async (
   const responses = await Promise.allSettled(
     urls.map(
       async (url) =>
-        await Requester.request({
+        await Requester.request<Record<string, number>>({
           ...config.api,
           method: 'post',
           url,
@@ -207,10 +203,7 @@ const getExecuteMedian = async (
   )
   const values = responses
     .filter((result) => result.status === 'fulfilled' && 'value' in result)
-    .map(
-      (result) =>
-        (result as PromiseFulfilledResult<AxiosResponse<Record<string, number>>>).value.data.result,
-    )
+    .map((result) => result.value.data.result)
   if (values.length < minAnswers)
     throw new AdapterResponseInvalidError({
       jobRunID,

--- a/packages/composites/implied-price/src/endpoint/impliedPrice.ts
+++ b/packages/composites/implied-price/src/endpoint/impliedPrice.ts
@@ -1,6 +1,5 @@
 import type {
   AdapterRequest,
-  AxiosRequestConfig,
   Config,
   ExecuteWithConfig,
   InputParameters,
@@ -9,8 +8,6 @@ import { Validator } from '@chainlink/ea-bootstrap'
 import { executeComputedPrice, validateInputPayload } from './computedPrice'
 
 export const supportedEndpoints = ['impliedPrice']
-
-export type SourceRequestOptions = { [source: string]: AxiosRequestConfig }
 
 export type TInputParameters = {
   dividendSources: string | string[]

--- a/yarn.lock
+++ b/yarn.lock
@@ -3784,7 +3784,6 @@ __metadata:
     "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:22.14.1"
     "@types/supertest": "npm:2.0.16"
-    axios: "npm:1.13.4"
     decimal.js: "npm:^10.3.1"
     nock: "npm:13.5.6"
     supertest: "npm:6.2.4"


### PR DESCRIPTION
## Description

When adapters depend on `axios` directly, the version they depend on needs to be the same as the version used by the framework version used by the EA. This makes it difficult to update the framework or the axios dependency.

## Changes

1. Change type declarations in `implied-price` to avoid depending on `axios` directly.
2. Remove `axios` dependency from `implied-price`.

## Steps to Test

```
yarn tsc -b --noEmit packages/composites/implied-price/tsconfig.test.json
yarn test packages/composites/implied-price
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
