### PR TITLE
OPDATA-8530 securitize asset pubkeys

### DIFF
--- a/.changeset/sunny-crabs-bow.md
+++ b/.changeset/sunny-crabs-bow.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/securitize-adapter': patch
+---
+
+Add ASSET_PUBKEYS variable env var in place of process.env

--- a/packages/sources/securitize/src/config/index.ts
+++ b/packages/sources/securitize/src/config/index.ts
@@ -17,7 +17,7 @@ export const config = new AdapterConfig({
     description:
       'The comma separated list of pubkeys to decrypt the Securitize NAV response for a given asset, where ${ASSET} is the upper-snake-case version of the asset input parameter',
     type: 'string',
-    required: false,
+    required: true,
     variablePlaceholder: 'ASSET',
     sensitive: true,
   },

--- a/packages/sources/securitize/src/config/index.ts
+++ b/packages/sources/securitize/src/config/index.ts
@@ -13,4 +13,12 @@ export const config = new AdapterConfig({
     default: 'https://partners-api.securitize.io/asset-metrics/api/v1/nav',
     sensitive: false,
   },
+  ASSET_PUBKEYS: {
+    description:
+      'The comma separated list of pubkeys to decrypt the Securitize NAV response for a given asset, where ${ASSET} is the upper-snake-case version of the asset input parameter',
+    type: 'string',
+    required: false,
+    variablePlaceholder: 'ASSET',
+    sensitive: true,
+  },
 })

--- a/packages/sources/securitize/src/endpoint/nav.ts
+++ b/packages/sources/securitize/src/endpoint/nav.ts
@@ -36,8 +36,8 @@ export const endpoint = new AdapterEndpoint({
   name: 'nav',
   transport: httpTransport,
   inputParameters,
-  customInputValidation: (req): AdapterInputError | undefined => {
-    getPubKeys(req.requestContext.data.envVarPrefix)
+  customInputValidation: (req, adapterSettings): AdapterInputError | undefined => {
+    getPubKeys(req.requestContext.data.envVarPrefix, adapterSettings)
     return
   },
 })

--- a/packages/sources/securitize/src/transport/nav.ts
+++ b/packages/sources/securitize/src/transport/nav.ts
@@ -2,7 +2,6 @@ import {
   HttpTransport,
   HttpTransportConfig,
 } from '@chainlink/external-adapter-framework/transports'
-import { AdapterInputError } from '@chainlink/external-adapter-framework/validation/error'
 import { config } from '../config'
 import { BaseEndpointTypes } from '../endpoint/nav'
 import { validateResponseSignature } from './sigutils'
@@ -38,14 +37,7 @@ export type HttpTransportTypes = BaseEndpointTypes & {
 }
 
 export function getPubKeys(assetEnvVarPrefix: string, settings: typeof config.settings): string[] {
-  const envVarName = `${assetEnvVarPrefix.toUpperCase()}_PUBKEYS`
   const pubkeys = settings.ASSET_PUBKEYS.get(assetEnvVarPrefix)
-  if (!pubkeys) {
-    throw new AdapterInputError({
-      message: `Missing env var ${envVarName}`,
-      statusCode: 400,
-    })
-  }
   return pubkeys.split(',').map((s) => s.trim()) ?? []
 }
 

--- a/packages/sources/securitize/src/transport/nav.ts
+++ b/packages/sources/securitize/src/transport/nav.ts
@@ -3,6 +3,7 @@ import {
   HttpTransportConfig,
 } from '@chainlink/external-adapter-framework/transports'
 import { AdapterInputError } from '@chainlink/external-adapter-framework/validation/error'
+import { config } from '../config'
 import { BaseEndpointTypes } from '../endpoint/nav'
 import { validateResponseSignature } from './sigutils'
 
@@ -36,9 +37,9 @@ export type HttpTransportTypes = BaseEndpointTypes & {
   }
 }
 
-export function getPubKeys(assetEnvVarPrefix: string): string[] {
+export function getPubKeys(assetEnvVarPrefix: string, settings: typeof config.settings): string[] {
   const envVarName = `${assetEnvVarPrefix.toUpperCase()}_PUBKEYS`
-  const pubkeys = process.env[envVarName]
+  const pubkeys = settings.ASSET_PUBKEYS.get(assetEnvVarPrefix)
   if (!pubkeys) {
     throw new AdapterInputError({
       message: `Missing env var ${envVarName}`,
@@ -86,7 +87,7 @@ const transportConfig: HttpTransportConfig<HttpTransportTypes> = {
         providerIndicatedTimeUnixMs: new Date(asset.recordDate).getTime(),
       }
 
-      const pubkeys = getPubKeys(param.envVarPrefix)
+      const pubkeys = getPubKeys(param.envVarPrefix, config.settings)
       validateResponseSignature(asset, pubkeys)
 
       if (asset.assetId !== param.assetId) {

--- a/packages/sources/securitize/test/integration/__snapshots__/adapter.test.ts.snap
+++ b/packages/sources/securitize/test/integration/__snapshots__/adapter.test.ts.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`execute nav endpoint should return 400 for invalid envVarPrefix 1`] = `
+exports[`execute nav endpoint should return 500 for missing ASSET_PUBKEYS 1`] = `
 {
   "error": {
-    "message": "Missing env var MISSING_PREFIX_PUBKEYS",
+    "message": "Missing required environment variable: MISSING_PREFIX_PUBKEYS",
     "name": "AdapterError",
   },
   "status": "errored",
-  "statusCode": 400,
+  "statusCode": 500,
 }
 `;
 

--- a/packages/sources/securitize/test/integration/adapter.test.ts
+++ b/packages/sources/securitize/test/integration/adapter.test.ts
@@ -78,14 +78,14 @@ describe('execute', () => {
       expect(response.statusCode).toBe(502)
       expect(response.json()).toMatchSnapshot()
     })
-    it('should return 400 for invalid envVarPrefix', async () => {
+    it('should return 500 for missing ASSET_PUBKEYS', async () => {
       const data = {
         endpoint: 'nav',
         assetId: '35d707cc-1563-4420-b6fd-ecdd47cfa0d1',
         envVarPrefix: 'missing_prefix',
       }
       const response = await testAdapter.request(data)
-      expect(response.statusCode).toBe(400)
+      expect(response.statusCode).toBe(500)
       expect(response.json()).toMatchSnapshot()
     })
   })

--- a/packages/sources/securitize/test/test-utils/signature-helper.ts
+++ b/packages/sources/securitize/test/test-utils/signature-helper.ts
@@ -10,6 +10,7 @@ export function generateSignature(
   recordDate: Date,
   previousSignature: string,
   previousHash: string,
+  keyPair: nacl.SignKeyPair = nacl.sign.keyPair(),
 ): {
   contentHex: string
   signatureHex: string
@@ -17,8 +18,6 @@ export function generateSignature(
   hashHex: string
   message: string
 } {
-  // Generate Ed25519 keypair
-  const keyPair = nacl.sign.keyPair()
   const publicKeyHex = Buffer.from(keyPair.publicKey).toString('hex')
   const privateKey = keyPair.secretKey
 

--- a/packages/sources/securitize/test/test-utils/signature-helper.ts
+++ b/packages/sources/securitize/test/test-utils/signature-helper.ts
@@ -10,7 +10,6 @@ export function generateSignature(
   recordDate: Date,
   previousSignature: string,
   previousHash: string,
-  keyPair: nacl.SignKeyPair = nacl.sign.keyPair(),
 ): {
   contentHex: string
   signatureHex: string
@@ -18,6 +17,8 @@ export function generateSignature(
   hashHex: string
   message: string
 } {
+  // Generate Ed25519 keypair
+  const keyPair = nacl.sign.keyPair()
   const publicKeyHex = Buffer.from(keyPair.publicKey).toString('hex')
   const privateKey = keyPair.secretKey
 

--- a/packages/sources/securitize/test/unit/nav.test.ts
+++ b/packages/sources/securitize/test/unit/nav.test.ts
@@ -4,6 +4,7 @@ import { metrics } from '@chainlink/external-adapter-framework/metrics'
 import { TransportDependencies } from '@chainlink/external-adapter-framework/transports'
 import { LoggerFactoryProvider } from '@chainlink/external-adapter-framework/util'
 import { makeStub } from '@chainlink/external-adapter-framework/util/testing-utils'
+import { config } from '../../src/config'
 import { inputParameters } from '../../src/endpoint/nav'
 import { getPubKeys, HttpTransportTypes, NavTransport } from '../../src/transport/nav'
 import { validateResponseSignature } from '../../src/transport/sigutils'
@@ -49,28 +50,33 @@ describe('nav transport', () => {
   const keyB = 'keyB'
 
   describe('getPubKeys', () => {
-    beforeAll(() => {
-      process.env.TEST_PUBKEYS = `${keyA},${keyB}`
-      process.env.SINGLE_PUBKEYS = keyA
-    })
+    const pubkeysByAsset: Record<string, string> = {
+      TEST: `${keyA},${keyB}`,
+      SINGLE: keyA,
+    }
+
+    const settings = makeStub('settings', {
+      ASSET_PUBKEYS: {
+        get: (assetEnvVarPrefix: string) => pubkeysByAsset[assetEnvVarPrefix.toUpperCase()],
+      },
+    } as unknown as typeof config.settings)
 
     it('should return expected data with existing prefix', async () => {
-      const actualPubKeys = getPubKeys('test')
+      const actualPubKeys = getPubKeys('test', settings)
       expect(actualPubKeys).toEqual([keyA, keyB])
     })
 
     it('should throw error for non-existent prefix', async () => {
-      expect(() => getPubKeys('nonexistent')).toThrow()
+      expect(() => getPubKeys('nonexistent', settings)).toThrow()
     })
 
     it('should handle single pubkey', async () => {
-      const actualPubKeys = getPubKeys('single')
+      const actualPubKeys = getPubKeys('single', settings)
       expect(actualPubKeys).toEqual([keyA])
     })
 
-    it('should handle empty pubkey list', async () => {
-      process.env.EMPTY_PUBKEY = ''
-      expect(() => getPubKeys('empty')).toThrow()
+    it('should handle empty pubkey', async () => {
+      expect(() => getPubKeys('empty', settings)).toThrow()
     })
   })
 
@@ -131,7 +137,7 @@ describe('nav transport', () => {
       jest.useFakeTimers()
 
       process.env.TEST_PUBKEYS = `${keyA},${keyB}`
-      process.env.SINGLE_PUBKEYS = keyA
+      config.initialize()
 
       // Mock signature validation to not throw
       mockedValidateResponseSignature.mockImplementation(() => undefined)

--- a/packages/sources/securitize/test/unit/nav.test.ts
+++ b/packages/sources/securitize/test/unit/nav.test.ts
@@ -74,10 +74,6 @@ describe('nav transport', () => {
       const actualPubKeys = getPubKeys('single', settings)
       expect(actualPubKeys).toEqual([keyA])
     })
-
-    it('should handle empty pubkey', async () => {
-      expect(() => getPubKeys('empty', settings)).toThrow()
-    })
   })
 
   describe('NavTransport', () => {


### PR DESCRIPTION
## Closes #[OPDATA-8530](https://smartcontract-it.atlassian.net/browse/OPDATA-8530)

## Description
Use variable env var framework feature to replace process.env lookup for `*_PUBKEYS` env vars

## Changes
- Replace `*_PUBKEYS` lookup with `ASSET_PUBKEYS` variable env var
- Update places where used & tests

<!-- Acceptance testing steps, automated tests should _always_ be included -->

## Steps to Test
1. yarn test securitize/
2. with payload
```json
{
    "data": {
        "endpoint": "nav",
        "assetId": "17eab62a-5347-484f-b26f-35b25c087b07",
        "envVarPrefix": "acred"
    }
}
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.


[OPDATA-8530]: https://smartcontract-it.atlassian.net/browse/OPDATA-8530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ