### PR TITLE
OPDATA-7589: Update ZEUS_ZBTC_API_URL on por-address-list

### DIFF
--- a/.changeset/icy-radios-join.md
+++ b/.changeset/icy-radios-join.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/por-address-list-adapter': patch
+---
+
+Change default value of ZEUS_ZBTC_API_URL

--- a/packages/sources/por-address-list/src/config/index.ts
+++ b/packages/sources/por-address-list/src/config/index.ts
@@ -79,7 +79,7 @@ export const config = new AdapterConfig({
   ZEUS_ZBTC_API_URL: {
     description: 'An API endpoint for Zeus native BTC wallet address',
     type: 'string',
-    default: 'https://indexer.zeuslayer.io/api/v2/chainlink/proof-of-reserves',
+    default: 'https://hermes.zeusnetwork.xyz/api/v2/chainlink/proof-of-reserves',
     sensitive: false,
   },
   VIRTUNE_API_URL: {

--- a/packages/sources/por-address-list/test/integration/adapter.test.ts
+++ b/packages/sources/por-address-list/test/integration/adapter.test.ts
@@ -71,6 +71,7 @@ describe('execute', () => {
     process.env.SOLVBTC_TRADING_API_ENDPOINT = 'http://solv-trading'
     process.env.SOLVBTC_CORE_API_ENDPOINT = 'http://solv-core'
     process.env.SOLVBTC_JUP_API_ENDPOINT = 'http://solv-jup'
+    process.env.ZEUS_ZBTC_API_URL = 'http://zeus-btc'
     process.env.BACKGROUND_EXECUTE_MS = '0'
     process.env.RATE_LIMIT_CAPACITY_SECOND = '500'
     const mockDate = new Date('2001-01-01T11:11:11.111Z')

--- a/packages/sources/por-address-list/test/integration/fixtures-api.ts
+++ b/packages/sources/por-address-list/test/integration/fixtures-api.ts
@@ -1,10 +1,10 @@
 import nock from 'nock'
 
 export const mockZeusResponseSuccess = (): nock.Scope =>
-  nock('https://indexer.zeuslayer.io', {
+  nock('http://zeus-btc', {
     encodedQueryParams: true,
   })
-    .get('/api/v2/chainlink/proof-of-reserves')
+    .get('/')
     .reply(
       200,
       () => ({


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/OPDATA-7589

## Description

The Zeus team changed the domain of their API URL.

## Changes

Change the default value of the `ZEUS_ZBTC_API_URL` config variable.

## Steps to Test

```
curl --silent -S -X POST http://localhost:8081 -H 'Content-Type: application/json' -d '{
  "data": {
    "endpoint": "zeusBtcAddress"
  }
}'

{
  "result": null,
  "data": {
    "result": [
      {
        "address": "bc1p00vntla5vtehaqxt7l24dmf7qwcxg06ft4py4w2j7lcpvgg60stsq4ma8x",
        "network": "bitcoin",
        "chainId": "mainnet"
      },
      ...
      {
        "address": "bc1qn6wjs6eg4x4fum7ucw8m4qy8ree7qartun4rja",
        "network": "bitcoin",
        "chainId": "mainnet"
      }
    ]
  },
  "timestamps": {
    "providerDataRequestedUnixMs": 1783407911919,
    "providerDataReceivedUnixMs": 1783407912290
  },
  "statusCode": 200,
  "meta": {
    "adapterName": "POR_ADDRESS_LIST",
    "transportName": "default_single_transport",
    "metrics": {
      "feedId": "N/A"
    }
  }
}
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
