### PR TITLE
Fix to support cfbenchmarks2 and composite adapters

### DIFF
--- a/.changeset/brown-teams-draw.md
+++ b/.changeset/brown-teams-draw.md
@@ -1,0 +1,6 @@
+---
+'@chainlink/market-status-adapter': patch
+'@chainlink/cfbenchmarks-adapter': patch
+---
+
+generate-endpoint-aliases fix to support cfbenchmarks2 and composite adapters

--- a/packages/scripts/src/generate-endpoint-aliases/index.ts
+++ b/packages/scripts/src/generate-endpoint-aliases/index.ts
@@ -5,6 +5,19 @@ import { getWorkspaceAdapters } from '../workspace'
 
 const OUTPUT_PATH = 'packages/streams-adapter/endpoint_aliases.json'
 
+/**
+ * Adapter types that are served by the streams adapter
+ */
+const INCLUDED_TYPES = ['sources', 'composites']
+
+/**
+ * Adapter keys that have no workspace package of their own, but are reachable at runtime via
+ * `adapterNameOverride`. Each entry copies the source key's config to the alias key.
+ */
+const ADAPTER_KEY_ALIASES: Record<string, string> = {
+  cfbenchmarks: 'cfbenchmarks2',
+}
+
 interface EndpointConfig {
   aliases?: string[]
 }
@@ -59,8 +72,9 @@ function extractEndpoints(adapter: Adapter): Record<string, EndpointConfig> | un
 
 async function main(): Promise<void> {
   const allAdapters = getWorkspaceAdapters()
-  const v3Sources = allAdapters.filter((a) => a.type === 'sources' && a.framework === '3')
-  const v2Sources = allAdapters.filter((a) => a.type === 'sources' && a.framework !== '3')
+  const included = allAdapters.filter((a) => INCLUDED_TYPES.includes(a.type))
+  const v3Sources = included.filter((a) => a.framework === '3')
+  const v2Sources = included.filter((a) => a.framework !== '3')
 
   if (v3Sources.length === 0) {
     console.error('No EAv3 source adapters found')
@@ -80,6 +94,16 @@ async function main(): Promise<void> {
       }
     } else {
       skipped.push({ name: meta.descopedName, reason: skipReason || 'unknown' })
+    }
+  }
+
+  for (const [sourceKey, aliasKey] of Object.entries(ADAPTER_KEY_ALIASES)) {
+    const source = result.adapters[sourceKey]
+    if (source) {
+      result.adapters[aliasKey] = JSON.parse(JSON.stringify(source))
+      console.log(`Copied ${sourceKey} config to ${aliasKey}`)
+    } else {
+      console.log(`Could not copy ${sourceKey} config to ${aliasKey}: ${sourceKey} not generated`)
     }
   }
 


### PR DESCRIPTION
## Closes #DS-3778

## Description

### Cfbenchmarks2

The adapter package is cfbenchmarks , however the bridgename is cfbenchmarks2. To fix this inconsistency, we will provide an environment variable, PACKAGE_NAME: cfbenchmarks2, but the corresponding entry should exist in the endpoint_aliases.json file.

### Market-status
Initially, the `generate-endpoint-aliases` script supported only the `sources` folder. We need to add composites to support the market-status adapter.

Last Comment Date


......

## Changes

- High level
- changes that
- you made

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test

1. Steps
2. to
3. test

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
