### PR TITLE
Fix CoinMetrics LWBA handler for asset-quotes websocket responses

### DIFF
--- a/.changeset/coinmetrics-lwba-skew-warn.md
+++ b/.changeset/coinmetrics-lwba-skew-warn.md
@@ -1,0 +1,6 @@
+---
+'@chainlink/coinmetrics-adapter': patch
+'@chainlink/coinmetrics-lwba-adapter': patch
+---
+
+Log a warning when a CoinMetrics LWBA websocket snapshot violates bid ≤ mid ≤ ask. CoinMetrics can occasionally emit such skewed snapshots on thinner/volatile markets due to timing skew between the bid, mid, and ask updates. The snapshot is still passed through so the framework's LWBA output validation rejects it as before; this only adds an ingest-time log attributing the violation to the provider and asset.

--- a/.changeset/fix-coinmetrics-lwba-asset-quotes.md
+++ b/.changeset/fix-coinmetrics-lwba-asset-quotes.md
@@ -1,0 +1,6 @@
+---
+'@chainlink/coinmetrics-adapter': patch
+'@chainlink/coinmetrics-lwba-adapter': patch
+---
+
+Fix LWBA websocket handler to parse CoinMetrics asset-quotes responses

--- a/packages/sources/coinmetrics-lwba/test/integration/fixtures.ts
+++ b/packages/sources/coinmetrics-lwba/test/integration/fixtures.ts
@@ -2,7 +2,7 @@ import { WsCryptoLwbaSuccessResponse } from '@chainlink/coinmetrics-adapter/tran
 import { MockWebsocketServer } from '@chainlink/external-adapter-framework/util/testing-utils'
 
 const wsLwbaResponseBody: WsCryptoLwbaSuccessResponse = {
-  pair: 'eth-usd',
+  asset: 'eth',
   time: '2023-03-08T04:04:33.750000000Z',
   ask_price: '1562.4083581615457',
   ask_size: '31.63132041',

--- a/packages/sources/coinmetrics/src/transport/lwba.ts
+++ b/packages/sources/coinmetrics/src/transport/lwba.ts
@@ -111,7 +111,20 @@ export const handleCryptoLwbaMessage = (
       logger.warn('LWBA quote message missing asset or pair field')
       return undefined
     }
-    const res = Number(message.mid_price)
+    const bid = Number(message.bid_price)
+    const mid = Number(message.mid_price)
+    const ask = Number(message.ask_price)
+    if (bid && mid && ask && (mid < bid || mid > ask)) {
+      // CoinMetrics can occasionally emit a snapshot where bid ≤ mid ≤ ask doesn't hold,
+      // typically due to timing skew between the bid, mid, and ask updates on thinner markets.
+      // The framework's LWBA output validation will reject this when served; log it here so the
+      // skewed snapshot is attributable to the provider (and asset) rather than only surfacing
+      // as a per-request validation error.
+      logger.warn(
+        { base, bid, mid, ask, time: message.time },
+        'CoinMetrics LWBA snapshot violates bid ≤ mid ≤ ask (likely timing skew between updates)',
+      )
+    }
     return [
       {
         params: {
@@ -121,9 +134,9 @@ export const handleCryptoLwbaMessage = (
         response: {
           result: null,
           data: {
-            bid: Number(message.bid_price),
-            mid: res,
-            ask: Number(message.ask_price),
+            bid,
+            mid,
+            ask,
           },
           timestamps: {
             providerIndicatedTimeUnixMs: new Date(message.time).getTime(),

--- a/packages/sources/coinmetrics/src/transport/lwba.ts
+++ b/packages/sources/coinmetrics/src/transport/lwba.ts
@@ -1,4 +1,5 @@
-import { BaseEndpointTypes, inputParameters } from '../endpoint/lwba'
+import { EndpointContext } from '@chainlink/external-adapter-framework/adapter'
+import { WebSocketTransport } from '@chainlink/external-adapter-framework/transports/websocket'
 import {
   makeLogger,
   PartialAdapterResponse,
@@ -6,8 +7,7 @@ import {
   ProviderResultGenerics,
 } from '@chainlink/external-adapter-framework/util'
 import { TypeFromDefinition } from '@chainlink/external-adapter-framework/validation/input-params'
-import { EndpointContext } from '@chainlink/external-adapter-framework/adapter'
-import { WebSocketTransport } from '@chainlink/external-adapter-framework/transports/websocket'
+import { BaseEndpointTypes, inputParameters } from '../endpoint/lwba'
 import { logPossibleSolutionForKnownErrors } from './error-handling'
 import { ResponseError } from './types'
 
@@ -18,8 +18,7 @@ export type MultiVarResult<T extends ProviderResultGenerics> = {
   response: PartialAdapterResponse<T['Response']>
 }
 
-export type WsCryptoLwbaSuccessResponse = {
-  pair: string
+export type WsCryptoLwbaQuoteFields = {
   time: string
   ask_price: string
   ask_size: string
@@ -29,6 +28,20 @@ export type WsCryptoLwbaSuccessResponse = {
   spread: string
   cm_sequence_id: string
 }
+
+/** Response shape from `/timeseries-stream/asset-quotes` */
+export type WsCryptoLwbaAssetQuoteSuccessResponse = WsCryptoLwbaQuoteFields & {
+  asset: string
+}
+
+/** Legacy response shape from `/timeseries-stream/pair-quotes` */
+export type WsCryptoLwbaPairQuoteSuccessResponse = WsCryptoLwbaQuoteFields & {
+  pair: string
+}
+
+export type WsCryptoLwbaSuccessResponse =
+  | WsCryptoLwbaAssetQuoteSuccessResponse
+  | WsCryptoLwbaPairQuoteSuccessResponse
 export type WsCryptoLwbaErrorResponse = {
   error: ResponseError
 }
@@ -85,7 +98,19 @@ export const handleCryptoLwbaMessage = (
   } else if ('type' in message && message.type === 'reorg') {
     logger.info(message, `Reorg response from websocket`)
   } else if ('mid_price' in message) {
-    const [base, quote] = message.pair.split('-')
+    let base: string
+    let quote: string
+    if ('asset' in message) {
+      base = message.asset
+      quote = 'USD'
+    } else if ('pair' in message) {
+      const [pairBase, pairQuote] = message.pair.split('-')
+      base = pairBase
+      quote = pairQuote ?? 'USD'
+    } else {
+      logger.warn('LWBA quote message missing asset or pair field')
+      return undefined
+    }
     const res = Number(message.mid_price)
     return [
       {

--- a/packages/sources/coinmetrics/test/integration/fixtures.ts
+++ b/packages/sources/coinmetrics/test/integration/fixtures.ts
@@ -1,7 +1,7 @@
-import nock from 'nock'
 import { MockWebsocketServer } from '@chainlink/external-adapter-framework/util/testing-utils'
-import { WsAssetMetricsSuccessResponse } from '../../src/transport/price-ws'
+import nock from 'nock'
 import { WsCryptoLwbaSuccessResponse } from '../../src/transport/lwba'
+import { WsAssetMetricsSuccessResponse } from '../../src/transport/price-ws'
 
 export const mockCoinmetricsResponseSuccess = (): nock.Scope =>
   nock('https://api.coinmetrics.io/v4')
@@ -86,7 +86,7 @@ const wsResponseBody: WsAssetMetricsSuccessResponse = {
 }
 
 const wsLwbaResponseBody: WsCryptoLwbaSuccessResponse = {
-  pair: 'eth-usd',
+  asset: 'eth',
   time: '2023-03-08T04:04:33.750000000Z',
   ask_price: '1562.4083581615457',
   ask_size: '31.63132041',

--- a/packages/sources/coinmetrics/test/unit/lwba.test.ts
+++ b/packages/sources/coinmetrics/test/unit/lwba.test.ts
@@ -85,4 +85,29 @@ describe('handleCryptoLwbaMessage', () => {
       quote: 'USD',
     })
   })
+
+  it('still passes through snapshots that violate bid ≤ mid ≤ ask (framework validation rejects them)', () => {
+    // CoinMetrics can occasionally emit a skewed snapshot on thinner markets. The transport logs
+    // a warning but still returns the data so the framework's LWBA output validation can reject it
+    // consistently, rather than silently dropping or "fixing" the update.
+    const result = handleCryptoLwbaMessage({
+      asset: 'fxs',
+      ...QUOTE_FIELDS,
+      bid_price: '1.10',
+      mid_price: '1.05',
+      ask_price: '1.20',
+    })
+    expect(result).toEqual([
+      {
+        params: { base: 'fxs', quote: 'USD' },
+        response: {
+          result: null,
+          data: { bid: 1.1, mid: 1.05, ask: 1.2 },
+          timestamps: {
+            providerIndicatedTimeUnixMs: new Date(QUOTE_FIELDS.time).getTime(),
+          },
+        },
+      },
+    ])
+  })
 })

--- a/packages/sources/coinmetrics/test/unit/lwba.test.ts
+++ b/packages/sources/coinmetrics/test/unit/lwba.test.ts
@@ -1,0 +1,88 @@
+import { LoggerFactoryProvider } from '@chainlink/external-adapter-framework/util'
+import {
+  handleCryptoLwbaMessage,
+  WsCryptoLwbaAssetQuoteSuccessResponse,
+  WsCryptoLwbaPairQuoteSuccessResponse,
+} from '../../src/transport/lwba'
+
+LoggerFactoryProvider.set()
+
+const QUOTE_FIELDS = {
+  time: '2023-03-08T04:04:33.750000000Z',
+  ask_price: '0.99',
+  ask_size: '1',
+  bid_price: '0.98',
+  bid_size: '1',
+  mid_price: '0.985',
+  spread: '0.01',
+  cm_sequence_id: '1',
+}
+
+const ASSET_QUOTE_MESSAGE: WsCryptoLwbaAssetQuoteSuccessResponse = {
+  asset: 'frax_frax',
+  ...QUOTE_FIELDS,
+}
+
+const PAIR_QUOTE_MESSAGE: WsCryptoLwbaPairQuoteSuccessResponse = {
+  pair: 'frax_frax-usd',
+  ...QUOTE_FIELDS,
+}
+
+describe('handleCryptoLwbaMessage', () => {
+  it('parses asset-quotes websocket messages', () => {
+    const result = handleCryptoLwbaMessage(ASSET_QUOTE_MESSAGE)
+    expect(result).toEqual([
+      {
+        params: {
+          base: 'frax_frax',
+          quote: 'USD',
+        },
+        response: {
+          result: null,
+          data: {
+            bid: 0.98,
+            mid: 0.985,
+            ask: 0.99,
+          },
+          timestamps: {
+            providerIndicatedTimeUnixMs: new Date(QUOTE_FIELDS.time).getTime(),
+          },
+        },
+      },
+    ])
+  })
+
+  it('parses legacy pair-quotes websocket messages', () => {
+    const result = handleCryptoLwbaMessage(PAIR_QUOTE_MESSAGE)
+    expect(result).toEqual([
+      {
+        params: {
+          base: 'frax_frax',
+          quote: 'usd',
+        },
+        response: {
+          result: null,
+          data: {
+            bid: 0.98,
+            mid: 0.985,
+            ask: 0.99,
+          },
+          timestamps: {
+            providerIndicatedTimeUnixMs: new Date(QUOTE_FIELDS.time).getTime(),
+          },
+        },
+      },
+    ])
+  })
+
+  it('defaults quote to USD when pair has no quote segment', () => {
+    const result = handleCryptoLwbaMessage({
+      pair: 'btc',
+      ...QUOTE_FIELDS,
+    })
+    expect(result?.[0].params).toEqual({
+      base: 'btc',
+      quote: 'USD',
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Fix the CoinMetrics LWBA transport to correctly parse **asset-quotes** websocket messages (it was still parsing pair-quotes after the switch in #3187, causing websocket updates to fail and feed uptime to flap for assets like FRAX).
- Add an ingest-time warn in the LWBA transport when CoinMetrics emits a skewed snapshot (bid ≤ mid ≤ ask violation), so the violation is attributable to the provider and asset. The snapshot is still passed through unchanged; the framework's LwbaEndpoint output validation remains the source of truth for rejecting it.

## Changes

- `packages/sources/coinmetrics/src/transport/lwba.ts` — parse asset-quotes response shape; add skew warn
- `packages/sources/coinmetrics/test/unit/lwba.test.ts` — unit tests for the fix and skew warn
- `packages/sources/coinmetrics/test/integration/fixtures.ts` — updated fixtures
- `.changeset/` — two changesets