### PR TITLE
OPDATA-6773: Restore SIX in market-status

### DIFF
--- a/.changeset/tired-lands-argue.md
+++ b/.changeset/tired-lands-argue.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/market-status-adapter': minor
+---
+
+Add SIX as market status source for SIX and BME

--- a/packages/composites/market-status/src/source/sources.ts
+++ b/packages/composites/market-status/src/source/sources.ts
@@ -3,7 +3,7 @@ import { TypeFromDefinition } from '@chainlink/external-adapter-framework/valida
 
 import type { StaticSourceName } from './static'
 
-export const ADAPTER_NAMES = ['NCFX', 'TRADINGHOURS', 'FINNHUB_SECONDARY'] as const
+export const ADAPTER_NAMES = ['NCFX', 'TRADINGHOURS', 'FINNHUB_SECONDARY', 'SIX'] as const
 export type AdapterName = (typeof ADAPTER_NAMES)[number]
 
 export type SourceName = AdapterName | StaticSourceName
@@ -35,8 +35,8 @@ const marketSources: Record<string, { primary: SourceName; secondary: SourceName
     secondary: 'FINNHUB_SECONDARY',
   },
   six: {
-    primary: 'TRADINGHOURS',
-    secondary: 'FINNHUB_SECONDARY',
+    primary: 'SIX',
+    secondary: 'TRADINGHOURS',
   },
   euronext_milan: {
     primary: 'TRADINGHOURS',
@@ -77,6 +77,10 @@ const marketSources: Record<string, { primary: SourceName; secondary: SourceName
   ice_europe_energy: {
     primary: 'TRADINGHOURS',
     secondary: 'STATIC_ICE_EUROPE_ENERGY',
+  },
+  bme: {
+    primary: 'SIX',
+    secondary: 'TRADINGHOURS',
   },
 }
 

--- a/packages/composites/market-status/test/integration/adapter.test.ts
+++ b/packages/composites/market-status/test/integration/adapter.test.ts
@@ -523,4 +523,18 @@ describe('execute', () => {
       })
     })
   })
+
+  describe('missing env var', () => {
+    it('throws error', async () => {
+      let response
+      for (let i = 0; i < 10; i++) {
+        response = await testAdapter.request({
+          market: 'six',
+        })
+      }
+      expect(response.json().errorMessage).toEqual(
+        'Missing required environment variable: SIX_ADAPTER_URL',
+      )
+    })
+  })
 })


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/OPDATA-6773

## Description

We want to provide market status for the exchanges SIX and BME.

This was already added in https://github.com/smartcontractkit/external-adapters-js/pull/4963 but then removed in https://github.com/smartcontractkit/external-adapters-js/pull/5057 because the SIX EA was not deployed yet.

The SIX EA is now deployed.

## Changes

1. Revert the commit that reverted the commit that added the support originally.

## Steps to Test

```
curl --silent -S -X POST http://localhost:8080 -H 'Content-Type: application/json' -d '{
  "data": {
    "endpoint": "market-status",
    "market": "bme"
  }
}'

{
  "data": {
    "result": 2,
    "statusString": "OPEN",
    "source": "SIX"
  },
  "result": 2,
  "statusCode": 200,
  "timestamps": {
    "providerDataRequestedUnixMs": 1784037698247,
    "providerDataReceivedUnixMs": 1784037698426,
    "providerIndicatedTimeUnixMs": 1784037698426
  },
  "meta": {
    "adapterName": "MARKET_STATUS",
    "transportName": "default_single_transport",
    "metrics": {
      "feedId": "{\"force245MarketStatus\":false,\"market\":\"bme\",\"type\":\"regular\"}"
    }
  }
}

curl --silent -S -X POST http://localhost:8080 -H 'Content-Type: application/json' -d '{
  "data": {
    "endpoint": "market-status",
    "market": "six"
  }
}'

{
  "data": {
    "result": 2,
    "statusString": "OPEN",
    "source": "SIX"
  },
  "result": 2,
  "statusCode": 200,
  "timestamps": {
    "providerDataRequestedUnixMs": 1784037738667,
    "providerDataReceivedUnixMs": 1784037738854,
    "providerIndicatedTimeUnixMs": 1784037738854
  },
  "meta": {
    "adapterName": "MARKET_STATUS",
    "transportName": "default_single_transport",
    "metrics": {
      "feedId": "{\"force245MarketStatus\":false,\"market\":\"six\",\"type\":\"regular\"}"
    }
  }
}
```
Then make a typo in `SIX_ADAPTER_URL` and check that the request changes to `"source": "TRADINGHOURS"`.

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
