### PR TITLE
Trigger a new market-status release

### DIFF
--- a/.changeset/better-actors-laugh.md
+++ b/.changeset/better-actors-laugh.md
@@ -1,0 +1,5 @@
+---
+'@chainlink/market-status-adapter': patch
+---
+
+Trigger a new release


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/OPDATA-8204

## Description

The release workflow failed to run to the end and when rerun it complains that the tag for version 1.14.1 already exists:
https://github.com/smartcontractkit/external-adapters-js/actions/runs/33364444902/job/99402960816

Instead of getting to the bottom of this, I think it's easier to just rerun the process with a new version.

## Changes

Created a patch changeset for `market-status`.

## Steps to Test

N/A

## Quality Assurance

- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `infra-k8s` configuration file.
- [ ] If a new adapter was made, or an existing one was modified so that its environment variables have changed, update the relevant `adapter-secrets` configuration file.
- [ ] If a new adapter was made, or a new endpoint was added, update the `test-payload.json` file with relevant requests.
- [ ] The branch naming follows git flow (`feature/x`, `chore/x`, `release/x`, `hotfix/x`, `fix/x`) or is created from Jira.
- [ ] This is related to a maximum of one Jira story or GitHub issue.
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types).
- [ ] All code changes have 100% unit and integration test coverage. If testing is not applicable or too difficult to justify doing, the reasoning should be documented explicitly in the PR.
