### PR TITLE
market-status: Add parameter useSecondaryForTesting

### DIFF
--- a/.changeset/fruity-wombats-stay.md
+++ b/.changeset/fruity-wombats-stay.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/market-status-adapter': patch
+---
+
+Add parameter useSecondaryForTesting

--- a/packages/composites/market-status/src/endpoint/market-status.ts
+++ b/packages/composites/market-status/src/endpoint/market-status.ts
@@ -6,7 +6,15 @@ import { InputParameters } from '@chainlink/external-adapter-framework/validatio
 import { transport } from '../transport/market-status'
 import { BaseMarketStatusEndpointTypes } from './common'
 
-export const inputParameters = new InputParameters(marketStatusEndpointInputParametersDefinition)
+export const inputParameters = new InputParameters({
+  ...marketStatusEndpointInputParametersDefinition,
+  useSecondaryForTesting: {
+    description: 'Skip primary source and use secondary source for testing',
+    required: false,
+    type: 'boolean',
+    default: false,
+  },
+})
 
 export type MarketStatusEndpointTypes = BaseMarketStatusEndpointTypes & {
   Parameters: typeof inputParameters.definition

--- a/packages/composites/market-status/src/endpoint/multi-market-status.ts
+++ b/packages/composites/market-status/src/endpoint/multi-market-status.ts
@@ -25,6 +25,12 @@ export const inputParameters = new InputParameters({
     default: 'all',
     type: 'string',
   },
+  useSecondaryForTesting: {
+    description: 'Skip primary source and use secondary source for testing',
+    required: false,
+    type: 'boolean',
+    default: false,
+  },
 })
 
 export type MultiMarketStatusEndpointTypes = BaseMarketStatusEndpointTypes & {

--- a/packages/composites/market-status/src/transport/market-status.ts
+++ b/packages/composites/market-status/src/transport/market-status.ts
@@ -23,9 +23,11 @@ export class MarketStatusTransport extends BaseMarketStatusTransport<MarketStatu
   ): Promise<MarketStatusResult> {
     const sources = getMarketSources(param.type, param.market)
 
-    const primaryResponse = await this.sendSourceRequest(context, sources.primary, param)
-    if (!UNKNOWN_STATUS.includes(primaryResponse.marketStatus)) {
-      return primaryResponse
+    if (!param.useSecondaryForTesting) {
+      const primaryResponse = await this.sendSourceRequest(context, sources.primary, param)
+      if (!UNKNOWN_STATUS.includes(primaryResponse.marketStatus)) {
+        return primaryResponse
+      }
     }
 
     logger.warn(

--- a/packages/composites/market-status/src/transport/multi-market-status.ts
+++ b/packages/composites/market-status/src/transport/multi-market-status.ts
@@ -20,12 +20,16 @@ export class MultiMarketStatusTransport extends BaseMarketStatusTransport<MultiM
 
     for (const market of markets) {
       const sourceNames = getMarketSources(param.type, market)
+      if (!param.useSecondaryForTesting) {
+        underlyingRequests.push(
+          this.sendSourceRequest(context, sourceNames.primary, {
+            market,
+            type: param.type,
+            force245MarketStatus: false,
+          }),
+        )
+      }
       underlyingRequests.push(
-        this.sendSourceRequest(context, sourceNames.primary, {
-          market,
-          type: param.type,
-          force245MarketStatus: false,
-        }),
         this.sendSourceRequest(context, sourceNames.secondary, {
           market,
           type: param.type,

--- a/packages/composites/market-status/test/integration/adapter.test.ts
+++ b/packages/composites/market-status/test/integration/adapter.test.ts
@@ -523,6 +523,55 @@ describe('execute', () => {
       })
     })
   })
+
+  describe('useSecondaryForTesting', () => {
+    afterEach(async () => {
+      await testAdapter.mockCache?.cache.clear()
+    })
+
+    it('skips primary and uses secondary when useSecondaryForTesting is true', async () => {
+      const market = 'nyse'
+      mockOpen(market, process.env.TRADINGHOURS_ADAPTER_URL)
+      mockClosed(market, process.env.FINNHUB_SECONDARY_ADAPTER_URL)
+
+      const response = await waitForSuccessfulRequest({
+        market,
+        useSecondaryForTesting: true,
+      })
+
+      expect(response.json()).toEqual({
+        data: {
+          result: 1,
+          statusString: 'CLOSED',
+          source: 'FINNHUB_SECONDARY',
+        },
+        result: 1,
+        statusCode: 200,
+        timestamps,
+      })
+    })
+
+    describe('for multi market', () => {
+      it('skips primary and uses secondary for all markets when useSecondaryForTesting is true', async () => {
+        mockClosed('lse', process.env.TRADINGHOURS_ADAPTER_URL)
+        mockOpen('lse', process.env.FINNHUB_SECONDARY_ADAPTER_URL)
+        mockClosed('xetra', process.env.TRADINGHOURS_ADAPTER_URL)
+        mockOpen('xetra', process.env.FINNHUB_SECONDARY_ADAPTER_URL)
+
+        const response = await waitForSuccessfulRequest({
+          endpoint: 'multi-market-status',
+          market: 'lse,xetra',
+          openMode: 'any',
+          useSecondaryForTesting: true,
+        })
+
+        const data = response.json()
+        expect(data.statusCode).toBe(200)
+        expect(data.data.result).toBe(2)
+        expect(data.data.statusString).toBe('OPEN')
+      })
+    })
+  })
   // This is working locally but for some reason failing on pipeline
   // describe('missing env var', () => {
   //   it('throws error', async () => {


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/OPDATA-8204

## Description

It's currently difficult to test if the secondary source for a market is set up correctly, both on CLL production and for NOPs.

## Changes

1. Add `useSecondaryForTesting` which will cause the EA to skip straight to using the secondary market status source.

## Steps to Test

```
curl --silent -S -X POST http://localhost:8080 -H 'Content-Type: application/json' -d '{
  "data": {
    "endpoint": "market-status",
    "market": "nymex_sugar",
    "useSecondaryForTesting": true
  }
}'

{
  "data": {
    "result": 2,
    "statusString": "OPEN",
    "source": "STATIC_MARKET_HOURS"
  },
  "result": 2,
  "statusCode": 200,
  "timestamps": {
    "providerDataRequestedUnixMs": 1787903681441,
    "providerDataReceivedUnixMs": 1787903681618,
    "providerIndicatedTimeUnixMs": 1787903681618
  },
  "meta": {
    "adapterName": "MARKET_STATUS",
    "transportName": "default_single_transport",
    "metrics": {
      "feedId": "{\"force245MarketStatus\":false,\"market\":\"nymex_sugar\",\"type\":\"regular\",\"useSecondaryForTesting\":true}"
    }
  }
}
```

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
