### PR TITLE
OPDATA-8131: Add type mark_price_index to markprice endpoint options of Coinpaprika

### DIFF
--- a/.changeset/gentle-friends-speak.md
+++ b/.changeset/gentle-friends-speak.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/coinpaprika-adapter': minor
+---
+
+Add type mark_price_index to markprice endpoint options

--- a/packages/sources/coinpaprika/src/endpoint/markprice.ts
+++ b/packages/sources/coinpaprika/src/endpoint/markprice.ts
@@ -3,15 +3,8 @@ import { InputParameters } from '@chainlink/external-adapter-framework/validatio
 import { config } from '../config'
 import { wsTransport } from '../transport/markprice'
 
-export const getEventTypeFromType = (type: string): string => {
-  if (type === 'mark_price_index') {
-    return 'mark_price'
-  }
-  return type
-}
-
 export const markPriceTypeOptions = ['mark_price', 'mark_price_index']
-export const markPriceEvents = Array.from(new Set(markPriceTypeOptions.map(getEventTypeFromType)))
+export const markPriceEvents = ['mark_price']
 export const legacyTopOfBookEvents = ['top_of_book']
 export const topOfBookEvents = ['top_of_book_perps', 'top_of_book_spot']
 

--- a/packages/sources/coinpaprika/src/endpoint/markprice.ts
+++ b/packages/sources/coinpaprika/src/endpoint/markprice.ts
@@ -3,7 +3,15 @@ import { InputParameters } from '@chainlink/external-adapter-framework/validatio
 import { config } from '../config'
 import { wsTransport } from '../transport/markprice'
 
-export const markPriceEvents = ['mark_price']
+export const getEventTypeFromType = (type: string): string => {
+  if (type === 'mark_price_index') {
+    return 'mark_price'
+  }
+  return type
+}
+
+export const markPriceTypeOptions = ['mark_price', 'mark_price_index']
+export const markPriceEvents = Array.from(new Set(markPriceTypeOptions.map(getEventTypeFromType)))
 export const legacyTopOfBookEvents = ['top_of_book']
 export const topOfBookEvents = ['top_of_book_perps', 'top_of_book_spot']
 
@@ -24,7 +32,7 @@ export const inputParameters = new InputParameters(
       description: 'The type of the price to obtain',
       required: true,
       type: 'string',
-      options: [...markPriceEvents, ...legacyTopOfBookEvents, ...topOfBookEvents],
+      options: [...markPriceTypeOptions, ...legacyTopOfBookEvents, ...topOfBookEvents],
     },
   },
   [
@@ -42,9 +50,10 @@ export type BaseEndpointTypes = {
   Response: {
     Result: number
     Data: {
-      mid: number
+      mid?: number
       bid?: number
       ask?: number
+      index_price?: number
     }
   }
 }

--- a/packages/sources/coinpaprika/src/transport/markprice.ts
+++ b/packages/sources/coinpaprika/src/transport/markprice.ts
@@ -1,9 +1,10 @@
 import { WebSocketTransport } from '@chainlink/external-adapter-framework/transports/websocket'
-import { makeLogger } from '@chainlink/external-adapter-framework/util'
+import { makeLogger, ProviderResult } from '@chainlink/external-adapter-framework/util'
 import { TypeFromDefinition } from '@chainlink/external-adapter-framework/validation/input-params'
 import Decimal from 'decimal.js'
 import {
   BaseEndpointTypes,
+  getEventTypeFromType,
   legacyTopOfBookEvents,
   markPriceEvents,
   topOfBookEvents,
@@ -16,6 +17,7 @@ type WsMessage = {
     exchange: string
     symbol: string
     price: string
+    index_price?: string
     bid_price: string
     ask_price: string
     timestamp: string // "2026-03-12T15:24:40Z"
@@ -72,7 +74,7 @@ export const wsTransport = new WebSocketTransport<WsTransportTypes>({
           (s) =>
             s.exchange === message.data.exchange &&
             s.symbol === normalizedSymbol &&
-            s.type === normalizedEventType,
+            getEventTypeFromType(s.type) === normalizedEventType,
         )
       ) {
         // Skip unsubscribed messages
@@ -88,23 +90,40 @@ export const wsTransport = new WebSocketTransport<WsTransportTypes>({
         providerIndicatedTimeUnixMs: new Date(message.data.timestamp).getTime(),
       }
 
-      if (
-        markPriceEvents.includes(normalizedEventType) &&
-        message.data.price &&
-        !isNaN(Number(message.data.price))
-      ) {
-        return [
-          {
+      if (markPriceEvents.includes(normalizedEventType)) {
+        const result: ProviderResult<WsTransportTypes>[] = []
+        if (message.data.price && !isNaN(Number(message.data.price))) {
+          const price = Number(message.data.price)
+          result.push({
             params: { ...params },
             response: {
-              result: Number(message.data.price),
+              result: price,
               data: {
-                mid: Number(message.data.price),
+                mid: price,
               },
               timestamps,
             },
-          },
-        ]
+          })
+        }
+        if (message.data.index_price && !isNaN(Number(message.data.index_price))) {
+          const indexPrice = Number(message.data.index_price)
+          result.push({
+            params: {
+              ...params,
+              type: 'mark_price_index',
+            },
+            response: {
+              result: indexPrice,
+              data: {
+                index_price: indexPrice,
+              },
+              timestamps,
+            },
+          })
+        }
+        if (result.length > 0) {
+          return result
+        }
       }
 
       if (

--- a/packages/sources/coinpaprika/src/transport/markprice.ts
+++ b/packages/sources/coinpaprika/src/transport/markprice.ts
@@ -4,11 +4,16 @@ import { TypeFromDefinition } from '@chainlink/external-adapter-framework/valida
 import Decimal from 'decimal.js'
 import {
   BaseEndpointTypes,
-  getEventTypeFromType,
   legacyTopOfBookEvents,
   markPriceEvents,
   topOfBookEvents,
 } from '../endpoint/markprice'
+
+export const toWsEventType = (type: string): string =>
+  type === 'mark_price_index' ? 'mark_price' : type
+
+const toNumber = (s?: string): number | undefined =>
+  s && !isNaN(Number(s)) ? Number(s) : undefined
 
 type WsMessage = {
   event: string
@@ -74,7 +79,7 @@ export const wsTransport = new WebSocketTransport<WsTransportTypes>({
           (s) =>
             s.exchange === message.data.exchange &&
             s.symbol === normalizedSymbol &&
-            getEventTypeFromType(s.type) === normalizedEventType,
+            toWsEventType(s.type) === normalizedEventType,
         )
       ) {
         // Skip unsubscribed messages
@@ -92,8 +97,8 @@ export const wsTransport = new WebSocketTransport<WsTransportTypes>({
 
       if (markPriceEvents.includes(normalizedEventType)) {
         const result: ProviderResult<WsTransportTypes>[] = []
-        if (message.data.price && !isNaN(Number(message.data.price))) {
-          const price = Number(message.data.price)
+        const price = toNumber(message.data.price)
+        if (price !== undefined) {
           result.push({
             params: { ...params },
             response: {
@@ -105,8 +110,8 @@ export const wsTransport = new WebSocketTransport<WsTransportTypes>({
             },
           })
         }
-        if (message.data.index_price && !isNaN(Number(message.data.index_price))) {
-          const indexPrice = Number(message.data.index_price)
+        const indexPrice = toNumber(message.data.index_price)
+        if (indexPrice !== undefined) {
           result.push({
             params: {
               ...params,

--- a/packages/sources/coinpaprika/test/integration/__snapshots__/adapter-markprice.test.ts.snap
+++ b/packages/sources/coinpaprika/test/integration/__snapshots__/adapter-markprice.test.ts.snap
@@ -49,6 +49,21 @@ exports[`markprice endpoint mark_price should return success with market price 1
 }
 `;
 
+exports[`markprice endpoint mark_price should return success with market price index 1`] = `
+{
+  "data": {
+    "index_price": 97501.67,
+  },
+  "result": 97501.67,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 1114,
+    "providerDataStreamEstablishedUnixMs": 1010,
+    "providerIndicatedTimeUnixMs": 1773329080000,
+  },
+}
+`;
+
 exports[`markprice endpoint top_of_book_perps should return same result when using legacy top_of_book alias 1`] = `
 {
   "data": {

--- a/packages/sources/coinpaprika/test/integration/adapter-markprice.test.ts
+++ b/packages/sources/coinpaprika/test/integration/adapter-markprice.test.ts
@@ -23,6 +23,13 @@ describe('markprice endpoint', () => {
     type: 'mark_price',
   }
 
+  const marketpriceIndexData = {
+    endpoint: 'markprice',
+    exchange: 'binance',
+    symbol: 'btcusdt',
+    type: 'mark_price_index',
+  }
+
   const topOfBookData = {
     endpoint: 'markprice',
     exchange: 'binance',
@@ -75,6 +82,7 @@ describe('markprice endpoint', () => {
 
     await Promise.all([
       testAdapter.request(marketpriceData),
+      testAdapter.request(marketpriceIndexData),
       testAdapter.request(topOfBookData),
       testAdapter.request(topOfBookPerpsData),
       testAdapter.request(topOfBookSpotData),
@@ -94,6 +102,12 @@ describe('markprice endpoint', () => {
   describe('mark_price', () => {
     it('should return success with market price', async () => {
       const response = await testAdapter.request(marketpriceData)
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toMatchSnapshot()
+    })
+
+    it('should return success with market price index', async () => {
+      const response = await testAdapter.request(marketpriceIndexData)
       expect(response.statusCode).toBe(200)
       expect(response.json()).toMatchSnapshot()
     })

--- a/packages/sources/coinpaprika/test/integration/markprice-fixtures.ts
+++ b/packages/sources/coinpaprika/test/integration/markprice-fixtures.ts
@@ -7,6 +7,7 @@ const MARK_PRICE_MESSAGE = {
     exchange: 'binance',
     symbol: 'BTCUSDT',
     price: '97500.50',
+    index_price: '97501.67',
     timestamp: '2026-03-12T15:24:40Z',
   },
 }


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/OPDATA-8131

## Description

This PR adds an extra option (`mark_price_index`) to the `type` parameter of the `markprice` endpoint of the `coinpaprika` EA. When this option is used, we return the `index_price` instead of the `price` value from the websocket message in the response.

## Changes

1. Add `getEventTypeFromType` to know which event type provides the values for a given option. This is needed because the options no longer match directly onto the event type.
2. Use `getEventTypeFromType` to make sure we don't discard `mark_price` messages if we have `mark_price_index` subscriptions.
3. If `index_price` is present on the response, record a response for the `mark_price_index` type. 

## Steps to Test

```
curl --silent -S -X POST http://localhost:8081 -H 'Content-Type: application/json' -d '{
  "data": {
    "endpoint": "markprice",
    "exchange": "binance",
    "symbol": "HYPEUSDT",
    "type": "mark_price_index"
  }
}'

{
  "result": 63.56642857,
  "data": {
    "index_price": 63.56642857
  },
  "timestamps": {
    "providerDataStreamEstablishedUnixMs": 1784017537705,
    "providerDataReceivedUnixMs": 1784017538204,
    "providerIndicatedTimeUnixMs": 1784017538004
  },
  "statusCode": 200,
  "meta": {
    "adapterName": "COINPAPRIKA",
    "transportName": "default_single_transport",
    "metrics": {
      "feedId": "{\"exchange\":\"binance\",\"symbol\":\"hypeusdt\",\"type\":\"mark_price_index\"}"
    }
  }
}
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
