### PR TITLE
OPDATA-7941: Add xstocks endpoint to tokenize-equity

### DIFF
--- a/.changeset/three-baboons-lick.md
+++ b/.changeset/three-baboons-lick.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/tokenized-equity-adapter': minor
+---
+
+Add xstocks endpoint

--- a/packages/composites/tokenized-equity/src/config/XstocksWrappedBackedTokenABI.json
+++ b/packages/composites/tokenized-equity/src/config/XstocksWrappedBackedTokenABI.json
@@ -1,0 +1,1097 @@
+[
+  {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "Deposit",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [],
+    "name": "EIP712DomainChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "version",
+        "type": "uint8"
+      }
+    ],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newPauser",
+        "type": "address"
+      }
+    ],
+    "name": "NewPauser",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "newTerms",
+        "type": "string"
+      }
+    ],
+    "name": "NewTerms",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "pauseMode",
+        "type": "bool"
+      }
+    ],
+    "name": "PauseModeChange",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "Withdraw",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "DELEGATED_TRANSFER_TYPEHASH",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "DOMAIN_SEPARATOR",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "VERSION",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      }
+    ],
+    "name": "allowance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "asset",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "convertToAssets",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      }
+    ],
+    "name": "convertToShares",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "subtractedValue",
+        "type": "uint256"
+      }
+    ],
+    "name": "decreaseAllowance",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "delegateMode",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "delegateWhitelist",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "v",
+        "type": "uint8"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "r",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "s",
+        "type": "bytes32"
+      }
+    ],
+    "name": "delegatedTransfer",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      }
+    ],
+    "name": "deposit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "eip712Domain",
+    "outputs": [
+      {
+        "internalType": "bytes1",
+        "name": "fields",
+        "type": "bytes1"
+      },
+      {
+        "internalType": "string",
+        "name": "name",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "version",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "chainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "verifyingContract",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "salt",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "extensions",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "addedValue",
+        "type": "uint256"
+      }
+    ],
+    "name": "increaseAllowance",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "name_",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "symbol_",
+        "type": "string"
+      },
+      {
+        "internalType": "address",
+        "name": "underlying_",
+        "type": "address"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isPaused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "maxDeposit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "maxMint",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "maxRedeem",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "maxWithdraw",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      }
+    ],
+    "name": "mint",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "nonces",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pauser",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "v",
+        "type": "uint8"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "r",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "s",
+        "type": "bytes32"
+      }
+    ],
+    "name": "permit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      }
+    ],
+    "name": "previewDeposit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "previewMint",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "previewRedeem",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      }
+    ],
+    "name": "previewWithdraw",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "redeem",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "newPauseMode",
+        "type": "bool"
+      }
+    ],
+    "name": "setPause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newPauser",
+        "type": "address"
+      }
+    ],
+    "name": "setPauser",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "newTerms",
+        "type": "string"
+      }
+    ],
+    "name": "setTerms",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "terms",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalAssets",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transfer",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "withdraw",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/packages/composites/tokenized-equity/src/endpoint/index.ts
+++ b/packages/composites/tokenized-equity/src/endpoint/index.ts
@@ -1,3 +1,4 @@
 export { endpoint as ondo } from './ondo'
 export { endpoint as price } from './price'
 export { endpoint as robinhood } from './robinhood'
+export { endpoint as xstocks } from './xstocks'

--- a/packages/composites/tokenized-equity/src/endpoint/xstocks.ts
+++ b/packages/composites/tokenized-equity/src/endpoint/xstocks.ts
@@ -2,33 +2,22 @@ import { AdapterEndpoint } from '@chainlink/external-adapter-framework/adapter'
 import { InputParameters } from '@chainlink/external-adapter-framework/validation'
 import { AdapterInputError } from '@chainlink/external-adapter-framework/validation/error'
 import { config } from '../config'
-import { robinhoodTransport } from '../transport/robinhoodTransport'
+import { xstocksTransport } from '../transport/xstocksTransport'
 import type { output } from './common'
 import { inputDefinition, inputExample, validateSmoother, validateStreamIds } from './common'
 
 export const inputParameters = new InputParameters(
   {
     ...inputDefinition.definition,
-    network: {
-      type: 'string',
-      description:
-        'Identifier to determine which RPC URL to use. Corresponds to ROBINHOOD_${NETWORK}_RPC_URL environment variable.',
-      default: 'mainnet',
-    },
-    // Repeat asset parameter from the share definition to override the
+    // Repeat asset parameter from the shared definition to override the
     // description.
     asset: {
       required: true,
       type: 'string',
-      description: 'Token address of the asset on the Robinhood chain',
+      description: 'Token address of the Xstocks asset on Ethereum Mainnet',
     },
   },
-  [
-    {
-      network: 'mainnet',
-      ...inputExample,
-    },
-  ],
+  [inputExample],
 )
 
 export type BaseEndpointTypes = {
@@ -38,7 +27,6 @@ export type BaseEndpointTypes = {
     Data: output & {
       tokenContract: {
         multiplier: string
-        paused: boolean
       }
     }
   }
@@ -46,13 +34,17 @@ export type BaseEndpointTypes = {
 }
 
 export const endpoint = new AdapterEndpoint({
-  name: 'robinhood',
+  name: 'xstocks',
   aliases: [],
-  transport: robinhoodTransport,
+  transport: xstocksTransport,
   inputParameters,
   customInputValidation: (req, adapterSettings): AdapterInputError | undefined => {
-    adapterSettings.ROBINHOOD_NETWORK_RPC_URL.get(req.requestContext.data.network)
-    adapterSettings.ROBINHOOD_NETWORK_CHAIN_ID.get(req.requestContext.data.network)
+    if (!adapterSettings.ETHEREUM_RPC_URL) {
+      throw new AdapterInputError({
+        message: 'Missing ETHEREUM_RPC_URL',
+        statusCode: 400,
+      })
+    }
 
     validateStreamIds(req.requestContext.data)
     validateSmoother(req.requestContext.data)

--- a/packages/composites/tokenized-equity/src/endpoint/xstocks.ts
+++ b/packages/composites/tokenized-equity/src/endpoint/xstocks.ts
@@ -1,0 +1,62 @@
+import { AdapterEndpoint } from '@chainlink/external-adapter-framework/adapter'
+import { InputParameters } from '@chainlink/external-adapter-framework/validation'
+import { AdapterInputError } from '@chainlink/external-adapter-framework/validation/error'
+import { config } from '../config'
+import { robinhoodTransport } from '../transport/robinhoodTransport'
+import type { output } from './common'
+import { inputDefinition, inputExample, validateSmoother, validateStreamIds } from './common'
+
+export const inputParameters = new InputParameters(
+  {
+    ...inputDefinition.definition,
+    network: {
+      type: 'string',
+      description:
+        'Identifier to determine which RPC URL to use. Corresponds to ROBINHOOD_${NETWORK}_RPC_URL environment variable.',
+      default: 'mainnet',
+    },
+    // Repeat asset parameter from the share definition to override the
+    // description.
+    asset: {
+      required: true,
+      type: 'string',
+      description: 'Token address of the asset on the Robinhood chain',
+    },
+  },
+  [
+    {
+      network: 'mainnet',
+      ...inputExample,
+    },
+  ],
+)
+
+export type BaseEndpointTypes = {
+  Parameters: typeof inputParameters.definition
+  Response: {
+    Result: string
+    Data: output & {
+      tokenContract: {
+        multiplier: string
+        paused: boolean
+      }
+    }
+  }
+  Settings: typeof config.settings
+}
+
+export const endpoint = new AdapterEndpoint({
+  name: 'robinhood',
+  aliases: [],
+  transport: robinhoodTransport,
+  inputParameters,
+  customInputValidation: (req, adapterSettings): AdapterInputError | undefined => {
+    adapterSettings.ROBINHOOD_NETWORK_RPC_URL.get(req.requestContext.data.network)
+    adapterSettings.ROBINHOOD_NETWORK_CHAIN_ID.get(req.requestContext.data.network)
+
+    validateStreamIds(req.requestContext.data)
+    validateSmoother(req.requestContext.data)
+
+    return
+  },
+})

--- a/packages/composites/tokenized-equity/src/index.ts
+++ b/packages/composites/tokenized-equity/src/index.ts
@@ -1,13 +1,13 @@
 import { expose, ServerInstance } from '@chainlink/external-adapter-framework'
 import { Adapter } from '@chainlink/external-adapter-framework/adapter'
 import { config } from './config'
-import { ondo, price, robinhood } from './endpoint'
+import { ondo, price, robinhood, xstocks } from './endpoint'
 
 export const adapter = new Adapter({
   defaultEndpoint: price.name,
   name: 'TOKENIZED_EQUITY',
   config,
-  endpoints: [price, ondo, robinhood],
+  endpoints: [price, ondo, robinhood, xstocks],
 })
 
 export const server = (): Promise<ServerInstance | undefined> => expose(adapter)

--- a/packages/composites/tokenized-equity/src/lib/xstocks.ts
+++ b/packages/composites/tokenized-equity/src/lib/xstocks.ts
@@ -1,13 +1,14 @@
-import { Contract, JsonRpcProvider } from 'ethers'
-import ABI from '../config/RobinhoodTokenABI.json'
+import { Contract, JsonRpcProvider, parseUnits } from 'ethers'
+import ABI from '../config/XstocksWrappedBackedTokenABI.json'
+import { MULTIPLIER_DECIMALS } from '../transport/xstocksPrice'
 
-export const getTokenData = async (tokenContractAddress: string, provider: JsonRpcProvider) => {
+const unit = parseUnits('1', MULTIPLIER_DECIMALS)
+
+export const getTokenMultiplier = async (
+  tokenContractAddress: string,
+  provider: JsonRpcProvider,
+) => {
   const contract = new Contract(tokenContractAddress, ABI, provider)
-
-  const [multiplier, paused] = await Promise.all([contract.uiMultiplier(), contract.oraclePaused()])
-
-  return {
-    multiplier: BigInt(multiplier),
-    paused: Boolean(paused),
-  }
+  const multiplier = await contract.convertToAssets(unit)
+  return BigInt(multiplier)
 }

--- a/packages/composites/tokenized-equity/src/lib/xstocks.ts
+++ b/packages/composites/tokenized-equity/src/lib/xstocks.ts
@@ -1,0 +1,13 @@
+import { Contract, JsonRpcProvider } from 'ethers'
+import ABI from '../config/RobinhoodTokenABI.json'
+
+export const getTokenData = async (tokenContractAddress: string, provider: JsonRpcProvider) => {
+  const contract = new Contract(tokenContractAddress, ABI, provider)
+
+  const [multiplier, paused] = await Promise.all([contract.uiMultiplier(), contract.oraclePaused()])
+
+  return {
+    multiplier: BigInt(multiplier),
+    paused: Boolean(paused),
+  }
+}

--- a/packages/composites/tokenized-equity/src/transport/robinhoodTransport.ts
+++ b/packages/composites/tokenized-equity/src/transport/robinhoodTransport.ts
@@ -15,7 +15,6 @@ type RequestParams = typeof inputParameters.validated
 
 export class RobinhoodTransport extends SubscriptionTransport<BaseEndpointTypes> {
   requester!: Requester
-  provider!: JsonRpcProvider
   config!: BaseEndpointTypes['Settings']
   dataEngineUrl!: string
   tradingHoursUrl!: string

--- a/packages/composites/tokenized-equity/src/transport/xstocksPrice.ts
+++ b/packages/composites/tokenized-equity/src/transport/xstocksPrice.ts
@@ -1,13 +1,10 @@
 import { Requester } from '@chainlink/external-adapter-framework/util/requester'
 import { JsonRpcProvider } from 'ethers'
-
-import { AdapterError } from '@chainlink/external-adapter-framework/validation/error'
 import { Smoother } from '../endpoint/common'
-import { getTokenData } from '../lib/robinhood'
-
+import { getTokenMultiplier } from '../lib/xstocks'
 import { smoothedStreamPrice } from './smoothedPrice'
 
-const MULTIPLIER_DECIMALS = 18n
+export const MULTIPLIER_DECIMALS = 18n
 
 export const calculatePrice = async (param: {
   asset: string
@@ -26,23 +23,15 @@ export const calculatePrice = async (param: {
   smoother: Smoother
   decimals: number
 }) => {
-  const [result, { multiplier, paused }] = await Promise.all([
+  const [result, multiplier] = await Promise.all([
     smoothedStreamPrice(param),
-    getTokenData(param.asset, param.provider),
+    getTokenMultiplier(param.asset, param.provider),
   ])
-
-  if (paused) {
-    throw new AdapterError({
-      statusCode: 503,
-      message: `asset: '${param.asset}' paused`,
-    })
-  }
 
   return result.map((r) => ({
     ...r,
     tokenContract: {
       multiplier: multiplier.toString(),
-      paused,
     },
     result: ((BigInt(r.result) * multiplier) / 10n ** MULTIPLIER_DECIMALS).toString(),
   }))

--- a/packages/composites/tokenized-equity/src/transport/xstocksPrice.ts
+++ b/packages/composites/tokenized-equity/src/transport/xstocksPrice.ts
@@ -1,0 +1,49 @@
+import { Requester } from '@chainlink/external-adapter-framework/util/requester'
+import { JsonRpcProvider } from 'ethers'
+
+import { AdapterError } from '@chainlink/external-adapter-framework/validation/error'
+import { Smoother } from '../endpoint/common'
+import { getTokenData } from '../lib/robinhood'
+
+import { smoothedStreamPrice } from './smoothedPrice'
+
+const MULTIPLIER_DECIMALS = 18n
+
+export const calculatePrice = async (param: {
+  asset: string
+  provider: JsonRpcProvider
+  regularStreamId?: string
+  extendedStreamId?: string
+  overnightStreamId?: string
+  overnightStreamMaxAgeInSeconds?: number
+  url: string
+  tradingHoursUrl: string
+  requester: Requester
+  sessionMarket?: string
+  sessionMarketType?: string
+  sessionBoundaries: string[]
+  sessionBoundariesTimeZone?: string
+  smoother: Smoother
+  decimals: number
+}) => {
+  const [result, { multiplier, paused }] = await Promise.all([
+    smoothedStreamPrice(param),
+    getTokenData(param.asset, param.provider),
+  ])
+
+  if (paused) {
+    throw new AdapterError({
+      statusCode: 503,
+      message: `asset: '${param.asset}' paused`,
+    })
+  }
+
+  return result.map((r) => ({
+    ...r,
+    tokenContract: {
+      multiplier: multiplier.toString(),
+      paused,
+    },
+    result: ((BigInt(r.result) * multiplier) / 10n ** MULTIPLIER_DECIMALS).toString(),
+  }))
+}

--- a/packages/composites/tokenized-equity/src/transport/xstocksTransport.ts
+++ b/packages/composites/tokenized-equity/src/transport/xstocksTransport.ts
@@ -1,0 +1,143 @@
+import { EndpointContext } from '@chainlink/external-adapter-framework/adapter'
+import { TransportDependencies } from '@chainlink/external-adapter-framework/transports'
+import { SubscriptionTransport } from '@chainlink/external-adapter-framework/transports/abstract/subscription'
+import { AdapterResponse, makeLogger, sleep } from '@chainlink/external-adapter-framework/util'
+import { Requester } from '@chainlink/external-adapter-framework/util/requester'
+import { AdapterError } from '@chainlink/external-adapter-framework/validation/error'
+import { JsonRpcProvider } from 'ethers'
+import { Smoother } from '../endpoint/common'
+import { BaseEndpointTypes, inputParameters } from '../endpoint/robinhood'
+import { calculatePrice } from './robinhoodPrice'
+
+const logger = makeLogger('RobinhoodTransport')
+
+type RequestParams = typeof inputParameters.validated
+
+export class RobinhoodTransport extends SubscriptionTransport<BaseEndpointTypes> {
+  requester!: Requester
+  provider!: JsonRpcProvider
+  config!: BaseEndpointTypes['Settings']
+  dataEngineUrl!: string
+  tradingHoursUrl!: string
+  providerForNetwork: Record<string, JsonRpcProvider> = {}
+
+  async initialize(
+    dependencies: TransportDependencies<BaseEndpointTypes>,
+    adapterSettings: BaseEndpointTypes['Settings'],
+    endpointName: string,
+    transportName: string,
+  ): Promise<void> {
+    await super.initialize(dependencies, adapterSettings, endpointName, transportName)
+    this.requester = dependencies.requester
+    this.config = adapterSettings
+    this.dataEngineUrl = adapterSettings.DATA_ENGINE_ADAPTER_URL
+    this.tradingHoursUrl = adapterSettings.TRADING_HOURS_ADAPTER_URL
+  }
+  async backgroundHandler(context: EndpointContext<BaseEndpointTypes>, entries: RequestParams[]) {
+    await Promise.all(dedupeParams(entries).map(async (param) => this.handleRequest(param)))
+    await sleep(context.adapterSettings.BACKGROUND_EXECUTE_MS)
+  }
+
+  async handleRequest(param: RequestParams) {
+    let responses: Partial<Record<Smoother, AdapterResponse<BaseEndpointTypes['Response']>>>
+    try {
+      responses = await this._handleRequest(param)
+    } catch (e) {
+      const errorMessage = e instanceof Error ? e.message : 'Unknown error occurred'
+      logger.error(e, errorMessage)
+
+      const errorResponse = {
+        statusCode: (e as AdapterError)?.statusCode || 502,
+        errorMessage,
+        timestamps: {
+          providerDataRequestedUnixMs: 0,
+          providerDataReceivedUnixMs: 0,
+          providerIndicatedTimeUnixMs: undefined,
+        },
+      }
+      responses =
+        param.smoother === 'none'
+          ? { none: errorResponse }
+          : {
+              ema: errorResponse,
+              kalman: errorResponse,
+            }
+    }
+
+    await this.responseCache.write(
+      this.name,
+      Object.entries(responses).map(([key, value]) => {
+        return {
+          params: {
+            ...param,
+            smoother: key as Smoother,
+          },
+          response: value,
+        }
+      }),
+    )
+  }
+
+  async _handleRequest(
+    param: RequestParams,
+  ): Promise<Record<string, AdapterResponse<BaseEndpointTypes['Response']>>> {
+    const providerDataRequestedUnixMs = Date.now()
+
+    this.providerForNetwork[param.network] ??= new JsonRpcProvider(
+      this.config.ROBINHOOD_NETWORK_RPC_URL.get(param.network),
+      this.config.ROBINHOOD_NETWORK_CHAIN_ID.get(param.network),
+    )
+
+    const results = await calculatePrice({
+      ...param,
+      provider: this.providerForNetwork[param.network],
+      url: this.dataEngineUrl,
+      tradingHoursUrl: this.tradingHoursUrl,
+      requester: this.requester,
+    })
+
+    return Object.fromEntries(
+      results.map((r) => [
+        r.smoother.smoother,
+        {
+          data: r,
+          statusCode: 200,
+          result: r.result,
+          timestamps: {
+            providerDataRequestedUnixMs,
+            providerDataReceivedUnixMs: Date.now(),
+            providerIndicatedTimeUnixMs: undefined,
+          },
+        },
+      ]),
+    )
+  }
+
+  getSubscriptionTtlFromConfig(adapterSettings: BaseEndpointTypes['Settings']): number {
+    return adapterSettings.WARMUP_SUBSCRIPTION_TTL
+  }
+}
+const dedupeParams = (params: RequestParams[]) => {
+  const seen = new Map<string, RequestParams>()
+  for (const p of params) {
+    const key = [
+      p.asset,
+      p.network,
+      p.regularStreamId,
+      p.extendedStreamId,
+      p.overnightStreamId,
+      p.overnightStreamMaxAgeInSeconds,
+      p.sessionMarket,
+      p.sessionMarketType,
+      p.sessionBoundaries.join('|'),
+      p.sessionBoundariesTimeZone,
+      p.decimals,
+    ].join('@@')
+    if (!seen.has(key)) {
+      seen.set(key, p)
+    }
+  }
+  return Array.from(seen.values())
+}
+
+export const robinhoodTransport = new RobinhoodTransport()

--- a/packages/composites/tokenized-equity/src/transport/xstocksTransport.ts
+++ b/packages/composites/tokenized-equity/src/transport/xstocksTransport.ts
@@ -6,20 +6,19 @@ import { Requester } from '@chainlink/external-adapter-framework/util/requester'
 import { AdapterError } from '@chainlink/external-adapter-framework/validation/error'
 import { JsonRpcProvider } from 'ethers'
 import { Smoother } from '../endpoint/common'
-import { BaseEndpointTypes, inputParameters } from '../endpoint/robinhood'
-import { calculatePrice } from './robinhoodPrice'
+import { BaseEndpointTypes, inputParameters } from '../endpoint/xstocks'
+import { calculatePrice } from './xstocksPrice'
 
-const logger = makeLogger('RobinhoodTransport')
+const logger = makeLogger('XstocksTransport')
 
 type RequestParams = typeof inputParameters.validated
 
-export class RobinhoodTransport extends SubscriptionTransport<BaseEndpointTypes> {
+export class XstocksTransport extends SubscriptionTransport<BaseEndpointTypes> {
   requester!: Requester
   provider!: JsonRpcProvider
   config!: BaseEndpointTypes['Settings']
   dataEngineUrl!: string
   tradingHoursUrl!: string
-  providerForNetwork: Record<string, JsonRpcProvider> = {}
 
   async initialize(
     dependencies: TransportDependencies<BaseEndpointTypes>,
@@ -32,6 +31,10 @@ export class RobinhoodTransport extends SubscriptionTransport<BaseEndpointTypes>
     this.config = adapterSettings
     this.dataEngineUrl = adapterSettings.DATA_ENGINE_ADAPTER_URL
     this.tradingHoursUrl = adapterSettings.TRADING_HOURS_ADAPTER_URL
+    this.provider = new JsonRpcProvider(
+      this.config.ETHEREUM_RPC_URL,
+      this.config.ETHEREUM_RPC_CHAIN_ID,
+    )
   }
   async backgroundHandler(context: EndpointContext<BaseEndpointTypes>, entries: RequestParams[]) {
     await Promise.all(dedupeParams(entries).map(async (param) => this.handleRequest(param)))
@@ -83,14 +86,9 @@ export class RobinhoodTransport extends SubscriptionTransport<BaseEndpointTypes>
   ): Promise<Record<string, AdapterResponse<BaseEndpointTypes['Response']>>> {
     const providerDataRequestedUnixMs = Date.now()
 
-    this.providerForNetwork[param.network] ??= new JsonRpcProvider(
-      this.config.ROBINHOOD_NETWORK_RPC_URL.get(param.network),
-      this.config.ROBINHOOD_NETWORK_CHAIN_ID.get(param.network),
-    )
-
     const results = await calculatePrice({
       ...param,
-      provider: this.providerForNetwork[param.network],
+      provider: this.provider,
       url: this.dataEngineUrl,
       tradingHoursUrl: this.tradingHoursUrl,
       requester: this.requester,
@@ -122,7 +120,6 @@ const dedupeParams = (params: RequestParams[]) => {
   for (const p of params) {
     const key = [
       p.asset,
-      p.network,
       p.regularStreamId,
       p.extendedStreamId,
       p.overnightStreamId,
@@ -140,4 +137,4 @@ const dedupeParams = (params: RequestParams[]) => {
   return Array.from(seen.values())
 }
 
-export const robinhoodTransport = new RobinhoodTransport()
+export const xstocksTransport = new XstocksTransport()

--- a/packages/composites/tokenized-equity/test/integration/__snapshots__/adapter-xstocks.test.ts.snap
+++ b/packages/composites/tokenized-equity/test/integration/__snapshots__/adapter-xstocks.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`execute robinhood endpoint bad sessionBoundaries 1`] = `
+exports[`execute xstocks endpoint bad sessionBoundaries 1`] = `
 {
   "error": {
     "message": "99:88 in [Param: sessionBoundaries] does not match format HH:MM",
@@ -11,7 +11,7 @@ exports[`execute robinhood endpoint bad sessionBoundaries 1`] = `
 }
 `;
 
-exports[`execute robinhood endpoint bad sessionBoundariesTimeZone 1`] = `
+exports[`execute xstocks endpoint bad sessionBoundariesTimeZone 1`] = `
 {
   "error": {
     "message": "[Param: sessionBoundariesTimeZone] is not valid timezone: RangeError: Invalid time zone specified: random",
@@ -22,7 +22,7 @@ exports[`execute robinhood endpoint bad sessionBoundariesTimeZone 1`] = `
 }
 `;
 
-exports[`execute robinhood endpoint missing sessionMarket 1`] = `
+exports[`execute xstocks endpoint missing sessionMarket 1`] = `
 {
   "error": {
     "message": "Missing required parameter sessionMarket when smoother is ema",
@@ -33,7 +33,7 @@ exports[`execute robinhood endpoint missing sessionMarket 1`] = `
 }
 `;
 
-exports[`execute robinhood endpoint should return success - ema 1`] = `
+exports[`execute xstocks endpoint should return success - ema 1`] = `
 {
   "data": {
     "decimals": 8,
@@ -84,7 +84,6 @@ exports[`execute robinhood endpoint should return success - ema 1`] = `
     },
     "tokenContract": {
       "multiplier": "2000000000000000000",
-      "paused": false,
     },
   },
   "result": "20000000",
@@ -96,7 +95,7 @@ exports[`execute robinhood endpoint should return success - ema 1`] = `
 }
 `;
 
-exports[`execute robinhood endpoint should return success - kalman 1`] = `
+exports[`execute xstocks endpoint should return success - kalman 1`] = `
 {
   "data": {
     "decimals": 8,
@@ -147,7 +146,6 @@ exports[`execute robinhood endpoint should return success - kalman 1`] = `
     },
     "tokenContract": {
       "multiplier": "2000000000000000000",
-      "paused": false,
     },
   },
   "result": "20000000",

--- a/packages/composites/tokenized-equity/test/integration/__snapshots__/adapter-xstocks.test.ts.snap
+++ b/packages/composites/tokenized-equity/test/integration/__snapshots__/adapter-xstocks.test.ts.snap
@@ -1,0 +1,160 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`execute robinhood endpoint bad sessionBoundaries 1`] = `
+{
+  "error": {
+    "message": "99:88 in [Param: sessionBoundaries] does not match format HH:MM",
+    "name": "AdapterError",
+  },
+  "status": "errored",
+  "statusCode": 400,
+}
+`;
+
+exports[`execute robinhood endpoint bad sessionBoundariesTimeZone 1`] = `
+{
+  "error": {
+    "message": "[Param: sessionBoundariesTimeZone] is not valid timezone: RangeError: Invalid time zone specified: random",
+    "name": "AdapterError",
+  },
+  "status": "errored",
+  "statusCode": 400,
+}
+`;
+
+exports[`execute robinhood endpoint missing sessionMarket 1`] = `
+{
+  "error": {
+    "message": "Missing required parameter sessionMarket when smoother is ema",
+    "name": "AdapterError",
+  },
+  "status": "errored",
+  "statusCode": 400,
+}
+`;
+
+exports[`execute robinhood endpoint should return success - ema 1`] = `
+{
+  "data": {
+    "decimals": 8,
+    "rawPrice": "1",
+    "result": "20000000",
+    "sessionSource": "FALLBACK",
+    "smoother": {
+      "p": "978347471111",
+      "price": "1",
+      "secondsFromTransition": 9007199254740991,
+      "smoother": "ema",
+      "x": "-1",
+    },
+    "stream": {
+      "extended": {
+        "ask": "5",
+        "askVolume": 6,
+        "bid": "3",
+        "bidVolume": 4,
+        "decimals": 1,
+        "lastSeenTimestampNs": "2",
+        "lastTradedPrice": "7",
+        "marketStatus": 1,
+        "mid": "1",
+      },
+      "overnight": {
+        "ask": "5",
+        "askVolume": 6,
+        "bid": "3",
+        "bidVolume": 4,
+        "decimals": 1,
+        "lastSeenTimestampNs": "2",
+        "lastTradedPrice": "7",
+        "marketStatus": 1,
+        "mid": "1",
+      },
+      "regular": {
+        "ask": "5",
+        "askVolume": 6,
+        "bid": "3",
+        "bidVolume": 4,
+        "decimals": 1,
+        "lastSeenTimestampNs": "2",
+        "lastTradedPrice": "7",
+        "marketStatus": 1,
+        "mid": "1",
+      },
+    },
+    "tokenContract": {
+      "multiplier": "2000000000000000000",
+      "paused": false,
+    },
+  },
+  "result": "20000000",
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 978347471111,
+    "providerDataRequestedUnixMs": 978347471111,
+  },
+}
+`;
+
+exports[`execute robinhood endpoint should return success - kalman 1`] = `
+{
+  "data": {
+    "decimals": 8,
+    "rawPrice": "1",
+    "result": "20000000",
+    "sessionSource": "FALLBACK",
+    "smoother": {
+      "p": "1500000000000000000",
+      "price": "1",
+      "secondsFromTransition": 9007199254740991,
+      "smoother": "kalman",
+      "x": "-1",
+    },
+    "stream": {
+      "extended": {
+        "ask": "5",
+        "askVolume": 6,
+        "bid": "3",
+        "bidVolume": 4,
+        "decimals": 1,
+        "lastSeenTimestampNs": "2",
+        "lastTradedPrice": "7",
+        "marketStatus": 1,
+        "mid": "1",
+      },
+      "overnight": {
+        "ask": "5",
+        "askVolume": 6,
+        "bid": "3",
+        "bidVolume": 4,
+        "decimals": 1,
+        "lastSeenTimestampNs": "2",
+        "lastTradedPrice": "7",
+        "marketStatus": 1,
+        "mid": "1",
+      },
+      "regular": {
+        "ask": "5",
+        "askVolume": 6,
+        "bid": "3",
+        "bidVolume": 4,
+        "decimals": 1,
+        "lastSeenTimestampNs": "2",
+        "lastTradedPrice": "7",
+        "marketStatus": 1,
+        "mid": "1",
+      },
+    },
+    "tokenContract": {
+      "multiplier": "2000000000000000000",
+      "paused": false,
+    },
+  },
+  "result": "20000000",
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 978347471111,
+    "providerDataRequestedUnixMs": 978347471111,
+  },
+}
+`;

--- a/packages/composites/tokenized-equity/test/integration/adapter-xstocks.test.ts
+++ b/packages/composites/tokenized-equity/test/integration/adapter-xstocks.test.ts
@@ -1,0 +1,207 @@
+import {
+  TestAdapter,
+  setEnvVariables,
+} from '@chainlink/external-adapter-framework/util/testing-utils'
+import { JsonRpcProvider } from 'ethers'
+import * as nock from 'nock'
+import { mockResponseSuccess, mockTradingHoursResponseFailure } from './fixtures'
+
+const validContract = '0x12345'
+jest.mock('ethers', () => {
+  const actualModule = jest.requireActual('ethers')
+  return {
+    ...actualModule,
+    JsonRpcProvider: jest.fn().mockImplementation(() => {
+      return {} as JsonRpcProvider
+    }),
+    Contract: jest.fn().mockImplementation((address: string) => {
+      if (address === validContract) {
+        return {
+          uiMultiplier: jest.fn().mockImplementation(() => {
+            return Promise.resolve(2n * 10n ** 18n)
+          }),
+          oraclePaused: jest.fn().mockImplementation(() => {
+            return Promise.resolve(false)
+          }),
+        }
+      } else {
+        return {}
+      }
+    }),
+  }
+})
+
+describe('execute', () => {
+  let spy: jest.SpyInstance
+  let testAdapter: TestAdapter
+  let oldEnv: NodeJS.ProcessEnv
+
+  beforeAll(async () => {
+    oldEnv = JSON.parse(JSON.stringify(process.env))
+    process.env.DATA_ENGINE_ADAPTER_URL = 'http://data-engine'
+    process.env.TRADING_HOURS_ADAPTER_URL = 'http://trading-hours'
+    process.env.ROBINHOOD_MAINNET_RPC_URL = 'rpc.url'
+    process.env.ROBINHOOD_MAINNET_CHAIN_ID = '4663'
+    process.env.BACKGROUND_EXECUTE_MS = process.env.BACKGROUND_EXECUTE_MS ?? '1000'
+    const mockDate = new Date('2001-01-01T11:11:11.111Z')
+    spy = jest.spyOn(Date, 'now').mockReturnValue(mockDate.getTime())
+
+    const adapter = (await import('../../src')).adapter
+    adapter.rateLimiting = undefined
+    testAdapter = await TestAdapter.startWithMockedCache(adapter, {
+      testAdapter: {} as TestAdapter<never>,
+    })
+  })
+
+  afterAll(async () => {
+    setEnvVariables(oldEnv)
+    await testAdapter.api.close()
+    nock.restore()
+    nock.cleanAll()
+    spy.mockRestore()
+  })
+
+  describe('robinhood endpoint', () => {
+    it('should return success - kalman', async () => {
+      const data = {
+        endpoint: 'robinhood',
+        asset: validContract,
+        regularStreamId: '0x000b5',
+        extendedStreamId: '0x000b6',
+        overnightStreamId: '0x000b7',
+        sessionMarket: 'nyse',
+        sessionMarketType: '24/5',
+        sessionBoundaries: [],
+        sessionBoundariesTimeZone: 'UTC',
+        decimals: 8,
+      }
+      mockResponseSuccess()
+      mockTradingHoursResponseFailure()
+
+      const response = await testAdapter.request(data)
+
+      expect(response.json()).toMatchSnapshot()
+      expect(response.statusCode).toBe(200)
+    })
+
+    it('should return success - ema', async () => {
+      const data = {
+        endpoint: 'robinhood',
+        asset: validContract,
+        regularStreamId: '0x000b5',
+        extendedStreamId: '0x000b6',
+        overnightStreamId: '0x000b7',
+        sessionMarket: 'nyse',
+        sessionMarketType: '24/5',
+        sessionBoundaries: [],
+        sessionBoundariesTimeZone: 'UTC',
+        smoother: 'ema',
+        decimals: 8,
+      }
+      mockResponseSuccess()
+      mockTradingHoursResponseFailure()
+
+      const response = await testAdapter.request(data)
+
+      expect(response.json()).toMatchSnapshot()
+      expect(response.statusCode).toBe(200)
+    })
+
+    it('missing sessionMarket', async () => {
+      const data = {
+        endpoint: 'robinhood',
+        asset: validContract,
+        regularStreamId: '0x000b5',
+        extendedStreamId: '0x000b6',
+        overnightStreamId: '0x000b7',
+        sessionMarketType: '24/5',
+        sessionBoundaries: [],
+        sessionBoundariesTimeZone: 'UTC',
+        smoother: 'ema',
+        decimals: 8,
+      }
+
+      const response = await testAdapter.request(data)
+
+      expect(response.json()).toMatchSnapshot()
+      expect(response.statusCode).toBe(400)
+    })
+
+    it('bad sessionBoundariesTimeZone', async () => {
+      const data = {
+        endpoint: 'robinhood',
+        asset: validContract,
+        regularStreamId: '0x000b5',
+        extendedStreamId: '0x000b5',
+        overnightStreamId: '0x000b5',
+        sessionMarket: 'nyse',
+        sessionMarketType: '24/5',
+        sessionBoundaries: ['00:00'],
+        sessionBoundariesTimeZone: 'random',
+        decimals: 8,
+      }
+
+      const response = await testAdapter.request(data)
+
+      expect(response.json()).toMatchSnapshot()
+      expect(response.statusCode).toBe(400)
+    })
+
+    it('bad sessionBoundaries', async () => {
+      const data = {
+        endpoint: 'robinhood',
+        asset: validContract,
+        regularStreamId: '0x000b5',
+        extendedStreamId: '0x000b5',
+        overnightStreamId: '0x000b5',
+        sessionMarket: 'nyse',
+        sessionMarketType: '24/5',
+        sessionBoundaries: ['99:88'],
+        sessionBoundariesTimeZone: 'UTC',
+        decimals: 8,
+      }
+
+      const response = await testAdapter.request(data)
+
+      expect(response.json()).toMatchSnapshot()
+      expect(response.statusCode).toBe(400)
+    })
+
+    it('should return failure - kalman', async () => {
+      const data = {
+        endpoint: 'robinhood',
+        asset: '0x0',
+        regularStreamId: '0x000b5',
+        extendedStreamId: '0x000b6',
+        overnightStreamId: '0x000b7',
+        sessionMarket: 'nyse',
+        sessionMarketType: '24/5',
+        sessionBoundaries: [],
+        sessionBoundariesTimeZone: 'UTC',
+        decimals: 8,
+      }
+
+      const response = await testAdapter.request(data)
+      expect(response.statusCode).toBe(502)
+    })
+
+    it('should return failure - ema', async () => {
+      const data = {
+        endpoint: 'robinhood',
+        asset: '0x0',
+        regularStreamId: '0x000b5',
+        extendedStreamId: '0x000b6',
+        overnightStreamId: '0x000b7',
+        sessionMarket: 'nyse',
+        sessionMarketType: '24/5',
+        sessionBoundaries: [],
+        sessionBoundariesTimeZone: 'UTC',
+        smoother: 'ema',
+        decimals: 8,
+      }
+
+      const response = await testAdapter.request(data)
+      expect(response.statusCode).toBe(502)
+    })
+  })
+})

--- a/packages/composites/tokenized-equity/test/integration/adapter-xstocks.test.ts
+++ b/packages/composites/tokenized-equity/test/integration/adapter-xstocks.test.ts
@@ -17,11 +17,8 @@ jest.mock('ethers', () => {
     Contract: jest.fn().mockImplementation((address: string) => {
       if (address === validContract) {
         return {
-          uiMultiplier: jest.fn().mockImplementation(() => {
+          convertToAssets: jest.fn().mockImplementation(() => {
             return Promise.resolve(2n * 10n ** 18n)
-          }),
-          oraclePaused: jest.fn().mockImplementation(() => {
-            return Promise.resolve(false)
           }),
         }
       } else {
@@ -40,8 +37,7 @@ describe('execute', () => {
     oldEnv = JSON.parse(JSON.stringify(process.env))
     process.env.DATA_ENGINE_ADAPTER_URL = 'http://data-engine'
     process.env.TRADING_HOURS_ADAPTER_URL = 'http://trading-hours'
-    process.env.ROBINHOOD_MAINNET_RPC_URL = 'rpc.url'
-    process.env.ROBINHOOD_MAINNET_CHAIN_ID = '4663'
+    process.env.ETHEREUM_RPC_URL = 'rpc.url'
     process.env.BACKGROUND_EXECUTE_MS = process.env.BACKGROUND_EXECUTE_MS ?? '1000'
     const mockDate = new Date('2001-01-01T11:11:11.111Z')
     spy = jest.spyOn(Date, 'now').mockReturnValue(mockDate.getTime())
@@ -61,10 +57,10 @@ describe('execute', () => {
     spy.mockRestore()
   })
 
-  describe('robinhood endpoint', () => {
+  describe('xstocks endpoint', () => {
     it('should return success - kalman', async () => {
       const data = {
-        endpoint: 'robinhood',
+        endpoint: 'xstocks',
         asset: validContract,
         regularStreamId: '0x000b5',
         extendedStreamId: '0x000b6',
@@ -86,7 +82,7 @@ describe('execute', () => {
 
     it('should return success - ema', async () => {
       const data = {
-        endpoint: 'robinhood',
+        endpoint: 'xstocks',
         asset: validContract,
         regularStreamId: '0x000b5',
         extendedStreamId: '0x000b6',
@@ -109,7 +105,7 @@ describe('execute', () => {
 
     it('missing sessionMarket', async () => {
       const data = {
-        endpoint: 'robinhood',
+        endpoint: 'xstocks',
         asset: validContract,
         regularStreamId: '0x000b5',
         extendedStreamId: '0x000b6',
@@ -129,7 +125,7 @@ describe('execute', () => {
 
     it('bad sessionBoundariesTimeZone', async () => {
       const data = {
-        endpoint: 'robinhood',
+        endpoint: 'xstocks',
         asset: validContract,
         regularStreamId: '0x000b5',
         extendedStreamId: '0x000b5',
@@ -149,7 +145,7 @@ describe('execute', () => {
 
     it('bad sessionBoundaries', async () => {
       const data = {
-        endpoint: 'robinhood',
+        endpoint: 'xstocks',
         asset: validContract,
         regularStreamId: '0x000b5',
         extendedStreamId: '0x000b5',
@@ -169,7 +165,7 @@ describe('execute', () => {
 
     it('should return failure - kalman', async () => {
       const data = {
-        endpoint: 'robinhood',
+        endpoint: 'xstocks',
         asset: '0x0',
         regularStreamId: '0x000b5',
         extendedStreamId: '0x000b6',
@@ -187,7 +183,7 @@ describe('execute', () => {
 
     it('should return failure - ema', async () => {
       const data = {
-        endpoint: 'robinhood',
+        endpoint: 'xstocks',
         asset: '0x0',
         regularStreamId: '0x000b5',
         extendedStreamId: '0x000b6',

--- a/packages/composites/tokenized-equity/test/unit/lib/xstocks.test.ts
+++ b/packages/composites/tokenized-equity/test/unit/lib/xstocks.test.ts
@@ -1,0 +1,26 @@
+import { JsonRpcProvider } from 'ethers'
+import { getTokenData } from '../../../src/lib/robinhood'
+
+const mockGetUiMultiplier = jest.fn()
+const mockGetOraclePaused = jest.fn()
+
+jest.mock('ethers', () => ({
+  Contract: jest.fn().mockImplementation(() => ({
+    uiMultiplier: mockGetUiMultiplier,
+    oraclePaused: mockGetOraclePaused,
+  })),
+  JsonRpcProvider: jest.fn(),
+}))
+
+describe('getTokenData', () => {
+  it('should return multiplier and paused status', async () => {
+    const multiplier = '1500000000000000000'
+    mockGetUiMultiplier.mockResolvedValue(multiplier)
+    mockGetOraclePaused.mockResolvedValue(false)
+
+    expect(await getTokenData('0x1', {} as JsonRpcProvider)).toEqual({
+      multiplier: BigInt(multiplier),
+      paused: false,
+    })
+  })
+})

--- a/packages/composites/tokenized-equity/test/unit/lib/xstocks.test.ts
+++ b/packages/composites/tokenized-equity/test/unit/lib/xstocks.test.ts
@@ -1,26 +1,26 @@
 import { JsonRpcProvider } from 'ethers'
-import { getTokenData } from '../../../src/lib/robinhood'
+import { getTokenMultiplier } from '../../../src/lib/xstocks'
 
-const mockGetUiMultiplier = jest.fn()
-const mockGetOraclePaused = jest.fn()
+const mockConvertToAssets = jest.fn()
 
-jest.mock('ethers', () => ({
-  Contract: jest.fn().mockImplementation(() => ({
-    uiMultiplier: mockGetUiMultiplier,
-    oraclePaused: mockGetOraclePaused,
-  })),
-  JsonRpcProvider: jest.fn(),
-}))
+jest.mock('ethers', () => {
+  const actualModule = jest.requireActual('ethers')
+  return {
+    ...actualModule,
+    Contract: jest.fn().mockImplementation(() => ({
+      convertToAssets: mockConvertToAssets,
+    })),
+    JsonRpcProvider: jest.fn(),
+  }
+})
 
-describe('getTokenData', () => {
-  it('should return multiplier and paused status', async () => {
+describe('getTokenMultiplier', () => {
+  it('should return multiplier', async () => {
     const multiplier = '1500000000000000000'
-    mockGetUiMultiplier.mockResolvedValue(multiplier)
-    mockGetOraclePaused.mockResolvedValue(false)
+    mockConvertToAssets.mockResolvedValue(multiplier)
 
-    expect(await getTokenData('0x1', {} as JsonRpcProvider)).toEqual({
-      multiplier: BigInt(multiplier),
-      paused: false,
-    })
+    expect(await getTokenMultiplier('0x1', {} as JsonRpcProvider)).toEqual(BigInt(multiplier))
+
+    expect(mockConvertToAssets).toHaveBeenCalledWith(10n ** 18n)
   })
 })

--- a/packages/composites/tokenized-equity/test/unit/transport/xstocksPrice.test.ts
+++ b/packages/composites/tokenized-equity/test/unit/transport/xstocksPrice.test.ts
@@ -1,16 +1,16 @@
 import { Requester } from '@chainlink/external-adapter-framework/util/requester'
 import { JsonRpcProvider } from 'ethers'
-import { getTokenData } from '../../../src/lib/robinhood'
-import { calculatePrice } from '../../../src/transport/robinhoodPrice'
+import { getTokenMultiplier } from '../../../src/lib/xstocks'
 import { smoothedStreamPrice } from '../../../src/transport/smoothedPrice'
+import { calculatePrice } from '../../../src/transport/xstocksPrice'
 
 jest.mock('../../../src/transport/smoothedPrice', () => ({ smoothedStreamPrice: jest.fn() }))
 const mockSmoothedStreamPrice = smoothedStreamPrice as jest.MockedFunction<
   typeof smoothedStreamPrice
 >
 
-jest.mock('../../../src/lib/robinhood', () => ({ getTokenData: jest.fn() }))
-const mockGetTokenData = getTokenData as jest.MockedFunction<typeof getTokenData>
+jest.mock('../../../src/lib/xstocks', () => ({ getTokenMultiplier: jest.fn() }))
+const mockGetTokenMultiplier = getTokenMultiplier as jest.MockedFunction<typeof getTokenMultiplier>
 
 describe('calculatePrice', () => {
   const defaultParams = {
@@ -102,10 +102,7 @@ describe('calculatePrice', () => {
     ]
 
     mockSmoothedStreamPrice.mockResolvedValue(smoothedStreamPriceReturn)
-    mockGetTokenData.mockResolvedValue({
-      multiplier: 5n * 10n ** 18n,
-      paused: false,
-    })
+    mockGetTokenMultiplier.mockResolvedValue(5n * 10n ** 18n)
 
     const result = await calculatePrice({
       ...defaultParams,
@@ -113,64 +110,16 @@ describe('calculatePrice', () => {
       decimals: 6,
     })
 
-    const expectedTokenData = { multiplier: '5000000000000000000', paused: false }
+    const expectedTokenMultiplier = { multiplier: '5000000000000000000' }
     expect(result[0]).toStrictEqual({
       ...smoothedStreamPriceReturn[0],
-      tokenContract: expectedTokenData,
+      tokenContract: expectedTokenMultiplier,
       result: '5',
     })
     expect(result[1]).toStrictEqual({
       ...smoothedStreamPriceReturn[1],
-      tokenContract: expectedTokenData,
+      tokenContract: expectedTokenMultiplier,
       result: '5',
-    })
-  })
-
-  it('throws when token is paused', async () => {
-    mockSmoothedStreamPrice.mockResolvedValue([
-      {
-        result: 1n,
-        rawPrice: '1',
-        decimals: 6,
-        stream: streams,
-        smoother: {
-          smoother: 'ema' as const,
-          price: '1',
-          x: '0',
-          p: '0',
-          secondsFromTransition: 0,
-        },
-        sessionSource: 'FALLBACK' as const,
-      },
-      {
-        result: 1n,
-        rawPrice: '1',
-        decimals: 6,
-        stream: streams,
-        smoother: {
-          smoother: 'kalman' as const,
-          price: '1',
-          x: '0',
-          p: '0',
-          secondsFromTransition: 0,
-        },
-        sessionSource: 'FALLBACK' as const,
-      },
-    ])
-    mockGetTokenData.mockResolvedValue({
-      multiplier: 5n * 10n ** 18n,
-      paused: true,
-    })
-
-    await expect(
-      calculatePrice({
-        ...defaultParams,
-        smoother: 'kalman',
-        decimals: 6,
-      }),
-    ).rejects.toMatchObject({
-      statusCode: 503,
-      message: `asset: '0x1234567890123456789012345678901234567890' paused`,
     })
   })
 })

--- a/packages/composites/tokenized-equity/test/unit/transport/xstocksPrice.test.ts
+++ b/packages/composites/tokenized-equity/test/unit/transport/xstocksPrice.test.ts
@@ -1,0 +1,176 @@
+import { Requester } from '@chainlink/external-adapter-framework/util/requester'
+import { JsonRpcProvider } from 'ethers'
+import { getTokenData } from '../../../src/lib/robinhood'
+import { calculatePrice } from '../../../src/transport/robinhoodPrice'
+import { smoothedStreamPrice } from '../../../src/transport/smoothedPrice'
+
+jest.mock('../../../src/transport/smoothedPrice', () => ({ smoothedStreamPrice: jest.fn() }))
+const mockSmoothedStreamPrice = smoothedStreamPrice as jest.MockedFunction<
+  typeof smoothedStreamPrice
+>
+
+jest.mock('../../../src/lib/robinhood', () => ({ getTokenData: jest.fn() }))
+const mockGetTokenData = getTokenData as jest.MockedFunction<typeof getTokenData>
+
+describe('calculatePrice', () => {
+  const defaultParams = {
+    asset: '0x1234567890123456789012345678901234567890',
+    provider: {} as JsonRpcProvider,
+    regularStreamId: 'regular-stream-id',
+    extendedStreamId: 'extended-stream-id',
+    overnightStreamId: 'overnight-stream-id',
+    url: 'https://api.example.com',
+    tradingHoursUrl: 'https://trading-hours.example.com',
+    requester: {} as Requester,
+    sessionBoundaries: ['09:00', '17:00'],
+    sessionBoundariesTimeZone: 'America/New_York',
+    sessionMarket: 'nyse',
+    sessionMarketType: '24/5',
+    decimals: 8,
+  }
+
+  const streams = {
+    regular: {
+      mid: '1',
+      lastSeenTimestampNs: '2',
+      bid: '0.99',
+      bidVolume: 100,
+      ask: '1.01',
+      askVolume: 100,
+      lastTradedPrice: '1.00',
+      marketStatus: 1,
+      decimals: 18,
+    },
+    extended: {
+      mid: '10',
+      lastSeenTimestampNs: '20',
+      bid: '9.9',
+      bidVolume: 1000,
+      ask: '10.1',
+      askVolume: 1000,
+      lastTradedPrice: '10.0',
+      marketStatus: 2,
+      decimals: 18,
+    },
+    overnight: {
+      mid: '100',
+      lastSeenTimestampNs: '200',
+      bid: '99',
+      bidVolume: 10000,
+      ask: '101',
+      askVolume: 10000,
+      lastTradedPrice: '100',
+      marketStatus: 3,
+      decimals: 18,
+    },
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('scales result', async () => {
+    const smoothedStreamPriceReturn = [
+      {
+        result: 1n,
+        rawPrice: '1',
+        decimals: 6,
+        stream: streams,
+        smoother: {
+          smoother: 'ema' as const,
+          price: '1',
+          x: '2',
+          p: '3',
+          secondsFromTransition: 0,
+        },
+        sessionSource: 'FALLBACK' as const,
+      },
+      {
+        result: 1n,
+        rawPrice: '1',
+        decimals: 6,
+        stream: streams,
+        smoother: {
+          smoother: 'kalman' as const,
+          price: '1',
+          x: '2',
+          p: '3',
+          secondsFromTransition: 0,
+        },
+        sessionSource: 'FALLBACK' as const,
+      },
+    ]
+
+    mockSmoothedStreamPrice.mockResolvedValue(smoothedStreamPriceReturn)
+    mockGetTokenData.mockResolvedValue({
+      multiplier: 5n * 10n ** 18n,
+      paused: false,
+    })
+
+    const result = await calculatePrice({
+      ...defaultParams,
+      smoother: 'kalman',
+      decimals: 6,
+    })
+
+    const expectedTokenData = { multiplier: '5000000000000000000', paused: false }
+    expect(result[0]).toStrictEqual({
+      ...smoothedStreamPriceReturn[0],
+      tokenContract: expectedTokenData,
+      result: '5',
+    })
+    expect(result[1]).toStrictEqual({
+      ...smoothedStreamPriceReturn[1],
+      tokenContract: expectedTokenData,
+      result: '5',
+    })
+  })
+
+  it('throws when token is paused', async () => {
+    mockSmoothedStreamPrice.mockResolvedValue([
+      {
+        result: 1n,
+        rawPrice: '1',
+        decimals: 6,
+        stream: streams,
+        smoother: {
+          smoother: 'ema' as const,
+          price: '1',
+          x: '0',
+          p: '0',
+          secondsFromTransition: 0,
+        },
+        sessionSource: 'FALLBACK' as const,
+      },
+      {
+        result: 1n,
+        rawPrice: '1',
+        decimals: 6,
+        stream: streams,
+        smoother: {
+          smoother: 'kalman' as const,
+          price: '1',
+          x: '0',
+          p: '0',
+          secondsFromTransition: 0,
+        },
+        sessionSource: 'FALLBACK' as const,
+      },
+    ])
+    mockGetTokenData.mockResolvedValue({
+      multiplier: 5n * 10n ** 18n,
+      paused: true,
+    })
+
+    await expect(
+      calculatePrice({
+        ...defaultParams,
+        smoother: 'kalman',
+        decimals: 6,
+      }),
+    ).rejects.toMatchObject({
+      statusCode: 503,
+      message: `asset: '0x1234567890123456789012345678901234567890' paused`,
+    })
+  })
+})


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/OPDATA-7941

## Description

The endpoint is identical to the `robinhood` endpoint, except:

* `xstocks` asset contracts are on Ethereum Mainnet instead of Robinhood chain.
* `xstocks` assets can't be paused.
* `xstocks` asset multipliers are calculated by calling `convertToAssets` on the asset contract.

## Changes

Two separate commits:
1. Copied `robinhood` files.
2. Adjusted files for `xstocks` use case.

## Steps to Test

```
curl --silent -S -X POST http://localhost:8080 -H 'Content-Type: application/json' -d '{
  "data": {
    "endpoint": "xstocks",
    "asset": "0xE7E553Cd128F0011777323A0b44a7b96EA1CB540",
    "decimals": 8,
    "extendedStreamId": "0x000b1a79f503e9b236bc13b01524d1955b5a4d5ff2e22d5a08404c35d23d7301",
    "overnightStreamId": "0x000b0580ced23f9ae7fd77f817ad7e6aec23a04314454365cfe93060a9041bd3",
    "regularStreamId": "0x000bc7e431fcd497f06b9e1dea869bcda3d05049d0601f3d1e56e64c8cdd05ac",
    "sessionBoundaries": [
      "04:00",
      "16:00",
      "20:00"
    ],
    "sessionBoundariesTimeZone": "America/New_York",
    "sessionMarket": "nyse",
    "sessionMarketType": "24/5"
  }
}'

{
  "data": {
    "result": "74682683703",
    "rawPrice": "742583300000000000000",
    "decimals": 8,
    "stream": {
      "regular": {
        "mid": "742583000000000000000",
        "lastSeenTimestampNs": "1782817099000000000",
        "bid": "742540000000000000000",
        "bidVolume": 9319535557742690000,
        "ask": "742620100000000000000",
        "askVolume": 12426047410323587000,
        "lastTradedPrice": "740890000000000000000",
        "marketStatus": 1,
        "decimals": 18
      },
      "extended": {
        "mid": "742583300000000000000",
        "lastSeenTimestampNs": "1782817101344000000",
        "bid": "742546200000000000000",
        "bidVolume": 9319535557742690000,
        "ask": "742620400000000000000",
        "askVolume": 12426047410323587000,
        "lastTradedPrice": "742589600000000000000",
        "marketStatus": 1,
        "decimals": 18
      },
      "overnight": {
        "mid": "742585000000000000000",
        "lastSeenTimestampNs": "1782817099000000000",
        "bid": "742540000000000000000",
        "bidVolume": 16872791484033139000,
        "ask": "742630000000000000000",
        "askVolume": 9319535557742690000,
        "lastTradedPrice": "741930000000000000000",
        "marketStatus": 1,
        "decimals": 18
      }
    },
    "smoother": {
      "smoother": "kalman",
      "price": "742583300000000000000",
      "x": "742569481576792875276",
      "p": "12076413501928450",
      "secondsFromTransition": 10703.58
    },
    "sessionSource": "TRADINGHOURS",
    "tokenContract": {
      "multiplier": "1005714560286254000"
    }
  },
  "statusCode": 200,
  "result": "74682683703",
  "timestamps": {
    "providerDataRequestedUnixMs": 1782817103580,
    "providerDataReceivedUnixMs": 1782817103841
  },
  "meta": {
    "adapterName": "TOKENIZED_EQUITY",
    "transportName": "default_single_transport",
    "metrics": {
      "feedId": "eEhAMr+VvA8JMrLCVUHGBpw/k1k="
    }
  }
}
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[OPDATA-6280]: https://smartcontract-it.atlassian.net/browse/OPDATA-6280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ