### PR TITLE
Refactor tickerlayer to align endpoints

### DIFF
--- a/.changeset/moody-snails-enter.md
+++ b/.changeset/moody-snails-enter.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/tickerlayer-adapter': patch
+---
+
+Minor refactoring to align endpoints.

--- a/packages/sources/tickerlayer/src/transport/stock.ts
+++ b/packages/sources/tickerlayer/src/transport/stock.ts
@@ -1,6 +1,7 @@
 import { WebSocketTransport } from '@chainlink/external-adapter-framework/transports'
 import { makeLogger } from '@chainlink/external-adapter-framework/util'
 import { BaseEndpointTypes } from '../endpoint/stock'
+import { toNumber } from './util'
 
 export interface WSResponse {
   type: string
@@ -20,6 +21,10 @@ export type WsTransportTypes = BaseEndpointTypes & {
 
 const logger = makeLogger('StockTransport')
 
+export const stockTradesType = 'trade'
+export const stockTradesChannel = 'stocks.trades'
+export const stockTradesAsset = 'stocks'
+
 export class StockWebSocketTransport extends WebSocketTransport<WsTransportTypes> {
   constructor() {
     super({
@@ -31,21 +36,21 @@ export class StockWebSocketTransport extends WebSocketTransport<WsTransportTypes
             logger.debug({ msg: 'Ignoring system message', ignoredMessage: message })
             return
           }
+          const price = toNumber(message.price)
+          const providerIndicatedTimeUnixMs = toNumber(message.ts)
           if (
-            message.type !== 'trade' ||
-            message.channel !== 'stocks.trades' ||
-            message.asset !== 'stocks' ||
+            message.type !== stockTradesType ||
+            message.channel !== stockTradesChannel ||
+            message.asset !== stockTradesAsset ||
             !message.symbol ||
-            !message.price ||
-            isNaN(Number(message.price)) ||
-            !message.ts ||
-            isNaN(Number(message.ts))
+            !price ||
+            !providerIndicatedTimeUnixMs
           ) {
             logger.warn({ msg: 'Ignoring unexpected message', ignoredMessage: message })
             return
           }
 
-          const result = Number(message.price)
+          const result = price
           return [
             {
               params: { base: message.symbol },
@@ -55,7 +60,7 @@ export class StockWebSocketTransport extends WebSocketTransport<WsTransportTypes
                   result,
                 },
                 timestamps: {
-                  providerIndicatedTimeUnixMs: message.ts,
+                  providerIndicatedTimeUnixMs,
                 },
               },
             },
@@ -66,14 +71,14 @@ export class StockWebSocketTransport extends WebSocketTransport<WsTransportTypes
         subscribeMessage: (params) => {
           return {
             action: 'subscribe',
-            channels: ['stocks.trades'],
+            channels: [stockTradesChannel],
             symbols: [params.base],
           }
         },
         unsubscribeMessage: (params) => {
           return {
             action: 'unsubscribe',
-            channels: ['stocks.trades'],
+            channels: [stockTradesChannel],
             symbols: [params.base],
           }
         },

--- a/packages/sources/tickerlayer/src/transport/stock_quotes.ts
+++ b/packages/sources/tickerlayer/src/transport/stock_quotes.ts
@@ -1,6 +1,7 @@
 import { WebSocketTransport } from '@chainlink/external-adapter-framework/transports'
 import { makeLogger } from '@chainlink/external-adapter-framework/util'
 import { BaseEndpointTypes } from '../endpoint/stock_quotes'
+import { toNumber } from './util'
 
 export interface WSResponse {
   type: string
@@ -25,11 +26,6 @@ const logger = makeLogger('StockQuotesTransport')
 export const stockQuotesType = 'quote'
 export const stockQuotesChannel = 'stocks.quotes'
 export const stockQuotesAsset = 'stocks'
-
-const toNumber = (s?: string | number) => {
-  const num = Number(s)
-  return isNaN(num) ? undefined : num
-}
 
 export class StockQuotesWebSocketTransport extends WebSocketTransport<WsTransportTypes> {
   constructor() {
@@ -77,7 +73,7 @@ export class StockQuotesWebSocketTransport extends WebSocketTransport<WsTranspor
                   ask_volume,
                 },
                 timestamps: {
-                  providerIndicatedTimeUnixMs: message.ts,
+                  providerIndicatedTimeUnixMs,
                 },
               },
             },

--- a/packages/sources/tickerlayer/src/transport/util.ts
+++ b/packages/sources/tickerlayer/src/transport/util.ts
@@ -1,0 +1,4 @@
+export const toNumber = (s?: string | number) => {
+  const num = Number(s)
+  return isNaN(num) ? undefined : num
+}

--- a/packages/sources/tickerlayer/test/unit/stock.test.ts
+++ b/packages/sources/tickerlayer/test/unit/stock.test.ts
@@ -13,7 +13,13 @@ import {
 } from '@chainlink/external-adapter-framework/util/testing-utils'
 import FakeTimers from '@sinonjs/fake-timers'
 import { BaseEndpointTypes } from '../../src/endpoint/stock'
-import { StockWebSocketTransport, WsTransportTypes } from '../../src/transport/stock'
+import {
+  stockTradesAsset,
+  stockTradesChannel,
+  stockTradesType,
+  StockWebSocketTransport,
+  WsTransportTypes,
+} from '../../src/transport/stock'
 
 const log = jest.fn()
 const debugLog = jest.fn()
@@ -102,9 +108,7 @@ describe('StockWebSocketTransport', () => {
     expect(log).not.toHaveBeenCalled()
   })
 
-  it('should subscribe to the stock symbol', async () => {
-    const symbol = 'US:AAPL'
-
+  const setUpSubscription = async (symbol: string) => {
     const params = makeStub('params', {
       base: symbol,
     })
@@ -116,12 +120,18 @@ describe('StockWebSocketTransport', () => {
     } as EndpointContext<WsTransportTypes>)
 
     await runAllUntilSettled(clock, transport.backgroundExecute(context))
+  }
+
+  it('should subscribe to the stock symbol', async () => {
+    const symbol = 'US:AAPL'
+    await setUpSubscription(symbol)
+
     expect(receivedMessages.length).toBe(1)
 
     await expect(receivedMessages[0]).toBe(
       JSON.stringify({
         action: 'subscribe',
-        channels: ['stocks.trades'],
+        channels: [stockTradesChannel],
         symbols: [symbol],
       }),
     )
@@ -133,15 +143,9 @@ describe('StockWebSocketTransport', () => {
     const params = makeStub('params', {
       base: symbol,
     })
-    subscriptionSet.getAll.mockReturnValue([params])
-
-    const context = makeStub('context', {
-      adapterSettings,
-      endpointName,
-    } as EndpointContext<WsTransportTypes>)
 
     const t0 = Date.now()
-    await runAllUntilSettled(clock, transport.backgroundExecute(context))
+    await setUpSubscription(params.base)
     const t1 = Date.now()
 
     const price = 123
@@ -149,9 +153,9 @@ describe('StockWebSocketTransport', () => {
 
     socket.send(
       JSON.stringify({
-        type: 'trade',
-        channel: 'stocks.trades',
-        asset: 'stocks',
+        type: stockTradesType,
+        channel: stockTradesChannel,
+        asset: stockTradesAsset,
         symbol,
         price: String(price),
         size: '3',
@@ -181,17 +185,7 @@ describe('StockWebSocketTransport', () => {
   it('should ignore system messages', async () => {
     const symbol = 'US:AAPL'
 
-    const params = makeStub('params', {
-      base: symbol,
-    })
-    subscriptionSet.getAll.mockReturnValue([params])
-
-    const context = makeStub('context', {
-      adapterSettings,
-      endpointName,
-    } as EndpointContext<WsTransportTypes>)
-
-    await runAllUntilSettled(clock, transport.backgroundExecute(context))
+    await setUpSubscription(symbol)
 
     const systemMessage = { type: 'system', message: 'connected' }
     socket.send(JSON.stringify(systemMessage))
@@ -206,22 +200,12 @@ describe('StockWebSocketTransport', () => {
   it('should ignore unexpected messages', async () => {
     const symbol = 'US:AAPL'
 
-    const params = makeStub('params', {
-      base: symbol,
-    })
-    subscriptionSet.getAll.mockReturnValue([params])
-
-    const context = makeStub('context', {
-      adapterSettings,
-      endpointName,
-    } as EndpointContext<WsTransportTypes>)
-
-    await runAllUntilSettled(clock, transport.backgroundExecute(context))
+    await setUpSubscription(symbol)
 
     const malformedMessage = {
-      type: 'trade',
-      channel: 'stocks.trades',
-      asset: 'stocks',
+      type: stockTradesType,
+      channel: stockTradesChannel,
+      asset: stockTradesAsset,
       symbol,
       price: 'not-a-number',
       size: '3',
@@ -260,7 +244,7 @@ describe('StockWebSocketTransport', () => {
     await expect(receivedMessages[1]).toBe(
       JSON.stringify({
         action: 'unsubscribe',
-        channels: ['stocks.trades'],
+        channels: [stockTradesChannel],
         symbols: [symbol],
       }),
     )


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/OPDATA-8339

## Description

The `tickerlayer` EA has 2 endpoints which were added in separate PRs and ended up following slightly different patterns. Before changing the endpoints to support more asset types, I want to make them follow the same patterns so the follow-up changes are easier to review.

## Changes

1. Move `toNumber` to `util.ts` and use it from `stock.ts`.
2. Add string constants to `stock.ts` similar to `stock_quotes.ts`.
3. Add `setUpSubscription` to `stock.test.ts`, similar to `stock_quotes.test.ts`.

## Steps to Test

1. `yarn test packages/sources/tickerlayer`

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
