### PR TITLE
OPDATA-7940: Add coinbase endpoint to tokenized-equity

### DIFF
--- a/.changeset/four-years-decide.md
+++ b/.changeset/four-years-decide.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/tokenized-equity-adapter': minor
+---
+
+Add coinbase endpoint

--- a/packages/composites/tokenized-equity/src/config/CoinbaseOracleRegistryABI.json
+++ b/packages/composites/tokenized-equity/src/config/CoinbaseOracleRegistryABI.json
@@ -1,0 +1,23 @@
+[
+  {
+    "type": "function",
+    "name": "getOracleParams",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "multiplier",
+        "type": "uint128"
+      },
+      {
+        "name": "paused",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  }
+]

--- a/packages/composites/tokenized-equity/src/config/index.ts
+++ b/packages/composites/tokenized-equity/src/config/index.ts
@@ -25,6 +25,18 @@ export const config = new AdapterConfig({
     default: 1,
     sensitive: false,
   },
+  BASE_RPC_URL: {
+    description: 'RPC URL of a Mainnet Base node',
+    type: 'string',
+    default: '',
+    sensitive: true,
+  },
+  BASE_RPC_CHAIN_ID: {
+    description: 'The chain id to connect to',
+    type: 'number',
+    default: 8453,
+    sensitive: false,
+  },
   ROBINHOOD_NETWORK_RPC_URL: {
     description:
       'JSON RPC URL for robinhood endpoint. ${NETWORK} should be "mainnet" or "testnet".',

--- a/packages/composites/tokenized-equity/src/endpoint/coinbase.ts
+++ b/packages/composites/tokenized-equity/src/endpoint/coinbase.ts
@@ -1,0 +1,58 @@
+import { AdapterEndpoint } from '@chainlink/external-adapter-framework/adapter'
+import { InputParameters } from '@chainlink/external-adapter-framework/validation'
+import { AdapterInputError } from '@chainlink/external-adapter-framework/validation/error'
+import { config } from '../config'
+import { ondoTransport } from '../transport/ondoTransport'
+import type { output } from './common'
+import { inputDefinition, inputExample, validateSmoother, validateStreamIds } from './common'
+
+export const inputParameters = new InputParameters(
+  {
+    registry: {
+      required: true,
+      type: 'string',
+      description: 'Ondo on-chain registry address',
+    },
+    ...inputDefinition.definition,
+  },
+  [
+    {
+      registry: '0x0',
+      ...inputExample,
+    },
+  ],
+)
+
+export type BaseEndpointTypes = {
+  Parameters: typeof inputParameters.definition
+  Response: {
+    Result: string
+    Data: output & {
+      registry: {
+        sValue: string
+        paused: boolean
+      }
+    }
+  }
+  Settings: typeof config.settings
+}
+
+export const endpoint = new AdapterEndpoint({
+  name: 'ondo',
+  aliases: [],
+  transport: ondoTransport,
+  inputParameters,
+  customInputValidation: (req, adapterSettings): AdapterInputError | undefined => {
+    if (!adapterSettings.ETHEREUM_RPC_URL) {
+      throw new AdapterInputError({
+        message: 'Missing ETHEREUM_RPC_URL',
+        statusCode: 400,
+      })
+    }
+
+    validateStreamIds(req.requestContext.data)
+    validateSmoother(req.requestContext.data)
+
+    return
+  },
+})

--- a/packages/composites/tokenized-equity/src/endpoint/coinbase.ts
+++ b/packages/composites/tokenized-equity/src/endpoint/coinbase.ts
@@ -2,7 +2,7 @@ import { AdapterEndpoint } from '@chainlink/external-adapter-framework/adapter'
 import { InputParameters } from '@chainlink/external-adapter-framework/validation'
 import { AdapterInputError } from '@chainlink/external-adapter-framework/validation/error'
 import { config } from '../config'
-import { ondoTransport } from '../transport/ondoTransport'
+import { coinbaseTransport } from '../transport/coinbaseTransport'
 import type { output } from './common'
 import { inputDefinition, inputExample, validateSmoother, validateStreamIds } from './common'
 
@@ -11,7 +11,7 @@ export const inputParameters = new InputParameters(
     registry: {
       required: true,
       type: 'string',
-      description: 'Ondo on-chain registry address',
+      description: 'Coinbase on-chain registry address',
     },
     ...inputDefinition.definition,
   },
@@ -29,7 +29,7 @@ export type BaseEndpointTypes = {
     Result: string
     Data: output & {
       registry: {
-        sValue: string
+        multiplier: string
         paused: boolean
       }
     }
@@ -38,14 +38,14 @@ export type BaseEndpointTypes = {
 }
 
 export const endpoint = new AdapterEndpoint({
-  name: 'ondo',
+  name: 'coinbase',
   aliases: [],
-  transport: ondoTransport,
+  transport: coinbaseTransport,
   inputParameters,
   customInputValidation: (req, adapterSettings): AdapterInputError | undefined => {
-    if (!adapterSettings.ETHEREUM_RPC_URL) {
+    if (!adapterSettings.BASE_RPC_URL) {
       throw new AdapterInputError({
-        message: 'Missing ETHEREUM_RPC_URL',
+        message: 'Missing BASE_RPC_URL',
         statusCode: 400,
       })
     }

--- a/packages/composites/tokenized-equity/src/endpoint/index.ts
+++ b/packages/composites/tokenized-equity/src/endpoint/index.ts
@@ -1,3 +1,4 @@
+export { endpoint as coinbase } from './coinbase'
 export { endpoint as ondo } from './ondo'
 export { endpoint as price } from './price'
 export { endpoint as robinhood } from './robinhood'

--- a/packages/composites/tokenized-equity/src/index.ts
+++ b/packages/composites/tokenized-equity/src/index.ts
@@ -1,13 +1,13 @@
 import { expose, ServerInstance } from '@chainlink/external-adapter-framework'
 import { Adapter } from '@chainlink/external-adapter-framework/adapter'
 import { config } from './config'
-import { ondo, price, robinhood, xstocks } from './endpoint'
+import { coinbase, ondo, price, robinhood, xstocks } from './endpoint'
 
 export const adapter = new Adapter({
   defaultEndpoint: price.name,
   name: 'TOKENIZED_EQUITY',
   config,
-  endpoints: [price, ondo, robinhood, xstocks],
+  endpoints: [coinbase, price, ondo, robinhood, xstocks],
 })
 
 export const server = (): Promise<ServerInstance | undefined> => expose(adapter)

--- a/packages/composites/tokenized-equity/src/lib/coinbase.ts
+++ b/packages/composites/tokenized-equity/src/lib/coinbase.ts
@@ -1,0 +1,17 @@
+import { Contract, JsonRpcProvider } from 'ethers'
+import ABI from '../config/SyntheticSharesOracleABI.json'
+
+export const getRegistryData = async (
+  asset: string,
+  registry: string,
+  provider: JsonRpcProvider,
+) => {
+  const registryContract = new Contract(registry, ABI, provider)
+
+  const { sValue, paused } = await registryContract.getSValue(asset)
+
+  return {
+    multiplier: BigInt(sValue),
+    paused: Boolean(paused),
+  }
+}

--- a/packages/composites/tokenized-equity/src/lib/coinbase.ts
+++ b/packages/composites/tokenized-equity/src/lib/coinbase.ts
@@ -1,5 +1,5 @@
 import { Contract, JsonRpcProvider } from 'ethers'
-import ABI from '../config/SyntheticSharesOracleABI.json'
+import ABI from '../config/CoinbaseOracleRegistryABI.json'
 
 export const getRegistryData = async (
   asset: string,
@@ -8,10 +8,10 @@ export const getRegistryData = async (
 ) => {
   const registryContract = new Contract(registry, ABI, provider)
 
-  const { sValue, paused } = await registryContract.getSValue(asset)
+  const { multiplier, paused } = await registryContract.getOracleParams(asset)
 
   return {
-    multiplier: BigInt(sValue),
+    multiplier: BigInt(multiplier),
     paused: Boolean(paused),
   }
 }

--- a/packages/composites/tokenized-equity/src/transport/coinbasePrice.ts
+++ b/packages/composites/tokenized-equity/src/transport/coinbasePrice.ts
@@ -3,7 +3,7 @@ import { JsonRpcProvider } from 'ethers'
 
 import { AdapterError } from '@chainlink/external-adapter-framework/validation/error'
 import { Smoother } from '../endpoint/common'
-import { getRegistryData } from '../lib/registry'
+import { getRegistryData } from '../lib/coinbase'
 
 import { smoothedStreamPrice } from './smoothedPrice'
 
@@ -42,7 +42,7 @@ export const calculatePrice = async (param: {
   return result.map((r) => ({
     ...r,
     registry: {
-      sValue: multiplier.toString(),
+      multiplier: multiplier.toString(),
       paused,
     },
     result: ((BigInt(r.result) * multiplier) / 10n ** MULTIPLIER_DECIMALS).toString(),

--- a/packages/composites/tokenized-equity/src/transport/coinbasePrice.ts
+++ b/packages/composites/tokenized-equity/src/transport/coinbasePrice.ts
@@ -1,0 +1,50 @@
+import { Requester } from '@chainlink/external-adapter-framework/util/requester'
+import { JsonRpcProvider } from 'ethers'
+
+import { AdapterError } from '@chainlink/external-adapter-framework/validation/error'
+import { Smoother } from '../endpoint/common'
+import { getRegistryData } from '../lib/registry'
+
+import { smoothedStreamPrice } from './smoothedPrice'
+
+const MULTIPLIER_DECIMALS = 18n
+
+export const calculatePrice = async (param: {
+  asset: string
+  registry: string
+  provider: JsonRpcProvider
+  regularStreamId?: string
+  extendedStreamId?: string
+  overnightStreamId?: string
+  overnightStreamMaxAgeInSeconds?: number
+  url: string
+  tradingHoursUrl: string
+  requester: Requester
+  sessionMarket?: string
+  sessionMarketType?: string
+  sessionBoundaries: string[]
+  sessionBoundariesTimeZone?: string
+  smoother: Smoother
+  decimals: number
+}) => {
+  const [result, { multiplier, paused }] = await Promise.all([
+    smoothedStreamPrice(param),
+    getRegistryData(param.asset, param.registry, param.provider),
+  ])
+
+  if (paused) {
+    throw new AdapterError({
+      statusCode: 503,
+      message: `asset: ${param.asset} paused on registry ${param.registry}`,
+    })
+  }
+
+  return result.map((r) => ({
+    ...r,
+    registry: {
+      sValue: multiplier.toString(),
+      paused,
+    },
+    result: ((BigInt(r.result) * multiplier) / 10n ** MULTIPLIER_DECIMALS).toString(),
+  }))
+}

--- a/packages/composites/tokenized-equity/src/transport/coinbaseTransport.ts
+++ b/packages/composites/tokenized-equity/src/transport/coinbaseTransport.ts
@@ -5,15 +5,15 @@ import { AdapterResponse, makeLogger, sleep } from '@chainlink/external-adapter-
 import { Requester } from '@chainlink/external-adapter-framework/util/requester'
 import { AdapterError } from '@chainlink/external-adapter-framework/validation/error'
 import { JsonRpcProvider } from 'ethers'
+import { BaseEndpointTypes, inputParameters } from '../endpoint/coinbase'
 import { Smoother } from '../endpoint/common'
-import { BaseEndpointTypes, inputParameters } from '../endpoint/ondo'
-import { calculatePrice } from './ondoPrice'
+import { calculatePrice } from './coinbasePrice'
 
-const logger = makeLogger('OndoTransport')
+const logger = makeLogger('CoinbaseTransport')
 
 type RequestParams = typeof inputParameters.validated
 
-export class OndoTransport extends SubscriptionTransport<BaseEndpointTypes> {
+export class CoinbaseTransport extends SubscriptionTransport<BaseEndpointTypes> {
   requester!: Requester
   provider!: JsonRpcProvider
   dataEngineUrl!: string
@@ -28,8 +28,8 @@ export class OndoTransport extends SubscriptionTransport<BaseEndpointTypes> {
     await super.initialize(dependencies, adapterSettings, endpointName, transportName)
     this.requester = dependencies.requester
     this.provider = new JsonRpcProvider(
-      adapterSettings.ETHEREUM_RPC_URL,
-      adapterSettings.ETHEREUM_RPC_CHAIN_ID,
+      adapterSettings.BASE_RPC_URL,
+      adapterSettings.BASE_RPC_CHAIN_ID,
     )
 
     this.dataEngineUrl = adapterSettings.DATA_ENGINE_ADAPTER_URL
@@ -137,4 +137,4 @@ const dedupeParams = (params: RequestParams[]) => {
   return Array.from(seen.values())
 }
 
-export const ondoTransport = new OndoTransport()
+export const coinbaseTransport = new CoinbaseTransport()

--- a/packages/composites/tokenized-equity/src/transport/coinbaseTransport.ts
+++ b/packages/composites/tokenized-equity/src/transport/coinbaseTransport.ts
@@ -1,0 +1,140 @@
+import { EndpointContext } from '@chainlink/external-adapter-framework/adapter'
+import { TransportDependencies } from '@chainlink/external-adapter-framework/transports'
+import { SubscriptionTransport } from '@chainlink/external-adapter-framework/transports/abstract/subscription'
+import { AdapterResponse, makeLogger, sleep } from '@chainlink/external-adapter-framework/util'
+import { Requester } from '@chainlink/external-adapter-framework/util/requester'
+import { AdapterError } from '@chainlink/external-adapter-framework/validation/error'
+import { JsonRpcProvider } from 'ethers'
+import { Smoother } from '../endpoint/common'
+import { BaseEndpointTypes, inputParameters } from '../endpoint/ondo'
+import { calculatePrice } from './ondoPrice'
+
+const logger = makeLogger('OndoTransport')
+
+type RequestParams = typeof inputParameters.validated
+
+export class OndoTransport extends SubscriptionTransport<BaseEndpointTypes> {
+  requester!: Requester
+  provider!: JsonRpcProvider
+  dataEngineUrl!: string
+  tradingHoursUrl!: string
+
+  async initialize(
+    dependencies: TransportDependencies<BaseEndpointTypes>,
+    adapterSettings: BaseEndpointTypes['Settings'],
+    endpointName: string,
+    transportName: string,
+  ): Promise<void> {
+    await super.initialize(dependencies, adapterSettings, endpointName, transportName)
+    this.requester = dependencies.requester
+    this.provider = new JsonRpcProvider(
+      adapterSettings.ETHEREUM_RPC_URL,
+      adapterSettings.ETHEREUM_RPC_CHAIN_ID,
+    )
+
+    this.dataEngineUrl = adapterSettings.DATA_ENGINE_ADAPTER_URL
+    this.tradingHoursUrl = adapterSettings.TRADING_HOURS_ADAPTER_URL
+  }
+  async backgroundHandler(context: EndpointContext<BaseEndpointTypes>, entries: RequestParams[]) {
+    await Promise.all(dedupeParams(entries).map(async (param) => this.handleRequest(param)))
+    await sleep(context.adapterSettings.BACKGROUND_EXECUTE_MS)
+  }
+
+  async handleRequest(param: RequestParams) {
+    let responses: Partial<Record<Smoother, AdapterResponse<BaseEndpointTypes['Response']>>>
+    try {
+      responses = await this._handleRequest(param)
+    } catch (e) {
+      const errorMessage = e instanceof Error ? e.message : 'Unknown error occurred'
+      logger.error(e, errorMessage)
+
+      const errorResponse = {
+        statusCode: (e as AdapterError)?.statusCode || 502,
+        errorMessage,
+        timestamps: {
+          providerDataRequestedUnixMs: 0,
+          providerDataReceivedUnixMs: 0,
+          providerIndicatedTimeUnixMs: undefined,
+        },
+      }
+      responses =
+        param.smoother === 'none'
+          ? { none: errorResponse }
+          : {
+              ema: errorResponse,
+              kalman: errorResponse,
+            }
+    }
+
+    await this.responseCache.write(
+      this.name,
+      Object.entries(responses).map(([key, value]) => {
+        return {
+          params: {
+            ...param,
+            smoother: key as Smoother,
+          },
+          response: value,
+        }
+      }),
+    )
+  }
+
+  async _handleRequest(
+    param: RequestParams,
+  ): Promise<Record<string, AdapterResponse<BaseEndpointTypes['Response']>>> {
+    const providerDataRequestedUnixMs = Date.now()
+
+    const results = await calculatePrice({
+      ...param,
+      provider: this.provider,
+      url: this.dataEngineUrl,
+      tradingHoursUrl: this.tradingHoursUrl,
+      requester: this.requester,
+    })
+
+    return Object.fromEntries(
+      results.map((r) => [
+        r.smoother.smoother,
+        {
+          data: r,
+          statusCode: 200,
+          result: r.result,
+          timestamps: {
+            providerDataRequestedUnixMs,
+            providerDataReceivedUnixMs: Date.now(),
+            providerIndicatedTimeUnixMs: undefined,
+          },
+        },
+      ]),
+    )
+  }
+
+  getSubscriptionTtlFromConfig(adapterSettings: BaseEndpointTypes['Settings']): number {
+    return adapterSettings.WARMUP_SUBSCRIPTION_TTL
+  }
+}
+const dedupeParams = (params: RequestParams[]) => {
+  const seen = new Map<string, RequestParams>()
+  for (const p of params) {
+    const key = [
+      p.registry,
+      p.asset,
+      p.regularStreamId,
+      p.extendedStreamId,
+      p.overnightStreamId,
+      p.overnightStreamMaxAgeInSeconds,
+      p.sessionMarket,
+      p.sessionMarketType,
+      p.sessionBoundaries.join('|'),
+      p.sessionBoundariesTimeZone,
+      p.decimals,
+    ].join('@@')
+    if (!seen.has(key)) {
+      seen.set(key, p)
+    }
+  }
+  return Array.from(seen.values())
+}
+
+export const ondoTransport = new OndoTransport()

--- a/packages/composites/tokenized-equity/test/integration/__snapshots__/adapter-coinbase.test.ts.snap
+++ b/packages/composites/tokenized-equity/test/integration/__snapshots__/adapter-coinbase.test.ts.snap
@@ -1,0 +1,160 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`execute price endpoint bad sessionBoundaries 1`] = `
+{
+  "error": {
+    "message": "99:88 in [Param: sessionBoundaries] does not match format HH:MM",
+    "name": "AdapterError",
+  },
+  "status": "errored",
+  "statusCode": 400,
+}
+`;
+
+exports[`execute price endpoint bad sessionBoundariesTimeZone 1`] = `
+{
+  "error": {
+    "message": "[Param: sessionBoundariesTimeZone] is not valid timezone: RangeError: Invalid time zone specified: random",
+    "name": "AdapterError",
+  },
+  "status": "errored",
+  "statusCode": 400,
+}
+`;
+
+exports[`execute price endpoint missing sessionMarket 1`] = `
+{
+  "error": {
+    "message": "Missing required parameter sessionMarket when smoother is ema",
+    "name": "AdapterError",
+  },
+  "status": "errored",
+  "statusCode": 400,
+}
+`;
+
+exports[`execute price endpoint should return success - ema 1`] = `
+{
+  "data": {
+    "decimals": 8,
+    "rawPrice": "1",
+    "registry": {
+      "paused": false,
+      "sValue": "2000000000000000000",
+    },
+    "result": "20000000",
+    "sessionSource": "FALLBACK",
+    "smoother": {
+      "p": "978347471111",
+      "price": "1",
+      "secondsFromTransition": 9007199254740991,
+      "smoother": "ema",
+      "x": "-1",
+    },
+    "stream": {
+      "extended": {
+        "ask": "5",
+        "askVolume": 6,
+        "bid": "3",
+        "bidVolume": 4,
+        "decimals": 1,
+        "lastSeenTimestampNs": "2",
+        "lastTradedPrice": "7",
+        "marketStatus": 1,
+        "mid": "1",
+      },
+      "overnight": {
+        "ask": "5",
+        "askVolume": 6,
+        "bid": "3",
+        "bidVolume": 4,
+        "decimals": 1,
+        "lastSeenTimestampNs": "2",
+        "lastTradedPrice": "7",
+        "marketStatus": 1,
+        "mid": "1",
+      },
+      "regular": {
+        "ask": "5",
+        "askVolume": 6,
+        "bid": "3",
+        "bidVolume": 4,
+        "decimals": 1,
+        "lastSeenTimestampNs": "2",
+        "lastTradedPrice": "7",
+        "marketStatus": 1,
+        "mid": "1",
+      },
+    },
+  },
+  "result": "20000000",
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 978347471111,
+    "providerDataRequestedUnixMs": 978347471111,
+  },
+}
+`;
+
+exports[`execute price endpoint should return success - kalman 1`] = `
+{
+  "data": {
+    "decimals": 8,
+    "rawPrice": "1",
+    "registry": {
+      "paused": false,
+      "sValue": "2000000000000000000",
+    },
+    "result": "20000000",
+    "sessionSource": "FALLBACK",
+    "smoother": {
+      "p": "1500000000000000000",
+      "price": "1",
+      "secondsFromTransition": 9007199254740991,
+      "smoother": "kalman",
+      "x": "-1",
+    },
+    "stream": {
+      "extended": {
+        "ask": "5",
+        "askVolume": 6,
+        "bid": "3",
+        "bidVolume": 4,
+        "decimals": 1,
+        "lastSeenTimestampNs": "2",
+        "lastTradedPrice": "7",
+        "marketStatus": 1,
+        "mid": "1",
+      },
+      "overnight": {
+        "ask": "5",
+        "askVolume": 6,
+        "bid": "3",
+        "bidVolume": 4,
+        "decimals": 1,
+        "lastSeenTimestampNs": "2",
+        "lastTradedPrice": "7",
+        "marketStatus": 1,
+        "mid": "1",
+      },
+      "regular": {
+        "ask": "5",
+        "askVolume": 6,
+        "bid": "3",
+        "bidVolume": 4,
+        "decimals": 1,
+        "lastSeenTimestampNs": "2",
+        "lastTradedPrice": "7",
+        "marketStatus": 1,
+        "mid": "1",
+      },
+    },
+  },
+  "result": "20000000",
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 978347471111,
+    "providerDataRequestedUnixMs": 978347471111,
+  },
+}
+`;

--- a/packages/composites/tokenized-equity/test/integration/__snapshots__/adapter-coinbase.test.ts.snap
+++ b/packages/composites/tokenized-equity/test/integration/__snapshots__/adapter-coinbase.test.ts.snap
@@ -39,8 +39,8 @@ exports[`execute price endpoint should return success - ema 1`] = `
     "decimals": 8,
     "rawPrice": "1",
     "registry": {
+      "multiplier": "2000000000000000000",
       "paused": false,
-      "sValue": "2000000000000000000",
     },
     "result": "20000000",
     "sessionSource": "FALLBACK",
@@ -102,8 +102,8 @@ exports[`execute price endpoint should return success - kalman 1`] = `
     "decimals": 8,
     "rawPrice": "1",
     "registry": {
+      "multiplier": "2000000000000000000",
       "paused": false,
-      "sValue": "2000000000000000000",
     },
     "result": "20000000",
     "sessionSource": "FALLBACK",

--- a/packages/composites/tokenized-equity/test/integration/adapter-coinbase.test.ts
+++ b/packages/composites/tokenized-equity/test/integration/adapter-coinbase.test.ts
@@ -1,0 +1,210 @@
+import {
+  TestAdapter,
+  setEnvVariables,
+} from '@chainlink/external-adapter-framework/util/testing-utils'
+import { JsonRpcProvider } from 'ethers'
+import * as nock from 'nock'
+import { mockResponseSuccess, mockTradingHoursResponseFailure } from './fixtures'
+
+const validContract = '0x12345'
+jest.mock('ethers', () => {
+  const actualModule = jest.requireActual('ethers')
+  return {
+    ...actualModule,
+    JsonRpcProvider: jest.fn().mockImplementation(() => {
+      return {} as JsonRpcProvider
+    }),
+    Contract: jest.fn().mockImplementation((address: string) => {
+      if (address === validContract) {
+        return {
+          getSValue: jest.fn().mockImplementation(() => {
+            return Promise.resolve({ sValue: 2n * 10n ** 18n, paused: false })
+          }),
+        }
+      } else {
+        return {}
+      }
+    }),
+  }
+})
+
+describe('execute', () => {
+  let spy: jest.SpyInstance
+  let testAdapter: TestAdapter
+  let oldEnv: NodeJS.ProcessEnv
+
+  beforeAll(async () => {
+    oldEnv = JSON.parse(JSON.stringify(process.env))
+    process.env.DATA_ENGINE_ADAPTER_URL = 'http://data-engine'
+    process.env.TRADING_HOURS_ADAPTER_URL = 'http://trading-hours'
+    process.env.ETHEREUM_RPC_URL = 'fake-url'
+    process.env.BACKGROUND_EXECUTE_MS = process.env.BACKGROUND_EXECUTE_MS ?? '1000'
+    const mockDate = new Date('2001-01-01T11:11:11.111Z')
+    spy = jest.spyOn(Date, 'now').mockReturnValue(mockDate.getTime())
+
+    const adapter = (await import('../../src')).adapter
+    adapter.rateLimiting = undefined
+    testAdapter = await TestAdapter.startWithMockedCache(adapter, {
+      testAdapter: {} as TestAdapter<never>,
+    })
+  })
+
+  afterAll(async () => {
+    setEnvVariables(oldEnv)
+    await testAdapter.api.close()
+    nock.restore()
+    nock.cleanAll()
+    spy.mockRestore()
+  })
+
+  describe('price endpoint', () => {
+    it('should return success - kalman', async () => {
+      const data = {
+        endpoint: 'ondo',
+        registry: validContract,
+        asset: '0x0',
+        regularStreamId: '0x000b5',
+        extendedStreamId: '0x000b6',
+        overnightStreamId: '0x000b7',
+        sessionMarket: 'nyse',
+        sessionMarketType: '24/5',
+        sessionBoundaries: [],
+        sessionBoundariesTimeZone: 'UTC',
+        decimals: 8,
+      }
+      mockResponseSuccess()
+      mockTradingHoursResponseFailure()
+
+      const response = await testAdapter.request(data)
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toMatchSnapshot()
+    })
+
+    it('should return success - ema', async () => {
+      const data = {
+        endpoint: 'ondo',
+        registry: validContract,
+        asset: '0x0',
+        regularStreamId: '0x000b5',
+        extendedStreamId: '0x000b6',
+        overnightStreamId: '0x000b7',
+        sessionMarket: 'nyse',
+        sessionMarketType: '24/5',
+        sessionBoundaries: [],
+        sessionBoundariesTimeZone: 'UTC',
+        smoother: 'ema',
+        decimals: 8,
+      }
+      mockResponseSuccess()
+      mockTradingHoursResponseFailure()
+
+      const response = await testAdapter.request(data)
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toMatchSnapshot()
+    })
+
+    it('missing sessionMarket', async () => {
+      const data = {
+        endpoint: 'ondo',
+        registry: validContract,
+        asset: '0x0',
+        regularStreamId: '0x000b5',
+        extendedStreamId: '0x000b6',
+        overnightStreamId: '0x000b7',
+        sessionMarketType: '24/5',
+        sessionBoundaries: [],
+        sessionBoundariesTimeZone: 'UTC',
+        smoother: 'ema',
+        decimals: 8,
+      }
+
+      const response = await testAdapter.request(data)
+
+      expect(response.statusCode).toBe(400)
+      expect(response.json()).toMatchSnapshot()
+    })
+
+    it('bad sessionBoundariesTimeZone', async () => {
+      const data = {
+        endpoint: 'ondo',
+        registry: validContract,
+        asset: '0x0',
+        regularStreamId: '0x000b5',
+        extendedStreamId: '0x000b5',
+        overnightStreamId: '0x000b5',
+        sessionMarket: 'nyse',
+        sessionMarketType: '24/5',
+        sessionBoundaries: ['00:00'],
+        sessionBoundariesTimeZone: 'random',
+        decimals: 8,
+      }
+
+      const response = await testAdapter.request(data)
+
+      expect(response.statusCode).toBe(400)
+      expect(response.json()).toMatchSnapshot()
+    })
+
+    it('bad sessionBoundaries', async () => {
+      const data = {
+        endpoint: 'ondo',
+        registry: validContract,
+        asset: '0x0',
+        regularStreamId: '0x000b5',
+        extendedStreamId: '0x000b5',
+        overnightStreamId: '0x000b5',
+        sessionMarket: 'nyse',
+        sessionMarketType: '24/5',
+        sessionBoundaries: ['99:88'],
+        sessionBoundariesTimeZone: 'UTC',
+        decimals: 8,
+      }
+
+      const response = await testAdapter.request(data)
+
+      expect(response.statusCode).toBe(400)
+      expect(response.json()).toMatchSnapshot()
+    })
+
+    it('should return failure - kalman', async () => {
+      const data = {
+        endpoint: 'ondo',
+        registry: '0x0',
+        asset: '0x0',
+        regularStreamId: '0x000b5',
+        extendedStreamId: '0x000b6',
+        overnightStreamId: '0x000b7',
+        sessionMarket: 'nyse',
+        sessionMarketType: '24/5',
+        sessionBoundaries: [],
+        sessionBoundariesTimeZone: 'UTC',
+        decimals: 8,
+      }
+
+      const response = await testAdapter.request(data)
+      expect(response.statusCode).toBe(502)
+    })
+
+    it('should return failure - ema', async () => {
+      const data = {
+        endpoint: 'ondo',
+        registry: '0x0',
+        asset: '0x0',
+        regularStreamId: '0x000b5',
+        extendedStreamId: '0x000b6',
+        overnightStreamId: '0x000b7',
+        sessionMarket: 'nyse',
+        sessionMarketType: '24/5',
+        sessionBoundaries: [],
+        sessionBoundariesTimeZone: 'UTC',
+        smoother: 'ema',
+        decimals: 8,
+      }
+
+      const response = await testAdapter.request(data)
+      expect(response.statusCode).toBe(502)
+    })
+  })
+})

--- a/packages/composites/tokenized-equity/test/integration/adapter-coinbase.test.ts
+++ b/packages/composites/tokenized-equity/test/integration/adapter-coinbase.test.ts
@@ -17,8 +17,8 @@ jest.mock('ethers', () => {
     Contract: jest.fn().mockImplementation((address: string) => {
       if (address === validContract) {
         return {
-          getSValue: jest.fn().mockImplementation(() => {
-            return Promise.resolve({ sValue: 2n * 10n ** 18n, paused: false })
+          getOracleParams: jest.fn().mockImplementation(() => {
+            return Promise.resolve({ multiplier: 2n * 10n ** 18n, paused: false })
           }),
         }
       } else {
@@ -37,7 +37,7 @@ describe('execute', () => {
     oldEnv = JSON.parse(JSON.stringify(process.env))
     process.env.DATA_ENGINE_ADAPTER_URL = 'http://data-engine'
     process.env.TRADING_HOURS_ADAPTER_URL = 'http://trading-hours'
-    process.env.ETHEREUM_RPC_URL = 'fake-url'
+    process.env.BASE_RPC_URL = 'fake-url'
     process.env.BACKGROUND_EXECUTE_MS = process.env.BACKGROUND_EXECUTE_MS ?? '1000'
     const mockDate = new Date('2001-01-01T11:11:11.111Z')
     spy = jest.spyOn(Date, 'now').mockReturnValue(mockDate.getTime())
@@ -60,7 +60,7 @@ describe('execute', () => {
   describe('price endpoint', () => {
     it('should return success - kalman', async () => {
       const data = {
-        endpoint: 'ondo',
+        endpoint: 'coinbase',
         registry: validContract,
         asset: '0x0',
         regularStreamId: '0x000b5',
@@ -83,7 +83,7 @@ describe('execute', () => {
 
     it('should return success - ema', async () => {
       const data = {
-        endpoint: 'ondo',
+        endpoint: 'coinbase',
         registry: validContract,
         asset: '0x0',
         regularStreamId: '0x000b5',
@@ -107,7 +107,7 @@ describe('execute', () => {
 
     it('missing sessionMarket', async () => {
       const data = {
-        endpoint: 'ondo',
+        endpoint: 'coinbase',
         registry: validContract,
         asset: '0x0',
         regularStreamId: '0x000b5',
@@ -128,7 +128,7 @@ describe('execute', () => {
 
     it('bad sessionBoundariesTimeZone', async () => {
       const data = {
-        endpoint: 'ondo',
+        endpoint: 'coinbase',
         registry: validContract,
         asset: '0x0',
         regularStreamId: '0x000b5',
@@ -149,7 +149,7 @@ describe('execute', () => {
 
     it('bad sessionBoundaries', async () => {
       const data = {
-        endpoint: 'ondo',
+        endpoint: 'coinbase',
         registry: validContract,
         asset: '0x0',
         regularStreamId: '0x000b5',
@@ -170,7 +170,7 @@ describe('execute', () => {
 
     it('should return failure - kalman', async () => {
       const data = {
-        endpoint: 'ondo',
+        endpoint: 'coinbase',
         registry: '0x0',
         asset: '0x0',
         regularStreamId: '0x000b5',
@@ -189,7 +189,7 @@ describe('execute', () => {
 
     it('should return failure - ema', async () => {
       const data = {
-        endpoint: 'ondo',
+        endpoint: 'coinbase',
         registry: '0x0',
         asset: '0x0',
         regularStreamId: '0x000b5',

--- a/packages/composites/tokenized-equity/test/unit/lib/coinbase.test.ts
+++ b/packages/composites/tokenized-equity/test/unit/lib/coinbase.test.ts
@@ -1,0 +1,23 @@
+import { JsonRpcProvider } from 'ethers'
+import { getRegistryData } from '../../../src/lib/registry'
+
+const mockGetSValue = jest.fn()
+
+jest.mock('ethers', () => ({
+  Contract: jest.fn().mockImplementation(() => ({
+    getSValue: mockGetSValue,
+  })),
+  JsonRpcProvider: jest.fn(),
+}))
+
+describe('getRegistryData', () => {
+  it('should return multiplier and paused status', async () => {
+    const sValue = '1500000000000000000'
+    mockGetSValue.mockResolvedValue({ sValue, paused: false })
+
+    expect(await getRegistryData('0x0', '0x1', {} as JsonRpcProvider)).toEqual({
+      multiplier: BigInt(sValue),
+      paused: false,
+    })
+  })
+})

--- a/packages/composites/tokenized-equity/test/unit/lib/coinbase.test.ts
+++ b/packages/composites/tokenized-equity/test/unit/lib/coinbase.test.ts
@@ -1,22 +1,22 @@
 import { JsonRpcProvider } from 'ethers'
-import { getRegistryData } from '../../../src/lib/registry'
+import { getRegistryData } from '../../../src/lib/coinbase'
 
-const mockGetSValue = jest.fn()
+const mockGetOracleParams = jest.fn()
 
 jest.mock('ethers', () => ({
   Contract: jest.fn().mockImplementation(() => ({
-    getSValue: mockGetSValue,
+    getOracleParams: mockGetOracleParams,
   })),
   JsonRpcProvider: jest.fn(),
 }))
 
 describe('getRegistryData', () => {
   it('should return multiplier and paused status', async () => {
-    const sValue = '1500000000000000000'
-    mockGetSValue.mockResolvedValue({ sValue, paused: false })
+    const multiplier = '1500000000000000000'
+    mockGetOracleParams.mockResolvedValue({ multiplier, paused: false })
 
     expect(await getRegistryData('0x0', '0x1', {} as JsonRpcProvider)).toEqual({
-      multiplier: BigInt(sValue),
+      multiplier: BigInt(multiplier),
       paused: false,
     })
   })

--- a/packages/composites/tokenized-equity/test/unit/transport/coinbasePrice.test.ts
+++ b/packages/composites/tokenized-equity/test/unit/transport/coinbasePrice.test.ts
@@ -1,0 +1,177 @@
+import { Requester } from '@chainlink/external-adapter-framework/util/requester'
+import { JsonRpcProvider } from 'ethers'
+import { getRegistryData } from '../../../src/lib/registry'
+import { calculatePrice } from '../../../src/transport/ondoPrice'
+import { smoothedStreamPrice } from '../../../src/transport/smoothedPrice'
+
+jest.mock('../../../src/transport/smoothedPrice', () => ({ smoothedStreamPrice: jest.fn() }))
+const mockSmoothedStreamPrice = smoothedStreamPrice as jest.MockedFunction<
+  typeof smoothedStreamPrice
+>
+
+jest.mock('../../../src/lib/registry', () => ({ getRegistryData: jest.fn() }))
+const mockGetRegistryData = getRegistryData as jest.MockedFunction<typeof getRegistryData>
+
+describe('calculatePrice', () => {
+  const defaultParams = {
+    asset: 'USDC',
+    registry: '0x1234567890123456789012345678901234567890',
+    provider: {} as JsonRpcProvider,
+    regularStreamId: 'regular-stream-id',
+    extendedStreamId: 'extended-stream-id',
+    overnightStreamId: 'overnight-stream-id',
+    url: 'https://api.example.com',
+    tradingHoursUrl: 'https://trading-hours.example.com',
+    requester: {} as Requester,
+    sessionBoundaries: ['09:00', '17:00'],
+    sessionBoundariesTimeZone: 'America/New_York',
+    sessionMarket: 'nyse',
+    sessionMarketType: '24/5',
+    decimals: 8,
+  }
+
+  const streams = {
+    regular: {
+      mid: '1',
+      lastSeenTimestampNs: '2',
+      bid: '0.99',
+      bidVolume: 100,
+      ask: '1.01',
+      askVolume: 100,
+      lastTradedPrice: '1.00',
+      marketStatus: 1,
+      decimals: 18,
+    },
+    extended: {
+      mid: '10',
+      lastSeenTimestampNs: '20',
+      bid: '9.9',
+      bidVolume: 1000,
+      ask: '10.1',
+      askVolume: 1000,
+      lastTradedPrice: '10.0',
+      marketStatus: 2,
+      decimals: 18,
+    },
+    overnight: {
+      mid: '100',
+      lastSeenTimestampNs: '200',
+      bid: '99',
+      bidVolume: 10000,
+      ask: '101',
+      askVolume: 10000,
+      lastTradedPrice: '100',
+      marketStatus: 3,
+      decimals: 18,
+    },
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('scales result', async () => {
+    const smoothedStreamPriceReturn = [
+      {
+        result: 1n,
+        rawPrice: '1',
+        decimals: 6,
+        stream: streams,
+        smoother: {
+          smoother: 'ema' as const,
+          price: '1',
+          x: '2',
+          p: '3',
+          secondsFromTransition: 0,
+        },
+        sessionSource: 'FALLBACK' as const,
+      },
+      {
+        result: 1n,
+        rawPrice: '1',
+        decimals: 6,
+        stream: streams,
+        smoother: {
+          smoother: 'kalman' as const,
+          price: '1',
+          x: '2',
+          p: '3',
+          secondsFromTransition: 0,
+        },
+        sessionSource: 'FALLBACK' as const,
+      },
+    ]
+
+    mockSmoothedStreamPrice.mockResolvedValue(smoothedStreamPriceReturn)
+    mockGetRegistryData.mockResolvedValue({
+      multiplier: 5n * 10n ** 18n,
+      paused: false,
+    })
+
+    const result = await calculatePrice({
+      ...defaultParams,
+      smoother: 'kalman',
+      decimals: 6,
+    })
+
+    const expectedRegistry = { sValue: '5000000000000000000', paused: false }
+    expect(result[0]).toStrictEqual({
+      ...smoothedStreamPriceReturn[0],
+      registry: expectedRegistry,
+      result: '5',
+    })
+    expect(result[1]).toStrictEqual({
+      ...smoothedStreamPriceReturn[1],
+      registry: expectedRegistry,
+      result: '5',
+    })
+  })
+
+  it('throws when registry is paused', async () => {
+    mockSmoothedStreamPrice.mockResolvedValue([
+      {
+        result: 1n,
+        rawPrice: '1',
+        decimals: 6,
+        stream: streams,
+        smoother: {
+          smoother: 'ema' as const,
+          price: '1',
+          x: '0',
+          p: '0',
+          secondsFromTransition: 0,
+        },
+        sessionSource: 'FALLBACK' as const,
+      },
+      {
+        result: 1n,
+        rawPrice: '1',
+        decimals: 6,
+        stream: streams,
+        smoother: {
+          smoother: 'kalman' as const,
+          price: '1',
+          x: '0',
+          p: '0',
+          secondsFromTransition: 0,
+        },
+        sessionSource: 'FALLBACK' as const,
+      },
+    ])
+    mockGetRegistryData.mockResolvedValue({
+      multiplier: 5n * 10n ** 18n,
+      paused: true,
+    })
+
+    await expect(
+      calculatePrice({
+        ...defaultParams,
+        smoother: 'kalman',
+        decimals: 6,
+      }),
+    ).rejects.toMatchObject({
+      statusCode: 503,
+      message: 'asset: USDC paused on registry 0x1234567890123456789012345678901234567890',
+    })
+  })
+})

--- a/packages/composites/tokenized-equity/test/unit/transport/coinbasePrice.test.ts
+++ b/packages/composites/tokenized-equity/test/unit/transport/coinbasePrice.test.ts
@@ -1,7 +1,7 @@
 import { Requester } from '@chainlink/external-adapter-framework/util/requester'
 import { JsonRpcProvider } from 'ethers'
-import { getRegistryData } from '../../../src/lib/registry'
-import { calculatePrice } from '../../../src/transport/ondoPrice'
+import { getRegistryData } from '../../../src/lib/coinbase'
+import { calculatePrice } from '../../../src/transport/coinbasePrice'
 import { smoothedStreamPrice } from '../../../src/transport/smoothedPrice'
 
 jest.mock('../../../src/transport/smoothedPrice', () => ({ smoothedStreamPrice: jest.fn() }))
@@ -9,7 +9,7 @@ const mockSmoothedStreamPrice = smoothedStreamPrice as jest.MockedFunction<
   typeof smoothedStreamPrice
 >
 
-jest.mock('../../../src/lib/registry', () => ({ getRegistryData: jest.fn() }))
+jest.mock('../../../src/lib/coinbase', () => ({ getRegistryData: jest.fn() }))
 const mockGetRegistryData = getRegistryData as jest.MockedFunction<typeof getRegistryData>
 
 describe('calculatePrice', () => {
@@ -114,7 +114,7 @@ describe('calculatePrice', () => {
       decimals: 6,
     })
 
-    const expectedRegistry = { sValue: '5000000000000000000', paused: false }
+    const expectedRegistry = { multiplier: '5000000000000000000', paused: false }
     expect(result[0]).toStrictEqual({
       ...smoothedStreamPriceReturn[0],
       registry: expectedRegistry,


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/OPDATA-7940

## Description

The endpoint is identical to the `coinbase` endpoint, except:

1. The function to get the registry params is called `getOracleParams` instead of `getSValue`,
2. It returns `{multiplier, paused}` instead of `{sValue, paused}`, and
3. The contracts live on Base mainnet instead of Ethereum mainnet.

## Changes

Two separate commits:
1. Copied `ondo` files.
4. Adjusted files for coinbase use case.

## Steps to Test

```
curl --silent -S -X POST http://localhost:8080 -H 'Content-Type: application/json' -d '{
  "data": {
    "endpoint": "coinbase",
    "registry": "0x3f3E8cf41cdd3b1D118c16471aB0113DfDDd5CaD",
    "asset": "0xB2000000000000000000007BF6D5CBB0E24CB301",
    "decimals": 8,
    "extendedStreamId": "0x000b9e87f3f1ac8e590e47cce07a3e964d94f2abd5692b2f92f1dbab79874b07",
    "overnightStreamId": "0x000b67554457bf6c7e70d4d599d9634888fc8d79145c534ddd77ba1dae840107",
    "regularStreamId": "0x000b2dbed1640ead18d37338b75e4755630a900649261baf4ed79d9a749be13d",
    "sessionBoundaries": [
      "04:00",
      "16:00",
      "20:00"
    ],
    "sessionBoundariesTimeZone": "America/New_York",
    "sessionMarket": "nyse",
    "sessionMarketType": "24/5"
  }
}'

{
  "data": {
    "result": "38535085000",
    "rawPrice": "385350850000000000000",
    "decimals": 8,
    "stream": {
      "regular": {
        "mid": "385350850000000000000",
        "lastSeenTimestampNs": "1784281113000000000",
        "bid": "385078700000000000000",
        "bidVolume": 18213023705161794000,
        "ask": "385690000000000000000",
        "askVolume": 384654083551658000,
        "lastTradedPrice": "390380000000000000000",
        "marketStatus": 1,
        "decimals": 18
      },
      "extended": {
        "mid": "385350850000000000000",
        "lastSeenTimestampNs": "1784281196388000000",
        "bid": "385078700000000000000",
        "bidVolume": 6213023705161794000,
        "ask": "385620300000000000000",
        "askVolume": 12810701493875245000,
        "lastTradedPrice": "385329100000000000000",
        "marketStatus": 1,
        "decimals": 18
      },
      "overnight": {
        "mid": "383845000000000000000",
        "lastSeenTimestampNs": "1784281113000000000",
        "bid": "382000000000000000000",
        "bidVolume": 18213023705161794000,
        "ask": "385690000000000000000",
        "askVolume": 7213023705161794000,
        "lastTradedPrice": "384940000000000000000",
        "marketStatus": 1,
        "decimals": 18
      }
    },
    "smoother": {
      "smoother": "kalman",
      "price": "385350850000000000000",
      "x": "384935218448810181027",
      "p": "4306216337466450",
      "secondsFromTransition": 5997.722
    },
    "sessionSource": "TRADINGHOURS",
    "registry": {
      "multiplier": "1000000000000000000",
      "paused": false
    }
  },
  "statusCode": 200,
  "result": "38535085000",
  "timestamps": {
    "providerDataRequestedUnixMs": 1784281197721,
    "providerDataReceivedUnixMs": 1784281197922
  },
  "meta": {
    "adapterName": "TOKENIZED_EQUITY",
    "transportName": "default_single_transport",
    "metrics": {
      "feedId": "HLOq6tLtZ0u6utDm7Ml2w3iJ3gY="
    }
  }
}
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[OPDATA-6280]: https://smartcontract-it.atlassian.net/browse/OPDATA-6280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ