### PR TITLE
Support additional asset types in tickerlayer

### DIFF
--- a/.changeset/jolly-swans-guess.md
+++ b/.changeset/jolly-swans-guess.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/tickerlayer-adapter': minor
+---
+
+Support additional asset types

--- a/packages/sources/tickerlayer/src/endpoint/common.ts
+++ b/packages/sources/tickerlayer/src/endpoint/common.ts
@@ -1,0 +1,33 @@
+import { stockEndpointInputParametersDefinition } from '@chainlink/external-adapter-framework/adapter/stock'
+import { AdapterRequest } from '@chainlink/external-adapter-framework/util'
+import { InputParameters } from '@chainlink/external-adapter-framework/validation'
+
+export const inputParameters = new InputParameters(
+  {
+    ...stockEndpointInputParametersDefinition,
+    assetType: {
+      description:
+        'The asset type is used to determine what channel to subscribe to. The Tickerlayer API supports "stocks", "fores", "crypto", "indices", "etfs", and "commodities".',
+      type: 'string',
+      default: 'stocks',
+      // We don't restrict to specific options in order to support future
+      // assets types without code changes.
+    },
+  },
+  [
+    {
+      base: 'US:AAPL',
+      assetType: 'stocks',
+    },
+  ],
+)
+
+export const customInputValidation = (
+  request: AdapterRequest<typeof inputParameters.validated>,
+): undefined => {
+  const { assetType } = request.requestContext.data
+  if (!/^[a-zA-Z]+$/.test(assetType)) {
+    throw new Error(`Asset type must contain only letters. Found '${assetType}'.`)
+  }
+  return
+}

--- a/packages/sources/tickerlayer/src/endpoint/stock.ts
+++ b/packages/sources/tickerlayer/src/endpoint/stock.ts
@@ -5,11 +5,25 @@ import { InputParameters } from '@chainlink/external-adapter-framework/validatio
 import { config } from '../config'
 import { wsTransport } from '../transport/stock'
 
-export const inputParameters = new InputParameters(stockEndpointInputParametersDefinition, [
+export const inputParameters = new InputParameters(
   {
-    base: 'US:AAPL',
+    ...stockEndpointInputParametersDefinition,
+    assetType: {
+      description:
+        'The asset type is used to determine what channel to subscribe to. The Tickerlayer API supports "stocks", "fores", "crypto", "indices", "etfs", and "commodities".',
+      type: 'string',
+      default: 'stocks',
+      // We don't restrict to specific options in order to support future
+      // assets types without code changes.
+    },
   },
-])
+  [
+    {
+      base: 'US:AAPL',
+      assetType: 'stocks',
+    },
+  ],
+)
 
 export type BaseEndpointTypes = {
   Parameters: typeof inputParameters.definition
@@ -19,7 +33,14 @@ export type BaseEndpointTypes = {
 
 export const endpoint = new AdapterEndpoint({
   name: 'stock',
-  aliases: [],
+  aliases: ['price'],
   transport: wsTransport,
   inputParameters,
+  customInputValidation: (request): undefined => {
+    const { assetType } = request.requestContext.data
+    if (!/^[a-zA-Z]+$/.test(assetType)) {
+      throw new Error(`Asset type must contain only letters. Found '${assetType}'.`)
+    }
+    return
+  },
 })

--- a/packages/sources/tickerlayer/src/endpoint/stock.ts
+++ b/packages/sources/tickerlayer/src/endpoint/stock.ts
@@ -1,29 +1,8 @@
 import { AdapterEndpoint } from '@chainlink/external-adapter-framework/adapter'
-import { stockEndpointInputParametersDefinition } from '@chainlink/external-adapter-framework/adapter/stock'
 import { SingleNumberResultResponse } from '@chainlink/external-adapter-framework/util'
-import { InputParameters } from '@chainlink/external-adapter-framework/validation'
 import { config } from '../config'
 import { wsTransport } from '../transport/stock'
-
-export const inputParameters = new InputParameters(
-  {
-    ...stockEndpointInputParametersDefinition,
-    assetType: {
-      description:
-        'The asset type is used to determine what channel to subscribe to. The Tickerlayer API supports "stocks", "fores", "crypto", "indices", "etfs", and "commodities".',
-      type: 'string',
-      default: 'stocks',
-      // We don't restrict to specific options in order to support future
-      // assets types without code changes.
-    },
-  },
-  [
-    {
-      base: 'US:AAPL',
-      assetType: 'stocks',
-    },
-  ],
-)
+import { customInputValidation, inputParameters } from './common'
 
 export type BaseEndpointTypes = {
   Parameters: typeof inputParameters.definition
@@ -36,11 +15,5 @@ export const endpoint = new AdapterEndpoint({
   aliases: ['price'],
   transport: wsTransport,
   inputParameters,
-  customInputValidation: (request): undefined => {
-    const { assetType } = request.requestContext.data
-    if (!/^[a-zA-Z]+$/.test(assetType)) {
-      throw new Error(`Asset type must contain only letters. Found '${assetType}'.`)
-    }
-    return
-  },
+  customInputValidation,
 })

--- a/packages/sources/tickerlayer/src/endpoint/stock_quotes.ts
+++ b/packages/sources/tickerlayer/src/endpoint/stock_quotes.ts
@@ -4,11 +4,25 @@ import { InputParameters } from '@chainlink/external-adapter-framework/validatio
 import { config } from '../config'
 import { wsTransport } from '../transport/stock_quotes'
 
-export const inputParameters = new InputParameters(stockEndpointInputParametersDefinition, [
+export const inputParameters = new InputParameters(
   {
-    base: 'US:AAPL',
+    ...stockEndpointInputParametersDefinition,
+    assetType: {
+      description:
+        'The asset type is used to determine what channel to subscribe to. The Tickerlayer API supports "stocks", "fores", "crypto", "indices", "etfs", and "commodities".',
+      type: 'string',
+      default: 'stocks',
+      // We don't restrict to specific options in order to support future
+      // assets types without code changes.
+    },
   },
-])
+  [
+    {
+      base: 'US:AAPL',
+      assetType: 'stocks',
+    },
+  ],
+)
 
 export type BaseEndpointTypes = {
   Parameters: typeof inputParameters.definition
@@ -27,7 +41,14 @@ export type BaseEndpointTypes = {
 
 export const endpoint = new AdapterEndpoint({
   name: 'stock_quotes',
-  aliases: [],
+  aliases: ['quotes'],
   transport: wsTransport,
   inputParameters,
+  customInputValidation: (request): undefined => {
+    const { assetType } = request.requestContext.data
+    if (!/^[a-zA-Z]+$/.test(assetType)) {
+      throw new Error(`Asset type must contain only letters. Found '${assetType}'.`)
+    }
+    return
+  },
 })

--- a/packages/sources/tickerlayer/src/endpoint/stock_quotes.ts
+++ b/packages/sources/tickerlayer/src/endpoint/stock_quotes.ts
@@ -1,28 +1,7 @@
 import { AdapterEndpoint } from '@chainlink/external-adapter-framework/adapter'
-import { stockEndpointInputParametersDefinition } from '@chainlink/external-adapter-framework/adapter/stock'
-import { InputParameters } from '@chainlink/external-adapter-framework/validation'
 import { config } from '../config'
 import { wsTransport } from '../transport/stock_quotes'
-
-export const inputParameters = new InputParameters(
-  {
-    ...stockEndpointInputParametersDefinition,
-    assetType: {
-      description:
-        'The asset type is used to determine what channel to subscribe to. The Tickerlayer API supports "stocks", "fores", "crypto", "indices", "etfs", and "commodities".',
-      type: 'string',
-      default: 'stocks',
-      // We don't restrict to specific options in order to support future
-      // assets types without code changes.
-    },
-  },
-  [
-    {
-      base: 'US:AAPL',
-      assetType: 'stocks',
-    },
-  ],
-)
+import { customInputValidation, inputParameters } from './common'
 
 export type BaseEndpointTypes = {
   Parameters: typeof inputParameters.definition
@@ -44,11 +23,5 @@ export const endpoint = new AdapterEndpoint({
   aliases: ['quotes'],
   transport: wsTransport,
   inputParameters,
-  customInputValidation: (request): undefined => {
-    const { assetType } = request.requestContext.data
-    if (!/^[a-zA-Z]+$/.test(assetType)) {
-      throw new Error(`Asset type must contain only letters. Found '${assetType}'.`)
-    }
-    return
-  },
+  customInputValidation,
 })

--- a/packages/sources/tickerlayer/src/transport/stock.ts
+++ b/packages/sources/tickerlayer/src/transport/stock.ts
@@ -8,8 +8,8 @@ export interface WSResponse {
   channel: string
   asset: string
   symbol: string
-  price: string
-  size: string
+  price: number | string
+  size: number | string
   ts: number
 }
 
@@ -21,9 +21,7 @@ export type WsTransportTypes = BaseEndpointTypes & {
 
 const logger = makeLogger('StockTransport')
 
-export const stockTradesType = 'trade'
-export const stockTradesChannel = 'stocks.trades'
-export const stockTradesAsset = 'stocks'
+export const tradesMessageType = 'trade'
 
 export class StockWebSocketTransport extends WebSocketTransport<WsTransportTypes> {
   constructor() {
@@ -39,9 +37,7 @@ export class StockWebSocketTransport extends WebSocketTransport<WsTransportTypes
           const price = toNumber(message.price)
           const providerIndicatedTimeUnixMs = toNumber(message.ts)
           if (
-            message.type !== stockTradesType ||
-            message.channel !== stockTradesChannel ||
-            message.asset !== stockTradesAsset ||
+            message.type !== tradesMessageType ||
             !message.symbol ||
             !price ||
             !providerIndicatedTimeUnixMs
@@ -53,7 +49,7 @@ export class StockWebSocketTransport extends WebSocketTransport<WsTransportTypes
           const result = price
           return [
             {
-              params: { base: message.symbol },
+              params: { base: message.symbol, assetType: message.asset },
               response: {
                 result,
                 data: {
@@ -71,14 +67,14 @@ export class StockWebSocketTransport extends WebSocketTransport<WsTransportTypes
         subscribeMessage: (params) => {
           return {
             action: 'subscribe',
-            channels: [stockTradesChannel],
+            channels: [`${params.assetType}.trades`],
             symbols: [params.base],
           }
         },
         unsubscribeMessage: (params) => {
           return {
             action: 'unsubscribe',
-            channels: [stockTradesChannel],
+            channels: [`${params.assetType}.trades`],
             symbols: [params.base],
           }
         },

--- a/packages/sources/tickerlayer/src/transport/stock_quotes.ts
+++ b/packages/sources/tickerlayer/src/transport/stock_quotes.ts
@@ -8,10 +8,10 @@ export interface WSResponse {
   channel: string
   asset: string
   symbol: string
-  bid: string
-  ask: string
-  bid_size: string
-  ask_size: string
+  bid: number | string
+  ask: number | string
+  bid_size: number | string
+  ask_size: number | string
   ts: number
 }
 
@@ -23,9 +23,7 @@ export type WsTransportTypes = BaseEndpointTypes & {
 
 const logger = makeLogger('StockQuotesTransport')
 
-export const stockQuotesType = 'quote'
-export const stockQuotesChannel = 'stocks.quotes'
-export const stockQuotesAsset = 'stocks'
+export const quotesMessageType = 'quote'
 
 export class StockQuotesWebSocketTransport extends WebSocketTransport<WsTransportTypes> {
   constructor() {
@@ -44,9 +42,7 @@ export class StockQuotesWebSocketTransport extends WebSocketTransport<WsTranspor
           const ask_volume = toNumber(message.ask_size)
           const providerIndicatedTimeUnixMs = toNumber(message.ts)
           if (
-            message.type !== stockQuotesType ||
-            message.channel !== stockQuotesChannel ||
-            message.asset !== stockQuotesAsset ||
+            message.type !== quotesMessageType ||
             !message.symbol ||
             !bid_price ||
             !ask_price ||
@@ -62,7 +58,7 @@ export class StockQuotesWebSocketTransport extends WebSocketTransport<WsTranspor
 
           return [
             {
-              params: { base: message.symbol },
+              params: { base: message.symbol, assetType: message.asset },
               response: {
                 result: null,
                 data: {
@@ -84,14 +80,14 @@ export class StockQuotesWebSocketTransport extends WebSocketTransport<WsTranspor
         subscribeMessage: (params) => {
           return {
             action: 'subscribe',
-            channels: [stockQuotesChannel],
+            channels: [`${params.assetType}.quotes`],
             symbols: [params.base],
           }
         },
         unsubscribeMessage: (params) => {
           return {
             action: 'unsubscribe',
-            channels: [stockQuotesChannel],
+            channels: [`${params.assetType}.quotes`],
             symbols: [params.base],
           }
         },

--- a/packages/sources/tickerlayer/test/unit/stock.test.ts
+++ b/packages/sources/tickerlayer/test/unit/stock.test.ts
@@ -13,13 +13,14 @@ import {
 } from '@chainlink/external-adapter-framework/util/testing-utils'
 import FakeTimers from '@sinonjs/fake-timers'
 import { BaseEndpointTypes } from '../../src/endpoint/stock'
-import {
-  stockTradesAsset,
-  stockTradesChannel,
-  stockTradesType,
-  StockWebSocketTransport,
-  WsTransportTypes,
-} from '../../src/transport/stock'
+import { StockWebSocketTransport, WsTransportTypes } from '../../src/transport/stock'
+
+const stockTradesAsset = 'stocks'
+const stockTradesChannel = 'stocks.trades'
+const tradesType = 'trade'
+
+const etfTradesAsset = 'etfs'
+const etfTradesChannel = 'etfs.trades'
 
 const log = jest.fn()
 const debugLog = jest.fn()
@@ -108,9 +109,10 @@ describe('StockWebSocketTransport', () => {
     expect(log).not.toHaveBeenCalled()
   })
 
-  const setUpSubscription = async (symbol: string) => {
+  const setUpSubscription = async (symbol: string, assetType: string) => {
     const params = makeStub('params', {
       base: symbol,
+      assetType,
     })
     subscriptionSet.getAll.mockReturnValue([params])
 
@@ -124,7 +126,7 @@ describe('StockWebSocketTransport', () => {
 
   it('should subscribe to the stock symbol', async () => {
     const symbol = 'US:AAPL'
-    await setUpSubscription(symbol)
+    await setUpSubscription(symbol, stockTradesAsset)
 
     expect(receivedMessages.length).toBe(1)
 
@@ -137,15 +139,31 @@ describe('StockWebSocketTransport', () => {
     )
   })
 
+  it('should subscribe to the etf symbol', async () => {
+    const symbol = 'JP:1329'
+    await setUpSubscription(symbol, etfTradesAsset)
+
+    expect(receivedMessages.length).toBe(1)
+
+    await expect(receivedMessages[0]).toBe(
+      JSON.stringify({
+        action: 'subscribe',
+        channels: [etfTradesChannel],
+        symbols: [symbol],
+      }),
+    )
+  })
+
   it('should write response to cache', async () => {
     const symbol = 'US:AAPL'
 
     const params = makeStub('params', {
       base: symbol,
+      assetType: stockTradesAsset,
     })
 
     const t0 = Date.now()
-    await setUpSubscription(params.base)
+    await setUpSubscription(params.base, stockTradesAsset)
     const t1 = Date.now()
 
     const price = 123
@@ -153,7 +171,7 @@ describe('StockWebSocketTransport', () => {
 
     socket.send(
       JSON.stringify({
-        type: stockTradesType,
+        type: tradesType,
         channel: stockTradesChannel,
         asset: stockTradesAsset,
         symbol,
@@ -182,10 +200,56 @@ describe('StockWebSocketTransport', () => {
     expect(responseCache.write).toHaveBeenCalledTimes(1)
   })
 
+  it('should write response to cache for etfs', async () => {
+    const symbol = 'JP:1329'
+
+    const params = makeStub('params', {
+      base: symbol,
+      assetType: etfTradesAsset,
+    })
+
+    const t0 = Date.now()
+    await setUpSubscription(params.base, etfTradesAsset)
+    const t1 = Date.now()
+
+    const price = 123
+    const providerIndicatedTimeUnixMs = 123456789
+
+    socket.send(
+      JSON.stringify({
+        type: tradesType,
+        channel: etfTradesChannel,
+        asset: etfTradesAsset,
+        symbol,
+        price: Number(price), // ETFs return number instead of string
+        size: 3,
+        ts: providerIndicatedTimeUnixMs,
+      }),
+    )
+
+    expect(responseCache.write).toHaveBeenCalledWith(transportName, [
+      {
+        params,
+        response: {
+          result: price,
+          data: {
+            result: price,
+          },
+          timestamps: {
+            providerDataStreamEstablishedUnixMs: t0,
+            providerDataReceivedUnixMs: t1,
+            providerIndicatedTimeUnixMs,
+          },
+        },
+      },
+    ])
+    expect(responseCache.write).toHaveBeenCalledTimes(1)
+  })
+
   it('should ignore system messages', async () => {
     const symbol = 'US:AAPL'
 
-    await setUpSubscription(symbol)
+    await setUpSubscription(symbol, stockTradesAsset)
 
     const systemMessage = { type: 'system', message: 'connected' }
     socket.send(JSON.stringify(systemMessage))
@@ -200,10 +264,10 @@ describe('StockWebSocketTransport', () => {
   it('should ignore unexpected messages', async () => {
     const symbol = 'US:AAPL'
 
-    await setUpSubscription(symbol)
+    await setUpSubscription(symbol, stockTradesAsset)
 
     const malformedMessage = {
-      type: stockTradesType,
+      type: tradesType,
       channel: stockTradesChannel,
       asset: stockTradesAsset,
       symbol,
@@ -226,6 +290,7 @@ describe('StockWebSocketTransport', () => {
 
     const params = makeStub('params', {
       base: symbol,
+      assetType: stockTradesAsset,
     })
 
     const context = makeStub('context', {

--- a/packages/sources/tickerlayer/test/unit/stock_quotes.test.ts
+++ b/packages/sources/tickerlayer/test/unit/stock_quotes.test.ts
@@ -13,13 +13,14 @@ import {
 } from '@chainlink/external-adapter-framework/util/testing-utils'
 import FakeTimers from '@sinonjs/fake-timers'
 import { BaseEndpointTypes } from '../../src/endpoint/stock_quotes'
-import {
-  stockQuotesAsset,
-  stockQuotesChannel,
-  stockQuotesType,
-  StockQuotesWebSocketTransport,
-  WsTransportTypes,
-} from '../../src/transport/stock_quotes'
+import { StockQuotesWebSocketTransport, WsTransportTypes } from '../../src/transport/stock_quotes'
+
+const stockQuotesAsset = 'stocks'
+const stockQuotesChannel = 'stocks.quotes'
+const quotesType = 'quote'
+
+const etfQuotesAsset = 'etfs'
+const etfQuotesChannel = 'etfs.quotes'
 
 const log = jest.fn()
 const debugLog = jest.fn()
@@ -108,9 +109,10 @@ describe('StockQuotesWebSocketTransport', () => {
     expect(log).not.toHaveBeenCalled()
   })
 
-  const setUpSubscription = async (symbol: string) => {
+  const setUpSubscription = async (symbol: string, assetType: string) => {
     const params = makeStub('params', {
       base: symbol,
+      assetType,
     })
     subscriptionSet.getAll.mockReturnValue([params])
 
@@ -124,7 +126,7 @@ describe('StockQuotesWebSocketTransport', () => {
 
   it('should subscribe to the stock symbol', async () => {
     const symbol = 'US:AAPL'
-    await setUpSubscription(symbol)
+    await setUpSubscription(symbol, stockQuotesAsset)
 
     expect(receivedMessages.length).toBe(1)
 
@@ -137,15 +139,31 @@ describe('StockQuotesWebSocketTransport', () => {
     )
   })
 
+  it('should subscribe to the etf symbol', async () => {
+    const symbol = 'JP:1329'
+    await setUpSubscription(symbol, etfQuotesAsset)
+
+    expect(receivedMessages.length).toBe(1)
+
+    await expect(receivedMessages[0]).toBe(
+      JSON.stringify({
+        action: 'subscribe',
+        channels: [etfQuotesChannel],
+        symbols: [symbol],
+      }),
+    )
+  })
+
   it('should write response to cache', async () => {
     const symbol = 'US:AAPL'
 
     const params = makeStub('params', {
       base: symbol,
+      assetType: stockQuotesAsset,
     })
 
     const t0 = Date.now()
-    await setUpSubscription(params.base)
+    await setUpSubscription(params.base, stockQuotesAsset)
     const t1 = Date.now()
 
     const bid_price = 123
@@ -157,7 +175,7 @@ describe('StockQuotesWebSocketTransport', () => {
 
     socket.send(
       JSON.stringify({
-        type: stockQuotesType,
+        type: quotesType,
         channel: stockQuotesChannel,
         asset: stockQuotesAsset,
         symbol,
@@ -192,10 +210,67 @@ describe('StockQuotesWebSocketTransport', () => {
     expect(responseCache.write).toHaveBeenCalledTimes(1)
   })
 
+  it('should write response to cache for etfs', async () => {
+    const symbol = 'JP:1329'
+
+    const params = makeStub('params', {
+      base: symbol,
+      assetType: etfQuotesAsset,
+    })
+
+    const t0 = Date.now()
+    await setUpSubscription(params.base, stockQuotesAsset)
+    const t1 = Date.now()
+
+    const bid_price = 123
+    const ask_price = 124
+    const mid_price = 123.5
+    const bid_volume = 5
+    const ask_volume = 6
+    const providerIndicatedTimeUnixMs = 123456789
+
+    socket.send(
+      JSON.stringify({
+        type: quotesType,
+        channel: etfQuotesChannel,
+        asset: etfQuotesAsset,
+        symbol,
+        // ETFs return number instead of string
+        bid: Number(bid_price),
+        ask: Number(ask_price),
+        bid_size: Number(bid_volume),
+        ask_size: Number(ask_volume),
+        ts: providerIndicatedTimeUnixMs,
+      }),
+    )
+
+    expect(responseCache.write).toHaveBeenCalledWith(transportName, [
+      {
+        params,
+        response: {
+          result: null,
+          data: {
+            bid_price,
+            ask_price,
+            mid_price,
+            bid_volume,
+            ask_volume,
+          },
+          timestamps: {
+            providerDataStreamEstablishedUnixMs: t0,
+            providerDataReceivedUnixMs: t1,
+            providerIndicatedTimeUnixMs,
+          },
+        },
+      },
+    ])
+    expect(responseCache.write).toHaveBeenCalledTimes(1)
+  })
+
   it('should ignore system messages', async () => {
     const symbol = 'US:AAPL'
 
-    await setUpSubscription(symbol)
+    await setUpSubscription(symbol, stockQuotesAsset)
 
     const systemMessage = { type: 'system', message: 'connected' }
     socket.send(JSON.stringify(systemMessage))
@@ -210,10 +285,10 @@ describe('StockQuotesWebSocketTransport', () => {
   it('should ignore unexpected messages', async () => {
     const symbol = 'US:AAPL'
 
-    await setUpSubscription(symbol)
+    await setUpSubscription(symbol, stockQuotesAsset)
 
     const malformedMessage = {
-      type: stockQuotesType,
+      type: quotesType,
       channel: stockQuotesChannel,
       asset: stockQuotesAsset,
       symbol,
@@ -234,10 +309,10 @@ describe('StockQuotesWebSocketTransport', () => {
   it('should ignore messages with zero ask volume', async () => {
     const symbol = 'US:AAPL'
 
-    await setUpSubscription(symbol)
+    await setUpSubscription(symbol, stockQuotesAsset)
 
     const zeroAskSizeMessage = {
-      type: stockQuotesType,
+      type: quotesType,
       channel: stockQuotesChannel,
       asset: stockQuotesAsset,
       symbol,
@@ -262,6 +337,7 @@ describe('StockQuotesWebSocketTransport', () => {
 
     const params = makeStub('params', {
       base: symbol,
+      assetType: stockQuotesAsset,
     })
 
     const context = makeStub('context', {


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/OPDATA-8339

## Description

Currently `tickerlayer` only supports stock prices and stock quotes.
We want to support prices and quotes for other asset types as well. In particular for ETFs.
We can get this over the same websocket connection and the API is almost the same.
We just need to specify a different `channel` in the subscription and take into account that while stock messages have numbers as strings, some other asset types have numbers as numbers.

## Changes

1. Add an `assetType` param to the `stock` and `stock_quotes` endpoints, defaulting to `stocks` for backwards compatilibilty.
2. Add `price` and `quotes` aliases to the endpoints to avoid confusion about using "stock" endpoints with a different asset type.
3. Use the `assetType` to construct the subscription messages.
4. Remove the restriction on `message.channel` and `message.asset` as they now depend on the asset type.
5. Update and add unit tests.

## Steps to Test

When Asian markets are open:
```
curl --silent -S -X POST http://localhost:8080 -H 'Content-Type: application/json' -d '{
  "data": {
    "endpoint": "price",
    "assetType": "etfs",
    "symbol": "JP:1329"
  }
}'
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
