### PR TITLE
Release 20 streams adapters with gRPC transport support

### DIFF
--- a/.changeset/fine-eggs-chew.md
+++ b/.changeset/fine-eggs-chew.md
@@ -1,0 +1,24 @@
+---
+'@chainlink/cfbenchmarks-adapter': patch
+'@chainlink/coinmetrics-adapter': patch
+'@chainlink/coinpaprika-adapter': patch
+'@chainlink/coinpaprika-state-adapter': patch
+'@chainlink/deutsche-boerse-adapter': patch
+'@chainlink/dxfeed-adapter': patch
+'@chainlink/elwood-adapter': patch
+'@chainlink/expand-network-adapter': patch
+'@chainlink/finage-adapter': patch
+'@chainlink/finalto-adapter': patch
+'@chainlink/finnhub-adapter': patch
+'@chainlink/gsr-adapter': patch
+'@chainlink/market-status-adapter': patch
+'@chainlink/mobula-state-adapter': patch
+'@chainlink/the-network-firm-adapter': patch
+'@chainlink/tiingo-adapter': patch
+'@chainlink/tiingo-state-adapter': patch
+'@chainlink/tp-adapter': patch
+'@chainlink/view-function-adapter': patch
+'@chainlink/view-function-multi-chain-adapter': patch
+---
+
+Release 20 streams adapters with gRPC transport support


### PR DESCRIPTION

## Description

Adapters to release:

- cfbenchmarks2
- coinmetrics
- coinpaprika
- coinpaprika-state
- deutsche-boerse
- dxfeed
- elwood
- expand-network
- finage
- finalto
- finnhub
- gsr
- market-status
- mobula-state
- ncfx
- the-network-firm
- tiingo
- tiingo-state
- tp
- view-function
- view-function-multi-chain

## Changes

- High level
- changes that
- you made

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. Steps
2. to
3. test

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
