### PR TITLE
Remove the-network-firm from shared empty framework-bump changeset

### DIFF
--- a/.changeset/calm-balloons-cheat.md
+++ b/.changeset/calm-balloons-cheat.md
@@ -1,5 +1,5 @@
 ---
-'@chainlink/the-network-firm-adapter': patch
+'@chainlink/the-network-firm-adapter': minor
 ---
 
 Add `wystc` endpoint for Wyoming Stablecoin Commission FRNT Proof-of-Reserves feed

--- a/.changeset/icy-emus-turn.md
+++ b/.changeset/icy-emus-turn.md
@@ -8,7 +8,6 @@
 '@chainlink/deutsche-boerse-adapter': minor
 '@chainlink/expand-network-adapter': minor
 '@chainlink/mobula-state-adapter': minor
-'@chainlink/the-network-firm-adapter': minor
 '@chainlink/tp-adapter': minor
 ---
 


### PR DESCRIPTION
## Description

This PR removes `the-network-firm` from the shared `icy-emus-turn.md` changeset so it can be released on its own, and drops the placeholder framework-bump changeset.

### Background

- `icy-emus-turn.md` was added in #5138 (changeset-only, no code changes). It does **not** actually update the framework version — the real framework bump was #5113, already released in #5123 (Release 1.362.0). All 11 adapters it lists already reference framework `2.17.1`.
- Because the changeset is shared across 11 adapters, `upsert-release-pr` with `selected-adapters=the-network-firm` bundles TNF with 15 other adapters (see closed PR #5186).

### Changes

- Remove the `@chainlink/the-network-firm-adapter` line from `icy-emus-turn.md`. The remaining 10 adapters are left untouched for @yaroslav-glukhov-chainlink's streams release (cc for coordination).
- Bump `calm-balloons-cheat.md` (the `wystc` endpoint, from #5161) from `patch` to `minor`, new endpoints are minor.

### Result

After merge, re-triggering `upsert-release-pr` with `selected-adapters=the-network-firm` produces a Release PR containing only `@chainlink/the-network-firm-adapter@1.9.0` (the `wystc` endpoint). TNF is a leaf dependency with no dependents, so no other adapters are pulled in.

## Related

- #5186 (closed) — previous bundled Release 1.372.0 PR (16 adapters)
- #5138 — PR that added `icy-emus-turn.md` (empty changeset)
- #5113 / #5123 — real framework bump and its release
- Runbook: [Runbook - Release external adapters](https://smartcontract-it.atlassian.net/wiki/spaces/DF/pages/1981284353/Runbook+-+Release+external+adapters)