### PR TITLE
Data Engine Adapter: Bump EA framework version for EAs

### DIFF
--- a/.changeset/orange-radios-prove.md
+++ b/.changeset/orange-radios-prove.md
@@ -1,0 +1,9 @@
+---
+'@chainlink/tokenized-equity-adapter': patch
+'@chainlink/gmx-tokens-adapter': patch
+'@chainlink/glv-token-adapter': patch
+'@chainlink/data-engine-adapter': patch
+'@chainlink/gold-adapter': patch
+---
+
+Bumped framework version

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -5269,7 +5269,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@chainlink/data-engine-adapter", "workspace:packages/sources/data-engine"],\
           ["@chainlink/data-streams-sdk", "virtual:29c8fa29f35f020f9160a35554f7b84949a383888c5d188e62624b9badf4ce684909c85071a7f24bdb3e6ab54384c111baed4ccde8d5ece49ebcf3df89864817#npm:1.2.0"],\
-          ["@chainlink/external-adapter-framework", "npm:2.16.1"],\
+          ["@chainlink/external-adapter-framework", "npm:2.18.0"],\
           ["@sinonjs/fake-timers", "npm:9.1.2"],\
           ["@types/jest", "npm:29.5.14"],\
           ["@types/node", "npm:22.14.1"],\
@@ -5965,7 +5965,7 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./packages/composites/glv-token/",\
         "packageDependencies": [\
           ["@chainlink/data-engine-adapter", "workspace:packages/sources/data-engine"],\
-          ["@chainlink/external-adapter-framework", "npm:2.16.1"],\
+          ["@chainlink/external-adapter-framework", "npm:2.18.0"],\
           ["@chainlink/glv-token-adapter", "workspace:packages/composites/glv-token"],\
           ["@types/jest", "npm:29.5.14"],\
           ["@types/node", "npm:22.14.1"],\
@@ -6017,7 +6017,7 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./packages/composites/gmx-tokens/",\
         "packageDependencies": [\
           ["@chainlink/data-engine-adapter", "workspace:packages/sources/data-engine"],\
-          ["@chainlink/external-adapter-framework", "npm:2.16.1"],\
+          ["@chainlink/external-adapter-framework", "npm:2.18.0"],\
           ["@chainlink/gmx-tokens-adapter", "workspace:packages/composites/gmx-tokens"],\
           ["@sinonjs/fake-timers", "npm:9.1.2"],\
           ["@types/jest", "npm:29.5.14"],\
@@ -6037,7 +6037,7 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./packages/composites/gold/",\
         "packageDependencies": [\
           ["@chainlink/data-engine-adapter", "workspace:packages/sources/data-engine"],\
-          ["@chainlink/external-adapter-framework", "npm:2.16.1"],\
+          ["@chainlink/external-adapter-framework", "npm:2.18.0"],\
           ["@chainlink/gold-adapter", "workspace:packages/composites/gold"],\
           ["@types/jest", "npm:29.5.14"],\
           ["@types/node", "npm:22.14.1"],\
@@ -7440,7 +7440,7 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./packages/composites/tokenized-equity/",\
         "packageDependencies": [\
           ["@chainlink/data-engine-adapter", "workspace:packages/sources/data-engine"],\
-          ["@chainlink/external-adapter-framework", "npm:2.16.1"],\
+          ["@chainlink/external-adapter-framework", "npm:2.18.0"],\
           ["@chainlink/tokenized-equity-adapter", "workspace:packages/composites/tokenized-equity"],\
           ["@date-fns/tz", "npm:1.4.1"],\
           ["@types/jest", "npm:29.5.14"],\

--- a/packages/composites/glv-token/package.json
+++ b/packages/composites/glv-token/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@chainlink/data-engine-adapter": "workspace:*",
-    "@chainlink/external-adapter-framework": "2.16.1",
+    "@chainlink/external-adapter-framework": "2.18.0",
     "decimal.js": "^10.3.1",
     "ethers": "^6.15.0",
     "tslib": "2.4.1"

--- a/packages/composites/gmx-tokens/package.json
+++ b/packages/composites/gmx-tokens/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@chainlink/data-engine-adapter": "workspace:*",
-    "@chainlink/external-adapter-framework": "2.16.1",
+    "@chainlink/external-adapter-framework": "2.18.0",
     "decimal.js": "^10.3.1",
     "ethers": "^6.15.0",
     "tslib": "2.4.1"

--- a/packages/composites/gold/package.json
+++ b/packages/composites/gold/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@chainlink/data-engine-adapter": "workspace:*",
-    "@chainlink/external-adapter-framework": "2.16.1",
+    "@chainlink/external-adapter-framework": "2.18.0",
     "decimal.js": "^10.6.0",
     "tslib": "2.4.1"
   }

--- a/packages/composites/tokenized-equity/package.json
+++ b/packages/composites/tokenized-equity/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@chainlink/data-engine-adapter": "workspace:*",
-    "@chainlink/external-adapter-framework": "2.16.1",
+    "@chainlink/external-adapter-framework": "2.18.0",
     "@date-fns/tz": "1.4.1",
     "ethers": "^6.13.2",
     "tslib": "2.4.1"

--- a/packages/sources/data-engine/package.json
+++ b/packages/sources/data-engine/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@chainlink/data-streams-sdk": "1.2.0",
-    "@chainlink/external-adapter-framework": "2.16.1",
+    "@chainlink/external-adapter-framework": "2.18.0",
     "decimal.js": "^10.5.0",
     "tslib": "2.4.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2902,7 +2902,7 @@ __metadata:
   resolution: "@chainlink/data-engine-adapter@workspace:packages/sources/data-engine"
   dependencies:
     "@chainlink/data-streams-sdk": "npm:1.2.0"
-    "@chainlink/external-adapter-framework": "npm:2.16.1"
+    "@chainlink/external-adapter-framework": "npm:2.18.0"
     "@sinonjs/fake-timers": "npm:9.1.2"
     "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:22.14.1"
@@ -3537,7 +3537,7 @@ __metadata:
   resolution: "@chainlink/glv-token-adapter@workspace:packages/composites/glv-token"
   dependencies:
     "@chainlink/data-engine-adapter": "workspace:*"
-    "@chainlink/external-adapter-framework": "npm:2.16.1"
+    "@chainlink/external-adapter-framework": "npm:2.18.0"
     "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:22.14.1"
     decimal.js: "npm:^10.3.1"
@@ -3583,7 +3583,7 @@ __metadata:
   resolution: "@chainlink/gmx-tokens-adapter@workspace:packages/composites/gmx-tokens"
   dependencies:
     "@chainlink/data-engine-adapter": "workspace:*"
-    "@chainlink/external-adapter-framework": "npm:2.16.1"
+    "@chainlink/external-adapter-framework": "npm:2.18.0"
     "@sinonjs/fake-timers": "npm:9.1.2"
     "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:22.14.1"
@@ -3601,7 +3601,7 @@ __metadata:
   resolution: "@chainlink/gold-adapter@workspace:packages/composites/gold"
   dependencies:
     "@chainlink/data-engine-adapter": "workspace:*"
-    "@chainlink/external-adapter-framework": "npm:2.16.1"
+    "@chainlink/external-adapter-framework": "npm:2.18.0"
     "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:22.14.1"
     decimal.js: "npm:^10.6.0"
@@ -4846,7 +4846,7 @@ __metadata:
   resolution: "@chainlink/tokenized-equity-adapter@workspace:packages/composites/tokenized-equity"
   dependencies:
     "@chainlink/data-engine-adapter": "workspace:*"
-    "@chainlink/external-adapter-framework": "npm:2.16.1"
+    "@chainlink/external-adapter-framework": "npm:2.18.0"
     "@date-fns/tz": "npm:1.4.1"
     "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:22.14.1"


### PR DESCRIPTION
## Closes # [DS-3616](https://smartcontract-it.atlassian.net/browse/DS-3616)

## Description
Bump EA Framework version for data engine adapter and it's dependents
......

## Changes

- Bump EA framework from `2.16.1` to `2.18.0`

<!-- Acceptance testing steps, automated tests should _always_ be included -->

No code changes here

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[DS-3616]: https://smartcontract-it.atlassian.net/browse/DS-3616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ