### PR TITLE
static-market-hours: Fix bug with daylight saving

### DIFF
--- a/.changeset/true-apes-refuse.md
+++ b/.changeset/true-apes-refuse.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/static-market-hours-adapter': patch
+---
+
+Fix bug with daylight saving

--- a/packages/sources/static-market-hours/src/util/schedule.ts
+++ b/packages/sources/static-market-hours/src/util/schedule.ts
@@ -3,7 +3,7 @@ import {
   TwentyfourFiveMarketStatus,
 } from '@chainlink/external-adapter-framework/adapter'
 import { tz, TZDate } from '@date-fns/tz'
-import { addDays, addHours, ContextFn, format, isValid, parse, startOfDay } from 'date-fns'
+import { addDays, addSeconds, ContextFn, format, isValid, parse, startOfDay } from 'date-fns'
 
 type Timezone = ContextFn<TZDate>
 
@@ -117,8 +117,8 @@ export const getStatusStringFromSchedule = <StatusType extends MarketStatusType>
 
 const parseTime = (time: string, date: TZDate): TZDate => {
   if (time === '24:00:00') {
-    const startOfDate = startOfDay(date)
-    return addHours(startOfDate, 24)
+    const oneSecondBefore = parse('23:59:59', timeFormat, date)
+    return addSeconds(oneSecondBefore, 1)
   }
   return parse(time, timeFormat, date)
 }

--- a/packages/sources/static-market-hours/test/unit/schedule.test.ts
+++ b/packages/sources/static-market-hours/test/unit/schedule.test.ts
@@ -432,6 +432,34 @@ describe('schedule', () => {
         })
       })
     })
+
+    describe('daylight saving', () => {
+      const scheduleData: Schedule<typeof MarketStatus> = {
+        timezone: 'US/Central',
+        lastValidDate: '2027-01-03',
+        defaultStatus: 'CLOSED',
+        weekly: [
+          {
+            status: 'OPEN',
+            when: [{ days: ['SUNDAY'], times: [{ start: '23:00:00', end: '24:00:00' }] }],
+          },
+        ],
+        exceptions: [],
+      }
+
+      it('should correctly interpret 24:00:00 on the day DST ends', () => {
+        // We previously had a bug where 24:00:00 was interpreted as 24 hours
+        // after the start of the day. But on the day DST ends, 24 hours after
+        // the start of the day is actually 23:00:00, so this would place
+        // 23:30:00 after then end of the day.
+        expect(
+          getStatusStringFromSchedule(
+            new TZDate(2026, 10, 1, 23, 55, 0, 0, scheduleData.timezone).getTime(),
+            scheduleData,
+          ),
+        ).toBe('OPEN')
+      })
+    })
   })
 
   describe('getScheduleValidationError', () => {


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/OPDATA-8204

## Description

In the schedule JSON, we use `24:00:00` to indicate the end of the day. Since `date-fns` doesn't treat this as a valid time, we had to add custom logic to parse this. Our custom logic treated it as 24 hours after the start of the day. But on the day that daylight saving ends, 24 hours after the start of the day is actually 23:00:00.

So when we have a time range that says the market is open from 17:00:00 until 24:00:00 on the day that daylight saving ends, this wouldn't include times between 23:00:00 and 23:59:59 and we'd fall back on the default status for those times.

I discovered this by comparing the respond from `static-market-hours` to the official TradingHours python code for every timestamp between now and 2026-12-31 in 1 minute intervals.

## Changes

1. Calculate 24:00:00 as 1 second after 23:59:59 instead of 24 hours after 00:00:00.

## Steps to Test

1. Unit test added.
2. After fixing the bug, `static-market-hours` now gives the same response as the TradingHours python code for every minute between now and 2026-12-31.

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
