### PR TITLE
OPDATA-7589: Update ZEUS_ZBTC_API_URL on por-indexer

### DIFF
--- a/.changeset/brave-pugs-know.md
+++ b/.changeset/brave-pugs-know.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/por-indexer-adapter': patch
+---
+
+Change default value of ZEUS_ZBTC_API_URL

--- a/packages/sources/por-indexer/src/config/index.ts
+++ b/packages/sources/por-indexer/src/config/index.ts
@@ -24,7 +24,7 @@ export const configDefinition = {
   ZEUS_ZBTC_API_URL: {
     description: 'API url for zeus zBTC',
     type: 'string',
-    default: 'https://indexer.zeuslayer.io/api/v2/chainlink/proof-of-reserves',
+    default: 'https://hermes.zeusnetwork.xyz/api/v2/chainlink/proof-of-reserves',
   },
   BATCH_SIZE: {
     description: 'Maximum number of addresses to send in a single request to the balance indexer',


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/OPDATA-7589

## Description

The Zeus team changed the domain of their API URL.

## Changes

Change the default value of the `ZEUS_ZBTC_API_URL` config variable.

## Steps to Test

```
curl --silent -S -X POST http://localhost:8080 -H 'Content-Type: application/json' -d '{
  "data": {
    "endpoint": "zeusMinerFee"
  }
}'

{
  "result": "0.04682",
  "data": {
    "result": "0.04682"
  },
  "timestamps": {
    "providerDataRequestedUnixMs": 1783415202592,
    "providerDataReceivedUnixMs": 1783415203260,
    "providerIndicatedTimeUnixMs": 1783414881874
  },
  "statusCode": 200,
  "meta": {
    "adapterName": "POR_INDEXER",
    "transportName": "default_single_transport",
    "metrics": {
      "feedId": "N/A"
    }
  }
}
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
