### PR TITLE
fix(coinmarketcap): scope crypto batch requests to their own quote currency

### DIFF
--- a/.changeset/coinmarketcap-crypto-quote-filter.md
+++ b/.changeset/coinmarketcap-crypto-quote-filter.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/coinmarketcap-adapter': patch
+---
+
+Fix crypto transport attaching the full param list to every per-quote request, which caused intermittent 502 "Data for quote X not found" for any param whose quote differed from the request's convert.

--- a/packages/sources/coinmarketcap/src/transport/crypto.ts
+++ b/packages/sources/coinmarketcap/src/transport/crypto.ts
@@ -92,7 +92,7 @@ export const httpTransport = new HttpTransport<HttpTransportTypes>({
         const uniqueQuotes = [...new Set(list.map((p) => p.quote.toUpperCase()))]
         uniqueQuotes.forEach((uniqueQuote) => {
           requests.push({
-            params: list,
+            params: list.filter((p) => p.quote.toUpperCase() === uniqueQuote),
             request: {
               baseURL: settings.API_ENDPOINT,
               url: '/cryptocurrency/quotes/latest',


### PR DESCRIPTION
Symptom: coinmarketcap crypto feeds intermittently return 502 "Data for quote "<QUOTE>" was not found in response"; the failing set is non-deterministic, reshuffles on restart, and is independent of API key/plan.

Cause: In crypto.ts one HTTP request is built per unique quote (convert=<quote>), but each is tagged with params: list — the entire param set across all quotes. parseResponse then looks up data.quote[p.quote] for every attached param, so any param whose quote ≠ the request's convert 502s.

Fix: Filter each request's params down to the params sharing its quote, so each param is resolved only by the request that actually requested its convert. One line; no behavioural change for single-quote batches.