### PR TITLE
OPDATA-8175: Revert breaking change requiring protocol parameter in mobula-state

### DIFF
--- a/.changeset/orange-otters-love.md
+++ b/.changeset/orange-otters-love.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/mobula-state-adapter': minor
+---
+
+Revert the change that requires the protocol param on funding-rate

--- a/packages/sources/mobula-state/src/endpoint/funding-rate.ts
+++ b/packages/sources/mobula-state/src/endpoint/funding-rate.ts
@@ -23,11 +23,6 @@ export const inputParameters = new InputParameters(
       type: 'string',
       description: 'Which exchange to return the funding rate for',
     },
-    protocol: {
-      required: false,
-      type: 'string',
-      description: 'The protocol to query funding rates for',
-    },
   },
   [
     {

--- a/packages/sources/mobula-state/src/transport/funding-rate.ts
+++ b/packages/sources/mobula-state/src/transport/funding-rate.ts
@@ -60,7 +60,6 @@ export const wsTransport = new WebSocketTransport<WsTransportTypes>({
         payload: {
           symbol: params.base,
           quote: params.quote,
-          ...(params.protocol && { protocol: params.protocol }),
         },
       }
     },
@@ -94,16 +93,8 @@ const getFundingRateResult = (
   queryDetails: WSResponse['queryDetails'],
   fundingRate: FundingRateResponse,
 ): ProviderResult<WsTransportTypes> => {
-  // Symbol may contain protocol prefix, e.g. "xyz:SILVER"
-  const symbolParts = String(fundingRate.symbol).split(':')
-  const protocol = symbolParts.length > 1 ? symbolParts[0] : undefined
   return {
-    params: {
-      base: queryDetails.base,
-      quote: queryDetails.quote ?? '',
-      exchange,
-      ...(protocol && { protocol }),
-    },
+    params: { base: queryDetails.base, quote: queryDetails.quote ?? '', exchange },
     response: {
       result: null,
       data: {

--- a/packages/sources/mobula-state/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/mobula-state/test/integration/__snapshots__/adapter.test.ts.snap
@@ -43,22 +43,6 @@ exports[`websocket funding rate endpoint no data should return failure 1`] = `
 }
 `;
 
-exports[`websocket funding rate endpoint with protocol param should return success 1`] = `
-{
-  "data": {
-    "epochDuration": 3600,
-    "fundingRate": 0.00000625,
-    "fundingTimestamp": 1773788400,
-  },
-  "result": null,
-  "statusCode": 200,
-  "timestamps": {
-    "providerDataReceivedUnixMs": 18188,
-    "providerDataStreamEstablishedUnixMs": 16160,
-  },
-}
-`;
-
 exports[`websocket graceful error handling and case-insensitive requests should continue working after receiving invalid symbol requests 1`] = `
 {
   "data": {

--- a/packages/sources/mobula-state/test/integration/adapter.test.ts
+++ b/packages/sources/mobula-state/test/integration/adapter.test.ts
@@ -42,14 +42,6 @@ describe('websocket', () => {
     endpoint: 'funding-rate',
   }
 
-  const dataFundingRateProtocol = {
-    base: 'SILVER',
-    quote: 'USDC',
-    exchange: 'hyperliquid',
-    protocol: 'xyz',
-    endpoint: 'funding-rate',
-  }
-
   beforeAll(async () => {
     oldEnv = JSON.parse(JSON.stringify(process.env))
     process.env['WS_API_ENDPOINT'] = wsEndpoint
@@ -295,11 +287,6 @@ describe('websocket', () => {
 
     it('have partial data return success', async () => {
       const response = await testAdapter.request(dataFundingRateAergo)
-      expect(response.json()).toMatchSnapshot()
-    })
-
-    it('with protocol param should return success', async () => {
-      const response = await testAdapter.request(dataFundingRateProtocol)
       expect(response.json()).toMatchSnapshot()
     })
 

--- a/packages/sources/mobula-state/test/integration/fixtures.ts
+++ b/packages/sources/mobula-state/test/integration/fixtures.ts
@@ -250,18 +250,6 @@ export const mockWebsocketServer = (URL: string): MockWebsocketServer => {
               queryDetails: { base: 'AERGO', quote: null },
             }),
           )
-        } else if (symbol === 'SILVER' && parsed.payload.protocol === 'xyz') {
-          socket.send(
-            JSON.stringify({
-              hyperliquidFundingRate: {
-                symbol: 'xyz:SILVER',
-                fundingTime: 1773788400011,
-                fundingRate: 0.00000625,
-                epochDurationMs: 3600000,
-              },
-              queryDetails: { base: 'SILVER', quote: 'USDC' },
-            }),
-          )
         }
       }
     })


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/OPDATA-8175
https://smartcontract-it.atlassian.net/browse/OPDATA-7607

## Description

https://github.com/smartcontractkit/external-adapters-js/pull/4745 introduced a change to the `funding-rate` endpoint of `mobula-state` where if the `base/from` parameter contained a colon `:`, the request required an extra `protocol` parameter matching the part of the `from` parameter before the colon. So for example if previously the request
```
{
  "endpoint": "funding-rate",
  "exchange": "hyperliquid",
  "from": "xyz:SILVER",
  "to": "USDC"
}
```
would work, now only this request would work:
```
{
  "endpoint": "funding-rate",
  "exchange": "hyperliquid",
  "from": "xyz:SILVER",
  "to": "USDC",
  "protocol": "xyz"
}
```

I can't think of any reason you'd want to require this and I suspect this was not the intention with the PR.

The author of the PR later opened this PR to revert the change but that was never merged: https://github.com/smartcontractkit/external-adapters-js/pull/4761

## Changes

1. `git revert 65c455fbe1ac3cedc0fc0b323c03acbe1ee807cf`
2. Changeset

## Steps to Test

```
curl --silent -S -X POST http://localhost:8080 -H 'Content-Type: application/json' -d '{
  "data": {
    "endpoint": "funding-rate",
    "exchange": "hyperliquid",
    "from": "xyz:SILVER",
    "to": "USDC"
  }
}'

{
  "result": null,
  "data": {
    "fundingRate": 0.0000191573,
    "fundingTimestamp": 1784192400,
    "epochDuration": 3600
  },
  "timestamps": {
    "providerDataStreamEstablishedUnixMs": 1784193966911,
    "providerDataReceivedUnixMs": 1784193977206
  },
  "statusCode": 200,
  "meta": {
    "adapterName": "MOBULA_STATE",
    "transportName": "default_single_transport",
    "metrics": {
      "feedId": "{\"base\":\"xyz:silver\",\"exchange\":\"hyperliquid\",\"quote\":\"usdc\"}"
    }
  }
}
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
