### PR TITLE
feat(dxfeed): use NumericResultEndpoint for price endpoint

### DIFF
--- a/.changeset/swift-pandas-rush.md
+++ b/.changeset/swift-pandas-rush.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/dxfeed-adapter': minor
+---
+
+Switched price endpoint to NumericResultEndpoint for automatic numeric result validation

--- a/packages/sources/dxfeed/src/endpoint/price.ts
+++ b/packages/sources/dxfeed/src/endpoint/price.ts
@@ -1,4 +1,4 @@
-import { AdapterEndpoint } from '@chainlink/external-adapter-framework/adapter'
+import { NumericResultEndpoint } from '@chainlink/external-adapter-framework/adapter'
 import { TransportRoutes } from '@chainlink/external-adapter-framework/transports'
 import { SingleNumberResultResponse } from '@chainlink/external-adapter-framework/util'
 import {
@@ -17,7 +17,7 @@ export type BaseEndpointTypes = {
   Response: SingleNumberResultResponse
 }
 
-export const endpoint = new AdapterEndpoint({
+export const endpoint = new NumericResultEndpoint<BaseEndpointTypes>({
   name: 'price',
   aliases: ['crypto', 'stock', 'forex', 'commodities'],
   transportRoutes: new TransportRoutes<BaseEndpointTypes>()

--- a/packages/sources/dxfeed/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/dxfeed/test/integration/__snapshots__/adapter.test.ts.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`execute price endpoint rest should return 502 when the provider returns a non-numeric result 1`] = `
+{
+  "errorMessage": "Invalid numeric result: null",
+  "statusCode": 502,
+  "timestamps": {
+    "providerDataReceivedUnixMs": 1641035471111,
+    "providerDataRequestedUnixMs": 1641035471111,
+  },
+}
+`;
+
 exports[`execute price endpoint rest should return success 1`] = `
 {
   "data": {

--- a/packages/sources/dxfeed/test/integration/adapter.test.ts
+++ b/packages/sources/dxfeed/test/integration/adapter.test.ts
@@ -1,4 +1,4 @@
-import { mockPriceEndpoint } from './fixtures'
+import { mockPriceEndpointWithSymbols } from './fixtures'
 import {
   TestAdapter,
   setEnvVariables,
@@ -10,12 +10,19 @@ describe('execute', () => {
   let spy: jest.SpyInstance
   let testAdapter: TestAdapter
   let oldEnv: NodeJS.ProcessEnv
+
   beforeAll(async () => {
     oldEnv = JSON.parse(JSON.stringify(process.env))
-    process.env['API_USERNAME'] = 'fake-api-username'
-    process.env['API_PASSWORD'] = 'fake-api-password'
     const mockDate = new Date('2022-01-01T11:11:11.111Z')
     spy = jest.spyOn(Date, 'now').mockReturnValue(mockDate.getTime())
+
+    process.env['API_USERNAME'] = 'fake-api-username'
+    process.env['API_PASSWORD'] = 'fake-api-password'
+
+    mockPriceEndpointWithSymbols({
+      TSLA: 239.255,
+      INVALID_RESULT: null,
+    })
 
     const adapter = (await import('./../../src')).adapter as unknown as Adapter
     adapter.rateLimiting = undefined
@@ -32,15 +39,38 @@ describe('execute', () => {
     spy.mockRestore()
   })
 
+  async function requestWithRetry(data: object): Promise<any> {
+    let response = await testAdapter.request(data)
+    let attempts = 0
+    while (response.statusCode === 504 && attempts < 20) {
+      await new Promise((resolve) => setTimeout(resolve, 500))
+      response = await testAdapter.request(data)
+      attempts++
+    }
+    return response
+  }
+
   describe('price endpoint rest', () => {
     it('should return success', async () => {
       const data = {
         base: 'TSLA',
       }
-      mockPriceEndpoint()
-      const response = await testAdapter.request(data)
+      const response = await requestWithRetry(data)
       expect(response.statusCode).toBe(200)
       expect(response.json()).toMatchSnapshot()
     })
+
+    it(
+      'should return 502 when the provider returns a non-numeric result',
+      async () => {
+        const data = {
+          base: 'INVALID_RESULT',
+        }
+        const response = await requestWithRetry(data)
+        expect(response.statusCode).toBe(502)
+        expect(response.json()).toMatchSnapshot()
+      },
+      30000,
+    )
   })
 })

--- a/packages/sources/dxfeed/test/integration/fixtures.ts
+++ b/packages/sources/dxfeed/test/integration/fixtures.ts
@@ -1,5 +1,6 @@
 import { MockWebsocketServer } from '@chainlink/external-adapter-framework/util/testing-utils'
 import nock from 'nock'
+
 export function mockPriceEndpoint(): nock.Scope {
   return nock('https://tools.dxfeed.com/webservice/rest', { encodedQueryParams: true })
     .get('/events.json')
@@ -48,6 +49,77 @@ export function mockPriceEndpoint(): nock.Scope {
         'X-Origin-Nginx',
         'tools1',
       ],
+    )
+    .persist()
+}
+
+export function mockPriceEndpointWithSymbols(
+  symbols: Record<string, number | null>,
+): nock.Scope {
+  return nock('https://tools.dxfeed.com/webservice/rest', { encodedQueryParams: true })
+    .get('/events.json')
+    .query((actualQuery) => {
+      return (
+        actualQuery.events === 'Trade,Quote' &&
+        typeof actualQuery.symbols === 'string' &&
+        actualQuery.symbols
+          .split(',')
+          .every((symbol: string) => Object.prototype.hasOwnProperty.call(symbols, symbol))
+      )
+    })
+    .reply(
+      (uri) => {
+        const url = new URL(uri, 'https://tools.dxfeed.com')
+        const requestedSymbols = (url.searchParams.get('symbols') || '').split(',')
+        return [
+          200,
+          {
+            status: 'OK',
+            Trade: Object.fromEntries(
+              requestedSymbols.map((symbol) => [
+                symbol,
+                {
+                  eventSymbol: symbol,
+                  eventTime: 0,
+                  time: 1636744209248,
+                  timeNanoPart: 0,
+                  sequence: 775394,
+                  exchangeCode: 'V',
+                  price: symbols[symbol] ?? null,
+                  change: 0.03,
+                  size: 3,
+                  dayVolume: 700004,
+                  dayTurnover: 167577930,
+                  tickDirection: 'ZERO_UP',
+                  extendedTradingHours: false,
+                },
+              ]),
+            ),
+          },
+          [
+            'Server',
+            'nginx',
+            'Date',
+            'Fri, 12 Nov 2021 19:10:13 GMT',
+            'Content-Type',
+            'application/json',
+            'Transfer-Encoding',
+            'chunked',
+            'Connection',
+            'close',
+            'X-Origin-Nginx',
+            'tools1',
+            'Access-Control-Allow-Origin',
+            '*',
+            'Access-Control-Allow-Methods',
+            'GET, POST, OPTIONS',
+            'Access-Control-Max-Age',
+            '86400',
+            'X-Origin-Nginx',
+            'tools1',
+          ],
+        ]
+      },
     )
     .persist()
 }


### PR DESCRIPTION
Switches the dxfeed price endpoint to use the framework's generic `NumericResultEndpoint` for automatic numeric result validation.

## Changes
- Replaced `AdapterEndpoint` with `NumericResultEndpoint<BaseEndpointTypes>` in `src/endpoint/price.ts`.
- Added integration tests covering the success path and the non-numeric result path (returns 502).

## Local verification
- Linked the framework from `ea-framework-js` via yarn `portal:` and ran the dxfeed test suite: 21 tests passed.
- Ran the adapter against the live dxfeed demo endpoint with staging credentials; TSLA returned a valid price.

## Dependency
This PR requires a framework release containing the generic `NumericResultEndpoint` (https://github.com/smartcontractkit/ea-framework-js/pull/876). The `package.json` dependency will be bumped to that release version once it is available.