### PR TITLE
feat(t-rize-proof-of-insurance-testnet): add testnet adapter for T-Rize proof API

### DIFF
--- a/.changeset/t-rize-testnet.md
+++ b/.changeset/t-rize-testnet.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/t-rize-proof-of-insurance-testnet-adapter': major
+---
+
+Initial version of T-Rize proof-of-insurance adapter targeting the testnet API endpoint.

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -619,6 +619,10 @@ const RAW_RUNTIME_STATE =
       "reference": "workspace:packages/sources/t-rize-proof-of-insurance"\
     },\
     {\
+      "name": "@chainlink/t-rize-proof-of-insurance-testnet-adapter",\
+      "reference": "workspace:packages/sources/t-rize-proof-of-insurance-testnet"\
+    },\
+    {\
       "name": "@chainlink/the-network-firm-adapter",\
       "reference": "workspace:packages/sources/the-network-firm"\
     },\
@@ -848,6 +852,7 @@ const RAW_RUNTIME_STATE =
     ["@chainlink/synthetix-debt-pool-adapter", ["workspace:packages/sources/synthetix-debt-pool"]],\
     ["@chainlink/synthetix-feeds-adapter", ["workspace:packages/sources/synthetix-feeds"]],\
     ["@chainlink/t-rize-proof-of-insurance-adapter", ["workspace:packages/sources/t-rize-proof-of-insurance"]],\
+    ["@chainlink/t-rize-proof-of-insurance-testnet-adapter", ["workspace:packages/sources/t-rize-proof-of-insurance-testnet"]],\
     ["@chainlink/the-network-firm-adapter", ["workspace:packages/sources/the-network-firm"]],\
     ["@chainlink/tiingo-adapter", ["workspace:packages/sources/tiingo"]],\
     ["@chainlink/tiingo-state-adapter", ["workspace:packages/sources/tiingo-state"]],\
@@ -7305,6 +7310,21 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@chainlink/external-adapter-framework", "npm:2.16.1"],\
           ["@chainlink/t-rize-proof-of-insurance-adapter", "workspace:packages/sources/t-rize-proof-of-insurance"],\
+          ["@types/jest", "npm:29.5.14"],\
+          ["@types/node", "npm:22.14.1"],\
+          ["nock", "npm:13.5.6"],\
+          ["tslib", "npm:2.4.1"],\
+          ["typescript", "patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"]\
+        ],\
+        "linkType": "SOFT"\
+      }]\
+    ]],\
+    ["@chainlink/t-rize-proof-of-insurance-testnet-adapter", [\
+      ["workspace:packages/sources/t-rize-proof-of-insurance-testnet", {\
+        "packageLocation": "./packages/sources/t-rize-proof-of-insurance-testnet/",\
+        "packageDependencies": [\
+          ["@chainlink/external-adapter-framework", "npm:2.16.1"],\
+          ["@chainlink/t-rize-proof-of-insurance-testnet-adapter", "workspace:packages/sources/t-rize-proof-of-insurance-testnet"],\
           ["@types/jest", "npm:29.5.14"],\
           ["@types/node", "npm:22.14.1"],\
           ["nock", "npm:13.5.6"],\

--- a/packages/sources/t-rize-proof-of-insurance-testnet/README.md
+++ b/packages/sources/t-rize-proof-of-insurance-testnet/README.md
@@ -1,0 +1,95 @@
+# T_RIZE_PROOF_OF_INSURANCE
+
+![1.0.1](https://img.shields.io/github/package-json/v/smartcontractkit/external-adapters-js?filename=packages/sources/t-rize-proof-of-insurance/package.json) ![v3](https://img.shields.io/badge/framework%20version-v3-blueviolet)
+
+This document was generated automatically. Please see [README Generator](../../scripts#readme-generator) for more info.
+
+## Staging vs. Production
+
+| Environment | URL                                                                       |
+| ----------- | ------------------------------------------------------------------------- |
+| Testnet     | `https://proof.t-rize.ca/v1/asset-verifier/merkle-tree/current-root`      |
+| Mainnet     | `https://proof.t-rize.network/v1/asset-verifier/merkle-tree/current-root` |
+
+The adapter defaults to the **production** endpoint. For testnet, set `API_ENDPOINT=https://proof.t-rize.ca/v1/asset-verifier/merkle-tree/current-root`.
+
+## Output Shape
+
+The adapter returns T-Rize carrier values and leaves any downstream stream-schema mapping or renaming to the jobspec.
+
+Because the downstream stream still targets SmartData v9 carrier fields, the adapter truncates `root` and `contractId` to the leftmost 23 bytes and converts those truncated bytes to decimal strings. These are deterministic derived values for T-Rize to replicate during verification, not the full raw provider values.
+
+| Field                                    | Type   | Description                                                      |
+| ---------------------------------------- | ------ | ---------------------------------------------------------------- |
+| `result`                                 | string | Leftmost 23 bytes of `root`, converted to a decimal string       |
+| `data.root`                              | string | Leftmost 23 bytes of `root`, converted to a decimal string       |
+| `data.contractId`                        | string | Leftmost 23 bytes of `contractId`, converted to a decimal string |
+| `timestamps.providerIndicatedTimeUnixMs` | number | Provider timestamp from `computedAt` in Unix milliseconds        |
+
+## Sample Output
+
+```json
+{
+  "result": "1354379164455806330400696522124505861414782960378538491",
+  "statusCode": 200,
+  "data": {
+    "root": "1354379164455806330400696522124505861414782960378538491",
+    "contractId": "57162387792002371595947067494468869255362946836973445"
+  },
+  "timestamps": {
+    "providerIndicatedTimeUnixMs": 1773147978000
+  }
+}
+```
+
+## Environment Variables
+
+| Required? |     Name      |                                                     Description                                                     |  Type  | Options |                                  Default                                  |
+| :-------: | :-----------: | :-----------------------------------------------------------------------------------------------------------------: | :----: | :-----: | :-----------------------------------------------------------------------: |
+|           | API_ENDPOINT  | The T-Rize current-root endpoint URL. Defaults to production. Set to the testnet current-root endpoint for testnet. | string |         | `https://proof.t-rize.network/v1/asset-verifier/merkle-tree/current-root` |
+|    ✅     | TRIZE_API_KEY |                         API key for T-Rize asset-verifier API (passed via x-api-key header)                         | string |         |                                                                           |
+
+---
+
+## Data Provider Rate Limits
+
+|  Name   | Requests/credits per second | Requests/credits per minute | Requests/credits per hour |                    Note                    |
+| :-----: | :-------------------------: | :-------------------------: | :-----------------------: | :----------------------------------------: |
+| default |                             |              1              |                           | Configured to poll at most once per minute |
+
+---
+
+## Input Parameters
+
+| Required? |   Name   |     Description     |  Type  |                      Options                       |       Default        |
+| :-------: | :------: | :-----------------: | :----: | :------------------------------------------------: | :------------------: |
+|           | endpoint | The endpoint to use | string | [proof-of-insurance](#proof-of-insurance-endpoint) | `proof-of-insurance` |
+
+## Proof-of-insurance Endpoint
+
+`proof-of-insurance` is the only supported name for this endpoint.
+
+### Input Params
+
+| Required? |     Name     | Aliases |                       Description                        |  Type  | Options | Default | Depends On | Not Valid With |
+| :-------: | :----------: | :-----: | :------------------------------------------------------: | :----: | :-----: | :-----: | :--------: | :------------: |
+|    ✅     | ownerPartyId |         | Party ID that owns the MerkleTree contract on the ledger | string |         |         |            |                |
+|    ✅     |    treeId    |         |           Tree identifier for the merkle tree            | string |         |         |            |                |
+
+### Example
+
+Request:
+
+```json
+{
+  "data": {
+    "endpoint": "proof-of-insurance",
+    "ownerPartyId": "TRIZEGroup-exampleValidator-1::0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    "treeId": "tree-001"
+  }
+}
+```
+
+---
+
+MIT License

--- a/packages/sources/t-rize-proof-of-insurance-testnet/docs/custom.md
+++ b/packages/sources/t-rize-proof-of-insurance-testnet/docs/custom.md
@@ -1,0 +1,37 @@
+## Staging vs. Production
+
+| Environment | URL                                                                       |
+| ----------- | ------------------------------------------------------------------------- |
+| Testnet     | `https://proof.t-rize.ca/v1/asset-verifier/merkle-tree/current-root`      |
+| Mainnet     | `https://proof.t-rize.network/v1/asset-verifier/merkle-tree/current-root` |
+
+The adapter defaults to the **production** endpoint. For testnet, set `API_ENDPOINT=https://proof.t-rize.ca/v1/asset-verifier/merkle-tree/current-root`.
+
+## Output Shape
+
+The adapter returns T-Rize carrier values and leaves any downstream stream-schema mapping or renaming to the jobspec.
+
+Because the downstream stream still targets SmartData v9 carrier fields, the adapter truncates `root` and `contractId` to the leftmost 23 bytes and converts those truncated bytes to decimal strings. These are deterministic derived values for T-Rize to replicate during verification, not the full raw provider values.
+
+| Field                                    | Type   | Description                                                      |
+| ---------------------------------------- | ------ | ---------------------------------------------------------------- |
+| `result`                                 | string | Leftmost 23 bytes of `root`, converted to a decimal string       |
+| `data.root`                              | string | Leftmost 23 bytes of `root`, converted to a decimal string       |
+| `data.contractId`                        | string | Leftmost 23 bytes of `contractId`, converted to a decimal string |
+| `timestamps.providerIndicatedTimeUnixMs` | number | Provider timestamp from `computedAt` in Unix milliseconds        |
+
+## Sample Output
+
+```json
+{
+  "result": "1354379164455806330400696522124505861414782960378538491",
+  "statusCode": 200,
+  "data": {
+    "root": "1354379164455806330400696522124505861414782960378538491",
+    "contractId": "57162387792002371595947067494468869255362946836973445"
+  },
+  "timestamps": {
+    "providerIndicatedTimeUnixMs": 1773147978000
+  }
+}
+```

--- a/packages/sources/t-rize-proof-of-insurance-testnet/package.json
+++ b/packages/sources/t-rize-proof-of-insurance-testnet/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@chainlink/t-rize-proof-of-insurance-testnet-adapter",
+  "version": "1.0.0",
+  "description": "External Adapter for querying the T-Rize Proof-of-Insurance API.",
+  "keywords": [
+    "Chainlink",
+    "LINK",
+    "blockchain",
+    "oracle",
+    "t-rize-proof-of-insurance"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "url": "https://github.com/smartcontractkit/external-adapters-js",
+    "type": "git"
+  },
+  "license": "MIT",
+  "scripts": {
+    "clean": "rm -rf dist && rm -f tsconfig.tsbuildinfo",
+    "prepack": "yarn build",
+    "build": "tsc -b",
+    "server": "node -e 'require(\"./index.js\").server()'",
+    "server:dist": "node -e 'require(\"./dist/index.js\").server()'",
+    "start": "yarn server:dist"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "@types/node": "22.14.1",
+    "nock": "13.5.6",
+    "typescript": "5.8.3"
+  },
+  "dependencies": {
+    "@chainlink/external-adapter-framework": "2.16.1",
+    "tslib": "2.4.1"
+  }
+}

--- a/packages/sources/t-rize-proof-of-insurance-testnet/src/config/index.ts
+++ b/packages/sources/t-rize-proof-of-insurance-testnet/src/config/index.ts
@@ -1,0 +1,16 @@
+import { AdapterConfig } from '@chainlink/external-adapter-framework/config'
+
+export const config = new AdapterConfig({
+  API_ENDPOINT: {
+    description:
+      'The T-Rize current-root endpoint URL. Defaults to testnet. Set to https://proof.t-rize.network/v1/asset-verifier/merkle-tree/current-root for production.',
+    type: 'string',
+    default: 'https://proof.t-rize.ca/v1/asset-verifier/merkle-tree/current-root',
+  },
+  TRIZE_API_KEY: {
+    description: 'API key for T-Rize asset-verifier API (passed via x-api-key header)',
+    type: 'string',
+    required: true,
+    sensitive: true,
+  },
+})

--- a/packages/sources/t-rize-proof-of-insurance-testnet/src/endpoint/index.ts
+++ b/packages/sources/t-rize-proof-of-insurance-testnet/src/endpoint/index.ts
@@ -1,0 +1,1 @@
+export { endpoint as proofOfInsurance } from './proof-of-insurance'

--- a/packages/sources/t-rize-proof-of-insurance-testnet/src/endpoint/proof-of-insurance.ts
+++ b/packages/sources/t-rize-proof-of-insurance-testnet/src/endpoint/proof-of-insurance.ts
@@ -1,0 +1,47 @@
+import { AdapterEndpoint } from '@chainlink/external-adapter-framework/adapter'
+import { InputParameters } from '@chainlink/external-adapter-framework/validation'
+import { config } from '../config'
+import { httpTransport } from '../transport/proof-of-insurance'
+
+const inputParameters = new InputParameters(
+  {
+    ownerPartyId: {
+      required: true,
+      type: 'string',
+      description: 'Party ID that owns the MerkleTree contract on the ledger',
+    },
+    treeId: {
+      required: true,
+      type: 'string',
+      description: 'Tree identifier for the merkle tree',
+    },
+  },
+  [
+    {
+      ownerPartyId:
+        'TRIZEGroup-exampleValidator-1::0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+      treeId: 'tree-001',
+    },
+  ],
+)
+
+// Returns T-Rize carrier values; any downstream schema renaming happens in the jobspec.
+
+export type BaseEndpointTypes = {
+  Parameters: typeof inputParameters.definition
+  Response: {
+    Result: string
+    Data: {
+      root: string
+      contractId: string
+    }
+  }
+  Settings: typeof config.settings
+}
+
+export const endpoint = new AdapterEndpoint({
+  name: 'proof-of-insurance',
+  aliases: [],
+  transport: httpTransport,
+  inputParameters,
+})

--- a/packages/sources/t-rize-proof-of-insurance-testnet/src/index.ts
+++ b/packages/sources/t-rize-proof-of-insurance-testnet/src/index.ts
@@ -1,0 +1,21 @@
+import { expose, ServerInstance } from '@chainlink/external-adapter-framework'
+import { Adapter } from '@chainlink/external-adapter-framework/adapter'
+import { config } from './config'
+import { proofOfInsurance } from './endpoint'
+
+export const adapter = new Adapter({
+  defaultEndpoint: proofOfInsurance.name,
+  name: 'T_RIZE_PROOF_OF_INSURANCE_TESTNET',
+  config,
+  endpoints: [proofOfInsurance],
+  rateLimiting: {
+    tiers: {
+      default: {
+        rateLimit1m: 1,
+        note: 'Configured to poll at most once per minute',
+      },
+    },
+  },
+})
+
+export const server = (): Promise<ServerInstance | undefined> => expose(adapter)

--- a/packages/sources/t-rize-proof-of-insurance-testnet/src/transport/proof-of-insurance.ts
+++ b/packages/sources/t-rize-proof-of-insurance-testnet/src/transport/proof-of-insurance.ts
@@ -1,0 +1,151 @@
+import { HttpTransport } from '@chainlink/external-adapter-framework/transports'
+import { BaseEndpointTypes } from '../endpoint/proof-of-insurance'
+
+// 23 bytes keeps the carrier value safely within positive int192 bounds.
+const TRUNCATED_CARRIER_BYTES = 23
+
+// Shared carrier rule for both fields: take the leftmost 23 bytes, interpret them
+// as an unsigned big-endian integer, and return its decimal string representation.
+const truncateBytesToDecimal = (byteValue: Buffer, sourceField: 'root' | 'contractId'): string => {
+  const truncatedHex = byteValue.subarray(0, TRUNCATED_CARRIER_BYTES).toString('hex')
+
+  if (!truncatedHex) {
+    throw new Error(`Unable to map ${sourceField}: decoded value is empty.`)
+  }
+
+  return BigInt(`0x${truncatedHex}`).toString()
+}
+
+const decodeRootToDecimal = (base64Value: string): string => {
+  let decodedBytes: Buffer
+
+  try {
+    decodedBytes = Buffer.from(atob(base64Value), 'binary')
+  } catch {
+    throw new Error(`Unable to decode root: invalid base64 value ${JSON.stringify(base64Value)}.`)
+  }
+
+  return truncateBytesToDecimal(decodedBytes, 'root')
+}
+
+const normalizeContractIdToDecimal = (hexValue: string): string => {
+  const normalizedHex = hexValue.replace(/^0x/i, '')
+
+  if (!/^(?:[0-9a-f]{2})+$/i.test(normalizedHex)) {
+    throw new Error(
+      `Unable to normalize contractId: invalid hex value ${JSON.stringify(hexValue)}.`,
+    )
+  }
+
+  return truncateBytesToDecimal(Buffer.from(normalizedHex, 'hex'), 'contractId')
+}
+
+export interface ResponseSchema {
+  root: string
+  contractId: string
+  computedAt: string
+  error?: string
+}
+
+export type HttpTransportTypes = BaseEndpointTypes & {
+  Provider: {
+    RequestBody: never
+    ResponseBody: ResponseSchema
+  }
+}
+
+export const httpTransport = new HttpTransport<HttpTransportTypes>({
+  prepareRequests: (params, config) => {
+    return params.map((param) => {
+      return {
+        params: [param],
+        request: {
+          url: config.API_ENDPOINT,
+          params: {
+            owner_party_id: param.ownerPartyId,
+            tree_id: param.treeId,
+          },
+          headers: {
+            Accept: 'application/json',
+            'x-api-key': config.TRIZE_API_KEY,
+          },
+        },
+      }
+    })
+  },
+  parseResponse: (params, response) => {
+    if (!response.data) {
+      return params.map((param) => {
+        return {
+          params: param,
+          response: {
+            errorMessage: `The data provider didn't return any value for ownerPartyId=${param.ownerPartyId}, treeId=${param.treeId}`,
+            statusCode: 502,
+          },
+        }
+      })
+    }
+
+    const providerError = response.data.error
+
+    if (providerError) {
+      return params.map((param) => {
+        return {
+          params: param,
+          response: {
+            errorMessage: providerError,
+            statusCode: 502,
+          },
+        }
+      })
+    }
+
+    try {
+      // Note: Both root and contractId are opaque hashes. We want to make these
+      // hashes available via Streams. Since there is no appropriate schema for this,
+      // we decided to encode these hashes as int192 numbers so they can be made
+      // available in the v9 schema. To fit the hashes into these numbers, we need to
+      // truncate them. This assumes that 23 bytes of each hash is enough to be able
+      // to reliably compare the hash to the original hash.
+      const rootDecimal = decodeRootToDecimal(response.data.root)
+      const contractIdDecimal = normalizeContractIdToDecimal(response.data.contractId)
+      const providerIndicatedTimeUnixMs = Date.parse(response.data.computedAt)
+
+      if (Number.isNaN(providerIndicatedTimeUnixMs)) {
+        throw new Error(
+          `Unable to parse computedAt: invalid timestamp value ${JSON.stringify(
+            response.data.computedAt,
+          )}.`,
+        )
+      }
+
+      return params.map((param) => {
+        return {
+          params: param,
+          response: {
+            result: rootDecimal,
+            data: {
+              root: rootDecimal,
+              contractId: contractIdDecimal,
+            },
+            timestamps: {
+              providerIndicatedTimeUnixMs,
+            },
+          },
+        }
+      })
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred'
+
+      return params.map((param) => {
+        return {
+          params: param,
+          response: {
+            errorMessage,
+            statusCode: 502,
+          },
+        }
+      })
+    }
+  },
+})

--- a/packages/sources/t-rize-proof-of-insurance-testnet/test-payload.json
+++ b/packages/sources/t-rize-proof-of-insurance-testnet/test-payload.json
@@ -1,0 +1,8 @@
+{
+  "requests": [
+    {
+      "ownerPartyId": "TRIZEGroup-cantonTestnetValidator-1::12205de11e389c7da899c66b0fec93ac08b8e9023e8deb30a1316ed9925955fbf06b",
+      "treeId": "tree-001"
+    }
+  ]
+}

--- a/packages/sources/t-rize-proof-of-insurance-testnet/tsconfig.json
+++ b/packages/sources/t-rize-proof-of-insurance-testnet/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*", "src/**/*.json"],
+  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]
+}

--- a/packages/sources/t-rize-proof-of-insurance-testnet/tsconfig.test.json
+++ b/packages/sources/t-rize-proof-of-insurance-testnet/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*", "**/test", "src/**/*.json"],
+  "compilerOptions": {
+    "noEmit": true
+  }
+}

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -447,6 +447,9 @@
       "path": "./sources/t-rize-proof-of-insurance"
     },
     {
+      "path": "./sources/t-rize-proof-of-insurance-testnet"
+    },
+    {
       "path": "./sources/the-network-firm"
     },
     {

--- a/packages/tsconfig.test.json
+++ b/packages/tsconfig.test.json
@@ -447,6 +447,9 @@
       "path": "./sources/t-rize-proof-of-insurance/tsconfig.test.json"
     },
     {
+      "path": "./sources/t-rize-proof-of-insurance-testnet/tsconfig.test.json"
+    },
+    {
       "path": "./sources/the-network-firm/tsconfig.test.json"
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4732,6 +4732,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@chainlink/t-rize-proof-of-insurance-testnet-adapter@workspace:packages/sources/t-rize-proof-of-insurance-testnet":
+  version: 0.0.0-use.local
+  resolution: "@chainlink/t-rize-proof-of-insurance-testnet-adapter@workspace:packages/sources/t-rize-proof-of-insurance-testnet"
+  dependencies:
+    "@chainlink/external-adapter-framework": "npm:2.16.1"
+    "@types/jest": "npm:^29.5.14"
+    "@types/node": "npm:22.14.1"
+    nock: "npm:13.5.6"
+    tslib: "npm:2.4.1"
+    typescript: "npm:5.8.3"
+  languageName: unknown
+  linkType: soft
+
 "@chainlink/the-network-firm-adapter@workspace:packages/sources/the-network-firm":
   version: 0.0.0-use.local
   resolution: "@chainlink/the-network-firm-adapter@workspace:packages/sources/the-network-firm"


### PR DESCRIPTION
Closes OPDATA-8178

## Description

Duplicates the existing `t-rize-proof-of-insurance` adapter (#4608) and changes only the `API_ENDPOINT` default to the T-Rize testnet endpoint (`https://proof.t-rize.ca`). No code logic changes.

The original adapter (prod/mainnet) is untouched. This allows a `-testnet` suffixed EA instance that targets the T-Rize testnet proof API to be deployed without needing a code change or new input param, per engineering recommendation.

## Background

The existing testnet Data Streams feed was reporting identical decoded values as mainnet because both the stage and prod EA deployments were defaulting to the same production proof API endpoint (`https://proof.t-rize.network`). The testnet feed's jobspec uses different `ownerPartyId` and `treeId` values that only resolve against the T-Rize testnet API (`https://proof.t-rize.ca`).

Since stage EAs != testnet, and the testnet feed needs a different payload, a separate adapter instance is the cleanest path -- as discussed with @matthew.mcallister.

## Changes

The testnet adapter differs from the original in exactly 4 files:

| File | Change |
|---|---|
| `package.json` | Package name suffixed `-testnet`, version `1.0.0` |
| `src/config/index.ts` | `API_ENDPOINT` default → testnet URL, description updated |
| `src/index.ts` | Adapter name → `T_RIZE_PROOF_OF_INSURANCE_TESTNET` |
| `test-payload.json` | Testnet `ownerPartyId` |

All other files (transport, endpoint logic, truncation, docs) are byte-for-byte identical to the original.

## Steps to Test

1. `yarn workspace @chainlink/t-rize-proof-of-insurance-testnet-adapter build`
2. Optionally set `TRIZE_API_KEY` and use `test-payload.json` against the testnet endpoint

## Quality Assurance

- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [x] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [x] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [x] The branch naming follows git flow (`feat/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [x] This is related to a maximum of one Jira story or GitHub issue.
- [x] Types are safe (avoid TypeScript/TSLint features like `any` and disable, instead use more specific types).