### PR TITLE
Initial code for tickerlayer EA with stock endpoint

### DIFF
--- a/.changeset/strict-ads-fold.md
+++ b/.changeset/strict-ads-fold.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/tickerlayer-adapter': major
+---
+
+Initial version with stock endpoint

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -623,6 +623,10 @@ const RAW_RUNTIME_STATE =
       "reference": "workspace:packages/sources/the-network-firm"\
     },\
     {\
+      "name": "@chainlink/tickerlayer-adapter",\
+      "reference": "workspace:packages/sources/tickerlayer"\
+    },\
+    {\
       "name": "@chainlink/tiingo-adapter",\
       "reference": "workspace:packages/sources/tiingo"\
     },\
@@ -849,6 +853,7 @@ const RAW_RUNTIME_STATE =
     ["@chainlink/synthetix-feeds-adapter", ["workspace:packages/sources/synthetix-feeds"]],\
     ["@chainlink/t-rize-proof-of-insurance-adapter", ["workspace:packages/sources/t-rize-proof-of-insurance"]],\
     ["@chainlink/the-network-firm-adapter", ["workspace:packages/sources/the-network-firm"]],\
+    ["@chainlink/tickerlayer-adapter", ["workspace:packages/sources/tickerlayer"]],\
     ["@chainlink/tiingo-adapter", ["workspace:packages/sources/tiingo"]],\
     ["@chainlink/tiingo-state-adapter", ["workspace:packages/sources/tiingo-state"]],\
     ["@chainlink/token-allocation-adapter", ["workspace:packages/non-deployable/token-allocation"]],\
@@ -7324,6 +7329,23 @@ const RAW_RUNTIME_STATE =
           ["@chainlink/the-network-firm-adapter", "workspace:packages/sources/the-network-firm"],\
           ["@types/jest", "npm:29.5.14"],\
           ["@types/node", "npm:22.14.1"],\
+          ["nock", "npm:13.5.6"],\
+          ["tslib", "npm:2.4.1"],\
+          ["typescript", "patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"]\
+        ],\
+        "linkType": "SOFT"\
+      }]\
+    ]],\
+    ["@chainlink/tickerlayer-adapter", [\
+      ["workspace:packages/sources/tickerlayer", {\
+        "packageLocation": "./packages/sources/tickerlayer/",\
+        "packageDependencies": [\
+          ["@chainlink/external-adapter-framework", "npm:2.18.0"],\
+          ["@chainlink/tickerlayer-adapter", "workspace:packages/sources/tickerlayer"],\
+          ["@sinonjs/fake-timers", "npm:9.1.2"],\
+          ["@types/jest", "npm:29.5.14"],\
+          ["@types/node", "npm:22.14.1"],\
+          ["@types/sinonjs__fake-timers", "npm:8.1.5"],\
           ["nock", "npm:13.5.6"],\
           ["tslib", "npm:2.4.1"],\
           ["typescript", "patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"]\

--- a/packages/sources/tickerlayer/README.md
+++ b/packages/sources/tickerlayer/README.md
@@ -1,0 +1,3 @@
+# Chainlink External Adapter for tickerlayer
+
+This README will be generated automatically when code is merged to `main`. If you would like to generate a preview of the README, please run `yarn generate:readme tickerlayer`.

--- a/packages/sources/tickerlayer/package.json
+++ b/packages/sources/tickerlayer/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@chainlink/tickerlayer-adapter",
+  "version": "0.0.0",
+  "description": "Chainlink tickerlayer adapter.",
+  "keywords": [
+    "Chainlink",
+    "LINK",
+    "blockchain",
+    "oracle",
+    "tickerlayer"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "url": "https://github.com/smartcontractkit/external-adapters-js",
+    "type": "git"
+  },
+  "license": "MIT",
+  "scripts": {
+    "clean": "rm -rf dist && rm -f tsconfig.tsbuildinfo",
+    "prepack": "yarn build",
+    "build": "tsc -b",
+    "server": "node -e 'require(\"./index.js\").server()'",
+    "server:dist": "node -e 'require(\"./dist/index.js\").server()'",
+    "start": "yarn server:dist"
+  },
+  "devDependencies": {
+    "@sinonjs/fake-timers": "9.1.2",
+    "@types/jest": "^29.5.14",
+    "@types/node": "22.14.1",
+    "@types/sinonjs__fake-timers": "8.1.5",
+    "nock": "13.5.6",
+    "typescript": "5.8.3"
+  },
+  "dependencies": {
+    "@chainlink/external-adapter-framework": "2.18.0",
+    "tslib": "2.4.1"
+  }
+}

--- a/packages/sources/tickerlayer/src/config/index.ts
+++ b/packages/sources/tickerlayer/src/config/index.ts
@@ -1,0 +1,22 @@
+import { AdapterConfig } from '@chainlink/external-adapter-framework/config'
+
+export const config = new AdapterConfig({
+  API_KEY: {
+    description: 'An API key for Data Provider',
+    type: 'string',
+    required: true,
+    sensitive: true,
+  },
+  API_ENDPOINT: {
+    description: 'An API endpoint for Data Provider',
+    type: 'string',
+    default: 'https://dataproviderapi.com',
+    sensitive: false,
+  },
+  WS_API_ENDPOINT: {
+    description: 'WS endpoint for Data Provider',
+    type: 'string',
+    default: 'ws://localhost:9090',
+    sensitive: false,
+  },
+})

--- a/packages/sources/tickerlayer/src/config/index.ts
+++ b/packages/sources/tickerlayer/src/config/index.ts
@@ -7,16 +7,10 @@ export const config = new AdapterConfig({
     required: true,
     sensitive: true,
   },
-  API_ENDPOINT: {
-    description: 'An API endpoint for Data Provider',
-    type: 'string',
-    default: 'https://dataproviderapi.com',
-    sensitive: false,
-  },
   WS_API_ENDPOINT: {
     description: 'WS endpoint for Data Provider',
     type: 'string',
-    default: 'ws://localhost:9090',
+    default: 'wss://stream.tickerlayer.com/',
     sensitive: false,
   },
 })

--- a/packages/sources/tickerlayer/src/config/overrides.json
+++ b/packages/sources/tickerlayer/src/config/overrides.json
@@ -1,3 +1,0 @@
-{
-  "tickerlayer": {}
-}

--- a/packages/sources/tickerlayer/src/config/overrides.json
+++ b/packages/sources/tickerlayer/src/config/overrides.json
@@ -1,0 +1,3 @@
+{
+  "tickerlayer": {}
+}

--- a/packages/sources/tickerlayer/src/endpoint/index.ts
+++ b/packages/sources/tickerlayer/src/endpoint/index.ts
@@ -1,0 +1,1 @@
+export { endpoint as stock } from './stock'

--- a/packages/sources/tickerlayer/src/endpoint/stock.ts
+++ b/packages/sources/tickerlayer/src/endpoint/stock.ts
@@ -1,32 +1,15 @@
 import { AdapterEndpoint } from '@chainlink/external-adapter-framework/adapter'
+import { stockEndpointInputParametersDefinition } from '@chainlink/external-adapter-framework/adapter/stock'
 import { SingleNumberResultResponse } from '@chainlink/external-adapter-framework/util'
 import { InputParameters } from '@chainlink/external-adapter-framework/validation'
 import { config } from '../config'
-import overrides from '../config/overrides.json'
 import { wsTransport } from '../transport/stock'
 
-export const inputParameters = new InputParameters(
+export const inputParameters = new InputParameters(stockEndpointInputParametersDefinition, [
   {
-    base: {
-      aliases: ['from', 'coin', 'symbol', 'market'],
-      required: true,
-      type: 'string',
-      description: 'The symbol of symbols of the currency to query',
-    },
-    quote: {
-      aliases: ['to', 'convert'],
-      required: true,
-      type: 'string',
-      description: 'The symbol of the currency to convert to',
-    },
+    base: 'US:AAPL',
   },
-  [
-    {
-      base: 'BTC',
-      quote: 'USD',
-    },
-  ],
-)
+])
 
 export type BaseEndpointTypes = {
   Parameters: typeof inputParameters.definition
@@ -39,5 +22,4 @@ export const endpoint = new AdapterEndpoint({
   aliases: [],
   transport: wsTransport,
   inputParameters,
-  overrides: overrides['tickerlayer'],
 })

--- a/packages/sources/tickerlayer/src/endpoint/stock.ts
+++ b/packages/sources/tickerlayer/src/endpoint/stock.ts
@@ -1,0 +1,43 @@
+import { AdapterEndpoint } from '@chainlink/external-adapter-framework/adapter'
+import { SingleNumberResultResponse } from '@chainlink/external-adapter-framework/util'
+import { InputParameters } from '@chainlink/external-adapter-framework/validation'
+import { config } from '../config'
+import overrides from '../config/overrides.json'
+import { wsTransport } from '../transport/stock'
+
+export const inputParameters = new InputParameters(
+  {
+    base: {
+      aliases: ['from', 'coin', 'symbol', 'market'],
+      required: true,
+      type: 'string',
+      description: 'The symbol of symbols of the currency to query',
+    },
+    quote: {
+      aliases: ['to', 'convert'],
+      required: true,
+      type: 'string',
+      description: 'The symbol of the currency to convert to',
+    },
+  },
+  [
+    {
+      base: 'BTC',
+      quote: 'USD',
+    },
+  ],
+)
+
+export type BaseEndpointTypes = {
+  Parameters: typeof inputParameters.definition
+  Response: SingleNumberResultResponse
+  Settings: typeof config.settings
+}
+
+export const endpoint = new AdapterEndpoint({
+  name: 'stock',
+  aliases: [],
+  transport: wsTransport,
+  inputParameters,
+  overrides: overrides['tickerlayer'],
+})

--- a/packages/sources/tickerlayer/src/index.ts
+++ b/packages/sources/tickerlayer/src/index.ts
@@ -1,0 +1,13 @@
+import { expose, ServerInstance } from '@chainlink/external-adapter-framework'
+import { Adapter } from '@chainlink/external-adapter-framework/adapter'
+import { config } from './config'
+import { stock } from './endpoint'
+
+export const adapter = new Adapter({
+  defaultEndpoint: stock.name,
+  name: 'TICKERLAYER',
+  config,
+  endpoints: [stock],
+})
+
+export const server = (): Promise<ServerInstance | undefined> => expose(adapter)

--- a/packages/sources/tickerlayer/src/transport/stock.ts
+++ b/packages/sources/tickerlayer/src/transport/stock.ts
@@ -1,12 +1,15 @@
 import { WebSocketTransport } from '@chainlink/external-adapter-framework/transports'
+import { makeLogger } from '@chainlink/external-adapter-framework/util'
 import { BaseEndpointTypes } from '../endpoint/stock'
 
 export interface WSResponse {
-  success: boolean
-  price: number
-  base: string
-  quote: string
-  time: number
+  type: string
+  channel: string
+  asset: string
+  symbol: string
+  price: string
+  size: string
+  ts: number
 }
 
 export type WsTransportTypes = BaseEndpointTypes & {
@@ -14,26 +17,45 @@ export type WsTransportTypes = BaseEndpointTypes & {
     WsMessage: WSResponse
   }
 }
+
+const logger = makeLogger('StockTransport')
+
 export class StockWebSocketTransport extends WebSocketTransport<WsTransportTypes> {
   constructor() {
     super({
-      url: (context) => context.adapterSettings.WS_API_ENDPOINT,
+      url: (context) =>
+        `${context.adapterSettings.WS_API_ENDPOINT}?apiKey=${context.adapterSettings.API_KEY}`,
       handlers: {
         message(message) {
-          if (message.success === false) {
+          if (message.type === 'system') {
+            logger.debug({ msg: 'Ignoring system message', ignoredMessage: message })
+            return
+          }
+          if (
+            message.type !== 'trade' ||
+            message.channel !== 'stocks.trades' ||
+            message.asset !== 'stocks' ||
+            !message.symbol ||
+            !message.price ||
+            isNaN(Number(message.price)) ||
+            !message.ts ||
+            isNaN(Number(message.ts))
+          ) {
+            logger.warn({ msg: 'Ignoring unexpected message', ignoredMessage: message })
             return
           }
 
+          const result = Number(message.price)
           return [
             {
-              params: { base: message.base, quote: message.quote },
+              params: { base: message.symbol },
               response: {
-                result: message.price,
+                result,
                 data: {
-                  result: message.price,
+                  result,
                 },
                 timestamps: {
-                  providerIndicatedTimeUnixMs: message.time,
+                  providerIndicatedTimeUnixMs: message.ts,
                 },
               },
             },
@@ -43,14 +65,16 @@ export class StockWebSocketTransport extends WebSocketTransport<WsTransportTypes
       builders: {
         subscribeMessage: (params) => {
           return {
-            type: 'subscribe',
-            symbols: `${params.base}/${params.quote}`.toUpperCase(),
+            action: 'subscribe',
+            channels: ['stocks.trades'],
+            symbols: [params.base],
           }
         },
         unsubscribeMessage: (params) => {
           return {
-            type: 'unsubscribe',
-            symbols: `${params.base}/${params.quote}`.toUpperCase(),
+            action: 'unsubscribe',
+            channels: ['stocks.trades'],
+            symbols: [params.base],
           }
         },
       },

--- a/packages/sources/tickerlayer/src/transport/stock.ts
+++ b/packages/sources/tickerlayer/src/transport/stock.ts
@@ -1,0 +1,61 @@
+import { WebSocketTransport } from '@chainlink/external-adapter-framework/transports'
+import { BaseEndpointTypes } from '../endpoint/stock'
+
+export interface WSResponse {
+  success: boolean
+  price: number
+  base: string
+  quote: string
+  time: number
+}
+
+export type WsTransportTypes = BaseEndpointTypes & {
+  Provider: {
+    WsMessage: WSResponse
+  }
+}
+export class StockWebSocketTransport extends WebSocketTransport<WsTransportTypes> {
+  constructor() {
+    super({
+      url: (context) => context.adapterSettings.WS_API_ENDPOINT,
+      handlers: {
+        message(message) {
+          if (message.success === false) {
+            return
+          }
+
+          return [
+            {
+              params: { base: message.base, quote: message.quote },
+              response: {
+                result: message.price,
+                data: {
+                  result: message.price,
+                },
+                timestamps: {
+                  providerIndicatedTimeUnixMs: message.time,
+                },
+              },
+            },
+          ]
+        },
+      },
+      builders: {
+        subscribeMessage: (params) => {
+          return {
+            type: 'subscribe',
+            symbols: `${params.base}/${params.quote}`.toUpperCase(),
+          }
+        },
+        unsubscribeMessage: (params) => {
+          return {
+            type: 'unsubscribe',
+            symbols: `${params.base}/${params.quote}`.toUpperCase(),
+          }
+        },
+      },
+    })
+  }
+}
+
+export const wsTransport = new StockWebSocketTransport()

--- a/packages/sources/tickerlayer/test-payload.json
+++ b/packages/sources/tickerlayer/test-payload.json
@@ -1,0 +1,6 @@
+{
+ "requests": [{
+  "from": "BTC",
+  "to": "USD"
+ }]
+}

--- a/packages/sources/tickerlayer/test-payload.json
+++ b/packages/sources/tickerlayer/test-payload.json
@@ -1,6 +1,0 @@
-{
- "requests": [{
-  "endpoint": "stock",
-  "symbol": "US:AAPL"
- }]
-}

--- a/packages/sources/tickerlayer/test-payload.json
+++ b/packages/sources/tickerlayer/test-payload.json
@@ -1,6 +1,6 @@
 {
  "requests": [{
-  "from": "BTC",
-  "to": "USD"
+  "endpoint": "stock",
+  "symbol": "US:AAPL"
  }]
 }

--- a/packages/sources/tickerlayer/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/tickerlayer/test/integration/__snapshots__/adapter.test.ts.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`websocket stock endpoint should return success 1`] = `
+{
+  "data": {
+    "result": 1000,
+  },
+  "result": 1000,
+  "statusCode": 200,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 1018,
+    "providerDataStreamEstablishedUnixMs": 1010,
+    "providerIndicatedTimeUnixMs": 1999999,
+  },
+}
+`;

--- a/packages/sources/tickerlayer/test/integration/adapter.test.ts
+++ b/packages/sources/tickerlayer/test/integration/adapter.test.ts
@@ -19,8 +19,7 @@ describe('websocket', () => {
   let oldEnv: NodeJS.ProcessEnv
 
   const dataStock = {
-    base: 'ETH',
-    quote: 'USD',
+    base: 'US:AAPL',
     endpoint: 'stock',
     transport: 'ws',
   }

--- a/packages/sources/tickerlayer/test/integration/adapter.test.ts
+++ b/packages/sources/tickerlayer/test/integration/adapter.test.ts
@@ -1,0 +1,60 @@
+import { SettingsDefinitionFromConfig } from '@chainlink/external-adapter-framework/config'
+import { WebSocketClassProvider } from '@chainlink/external-adapter-framework/transports'
+import {
+  mockWebSocketProvider,
+  MockWebsocketServer,
+  setEnvVariables,
+  TestAdapter,
+} from '@chainlink/external-adapter-framework/util/testing-utils'
+import FakeTimers, { InstalledClock } from '@sinonjs/fake-timers'
+import { config } from '../../src/config'
+import { mockWebsocketServer } from './fixtures'
+
+type SettingsDefinition = SettingsDefinitionFromConfig<typeof config>
+
+describe('websocket', () => {
+  let mockWsServer: MockWebsocketServer | undefined
+  let testAdapter: TestAdapter<SettingsDefinition>
+  const wsEndpoint = 'ws://localhost:9090'
+  let oldEnv: NodeJS.ProcessEnv
+
+  const dataStock = {
+    base: 'ETH',
+    quote: 'USD',
+    endpoint: 'stock',
+    transport: 'ws',
+  }
+
+  beforeAll(async () => {
+    oldEnv = JSON.parse(JSON.stringify(process.env))
+    process.env['WS_API_ENDPOINT'] = wsEndpoint
+    process.env['API_KEY'] = 'fake-api-key'
+    mockWebSocketProvider(WebSocketClassProvider)
+    mockWsServer = mockWebsocketServer(wsEndpoint)
+
+    const adapter = (await import('./../../src')).adapter
+    testAdapter = await TestAdapter.startWithMockedCache(adapter, {
+      clock: FakeTimers.install(),
+      testAdapter: {} as TestAdapter<SettingsDefinition>,
+    })
+
+    // Send initial request to start background execute and wait for cache to be filled with results
+
+    await testAdapter.request(dataStock)
+    await testAdapter.waitForCache(1)
+  })
+
+  afterAll(async () => {
+    setEnvVariables(oldEnv)
+    mockWsServer?.close()
+    ;(testAdapter.clock as InstalledClock | undefined)?.uninstall()
+    await testAdapter.api.close()
+  })
+
+  describe('stock endpoint', () => {
+    it('should return success', async () => {
+      const response = await testAdapter.request(dataStock)
+      expect(response.json()).toMatchSnapshot()
+    })
+  })
+})

--- a/packages/sources/tickerlayer/test/integration/fixtures.ts
+++ b/packages/sources/tickerlayer/test/integration/fixtures.ts
@@ -1,0 +1,20 @@
+import { MockWebsocketServer } from '@chainlink/external-adapter-framework/util/testing-utils'
+
+export const mockWebsocketServer = (URL: string): MockWebsocketServer => {
+  const mockWsServer = new MockWebsocketServer(URL, { mock: false })
+  mockWsServer.on('connection', (socket) => {
+    socket.on('message', (_message) => {
+      return socket.send(
+        JSON.stringify({
+          success: true,
+          price: 1000,
+          base: 'ETH',
+          quote: 'USD',
+          time: '1999999',
+        }),
+      )
+    })
+  })
+
+  return mockWsServer
+}

--- a/packages/sources/tickerlayer/test/integration/fixtures.ts
+++ b/packages/sources/tickerlayer/test/integration/fixtures.ts
@@ -6,11 +6,13 @@ export const mockWebsocketServer = (URL: string): MockWebsocketServer => {
     socket.on('message', (_message) => {
       return socket.send(
         JSON.stringify({
-          success: true,
-          price: 1000,
-          base: 'ETH',
-          quote: 'USD',
-          time: '1999999',
+          type: 'trade',
+          channel: 'stocks.trades',
+          asset: 'stocks',
+          symbol: 'US:AAPL',
+          price: '1000',
+          size: '3',
+          ts: 1999999,
         }),
       )
     })

--- a/packages/sources/tickerlayer/test/unit/stock.test.ts
+++ b/packages/sources/tickerlayer/test/unit/stock.test.ts
@@ -1,0 +1,209 @@
+import { EndpointContext } from '@chainlink/external-adapter-framework/adapter'
+import { metrics } from '@chainlink/external-adapter-framework/metrics'
+import {
+  TransportDependencies,
+  WebSocketClassProvider,
+} from '@chainlink/external-adapter-framework/transports'
+import { LoggerFactoryProvider } from '@chainlink/external-adapter-framework/util'
+import {
+  makeStub,
+  mockWebSocketProvider,
+  MockWebsocketServer,
+  runAllUntilSettled,
+} from '@chainlink/external-adapter-framework/util/testing-utils'
+import FakeTimers from '@sinonjs/fake-timers'
+import { BaseEndpointTypes } from '../../src/endpoint/stock'
+import { StockWebSocketTransport, WsTransportTypes } from '../../src/transport/stock'
+
+const log = jest.fn()
+const debugLog = jest.fn()
+const logger = {
+  fatal: log,
+  error: log,
+  warn: log,
+  info: log,
+  debug: debugLog,
+  trace: debugLog,
+  msgPrefix: 'mock-logger',
+}
+
+LoggerFactoryProvider.set({ child: () => logger })
+metrics.initialize()
+
+describe('StockWebSocketTransport', () => {
+  const transportName = 'default_single_transport'
+  const endpointName = 'stock'
+
+  const adapterSettings = makeStub('adapterSettings', {
+    WS_API_ENDPOINT: 'ws://api.example.com',
+    WS_SUBSCRIPTION_TTL: 30_000,
+    WS_SUBSCRIPTION_UNRESPONSIVE_TTL: 120_000,
+    STREAM_HANDLER_RETRY_MIN_MS: 100,
+    STREAM_HANDLER_RETRY_EXP_FACTOR: 3,
+    STREAM_HANDLER_RETRY_MAX_MS: 1_200_000,
+    MAX_COMMON_KEY_SIZE: 300,
+    WS_CONNECTION_OPEN_TIMEOUT: 10_000,
+    BACKGROUND_EXECUTE_MS_WS: 1_000,
+    WS_HEARTBEAT_INTERVAL_MS: 30_000,
+  } as unknown as BaseEndpointTypes['Settings'])
+
+  const subscriptionSet = makeStub('subscriptionSet', {
+    getAll: jest.fn(),
+  })
+
+  const subscriptionSetFactory = makeStub('subscriptionSetFactory', {
+    buildSet() {
+      return subscriptionSet
+    },
+  })
+
+  const responseCache = {
+    write: jest.fn(),
+  }
+  const dependencies = makeStub('dependencies', {
+    responseCache,
+    subscriptionSetFactory,
+  } as unknown as TransportDependencies<WsTransportTypes>)
+
+  let transport: StockWebSocketTransport
+
+  let clock: FakeTimers.Clock
+  let mockWsServer: MockWebsocketServer
+  let socket: WebSocket
+  const receivedMessages: string[] = []
+
+  beforeAll(() => {
+    clock = FakeTimers.install()
+  })
+
+  beforeEach(async () => {
+    jest.resetAllMocks()
+
+    mockWebSocketProvider(WebSocketClassProvider)
+    receivedMessages.length = 0
+    mockWsServer?.close()
+    mockWsServer = new MockWebsocketServer(adapterSettings.WS_API_ENDPOINT, {
+      mock: false,
+    })
+
+    mockWsServer.on('connection', (sock) => {
+      socket = sock as WebSocket
+      sock.on('message', (message) => {
+        receivedMessages.push(String(message))
+      })
+    })
+
+    transport = new StockWebSocketTransport()
+    await transport.initialize(dependencies, adapterSettings, endpointName, transportName)
+  })
+
+  afterEach(() => {
+    expect(log).not.toHaveBeenCalled()
+  })
+
+  it('should subscribe to the currency pair', async () => {
+    const from = 'ETH'
+    const to = 'USD'
+
+    const params = makeStub('params', {
+      base: from,
+      quote: to,
+    })
+    subscriptionSet.getAll.mockReturnValue([params])
+
+    const context = makeStub('context', {
+      adapterSettings,
+      endpointName,
+    } as EndpointContext<WsTransportTypes>)
+
+    await runAllUntilSettled(clock, transport.backgroundExecute(context))
+    expect(receivedMessages.length).toBe(1)
+
+    await expect(receivedMessages[0]).toBe(
+      JSON.stringify({
+        type: 'subscribe',
+        symbols: `${from}/${to}`,
+      }),
+    )
+  })
+
+  it('should write response to cache', async () => {
+    const from = 'ETH'
+    const to = 'USD'
+
+    const params = makeStub('params', {
+      base: from,
+      quote: to,
+    })
+    subscriptionSet.getAll.mockReturnValue([params])
+
+    const context = makeStub('context', {
+      adapterSettings,
+      endpointName,
+    } as EndpointContext<WsTransportTypes>)
+
+    const t0 = Date.now()
+    await runAllUntilSettled(clock, transport.backgroundExecute(context))
+    const t1 = Date.now()
+
+    const price = 123
+    const providerIndicatedTimeUnixMs = 123456789
+
+    socket.send(
+      JSON.stringify({
+        base: from,
+        quote: to,
+        price,
+        time: providerIndicatedTimeUnixMs,
+      }),
+    )
+
+    expect(responseCache.write).toHaveBeenCalledWith(transportName, [
+      {
+        params,
+        response: {
+          result: price,
+          data: {
+            result: price,
+          },
+          timestamps: {
+            providerDataStreamEstablishedUnixMs: t0,
+            providerDataReceivedUnixMs: t1,
+            providerIndicatedTimeUnixMs,
+          },
+        },
+      },
+    ])
+    expect(responseCache.write).toHaveBeenCalledTimes(1)
+  })
+
+  it('should unsubscribe', async () => {
+    const from = 'ETH'
+    const to = 'USD'
+
+    const params = makeStub('params', {
+      base: from,
+      quote: to,
+    })
+
+    const context = makeStub('context', {
+      adapterSettings,
+      endpointName,
+    } as EndpointContext<WsTransportTypes>)
+
+    subscriptionSet.getAll.mockReturnValue([params])
+    await runAllUntilSettled(clock, transport.backgroundExecute(context))
+    expect(receivedMessages.length).toBe(1)
+
+    subscriptionSet.getAll.mockReturnValue([])
+    await runAllUntilSettled(clock, transport.backgroundExecute(context))
+    expect(receivedMessages.length).toBe(2)
+
+    await expect(receivedMessages[1]).toBe(
+      JSON.stringify({
+        type: 'unsubscribe',
+        symbols: `${from}/${to}`,
+      }),
+    )
+  })
+})

--- a/packages/sources/tickerlayer/test/unit/stock.test.ts
+++ b/packages/sources/tickerlayer/test/unit/stock.test.ts
@@ -35,6 +35,7 @@ describe('StockWebSocketTransport', () => {
   const endpointName = 'stock'
 
   const adapterSettings = makeStub('adapterSettings', {
+    API_KEY: 'test-api-key',
     WS_API_ENDPOINT: 'ws://api.example.com',
     WS_SUBSCRIPTION_TTL: 30_000,
     WS_SUBSCRIPTION_UNRESPONSIVE_TTL: 120_000,
@@ -101,13 +102,11 @@ describe('StockWebSocketTransport', () => {
     expect(log).not.toHaveBeenCalled()
   })
 
-  it('should subscribe to the currency pair', async () => {
-    const from = 'ETH'
-    const to = 'USD'
+  it('should subscribe to the stock symbol', async () => {
+    const symbol = 'US:AAPL'
 
     const params = makeStub('params', {
-      base: from,
-      quote: to,
+      base: symbol,
     })
     subscriptionSet.getAll.mockReturnValue([params])
 
@@ -121,19 +120,18 @@ describe('StockWebSocketTransport', () => {
 
     await expect(receivedMessages[0]).toBe(
       JSON.stringify({
-        type: 'subscribe',
-        symbols: `${from}/${to}`,
+        action: 'subscribe',
+        channels: ['stocks.trades'],
+        symbols: [symbol],
       }),
     )
   })
 
   it('should write response to cache', async () => {
-    const from = 'ETH'
-    const to = 'USD'
+    const symbol = 'US:AAPL'
 
     const params = makeStub('params', {
-      base: from,
-      quote: to,
+      base: symbol,
     })
     subscriptionSet.getAll.mockReturnValue([params])
 
@@ -151,10 +149,13 @@ describe('StockWebSocketTransport', () => {
 
     socket.send(
       JSON.stringify({
-        base: from,
-        quote: to,
-        price,
-        time: providerIndicatedTimeUnixMs,
+        type: 'trade',
+        channel: 'stocks.trades',
+        asset: 'stocks',
+        symbol,
+        price: String(price),
+        size: '3',
+        ts: providerIndicatedTimeUnixMs,
       }),
     )
 
@@ -177,13 +178,70 @@ describe('StockWebSocketTransport', () => {
     expect(responseCache.write).toHaveBeenCalledTimes(1)
   })
 
-  it('should unsubscribe', async () => {
-    const from = 'ETH'
-    const to = 'USD'
+  it('should ignore system messages', async () => {
+    const symbol = 'US:AAPL'
 
     const params = makeStub('params', {
-      base: from,
-      quote: to,
+      base: symbol,
+    })
+    subscriptionSet.getAll.mockReturnValue([params])
+
+    const context = makeStub('context', {
+      adapterSettings,
+      endpointName,
+    } as EndpointContext<WsTransportTypes>)
+
+    await runAllUntilSettled(clock, transport.backgroundExecute(context))
+
+    const systemMessage = { type: 'system', message: 'connected' }
+    socket.send(JSON.stringify(systemMessage))
+
+    expect(responseCache.write).not.toHaveBeenCalled()
+    expect(debugLog).toHaveBeenCalledWith({
+      msg: 'Ignoring system message',
+      ignoredMessage: systemMessage,
+    })
+  })
+
+  it('should ignore unexpected messages', async () => {
+    const symbol = 'US:AAPL'
+
+    const params = makeStub('params', {
+      base: symbol,
+    })
+    subscriptionSet.getAll.mockReturnValue([params])
+
+    const context = makeStub('context', {
+      adapterSettings,
+      endpointName,
+    } as EndpointContext<WsTransportTypes>)
+
+    await runAllUntilSettled(clock, transport.backgroundExecute(context))
+
+    const malformedMessage = {
+      type: 'trade',
+      channel: 'stocks.trades',
+      asset: 'stocks',
+      symbol,
+      price: 'not-a-number',
+      size: '3',
+      ts: 123456789,
+    }
+    socket.send(JSON.stringify(malformedMessage))
+
+    expect(responseCache.write).not.toHaveBeenCalled()
+    expect(log).toHaveBeenCalledWith({
+      msg: 'Ignoring unexpected message',
+      ignoredMessage: malformedMessage,
+    })
+    log.mockClear()
+  })
+
+  it('should unsubscribe', async () => {
+    const symbol = 'US:AAPL'
+
+    const params = makeStub('params', {
+      base: symbol,
     })
 
     const context = makeStub('context', {
@@ -201,8 +259,9 @@ describe('StockWebSocketTransport', () => {
 
     await expect(receivedMessages[1]).toBe(
       JSON.stringify({
-        type: 'unsubscribe',
-        symbols: `${from}/${to}`,
+        action: 'unsubscribe',
+        channels: ['stocks.trades'],
+        symbols: [symbol],
       }),
     )
   })

--- a/packages/sources/tickerlayer/tsconfig.json
+++ b/packages/sources/tickerlayer/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true
+  },
+  "include": ["src/**/*", "src/**/*.json"],
+  "exclude": ["dist", "**/*.spec.ts", "**/*.test.ts"]
+}

--- a/packages/sources/tickerlayer/tsconfig.test.json
+++ b/packages/sources/tickerlayer/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*", "**/test", "src/**/*.json"],
+  "compilerOptions": {
+    "noEmit": true
+  }
+}

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -450,6 +450,9 @@
       "path": "./sources/the-network-firm"
     },
     {
+      "path": "./sources/tickerlayer"
+    },
+    {
       "path": "./sources/tiingo"
     },
     {

--- a/packages/tsconfig.test.json
+++ b/packages/tsconfig.test.json
@@ -450,6 +450,9 @@
       "path": "./sources/the-network-firm/tsconfig.test.json"
     },
     {
+      "path": "./sources/tickerlayer/tsconfig.test.json"
+    },
+    {
       "path": "./sources/tiingo/tsconfig.test.json"
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4747,6 +4747,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@chainlink/tickerlayer-adapter@workspace:packages/sources/tickerlayer":
+  version: 0.0.0-use.local
+  resolution: "@chainlink/tickerlayer-adapter@workspace:packages/sources/tickerlayer"
+  dependencies:
+    "@chainlink/external-adapter-framework": "npm:2.18.0"
+    "@sinonjs/fake-timers": "npm:9.1.2"
+    "@types/jest": "npm:^29.5.14"
+    "@types/node": "npm:22.14.1"
+    "@types/sinonjs__fake-timers": "npm:8.1.5"
+    nock: "npm:13.5.6"
+    tslib: "npm:2.4.1"
+    typescript: "npm:5.8.3"
+  languageName: unknown
+  linkType: soft
+
 "@chainlink/tiingo-adapter@workspace:*, @chainlink/tiingo-adapter@workspace:packages/sources/tiingo":
   version: 0.0.0-use.local
   resolution: "@chainlink/tiingo-adapter@workspace:packages/sources/tiingo"


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/OPDATA-8220

## Description

Tickerlayer is a standard WS EA with `stock` and `stock_quotes` endpoints.
This PR adds only the `stock` endpoint.
The `stock_quotes` endpoint will be added in the next PR.

## Changes

1. `yarn new`.
2. Tickerlayer specific changes.

## Steps to Test

Only works when US markets are open:
```
curl --silent -S -X POST http://localhost:8080 -H 'Content-Type: application/json' -d '{
  "data": {
    "endpoint": "stock",
    "symbol": "US:AAPL"
  }
}'

{
  "result": 324,
  "data": {
    "result": 324
  },
  "timestamps": {
    "providerDataStreamEstablishedUnixMs": 1784805840455,
    "providerDataReceivedUnixMs": 1784805840889,
    "providerIndicatedTimeUnixMs": 1784805840372
  },
  "statusCode": 200,
  "meta": {
    "adapterName": "TICKERLAYER",
    "transportName": "default_single_transport",
    "metrics": {
      "feedId": "{\"base\":\"us:aapl\"}"
    }
  }
}
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
