### PR TITLE
Feat/opdata 8320 marketstatus additions

### DIFF
--- a/.changeset/sweet-insects-say.md
+++ b/.changeset/sweet-insects-say.md
@@ -1,0 +1,6 @@
+---
+'@chainlink/market-status-adapter': minor
+'@chainlink/tradinghours-adapter': minor
+---
+
+add hkex as market

--- a/packages/composites/market-status/src/source/sources.ts
+++ b/packages/composites/market-status/src/source/sources.ts
@@ -74,6 +74,10 @@ const marketSources: Record<string, { primary: SourceName; secondary: SourceName
     primary: 'TRADINGHOURS',
     secondary: 'STATIC_SZSE',
   },
+  hkex: {
+    primary: 'TRADINGHOURS',
+    secondary: 'STATIC_HKEX',
+  },
   ice_europe_energy: {
     primary: 'TRADINGHOURS',
     secondary: 'STATIC_ICE_EUROPE_ENERGY',

--- a/packages/composites/market-status/src/source/static-hkex.ts
+++ b/packages/composites/market-status/src/source/static-hkex.ts
@@ -1,0 +1,75 @@
+import { MarketStatus } from '@chainlink/external-adapter-framework/adapter'
+import { isWeekendNow } from '@chainlink/external-adapter-framework/validation/market-status'
+import { TZDate } from '@date-fns/tz'
+import { HALF_HOUR, HOUR, Month, tzDate } from './utils'
+
+const TZ = 'Asia/Hong_Kong'
+const weekend = `516-109:${TZ}` // Friday 16:00 - Monday 9:00
+
+const HOLIDAY_SCHEDULE = [
+  // National Day
+  {
+    start: tzDate(2026, Month.Oct, 1, 9, 0, TZ),
+    end: tzDate(2026, Month.Oct, 1, 16, 0, TZ),
+    status: MarketStatus.CLOSED,
+  },
+  // Day after Chung Yeung
+  {
+    start: tzDate(2026, Month.Oct, 19, 9, 0, TZ),
+    end: tzDate(2026, Month.Oct, 19, 16, 0, TZ),
+    status: MarketStatus.CLOSED,
+  },
+  // Eve of Christmas - half day, morning session only
+  {
+    start: tzDate(2026, Month.Dec, 24, 12, 0, TZ),
+    end: tzDate(2026, Month.Dec, 24, 16, 0, TZ),
+    status: MarketStatus.CLOSED,
+  },
+  // Christmas Day
+  {
+    start: tzDate(2026, Month.Dec, 25, 9, 0, TZ),
+    end: tzDate(2026, Month.Dec, 25, 16, 0, TZ),
+    status: MarketStatus.CLOSED,
+  },
+  // Eve of New Year - half day, morning session only
+  {
+    start: tzDate(2026, Month.Dec, 31, 12, 0, TZ),
+    end: tzDate(2026, Month.Dec, 31, 16, 0, TZ),
+    status: MarketStatus.CLOSED,
+  },
+]
+
+// Open 09:30 - 12:00, 13:00 - 16:00 HKT Mon-Fri
+// (09:00 - 09:30 pre-opening auction, 12:00 - 13:00 lunch break and 16:00 - 16:10 closing auction are not
+// continuous trading, so they are reported as CLOSED)
+export const getStatus = () => {
+  const now = TZDate.tz(TZ)
+
+  const holiday = HOLIDAY_SCHEDULE.find(
+    (s) => now.getTime() >= s.start.getTime() && now.getTime() < s.end.getTime(),
+  )
+  if (holiday) {
+    return {
+      marketStatus: holiday.status,
+      statusString: MarketStatus[holiday.status],
+      providerIndicatedTimeUnixMs: now.getTime(),
+    }
+  }
+
+  let status = MarketStatus.CLOSED
+  const minutes = now.getHours() * HOUR + now.getMinutes()
+
+  if (isWeekendNow(weekend)) {
+    status = MarketStatus.CLOSED
+  } else if (minutes >= 9 * HOUR + HALF_HOUR && minutes < 12 * HOUR) {
+    status = MarketStatus.OPEN
+  } else if (minutes >= 13 * HOUR && minutes < 16 * HOUR) {
+    status = MarketStatus.OPEN
+  }
+
+  return {
+    marketStatus: status,
+    statusString: MarketStatus[status],
+    providerIndicatedTimeUnixMs: now.getTime(),
+  }
+}

--- a/packages/composites/market-status/src/source/static.ts
+++ b/packages/composites/market-status/src/source/static.ts
@@ -1,4 +1,5 @@
 import type { MarketStatusResult } from '../transport/base-market-status'
+import { getStatus as staticHkexStatus } from './static-hkex'
 import { getStatus as staticIceEuropeEnergy } from './static-ice-europe-energy'
 import { getStatus as staticJpxStatus } from './static-jpx'
 import { getStatus as staticKrxStatus } from './static-krx'
@@ -16,6 +17,7 @@ const mapping = {
   STATIC_TPEX: staticTpexStatus,
   STATIC_TWSE: staticTpexStatus,
   STATIC_KRX: staticKrxStatus,
+  STATIC_HKEX: staticHkexStatus,
   STATIC_ICE_EUROPE_ENERGY: staticIceEuropeEnergy,
 }
 

--- a/packages/composites/market-status/test/unit/static-hkex.test.ts
+++ b/packages/composites/market-status/test/unit/static-hkex.test.ts
@@ -1,0 +1,125 @@
+import { MarketStatus } from '@chainlink/external-adapter-framework/adapter'
+import { TZDate } from '@date-fns/tz'
+import { getStatusFromStaticSchedule } from '../../src/source/static'
+import { expectClosesAt, expectOpensAt } from './utils'
+
+describe('getStatusFromStaticSchedule (STATIC_HKEX)', () => {
+  const TZ = 'Asia/Hong_Kong'
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  describe('holidays (HOLIDAY_SCHEDULE in static-hkex.ts)', () => {
+    it('Oct 1: closes at 16:00 HKT Sep 30, closed Oct 1 10:00, reopens at 9:30AM HKT Oct 2 2026', () => {
+      expectClosesAt('STATIC_HKEX', new TZDate(2026, 8, 30, 16, 0, 0, 0, TZ))
+      jest.setSystemTime(new TZDate(2026, 9, 1, 10, 0, 0, 0, TZ).getTime())
+      expect(getStatusFromStaticSchedule('STATIC_HKEX').marketStatus).toEqual(MarketStatus.CLOSED)
+      expectOpensAt('STATIC_HKEX', new TZDate(2026, 9, 2, 9, 30, 0, 0, TZ))
+    })
+
+    it('Oct 19: closes at 16:00 HKT Oct 16, closed Oct 19 10:00, reopens at 9:30AM HKT Oct 20 2026', () => {
+      expectClosesAt('STATIC_HKEX', new TZDate(2026, 9, 16, 16, 0, 0, 0, TZ))
+      jest.setSystemTime(new TZDate(2026, 9, 19, 10, 0, 0, 0, TZ).getTime())
+      expect(getStatusFromStaticSchedule('STATIC_HKEX').marketStatus).toEqual(MarketStatus.CLOSED)
+      expectOpensAt('STATIC_HKEX', new TZDate(2026, 9, 20, 9, 30, 0, 0, TZ))
+    })
+
+    describe('Dec 24: half day (morning session only, closes 12:00 HKT)', () => {
+      it('is open at 10:00 HKT on Dec 24, 2026', () => {
+        jest.setSystemTime(new TZDate(2026, 11, 24, 10, 0, 0, 0, TZ).getTime())
+        expect(getStatusFromStaticSchedule('STATIC_HKEX').marketStatus).toEqual(MarketStatus.OPEN)
+      })
+
+      it('closes at 12:00 HKT on Dec 24, 2026', () => {
+        expectClosesAt('STATIC_HKEX', new TZDate(2026, 11, 24, 12, 0, 0, 0, TZ))
+      })
+
+      it('stays closed through the afternoon session on Dec 24, 2026', () => {
+        jest.setSystemTime(new TZDate(2026, 11, 24, 14, 0, 0, 0, TZ).getTime())
+        expect(getStatusFromStaticSchedule('STATIC_HKEX').marketStatus).toEqual(MarketStatus.CLOSED)
+      })
+    })
+
+    it('Dec 25: closed Dec 25 10:00, reopens at 9:30AM HKT Dec 28 2026', () => {
+      jest.setSystemTime(new TZDate(2026, 11, 25, 10, 0, 0, 0, TZ).getTime())
+      expect(getStatusFromStaticSchedule('STATIC_HKEX').marketStatus).toEqual(MarketStatus.CLOSED)
+      expectOpensAt('STATIC_HKEX', new TZDate(2026, 11, 28, 9, 30, 0, 0, TZ))
+    })
+
+    describe('Dec 31: half day (morning session only, closes 12:00 HKT)', () => {
+      it('is open at 10:00 HKT on Dec 31, 2026', () => {
+        jest.setSystemTime(new TZDate(2026, 11, 31, 10, 0, 0, 0, TZ).getTime())
+        expect(getStatusFromStaticSchedule('STATIC_HKEX').marketStatus).toEqual(MarketStatus.OPEN)
+      })
+
+      it('closes at 12:00 HKT on Dec 31, 2026', () => {
+        expectClosesAt('STATIC_HKEX', new TZDate(2026, 11, 31, 12, 0, 0, 0, TZ))
+      })
+
+      it('stays closed through the afternoon session, reopens at 9:30AM HKT Jan 1 2027 (not in schedule)', () => {
+        jest.setSystemTime(new TZDate(2026, 11, 31, 14, 0, 0, 0, TZ).getTime())
+        expect(getStatusFromStaticSchedule('STATIC_HKEX').marketStatus).toEqual(MarketStatus.CLOSED)
+        expectOpensAt('STATIC_HKEX', new TZDate(2027, 0, 1, 9, 30, 0, 0, TZ))
+      })
+    })
+  })
+
+  describe('weekend (Friday close - Monday 9:30AM HKT open)', () => {
+    it('closes at Friday 16:00 HKT (Jan 9, 2026)', () => {
+      expectClosesAt('STATIC_HKEX', new TZDate(2026, 0, 9, 16, 0, 0, 0, TZ))
+    })
+
+    it('reopens at Monday 9:30AM HKT (Jan 12, 2026)', () => {
+      expectOpensAt('STATIC_HKEX', new TZDate(2026, 0, 12, 9, 30, 0, 0, TZ))
+    })
+  })
+
+  describe('pre-opening auction (9:00 - 9:30 HKT)', () => {
+    it('is closed at 9:00 HKT on a weekday (Jan 12, 2026)', () => {
+      jest.setSystemTime(new TZDate(2026, 0, 12, 9, 0, 0, 0, TZ).getTime())
+      expect(getStatusFromStaticSchedule('STATIC_HKEX').marketStatus).toEqual(MarketStatus.CLOSED)
+    })
+
+    it('opens at 9:30 HKT on a weekday (Jan 12, 2026)', () => {
+      expectOpensAt('STATIC_HKEX', new TZDate(2026, 0, 12, 9, 30, 0, 0, TZ))
+    })
+  })
+
+  describe('lunch break (12:00 - 13:00 HKT)', () => {
+    it('closes at 12:00 HKT on a weekday (Jan 12, 2026)', () => {
+      expectClosesAt('STATIC_HKEX', new TZDate(2026, 0, 12, 12, 0, 0, 0, TZ))
+    })
+
+    it('reopens at 13:00 HKT on a weekday (Jan 12, 2026)', () => {
+      expectOpensAt('STATIC_HKEX', new TZDate(2026, 0, 12, 13, 0, 0, 0, TZ))
+    })
+  })
+
+  describe('end of day (16:00 HKT, closing auction 16:00 - 16:10 is closed)', () => {
+    it('closes at 16:00 HKT on a weekday (Jan 12, 2026)', () => {
+      expectClosesAt('STATIC_HKEX', new TZDate(2026, 0, 12, 16, 0, 0, 0, TZ))
+    })
+
+    it('is closed at 16:05 HKT on a weekday (Jan 12, 2026)', () => {
+      jest.setSystemTime(new TZDate(2026, 0, 12, 16, 5, 0, 0, TZ).getTime())
+      expect(getStatusFromStaticSchedule('STATIC_HKEX').marketStatus).toEqual(MarketStatus.CLOSED)
+    })
+  })
+
+  describe('open', () => {
+    it('is open at 10AM HKT on a weekday (Jan 12, 2026)', () => {
+      jest.setSystemTime(new TZDate(2026, 0, 12, 10, 0, 0, 0, TZ).getTime())
+      expect(getStatusFromStaticSchedule('STATIC_HKEX').marketStatus).toEqual(MarketStatus.OPEN)
+    })
+
+    it('is open at 2PM HKT on a weekday (Jan 12, 2026)', () => {
+      jest.setSystemTime(new TZDate(2026, 0, 12, 14, 0, 0, 0, TZ).getTime())
+      expect(getStatusFromStaticSchedule('STATIC_HKEX').marketStatus).toEqual(MarketStatus.OPEN)
+    })
+  })
+})

--- a/packages/sources/tradinghours/src/transport/utils.ts
+++ b/packages/sources/tradinghours/src/transport/utils.ts
@@ -21,6 +21,7 @@ const marketToFinId = {
   jpx: 'JP.JPX', // Japan Exchange Group
   sse: 'CN.SSE', // Shanghai Stock Exchange
   szse: 'CN.SZSE', // Shenzhen Stock Exchange
+  hkex: 'HK.HKEX', // Hong Kong Exchanges and Clearing
   nymex: 'US.CHNLNK.WTI',
   ice_europe_energy: 'US.ICE.ENERGY.GROUP3',
   bme: 'ES.BME',

--- a/packages/sources/tradinghours/test/integration/__snapshots__/adapter-session.test.ts.snap
+++ b/packages/sources/tradinghours/test/integration/__snapshots__/adapter-session.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Market status endpoint should return failure with invalid market 1`] = `
 {
   "error": {
-    "message": "[Param: market] input is not one of valid options (forex,metals,wti,nyse,lse,xetra,tradegate,six,euronext_milan,euronext_paris,tpex,twse,krx,jpx,sse,szse,nymex,ice_europe_energy,bme,cbot_ag,cme_cattle,cme_equity_index,cme_trsy,comex_copper,comex_gold,comex_silver,nymex_brent,nymex_cocoa,nymex_coffee,nymex_gasoil,nymex_hhng,nymex_pld,nymex_plt,nymex_sugar,FOREX,METALS,WTI,NYSE,LSE,XETRA,TRADEGATE,SIX,EURONEXT_MILAN,EURONEXT_PARIS,TPEX,TWSE,KRX,JPX,SSE,SZSE,NYMEX,ICE_EUROPE_ENERGY,BME,CBOT_AG,CME_CATTLE,CME_EQUITY_INDEX,CME_TRSY,COMEX_COPPER,COMEX_GOLD,COMEX_SILVER,NYMEX_BRENT,NYMEX_COCOA,NYMEX_COFFEE,NYMEX_GASOIL,NYMEX_HHNG,NYMEX_PLD,NYMEX_PLT,NYMEX_SUGAR)",
+    "message": "[Param: market] input is not one of valid options (forex,metals,wti,nyse,lse,xetra,tradegate,six,euronext_milan,euronext_paris,tpex,twse,krx,jpx,sse,szse,hkex,nymex,ice_europe_energy,bme,cbot_ag,cme_cattle,cme_equity_index,cme_trsy,comex_copper,comex_gold,comex_silver,nymex_brent,nymex_cocoa,nymex_coffee,nymex_gasoil,nymex_hhng,nymex_pld,nymex_plt,nymex_sugar,FOREX,METALS,WTI,NYSE,LSE,XETRA,TRADEGATE,SIX,EURONEXT_MILAN,EURONEXT_PARIS,TPEX,TWSE,KRX,JPX,SSE,SZSE,HKEX,NYMEX,ICE_EUROPE_ENERGY,BME,CBOT_AG,CME_CATTLE,CME_EQUITY_INDEX,CME_TRSY,COMEX_COPPER,COMEX_GOLD,COMEX_SILVER,NYMEX_BRENT,NYMEX_COCOA,NYMEX_COFFEE,NYMEX_GASOIL,NYMEX_HHNG,NYMEX_PLD,NYMEX_PLT,NYMEX_SUGAR)",
     "name": "AdapterError",
   },
   "status": "errored",


### PR DESCRIPTION
## Closes #[OPDATA-8320](https://smartcontract-it.atlassian.net/browse/OPDATA-8320)

## Description
add hkex (Hong Kong Exchanges and Clearing) as a market to the market-status adapter

## Changes
- add `hkex` market to market-status, using tradinghours as primary source and a new static source as secondary
- add `hkex` to the tradinghours market map (`HK.HKEX`)
- new static source for hkex: open 09:30-12:00 and 13:00-16:00 HKT Mon-Fri, plus 2026 holidays

## Steps to Test
1. yarn test market-status
2. yarn test tradinghours
3. example input for both market-status and tradinghours
```
curl --silent --location --request POST 'localhost:8080' \
--header 'Content-Type: application/json' \
--data '{
    "data": {
        "endpoint": "market-status",
        "market": "hkex"
    }
}'
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[OPDATA-8320]: https://smartcontract-it.atlassian.net/browse/OPDATA-8320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ