### PR TITLE
OPDATA-6579: Use variable env vars in view-function-multi-chain

### DIFF
--- a/.changeset/tender-paws-ring.md
+++ b/.changeset/tender-paws-ring.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/view-function-multi-chain-adapter': patch
+---
+
+Use variablePlaceholder instead of custom env vars

--- a/packages/sources/view-function-multi-chain/README.md
+++ b/packages/sources/view-function-multi-chain/README.md
@@ -4,21 +4,14 @@
 
 This document was generated automatically. Please see [README Generator](../../scripts#readme-generator) for more info.
 
-## Generic Environment Variables
-
-In order to connect to different blockchains, you may need to set additional environment variables for the respective RPC URLs.
-
-| Required? |        Name         |       Description       |  Type  | Options | Default |
-| :-------: | :-----------------: | :---------------------: | :----: | :-----: | :-----: |
-|           | {NETWORK}\_RPC_URL  | RPC url for a NETWORK.  | string |         |         |
-|           | {NETWORK}\_CHAIN_ID | Chain id for a NETWORK. | number |         |         |
-
 ## Environment Variables
 
 | Required? |         Name          |                                                 Description                                                  |  Type  | Options | Default |
 | :-------: | :-------------------: | :----------------------------------------------------------------------------------------------------------: | :----: | :-----: | :-----: |
 |           |       APTOS_URL       |                                              Aptos rest api url                                              | string |         |   ``    |
 |           |   APTOS_TESTNET_URL   |                                          Aptos testnet rest api url                                          | string |         |   ``    |
+|    ✅     |  ${NETWORK}\_RPC_URL  |  The RPC URL for ${NETWORK} where ${NETWORK} is the upper-snake-case name of the `network` input parameter.  | string |         |         |
+|    ✅     | ${NETWORK}\_CHAIN_ID  | The chain ID for ${NETWORK} where ${NETWORK} is the upper-snake-case name of the `network` input parameter.  | number |         |         |
 |           |      GROUP_SIZE       | Number of requests to execute asynchronously before the adapter waits to execute the next group of requests. | number |         |  `10`   |
 |           | BACKGROUND_EXECUTE_MS |          The amount of time the background execute should sleep before performing the next request           | number |         | `10000` |
 

--- a/packages/sources/view-function-multi-chain/docs/custom.md
+++ b/packages/sources/view-function-multi-chain/docs/custom.md
@@ -1,8 +1,0 @@
-## Generic Environment Variables
-
-In order to connect to different blockchains, you may need to set additional environment variables for the respective RPC URLs.
-
-| Required? |        Name         |       Description       |  Type  | Options | Default |
-| :-------: | :-----------------: | :---------------------: | :----: | :-----: | :-----: |
-|           | {NETWORK}\_RPC_URL  | RPC url for a NETWORK.  | string |         |         |
-|           | {NETWORK}\_CHAIN_ID | Chain id for a NETWORK. | number |         |         |

--- a/packages/sources/view-function-multi-chain/src/config/index.ts
+++ b/packages/sources/view-function-multi-chain/src/config/index.ts
@@ -15,6 +15,22 @@ export const config = new AdapterConfig({
     default: '',
     sensitive: false,
   },
+  NETWORK_RPC_URL: {
+    description:
+      'The RPC URL for ${NETWORK} where ${NETWORK} is the upper-snake-case name of the `network` input parameter.',
+    type: 'string',
+    required: true,
+    sensitive: true,
+    variablePlaceholder: 'NETWORK',
+  },
+  NETWORK_CHAIN_ID: {
+    description:
+      'The chain ID for ${NETWORK} where ${NETWORK} is the upper-snake-case name of the `network` input parameter.',
+    type: 'number',
+    required: true,
+    sensitive: false,
+    variablePlaceholder: 'NETWORK',
+  },
   GROUP_SIZE: {
     description:
       'Number of requests to execute asynchronously before the adapter waits to execute the next group of requests.',

--- a/packages/sources/view-function-multi-chain/src/endpoint/calculated-multi-function.ts
+++ b/packages/sources/view-function-multi-chain/src/endpoint/calculated-multi-function.ts
@@ -205,20 +205,19 @@ export const endpoint = new AdapterEndpoint({
   name: 'calculated-multi-function',
   transport: calculatedMultiFunctionTransport,
   inputParameters,
-  customInputValidation: (req): AdapterError | undefined => {
+  customInputValidation: (req, settings): AdapterError | undefined => {
     const params: RequestParams = req.requestContext.data
     for (const fc of params.functionCalls) {
       const networkName = fc.network.toUpperCase()
-      const networkEnvName = `${networkName}_RPC_URL`
       const chainIdEnvName = `${networkName}_CHAIN_ID`
 
-      const rpcUrl = process.env[networkEnvName]
-      const chainId = Number(process.env[chainIdEnvName])
+      settings.NETWORK_RPC_URL.get(fc.network)
+      const chainId = settings.NETWORK_CHAIN_ID.get(fc.network)
 
-      if (!rpcUrl || isNaN(chainId)) {
+      if (isNaN(chainId)) {
         throw new AdapterInputError({
-          statusCode: 400,
-          message: `Missing '${networkEnvName}' or '${chainIdEnvName}' environment variables.`,
+          statusCode: 500,
+          message: `'${chainIdEnvName}' environment variable must be a number.`,
         })
       }
     }

--- a/packages/sources/view-function-multi-chain/src/endpoint/function.ts
+++ b/packages/sources/view-function-multi-chain/src/endpoint/function.ts
@@ -1,5 +1,9 @@
 import { AdapterEndpoint } from '@chainlink/external-adapter-framework/adapter'
 import { InputParameters } from '@chainlink/external-adapter-framework/validation'
+import {
+  AdapterError,
+  AdapterInputError,
+} from '@chainlink/external-adapter-framework/validation/error'
 import { config } from '../config'
 import { functionTransport } from '../transport/function'
 
@@ -53,4 +57,20 @@ export const endpoint = new AdapterEndpoint({
   name: 'function',
   transport: functionTransport,
   inputParameters,
+  customInputValidation: (req, settings): AdapterError | undefined => {
+    const params = req.requestContext.data
+    const networkName = params.network.toUpperCase()
+    const chainIdEnvName = `${networkName}_CHAIN_ID`
+
+    settings.NETWORK_RPC_URL.get(params.network)
+    const chainId = settings.NETWORK_CHAIN_ID.get(params.network)
+
+    if (isNaN(chainId)) {
+      throw new AdapterInputError({
+        statusCode: 500,
+        message: `'${chainIdEnvName}' environment variable must be a number.`,
+      })
+    }
+    return
+  },
 })

--- a/packages/sources/view-function-multi-chain/src/transport/calculated-multi-function.ts
+++ b/packages/sources/view-function-multi-chain/src/transport/calculated-multi-function.ts
@@ -112,11 +112,8 @@ export class CalculatedMultiFunctionTransport extends SubscriptionTransport<Base
     const { address, signature, inputParams, network } = params
 
     const networkName = network.toUpperCase()
-    const networkEnvName = `${networkName}_RPC_URL`
-    const chainIdEnvName = `${networkName}_CHAIN_ID`
-
-    const rpcUrl = process.env[networkEnvName]
-    const chainId = Number(process.env[chainIdEnvName])
+    const rpcUrl = this.config.NETWORK_RPC_URL.get(network)
+    const chainId = this.config.NETWORK_CHAIN_ID.get(network)
 
     if (!this.providers[networkName]) {
       this.providers[networkName] = new ethers.JsonRpcProvider(rpcUrl, chainId)

--- a/packages/sources/view-function-multi-chain/src/transport/function-common.ts
+++ b/packages/sources/view-function-multi-chain/src/transport/function-common.ts
@@ -36,6 +36,7 @@ export type HexResultPostProcessor = (
 export class MultiChainFunctionTransport<
   T extends GenericFunctionEndpointTypes,
 > extends SubscriptionTransport<T> {
+  config!: GenericFunctionEndpointTypes['Settings']
   providers: Record<string, ethers.JsonRpcProvider> = {}
   hexResultPostProcessor: HexResultPostProcessor
 
@@ -51,6 +52,7 @@ export class MultiChainFunctionTransport<
     transportName: string,
   ): Promise<void> {
     await super.initialize(dependencies, adapterSettings, endpointName, transportName)
+    this.config = adapterSettings
   }
 
   async backgroundHandler(context: EndpointContext<T>, entries: RequestParams<T>[]) {
@@ -108,18 +110,8 @@ export class MultiChainFunctionTransport<
     const { address, signature, inputParams, network, resultField } = params
 
     const networkName = network.toUpperCase()
-    const networkEnvName = `${networkName}_RPC_URL`
-    const chainIdEnvName = `${networkName}_CHAIN_ID`
-
-    const rpcUrl = process.env[networkEnvName]
-    const chainId = Number(process.env[chainIdEnvName])
-
-    if (!rpcUrl || isNaN(chainId)) {
-      throw new AdapterInputError({
-        statusCode: 400,
-        message: `Missing '${networkEnvName}' or '${chainIdEnvName}' environment variables.`,
-      })
-    }
+    const rpcUrl = this.config.NETWORK_RPC_URL.get(network)
+    const chainId = this.config.NETWORK_CHAIN_ID.get(network)
 
     if (!this.providers[networkName]) {
       this.providers[networkName] = new ethers.JsonRpcProvider(rpcUrl, chainId)

--- a/packages/sources/view-function-multi-chain/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/view-function-multi-chain/test/integration/__snapshots__/adapter.test.ts.snap
@@ -42,22 +42,22 @@ exports[`execute calculated-multi-function endpoint should fail additional data 
 exports[`execute calculated-multi-function endpoint should return error for missing RPC url env var 1`] = `
 {
   "error": {
-    "message": "Missing 'ARBITRUM_MAINNET_RPC_URL' or 'ARBITRUM_MAINNET_CHAIN_ID' environment variables.",
+    "message": "Missing required environment variable: ARBITRUM_MAINNET_RPC_URL",
     "name": "AdapterError",
   },
   "status": "errored",
-  "statusCode": 400,
+  "statusCode": 500,
 }
 `;
 
 exports[`execute calculated-multi-function endpoint should return error for missing chain id env var 1`] = `
 {
   "error": {
-    "message": "Missing 'ARBITRUM_MAINNET_RPC_URL' or 'ARBITRUM_MAINNET_CHAIN_ID' environment variables.",
+    "message": "Missing required environment variable: ARBITRUM_MAINNET_RPC_URL",
     "name": "AdapterError",
   },
   "status": "errored",
-  "statusCode": 400,
+  "statusCode": 500,
 }
 `;
 

--- a/packages/sources/view-function-multi-chain/test/integration/adapter.test.ts
+++ b/packages/sources/view-function-multi-chain/test/integration/adapter.test.ts
@@ -114,7 +114,7 @@ describe('execute', () => {
         network: 'arbitrum_mainnet', // ARBITRUM_MAINNET_RPC_URL is not provided
       }
       const response = await testAdapter.request(data)
-      expect(response.statusCode).toBe(400)
+      expect(response.statusCode).toBe(500)
     })
 
     it('should return error for missing chain id env var', async () => {
@@ -125,7 +125,7 @@ describe('execute', () => {
         network: 'arbitrum_mainnet', // ARBITRUM_MAINNET_CHAIN_ID is not provided
       }
       const response = await testAdapter.request(data)
-      expect(response.statusCode).toBe(400)
+      expect(response.statusCode).toBe(500)
     })
 
     it('should return error for invalid input', async () => {
@@ -410,7 +410,7 @@ describe('execute', () => {
       }
       const response = await testAdapter.request(data)
       expect(response.json()).toMatchSnapshot()
-      expect(response.statusCode).toBe(400)
+      expect(response.statusCode).toBe(500)
     })
 
     it('should return error for missing chain id env var', async () => {
@@ -428,7 +428,7 @@ describe('execute', () => {
       }
       const response = await testAdapter.request(data)
       expect(response.json()).toMatchSnapshot()
-      expect(response.statusCode).toBe(400)
+      expect(response.statusCode).toBe(500)
     })
 
     it('should return error for invalid input', async () => {


### PR DESCRIPTION
## [OPDATA-6579](https://smartcontract-it.atlassian.net/browse/OPDATA-6579)

## Description

Since version 2.14.1 the EA framework has built-in support for variable env vars.
`view-function-multi-chain` uses "ad-hoc" variable env vars for RPC URLs and chain IDs.

This PR replaces the ad-hoc implementation with the framework supported one.

## Changes

1. Add `NETWORK_RPC_URL` and `NETWORK_CHAIN_ID` to config.
2. Remove `docs/custom.md`.
3. Use `settings.NETWORK_RPC_URL.get(network)`, etc., instead of `process.env[networkEnvName]`.
5. Update `README.md`.
6. Update integration tests.

## Steps to Test

```
yarn test packages/sources/view-function-multi-chain
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[OPDATA-6579]: https://smartcontract-it.atlassian.net/browse/OPDATA-6579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ