### PR TITLE
OPDATA-6773: Add six market-status logic

### DIFF
--- a/.changeset/tiny-seas-worry.md
+++ b/.changeset/tiny-seas-worry.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/six-adapter': minor
+---
+
+Implement market-status logic

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -7001,9 +7001,11 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@chainlink/external-adapter-framework", "npm:2.16.1"],\
           ["@chainlink/six-adapter", "workspace:packages/sources/six"],\
+          ["@date-fns/tz", "npm:1.4.1"],\
           ["@sinonjs/fake-timers", "npm:15.4.0"],\
           ["@types/jest", "npm:29.5.14"],\
           ["@types/node", "npm:22.14.1"],\
+          ["date-fns", "npm:4.1.0"],\
           ["nock", "npm:13.5.6"],\
           ["tslib", "npm:2.4.1"],\
           ["typescript", "patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"]\

--- a/packages/sources/six/package.json
+++ b/packages/sources/six/package.json
@@ -36,6 +36,8 @@
   },
   "dependencies": {
     "@chainlink/external-adapter-framework": "2.16.1",
+    "@date-fns/tz": "^1.4.1",
+    "date-fns": "^4.1.0",
     "tslib": "2.4.1"
   }
 }

--- a/packages/sources/six/src/transport/market-status.ts
+++ b/packages/sources/six/src/transport/market-status.ts
@@ -1,7 +1,12 @@
 import { MarketStatus } from '@chainlink/external-adapter-framework/adapter'
 import { HttpTransport } from '@chainlink/external-adapter-framework/transports'
+import { AdapterError } from '@chainlink/external-adapter-framework/validation/error'
+import { tz, TZDate } from '@date-fns/tz'
+import { ContextFn, format, isValid, isWithinInterval, parse, startOfDay } from 'date-fns'
 import https from 'https'
 import { BaseEndpointTypes } from '../endpoint/market-status'
+
+type Timezone = ContextFn<TZDate>
 
 export interface GraphqlRequest {
   query: string
@@ -10,14 +15,32 @@ export interface GraphqlRequest {
   }
 }
 
+type Holiday =
+  | {
+      date: string
+      extraordinaryTradingDay: true
+      extraordinaryOpeningTime: string
+      extraordinaryClosingTime: string
+    }
+  | {
+      date: string
+      extraordinaryTradingDay: false
+      extraordinaryOpeningTime: null
+      extraordinaryClosingTime: null
+    }
+
 export interface ResponseSchema {
   data: {
     markets: {
       referenceData: {
         marketBase: {
           bc: number | string
-          marketStatus: string
+          tradingDays: string[]
+          marketTimeZone: string
+          marketOpenTime: string
+          marketCloseTime: string
         }
+        marketHolidays: Holiday[]
       }
     }[]
   }
@@ -29,54 +52,71 @@ export type HttpTransportTypes = BaseEndpointTypes & {
     ResponseBody: ResponseSchema
   }
 }
-export const httpTransport = new HttpTransport<HttpTransportTypes>({
-  prepareRequests: (params, config) => {
-    return {
-      params,
-      request: {
-        method: 'POST',
-        baseURL: config.API_ENDPOINT,
-        url: '/web/v2/graphql',
-        headers: {
-          accept: 'application/json',
-          'content-type': 'application/json',
-        },
-        data: {
-          query: marketStatusGraphqlQuery,
-          variables: {
-            ids: params.map((p) => p.market).sort(),
-          },
-        },
-        httpsAgent: new https.Agent({
-          cert: config.PUBLIC_CERT,
-          key: config.PRIVATE_KEY,
-        }),
-      },
-    }
-  },
-  parseResponse: (params, response) => {
-    if (!response.data?.data?.markets) {
-      return params.map((param) => ({
-        params: param,
-        response: {
-          errorMessage: `The data provider didn't return any value for ${param.market}`,
-          statusCode: 502,
-        },
-      }))
-    }
 
-    return params.map((param) => {
-      const result = getMarketStatus(param.market, response.data.data.markets)
-      return {
-        params: param,
-        response: {
-          result: result.result,
-          data: result,
-        },
-      }
+export class MarketStatusHttpTransport extends HttpTransport<HttpTransportTypes> {
+  constructor() {
+    super({
+      prepareRequests: (params, config) => {
+        return {
+          params,
+          request: {
+            method: 'POST',
+            baseURL: config.API_ENDPOINT,
+            url: '/web/v2/graphql',
+            headers: {
+              accept: 'application/json',
+              'content-type': 'application/json',
+            },
+            data: {
+              query: marketStatusGraphqlQuery,
+              variables: {
+                ids: params.map((p) => p.market).sort(),
+              },
+            },
+            httpsAgent: new https.Agent({
+              cert: config.PUBLIC_CERT,
+              key: config.PRIVATE_KEY,
+            }),
+          },
+        }
+      },
+      parseResponse: (params, response) => {
+        if (!response.data?.data?.markets) {
+          return params.map((param) => ({
+            params: param,
+            response: {
+              errorMessage: `The data provider didn't return any value for ${param.market}`,
+              statusCode: 502,
+            },
+          }))
+        }
+
+        return params.map((param) => {
+          try {
+            const result = getMarketStatusResult(param.market, response.data.data.markets)
+            return {
+              params: param,
+              response: {
+                result: result.result,
+                data: result,
+              },
+            }
+          } catch (error) {
+            const statusCode = error instanceof AdapterError ? error.statusCode : 502
+            const errorMessage = error instanceof Error ? error.message : String(error)
+            return {
+              params: param,
+              response: {
+                errorMessage,
+                statusCode,
+              },
+            }
+          }
+        })
+      },
     })
-  },
-})
+  }
+}
 
 export const marketStatusGraphqlQuery = `
   query MarketBase($ids: [UserInputId!]!) {
@@ -84,25 +124,116 @@ export const marketStatusGraphqlQuery = `
       referenceData {
         marketBase {
           bc
-          marketStatus
+          tradingDays
+          marketTimeZone
+          marketOpenTime
+          marketCloseTime
+        }
+        marketHolidays {
+          date
+          extraordinaryTradingDay
+          extraordinaryOpeningTime
+          extraordinaryClosingTime
         }
       }
     }
   }`.replace(/\s+/g, ' ')
 
-const getMarketStatus = (market: string, statuses: ResponseSchema['data']['markets']) => {
-  const status = statuses.find((s) => s.referenceData?.marketBase?.bc?.toString() === market)
-  const marketStatus = status?.referenceData?.marketBase?.marketStatus
-
-  let result = MarketStatus.UNKNOWN
-  if (marketStatus === 'ACTIVE') {
-    result = MarketStatus.OPEN
-  } else if (marketStatus === 'INACTIVE') {
-    result = MarketStatus.CLOSED
-  }
+const getMarketStatusResult = (
+  market: string,
+  responseMarkets: ResponseSchema['data']['markets'],
+) => {
+  const result = getMarketStatus(market, responseMarkets)
 
   return {
     result,
     statusString: MarketStatus[result],
   }
 }
+
+const getMarketStatus = (market: string, responseMarkets: ResponseSchema['data']['markets']) => {
+  const referenceData = responseMarkets.find(
+    (m) => m.referenceData.marketBase.bc?.toString() === market,
+  )?.referenceData
+
+  if (!referenceData) {
+    const foundMarkets = responseMarkets
+      .map((m) => m.referenceData.marketBase.bc?.toString())
+      .join(', ')
+    throw new AdapterError({
+      statusCode: 502,
+      message: `Market '${market}' not found in response. Found: ${foundMarkets}`,
+    })
+  }
+
+  const timezone = tz(referenceData.marketBase.marketTimeZone)
+  const now = Date.now()
+  const today = startOfDay(now, { in: timezone })
+
+  const openAndCloseTime = getOpenAndCloseTimeFor(today, referenceData)
+  if (!openAndCloseTime) {
+    return MarketStatus.CLOSED
+  }
+  const { openTime, closeTime } = openAndCloseTime
+
+  const start = parseTimeOfDay({ timeStr: openTime, day: today, timezone })
+  const end = parseTimeOfDay({ timeStr: closeTime, day: today, timezone })
+  if (isWithinInterval(now, { start, end })) {
+    return MarketStatus.OPEN
+  } else {
+    return MarketStatus.CLOSED
+  }
+}
+
+const getOpenAndCloseTimeFor = (
+  today: TZDate,
+  referenceData: ResponseSchema['data']['markets'][0]['referenceData'],
+): { openTime: string; closeTime: string } | undefined => {
+  const todayString = format(today, 'yyyy-MM-dd')
+  const holiday = referenceData.marketHolidays.find((h) => h.date === todayString)
+
+  if (holiday !== undefined) {
+    if (!holiday.extraordinaryTradingDay) {
+      return undefined
+    }
+
+    return {
+      openTime: holiday.extraordinaryOpeningTime,
+      closeTime: holiday.extraordinaryClosingTime,
+    }
+  }
+
+  const tradingDays = referenceData.marketBase.tradingDays.map((d) => d.toUpperCase())
+  const dayOfWeek = format(today, 'EEEE').toUpperCase()
+
+  if (!tradingDays.includes(dayOfWeek)) {
+    return undefined
+  }
+
+  return {
+    openTime: referenceData.marketBase.marketOpenTime,
+    closeTime: referenceData.marketBase.marketCloseTime,
+  }
+}
+
+const parseTimeOfDay = ({
+  timeStr,
+  day,
+  timezone,
+}: {
+  timeStr: string
+  day: TZDate
+  timezone: Timezone
+}): TZDate => {
+  const timeFormat = 'HH:mm:ss'
+  const time = parse(timeStr, timeFormat, day, { in: timezone })
+  if (!isValid(time)) {
+    throw new AdapterError({
+      statusCode: 502,
+      message: `Invalid time format: '${timeStr}', expected '${timeFormat}'`,
+    })
+  }
+  return time
+}
+
+export const httpTransport = new MarketStatusHttpTransport()

--- a/packages/sources/six/src/transport/market-status.ts
+++ b/packages/sources/six/src/transport/market-status.ts
@@ -194,6 +194,7 @@ const getOpenAndCloseTimeFor = (
 
   if (holiday !== undefined) {
     if (!holiday.extraordinaryTradingDay) {
+      // market is closed the entire day
       return undefined
     }
 
@@ -207,6 +208,7 @@ const getOpenAndCloseTimeFor = (
   const dayOfWeek = format(today, 'EEEE').toUpperCase()
 
   if (!tradingDays.includes(dayOfWeek)) {
+    // market is not open on this day of the week
     return undefined
   }
 

--- a/packages/sources/six/test/integration/__snapshots__/market-status.test.ts.snap
+++ b/packages/sources/six/test/integration/__snapshots__/market-status.test.ts.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`execute market-status endpoint should return error when market is not in response 1`] = `
+{
+  "errorMessage": "Market '5' not found in response. Found: 4, 2",
+  "statusCode": 502,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 978347471111,
+    "providerDataRequestedUnixMs": 978347471111,
+  },
+}
+`;
+
 exports[`execute market-status endpoint should return success with closed market 1`] = `
 {
   "data": {
@@ -22,36 +33,6 @@ exports[`execute market-status endpoint should return success with open market 1
     "statusString": "OPEN",
   },
   "result": 2,
-  "statusCode": 200,
-  "timestamps": {
-    "providerDataReceivedUnixMs": 978347471111,
-    "providerDataRequestedUnixMs": 978347471111,
-  },
-}
-`;
-
-exports[`execute market-status endpoint should return unknown for REFERENCE_ONLY market status 1`] = `
-{
-  "data": {
-    "result": 0,
-    "statusString": "UNKNOWN",
-  },
-  "result": 0,
-  "statusCode": 200,
-  "timestamps": {
-    "providerDataReceivedUnixMs": 978347471111,
-    "providerDataRequestedUnixMs": 978347471111,
-  },
-}
-`;
-
-exports[`execute market-status endpoint should return unknown when market is not in response 1`] = `
-{
-  "data": {
-    "result": 0,
-    "statusString": "UNKNOWN",
-  },
-  "result": 0,
   "statusCode": 200,
   "timestamps": {
     "providerDataReceivedUnixMs": 978347471111,

--- a/packages/sources/six/test/integration/market-status-fixtures.ts
+++ b/packages/sources/six/test/integration/market-status-fixtures.ts
@@ -1,6 +1,45 @@
 import nock from 'nock'
 import { marketStatusGraphqlQuery } from '../../src/transport/market-status'
 
+const allMarketData = [
+  {
+    referenceData: {
+      marketBase: {
+        bc: 4,
+        tradingDays: ['MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY'],
+        marketOpenTime: '08:30:00',
+        marketCloseTime: '17:40:00',
+        marketTimeZone: 'Europe/Zurich',
+      },
+      marketHolidays: [],
+    },
+  },
+  {
+    referenceData: {
+      marketBase: {
+        bc: 2,
+        tradingDays: ['MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY'],
+        marketOpenTime: '08:30:00',
+        marketCloseTime: '17:40:00',
+        marketTimeZone: 'Europe/Zurich',
+      },
+      marketHolidays: [
+        {
+          date: '2001-01-01',
+          extraordinaryTradingDay: false,
+          extraordinaryOpeningTime: null,
+          extraordinaryClosingTime: null,
+        },
+      ],
+    },
+  },
+]
+
+const getMarketData = (ids: string[]) => {
+  const idSet = new Set(ids)
+  return allMarketData.filter((market) => idSet.has(market.referenceData.marketBase.bc.toString()))
+}
+
 export const mockOneMarket = (): nock.Scope =>
   nock('https://api.six-group.com')
     .post('/web/v2/graphql', {
@@ -13,16 +52,7 @@ export const mockOneMarket = (): nock.Scope =>
       200,
       {
         data: {
-          markets: [
-            {
-              referenceData: {
-                marketBase: {
-                  bc: 4,
-                  marketStatus: 'ACTIVE',
-                },
-              },
-            },
-          ],
+          markets: getMarketData(['4']),
         },
       },
       ['Content-Type', 'application/json'],
@@ -41,24 +71,7 @@ export const mockTwoMarkets = (): nock.Scope =>
       200,
       {
         data: {
-          markets: [
-            {
-              referenceData: {
-                marketBase: {
-                  bc: 4,
-                  marketStatus: 'ACTIVE',
-                },
-              },
-            },
-            {
-              referenceData: {
-                marketBase: {
-                  bc: 2,
-                  marketStatus: 'INACTIVE',
-                },
-              },
-            },
-          ],
+          markets: getMarketData(['2', '4']),
         },
       },
       ['Content-Type', 'application/json'],
@@ -70,83 +83,14 @@ export const mockThreeMarkets = (): nock.Scope =>
     .post('/web/v2/graphql', {
       query: marketStatusGraphqlQuery,
       variables: {
-        ids: ['2', '3', '4'],
+        ids: ['2', '4', '5'],
       },
     })
     .reply(
       200,
       {
         data: {
-          markets: [
-            {
-              referenceData: {
-                marketBase: {
-                  bc: 4,
-                  marketStatus: 'ACTIVE',
-                },
-              },
-            },
-            {
-              referenceData: {
-                marketBase: {
-                  bc: 2,
-                  marketStatus: 'INACTIVE',
-                },
-              },
-            },
-            {
-              referenceData: {
-                marketBase: {
-                  bc: 3,
-                  marketStatus: 'REFERENCE_ONLY',
-                },
-              },
-            },
-          ],
-        },
-      },
-      ['Content-Type', 'application/json'],
-    )
-    .persist()
-
-export const mockFourMarkets = (): nock.Scope =>
-  nock('https://api.six-group.com')
-    .post('/web/v2/graphql', {
-      query: marketStatusGraphqlQuery,
-      variables: {
-        ids: ['2', '3', '4', '5'],
-      },
-    })
-    .reply(
-      200,
-      {
-        data: {
-          markets: [
-            {
-              referenceData: {
-                marketBase: {
-                  bc: 4,
-                  marketStatus: 'ACTIVE',
-                },
-              },
-            },
-            {
-              referenceData: {
-                marketBase: {
-                  bc: 2,
-                  marketStatus: 'INACTIVE',
-                },
-              },
-            },
-            {
-              referenceData: {
-                marketBase: {
-                  bc: 3,
-                  marketStatus: 'REFERENCE_ONLY',
-                },
-              },
-            },
-          ],
+          markets: getMarketData(['2', '4', '5']),
         },
       },
       ['Content-Type', 'application/json'],

--- a/packages/sources/six/test/integration/market-status.test.ts
+++ b/packages/sources/six/test/integration/market-status.test.ts
@@ -4,12 +4,7 @@ import {
   setEnvVariables,
 } from '@chainlink/external-adapter-framework/util/testing-utils'
 import * as nock from 'nock'
-import {
-  mockFourMarkets,
-  mockOneMarket,
-  mockThreeMarkets,
-  mockTwoMarkets,
-} from './market-status-fixtures'
+import { mockOneMarket, mockThreeMarkets, mockTwoMarkets } from './market-status-fixtures'
 
 describe('execute', () => {
   let spy: jest.SpyInstance
@@ -50,9 +45,9 @@ describe('execute', () => {
         endpoint: 'market-status',
         market: 'six',
       })
-      expect(response.statusCode).toBe(200)
-      expect(response.json().result).toEqual(MarketStatus.OPEN)
       expect(response.json()).toMatchSnapshot()
+      expect(response.json().result).toEqual(MarketStatus.OPEN)
+      expect(response.statusCode).toBe(200)
     })
 
     it('should return success with closed market', async () => {
@@ -61,31 +56,19 @@ describe('execute', () => {
         endpoint: 'market-status',
         market: '2',
       })
-      expect(response.statusCode).toBe(200)
+      expect(response.json()).toMatchSnapshot()
       expect(response.json().result).toEqual(MarketStatus.CLOSED)
-      expect(response.json()).toMatchSnapshot()
-    })
-
-    it('should return unknown for REFERENCE_ONLY market status', async () => {
-      mockThreeMarkets()
-      const response = await testAdapter.request({
-        endpoint: 'market-status',
-        market: '3',
-      })
       expect(response.statusCode).toBe(200)
-      expect(response.json().result).toEqual(MarketStatus.UNKNOWN)
-      expect(response.json()).toMatchSnapshot()
     })
 
-    it('should return unknown when market is not in response', async () => {
-      mockFourMarkets()
+    it('should return error when market is not in response', async () => {
+      mockThreeMarkets()
       const response = await testAdapter.request({
         endpoint: 'market-status',
         market: '5',
       })
-      expect(response.statusCode).toBe(200)
-      expect(response.json().result).toEqual(MarketStatus.UNKNOWN)
       expect(response.json()).toMatchSnapshot()
+      expect(response.statusCode).toBe(502)
     })
   })
 })

--- a/packages/sources/six/test/unit/market-status.test.ts
+++ b/packages/sources/six/test/unit/market-status.test.ts
@@ -1,0 +1,473 @@
+import { EndpointContext } from '@chainlink/external-adapter-framework/adapter'
+import { calculateHttpRequestKey } from '@chainlink/external-adapter-framework/cache'
+import { metrics } from '@chainlink/external-adapter-framework/metrics'
+import { TransportDependencies } from '@chainlink/external-adapter-framework/transports'
+import { LoggerFactoryProvider } from '@chainlink/external-adapter-framework/util'
+import { makeStub } from '@chainlink/external-adapter-framework/util/testing-utils'
+import { inputParameters } from '../../src/endpoint/market-status'
+import { HttpTransportTypes, MarketStatusHttpTransport } from '../../src/transport/market-status'
+
+const log = jest.fn()
+const debugLog = jest.fn()
+const logger = {
+  fatal: log,
+  error: log,
+  warn: log,
+  info: log,
+  debug: debugLog,
+  trace: debugLog,
+  msgPrefix: 'mock-logger',
+}
+
+const loggerFactory = { child: () => logger }
+
+LoggerFactoryProvider.set(loggerFactory)
+metrics.initialize()
+
+const marketStatusGraphqlQuery = `
+  query MarketBase($ids: [UserInputId!]!) {
+    markets(scheme: BC, ids: $ids) {
+      referenceData {
+        marketBase {
+          bc
+          tradingDays
+          marketTimeZone
+          marketOpenTime
+          marketCloseTime
+        }
+        marketHolidays {
+          date
+          extraordinaryTradingDay
+          extraordinaryOpeningTime
+          extraordinaryClosingTime
+        }
+      }
+    }
+  }`.replace(/\s+/g, ' ')
+
+const marketStatusResponse = {
+  data: {
+    markets: [
+      {
+        referenceData: {
+          marketBase: {
+            bc: 1058,
+            tradingDays: ['MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY'],
+            marketOpenTime: '08:30:00',
+            marketCloseTime: '17:45:00',
+            marketTimeZone: 'Europe/Madrid',
+          },
+          marketHolidays: [
+            {
+              date: '2026-01-01',
+              extraordinaryTradingDay: false,
+              extraordinaryOpeningTime: null,
+              extraordinaryClosingTime: null,
+            },
+            {
+              date: '2026-04-03',
+              extraordinaryTradingDay: false,
+              extraordinaryOpeningTime: null,
+              extraordinaryClosingTime: null,
+            },
+            {
+              date: '2026-04-06',
+              extraordinaryTradingDay: false,
+              extraordinaryOpeningTime: null,
+              extraordinaryClosingTime: null,
+            },
+            {
+              date: '2026-05-01',
+              extraordinaryTradingDay: false,
+              extraordinaryOpeningTime: null,
+              extraordinaryClosingTime: null,
+            },
+            {
+              date: '2026-12-24',
+              extraordinaryTradingDay: true,
+              extraordinaryOpeningTime: '09:00:00',
+              extraordinaryClosingTime: '13:55:00',
+            },
+            {
+              date: '2026-12-25',
+              extraordinaryTradingDay: false,
+              extraordinaryOpeningTime: null,
+              extraordinaryClosingTime: null,
+            },
+            {
+              date: '2026-12-31',
+              extraordinaryTradingDay: true,
+              extraordinaryOpeningTime: '09:00:00',
+              extraordinaryClosingTime: '13:55:00',
+            },
+          ],
+        },
+      },
+    ],
+  },
+}
+
+describe('MarketStatusHttpTransport', () => {
+  const transportName = 'default_single_transport'
+  const endpointName = 'market-status'
+  const publicCert = 'test-public-cert'
+  const privateKey = 'test-private-key'
+  const apiUrl = 'http://api.example.com'
+
+  const bmeId = '1058'
+
+  const adapterSettings = makeStub('adapterSettings', {
+    API_ENDPOINT: apiUrl,
+    PUBLIC_CERT: publicCert,
+    PRIVATE_KEY: privateKey,
+    CACHE_MAX_AGE: 90_000,
+    MAX_COMMON_KEY_SIZE: 300,
+    WARMUP_SUBSCRIPTION_TTL: 10_000,
+  } as unknown as HttpTransportTypes['Settings'])
+
+  const subscriptionSet = makeStub('subscriptionSet', {
+    getAll: jest.fn(),
+  })
+
+  const subscriptionSetFactory = makeStub('subscriptionSetFactory', {
+    buildSet() {
+      return subscriptionSet
+    },
+  })
+
+  const requester = makeStub('requester', {
+    request: jest.fn(),
+  })
+
+  const responseCache = {
+    write: jest.fn(),
+  }
+  const dependencies = makeStub('dependencies', {
+    requester,
+    responseCache,
+    subscriptionSetFactory,
+  } as unknown as TransportDependencies<HttpTransportTypes>)
+
+  let transport: MarketStatusHttpTransport
+
+  const requestKeyForParams = (params: typeof inputParameters.validated) => {
+    const requestKey = calculateHttpRequestKey<HttpTransportTypes>({
+      context: {
+        adapterSettings,
+        inputParameters,
+        endpointName,
+      },
+      data: [params],
+      transportName,
+    })
+    return requestKey
+  }
+
+  beforeEach(async () => {
+    jest.resetAllMocks()
+    jest.useFakeTimers()
+
+    transport = new MarketStatusHttpTransport()
+
+    await transport.initialize(dependencies, adapterSettings, endpointName, transportName)
+  })
+
+  afterEach(() => {
+    expect(log).not.toHaveBeenCalled()
+  })
+
+  const doMarketStatusTest = async (
+    currentTime: Date,
+    expectedResponseData: { result: number; statusString: string },
+  ) => {
+    jest.setSystemTime(currentTime)
+    const params = makeStub('params', {
+      market: bmeId,
+      type: 'regular',
+      force245MarketStatus: false,
+    } as const)
+    subscriptionSet.getAll.mockReturnValue([params])
+
+    const context = makeStub('context', {
+      adapterSettings,
+      endpointName,
+    } as EndpointContext<HttpTransportTypes>)
+
+    const response = makeStub('response', {
+      response: {
+        data: {
+          ...marketStatusResponse,
+          cost: undefined,
+        },
+      },
+      timestamps: {},
+    })
+
+    requester.request.mockResolvedValue(response)
+
+    await transport.backgroundExecute(context)
+
+    const expectedRequestConfig = {
+      method: 'POST',
+      baseURL: adapterSettings.API_ENDPOINT,
+      url: '/web/v2/graphql',
+      headers: {
+        accept: 'application/json',
+        'content-type': 'application/json',
+      },
+      data: {
+        query: marketStatusGraphqlQuery,
+        variables: {
+          ids: [params.market],
+        },
+      },
+      httpsAgent: expect.anything(),
+    }
+    const expectedRequestKey = requestKeyForParams(params)
+
+    const expectedResponse = {
+      result: expectedResponseData.result,
+      data: expectedResponseData,
+      timestamps: {},
+    }
+
+    expect(requester.request).toHaveBeenCalledWith(
+      expectedRequestKey,
+      expectedRequestConfig,
+      undefined,
+    )
+    expect(requester.request).toHaveBeenCalledTimes(1)
+
+    expect(responseCache.write).toHaveBeenCalledWith(transportName, [
+      {
+        params,
+        response: expectedResponse,
+      },
+    ])
+    expect(responseCache.write).toHaveBeenCalledTimes(1)
+  }
+
+  it('should open the market Monday morning', async () => {
+    await doMarketStatusTest(new Date('2026-01-05T08:29:59+01:00'), {
+      result: 1,
+      statusString: 'CLOSED',
+    })
+    jest.resetAllMocks()
+    await doMarketStatusTest(new Date('2026-01-05T08:30:01+01:00'), {
+      result: 2,
+      statusString: 'OPEN',
+    })
+  })
+
+  it('should close the market Monday afternoon', async () => {
+    await doMarketStatusTest(new Date('2026-01-05T17:44:59+01:00'), {
+      result: 2,
+      statusString: 'OPEN',
+    })
+    jest.resetAllMocks()
+    await doMarketStatusTest(new Date('2026-01-05T17:45:01+01:00'), {
+      result: 1,
+      statusString: 'CLOSED',
+    })
+  })
+
+  it('should open the market Friday morning', async () => {
+    await doMarketStatusTest(new Date('2026-01-09T08:29:59+01:00'), {
+      result: 1,
+      statusString: 'CLOSED',
+    })
+    jest.resetAllMocks()
+    await doMarketStatusTest(new Date('2026-01-09T08:30:01+01:00'), {
+      result: 2,
+      statusString: 'OPEN',
+    })
+  })
+
+  it('should close the market Friday afternoon', async () => {
+    await doMarketStatusTest(new Date('2026-01-09T17:44:59+01:00'), {
+      result: 2,
+      statusString: 'OPEN',
+    })
+    jest.resetAllMocks()
+    await doMarketStatusTest(new Date('2026-01-09T17:45:01+01:00'), {
+      result: 1,
+      statusString: 'CLOSED',
+    })
+  })
+
+  it('should be closed on Saturday', async () => {
+    await doMarketStatusTest(new Date('2026-01-10T10:45:00+01:00'), {
+      result: 1,
+      statusString: 'CLOSED',
+    })
+  })
+
+  it('should be closed on Sunday', async () => {
+    await doMarketStatusTest(new Date('2026-01-11T10:45:00+01:00'), {
+      result: 1,
+      statusString: 'CLOSED',
+    })
+  })
+
+  it('should open the market in the morning in summer time', async () => {
+    await doMarketStatusTest(new Date('2026-07-08T08:29:59+02:00'), {
+      result: 1,
+      statusString: 'CLOSED',
+    })
+    jest.resetAllMocks()
+    await doMarketStatusTest(new Date('2026-07-08T08:30:01+02:00'), {
+      result: 2,
+      statusString: 'OPEN',
+    })
+  })
+
+  it('should close the market in the evening in summer time', async () => {
+    await doMarketStatusTest(new Date('2026-07-08T17:44:59+02:00'), {
+      result: 2,
+      statusString: 'OPEN',
+    })
+    jest.resetAllMocks()
+    await doMarketStatusTest(new Date('2026-07-08T17:45:01+02:00'), {
+      result: 1,
+      statusString: 'CLOSED',
+    })
+  })
+
+  it('should open the market late on Christmas eve', async () => {
+    await doMarketStatusTest(new Date('2026-12-24T08:59:59+01:00'), {
+      result: 1,
+      statusString: 'CLOSED',
+    })
+    jest.resetAllMocks()
+    await doMarketStatusTest(new Date('2026-12-24T09:00:01+01:00'), {
+      result: 2,
+      statusString: 'OPEN',
+    })
+  })
+
+  it('should close the market early on Christmas eve', async () => {
+    await doMarketStatusTest(new Date('2026-12-24T13:54:50+01:00'), {
+      result: 2,
+      statusString: 'OPEN',
+    })
+    jest.resetAllMocks()
+    await doMarketStatusTest(new Date('2026-12-24T13:55:01+01:00'), {
+      result: 1,
+      statusString: 'CLOSED',
+    })
+  })
+
+  it('should be closed on Christmas', async () => {
+    await doMarketStatusTest(new Date('2026-12-25T10:45:00+01:00'), {
+      result: 1,
+      statusString: 'CLOSED',
+    })
+  })
+
+  const doMarketStatusErrorTest = async (
+    responseData: object,
+    expectedErrorResponse: { errorMessage: string; statusCode: number },
+  ) => {
+    // A trading day (Monday) during market hours, so that the invalid time format
+    // test reaches the time parsing. The other error cases fail before any time logic.
+    jest.setSystemTime(new Date('2026-01-05T10:45:00+01:00'))
+    const params = makeStub('params', {
+      market: bmeId,
+      type: 'regular',
+      force245MarketStatus: false,
+    } as const)
+    subscriptionSet.getAll.mockReturnValue([params])
+
+    const context = makeStub('context', {
+      adapterSettings,
+      endpointName,
+    } as EndpointContext<HttpTransportTypes>)
+
+    const response = makeStub('response', {
+      response: {
+        data: {
+          ...responseData,
+          cost: undefined,
+        },
+      },
+      timestamps: {},
+    })
+
+    requester.request.mockResolvedValue(response)
+
+    await transport.backgroundExecute(context)
+
+    const expectedResponse = {
+      ...expectedErrorResponse,
+      timestamps: {},
+    }
+
+    expect(responseCache.write).toHaveBeenCalledWith(transportName, [
+      {
+        params,
+        response: expectedResponse,
+      },
+    ])
+    expect(responseCache.write).toHaveBeenCalledTimes(1)
+  }
+
+  it('should return an error when the provider returns no markets', async () => {
+    await doMarketStatusErrorTest(
+      { data: { markets: undefined } },
+      {
+        errorMessage: `The data provider didn't return any value for ${bmeId}`,
+        statusCode: 502,
+      },
+    )
+  })
+
+  it('should return an error when the requested market is not in the response', async () => {
+    const otherMarketResponse = {
+      data: {
+        markets: [
+          {
+            referenceData: {
+              marketBase: {
+                bc: 9999,
+                tradingDays: ['MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY'],
+                marketOpenTime: '08:30:00',
+                marketCloseTime: '17:45:00',
+                marketTimeZone: 'Europe/Madrid',
+              },
+              marketHolidays: [],
+            },
+          },
+        ],
+      },
+    }
+    await doMarketStatusErrorTest(otherMarketResponse, {
+      errorMessage: `Market '${bmeId}' not found in response. Found: 9999`,
+      statusCode: 502,
+    })
+  })
+
+  it('should return an error when the market has an invalid time format', async () => {
+    const invalidTimeResponse = {
+      data: {
+        markets: [
+          {
+            referenceData: {
+              marketBase: {
+                bc: 1058,
+                tradingDays: ['MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY'],
+                marketOpenTime: 'not-a-time',
+                marketCloseTime: '17:45:00',
+                marketTimeZone: 'Europe/Madrid',
+              },
+              marketHolidays: [],
+            },
+          },
+        ],
+      },
+    }
+    await doMarketStatusErrorTest(invalidTimeResponse, {
+      errorMessage: `Invalid time format: 'not-a-time', expected 'HH:mm:ss'`,
+      statusCode: 502,
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -4447,9 +4447,11 @@ __metadata:
   resolution: "@chainlink/six-adapter@workspace:packages/sources/six"
   dependencies:
     "@chainlink/external-adapter-framework": "npm:2.16.1"
+    "@date-fns/tz": "npm:^1.4.1"
     "@sinonjs/fake-timers": "npm:15.4.0"
     "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:22.14.1"
+    date-fns: "npm:^4.1.0"
     nock: "npm:13.5.6"
     tslib: "npm:2.4.1"
     typescript: "npm:5.8.3"


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/OPDATA-6773

## Description

The current market-status logic in `six` is not correct.
We need to:

1. Fetch the list of holidays
    1. On some holidays the market is closed and on others there are adjusted opening times.
2. Fetch the weekdays that are trading day and normal trading hours.
3. Check which case we are in and whether the current time is during opening hours.

Everything is fetched in a single request using graphql.

## Changes

1. Add an exported transport class for testing.
2. Adjust the logic as described above.
3. Update the integration test.
4. Add unit tests.

## Steps to Test

```
yarn test packages/sources/six
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
