### PR TITLE
DS-4004/fix for gRPC subscription snapshot

### DIFF
--- a/.changeset/yellow-houses-fall.md
+++ b/.changeset/yellow-houses-fall.md
@@ -1,0 +1,51 @@
+---
+'@chainlink/aleno-adapter': patch
+'@chainlink/allium-state-adapter': patch
+'@chainlink/anchorage-adapter': patch
+'@chainlink/backed-fi-adapter': patch
+'@chainlink/blocksize-capital-adapter': patch
+'@chainlink/blocksize-capital-state-adapter': patch
+'@chainlink/cfbenchmarks-adapter': patch
+'@chainlink/coingecko-adapter': patch
+'@chainlink/coinmetrics-adapter': patch
+'@chainlink/coinpaprika-adapter': patch
+'@chainlink/coinpaprika-state-adapter': patch
+'@chainlink/data-engine-adapter': patch
+'@chainlink/deutsche-boerse-adapter': patch
+'@chainlink/dlc-cbtc-por-adapter': patch
+'@chainlink/dxfeed-adapter': patch
+'@chainlink/elwood-adapter': patch
+'@chainlink/finage-adapter': patch
+'@chainlink/finalto-adapter': patch
+'@chainlink/finnhub-adapter': patch
+'@chainlink/generic-api-adapter': patch
+'@chainlink/glv-token-adapter': patch
+'@chainlink/gmx-tokens-adapter': patch
+'@chainlink/gsr-adapter': patch
+'@chainlink/hastra-adapter': patch
+'@chainlink/ice-adapter': patch
+'@chainlink/lo-tech-adapter': patch
+'@chainlink/market-status-adapter': patch
+'@chainlink/matrixdock-adapter': patch
+'@chainlink/mobula-state-adapter': patch
+'@chainlink/nav-fund-services-adapter': patch
+'@chainlink/ncfx-adapter': patch
+'@chainlink/nobi-adapter': patch
+'@chainlink/nomia2-adapter': patch
+'@chainlink/onre-adapter': patch
+'@chainlink/proof-of-reserves-v2-adapter': patch
+'@chainlink/r25-adapter': patch
+'@chainlink/solana-functions-adapter': patch
+'@chainlink/superstate-adapter': patch
+'@chainlink/t-rize-proof-of-insurance-adapter': patch
+'@chainlink/the-network-firm-adapter': patch
+'@chainlink/tickerlayer-adapter': patch
+'@chainlink/tiingo-adapter': patch
+'@chainlink/tiingo-state-adapter': patch
+'@chainlink/tp-adapter': patch
+'@chainlink/truflation-adapter': patch
+'@chainlink/view-function-adapter': patch
+'@chainlink/view-function-multi-chain-adapter': patch
+---
+
+gRPC subscription snapshot fix

--- a/packages/streams-adapter-client/README.md
+++ b/packages/streams-adapter-client/README.md
@@ -1,0 +1,67 @@
+# Streams Adapter Client
+
+A Go-based gRPC client for subscribing to Chainlink streams adapters. The client maintains a bidirectional gRPC stream with a streams adapter runtime and displays incoming observations in an interactive terminal UI.
+
+## What it does
+
+- Opens a bidirectional gRPC stream to a streams adapter server.
+- Sends full subscription snapshots at a regular interval.
+- Receives observations pushed from the server and stores them in an in-memory cache.
+- Provides an interactive terminal UI to inspect cached observations, rates, and manage subscriptions.
+
+## Build
+
+```sh
+make generate
+make run-client
+```
+
+To run without Make:
+
+```sh
+buf generate
+go run ./cmd/client
+```
+
+## Configuration
+
+| Environment variable     | Default          | Description                                                                                                                               |
+| ------------------------ | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `SERVER_ADDR`            | `localhost:5050` | gRPC server address. Accepts `host:port` or a URL such as `https://host:port/path`. TLS is enabled when the scheme is `https` or `grpcs`. |
+| `CACHE_CLEANUP_INTERVAL` | `60`             | Subscription refresh interval in seconds.                                                                                                 |
+
+## Interactive commands
+
+```
+help | h | ?                           Show help
+subscribe payload='{"data":{...}}'     Add a new subscription
+quit | q                               Exit the client
+```
+
+Use `Tab` / `Shift+Tab` to switch between the **Cache**, **Rates**, and **Help** views. Use `PgUp` / `PgDn` to scroll.
+
+## NCFX example
+
+Subscribe to NCFX crypto-lwba price data for ETH/USD:
+
+```sh
+SERVER_ADDR=localhost:5050 go run ./cmd/client
+```
+
+Then enter the following command in the interactive UI:
+
+```
+subscribe payload='{"data":{"endpoint":"cryptolwba","from":"ETH","to":"USD"}}'
+```
+
+Or use the `-subscriptions` flag with a JSON file containing the payload list:
+
+```sh
+cat > subscriptions.json << 'EOF'
+[
+  "{\"data\":{\"endpoint\":\"cryptolwba\",\"from\":\"ETH\",\"to\":\"USD\"}}"
+]
+EOF
+
+SERVER_ADDR=localhost:5050 go run ./cmd/client -subscriptions subscriptions.json
+```

--- a/packages/streams-adapter/transmitter/server.go
+++ b/packages/streams-adapter/transmitter/server.go
@@ -41,8 +41,9 @@ type normalizedSubscription struct {
 	resolved *types.ResolvedSubscription
 }
 
-// normalizeSnapshot validates the complete snapshot before any subscription
-// registrations are changed.
+// normalizeSnapshot resolves each subscription in the snapshot individually.
+// Invalid subscriptions are logged and discarded so that a single bad item does
+// not prevent the rest of the snapshot from being applied.
 func (s *StreamTransmitter) normalizeSnapshot(req *pb.SubscribeRequest) ([]normalizedSubscription, error) {
 	if len(req.GetSubscriptions()) > 0 && s.resolver == nil {
 		return nil, fmt.Errorf("subscription resolver is not configured")
@@ -50,12 +51,18 @@ func (s *StreamTransmitter) normalizeSnapshot(req *pb.SubscribeRequest) ([]norma
 	result := make([]normalizedSubscription, 0, len(req.GetSubscriptions()))
 	for i, subscription := range req.GetSubscriptions() {
 		if subscription == nil || subscription.GetData() == nil {
-			return nil, fmt.Errorf("subscription %d is missing data", i)
+			if s.logger != nil {
+				s.logger.Warn("invalid subscription item, discarding", "index", i, "reason", "missing data")
+			}
+			continue
 		}
 		data := subscription.GetData().AsMap()
 		resolved, err := s.resolver(data)
 		if err != nil {
-			return nil, fmt.Errorf("subscription %d: %w", i, err)
+			if s.logger != nil {
+				s.logger.Warn("invalid subscription item, discarding", "index", i, "error", err)
+			}
+			continue
 		}
 		result = append(result, normalizedSubscription{resolved: resolved})
 	}

--- a/packages/streams-adapter/transmitter/server_test.go
+++ b/packages/streams-adapter/transmitter/server_test.go
@@ -1,9 +1,13 @@
 package transmitter
 
 import (
+	"errors"
 	"testing"
 
+	types "streams-adapter/common"
+
 	pb "streams-adapter/gen/streams/v1"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func TestNormalizeSnapshotAcceptsEmptySnapshot(t *testing.T) {
@@ -17,10 +21,56 @@ func TestNormalizeSnapshotAcceptsEmptySnapshot(t *testing.T) {
 	}
 }
 
-func TestNormalizeSnapshotRejectsMissingData(t *testing.T) {
-	server := &StreamTransmitter{}
-	_, err := server.normalizeSnapshot(&pb.SubscribeRequest{Subscriptions: []*pb.Subscription{{}}})
-	if err == nil {
-		t.Fatal("expected missing data error")
+func TestNormalizeSnapshotDiscardsMissingData(t *testing.T) {
+	server := &StreamTransmitter{resolver: func(map[string]interface{}) (*types.ResolvedSubscription, error) {
+		return &types.ResolvedSubscription{}, nil
+	}}
+	normalized, err := server.normalizeSnapshot(&pb.SubscribeRequest{Subscriptions: []*pb.Subscription{{}}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
+	if len(normalized) != 0 {
+		t.Fatalf("expected 0 valid subscriptions, got %d", len(normalized))
+	}
+}
+
+func TestNormalizeSnapshotDiscardsInvalidItemsAndKeepsValidOnes(t *testing.T) {
+	server := &StreamTransmitter{resolver: func(data map[string]interface{}) (*types.ResolvedSubscription, error) {
+		if data["valid"] == true {
+			return &types.ResolvedSubscription{}, nil
+		}
+		return nil, errors.New("resolver error")
+	}}
+
+	validSub, err := makeSubscription(map[string]interface{}{"valid": true})
+	if err != nil {
+		t.Fatalf("failed to create valid subscription: %v", err)
+	}
+	invalidSub, err := makeSubscription(map[string]interface{}{"valid": false})
+	if err != nil {
+		t.Fatalf("failed to create invalid subscription: %v", err)
+	}
+
+	req := &pb.SubscribeRequest{Subscriptions: []*pb.Subscription{
+		validSub,
+		invalidSub,
+		{},
+		validSub,
+	}}
+
+	normalized, err := server.normalizeSnapshot(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(normalized) != 2 {
+		t.Fatalf("expected 2 valid subscriptions, got %d", len(normalized))
+	}
+}
+
+func makeSubscription(data map[string]interface{}) (*pb.Subscription, error) {
+	structData, err := structpb.NewStruct(data)
+	if err != nil {
+		return nil, err
+	}
+	return &pb.Subscription{Data: structData}, nil
 }


### PR DESCRIPTION
## Closes #DS-4004

## Description
Per-item discard instead of rejecting the whole snapshot.

## Changes

- normalizeSnapshot now logs each invalid subscription and continues, keeping only the valid ones.
- The whole snapshot is still rejected only if the resolver is not configured (a server-side misconfiguration).
- The Subscribe handler keeps the existing warning path for true whole-snapshot failures.

Tests updated in packages/streams-adapter/transmitter/server_test.go:
- TestNormalizeSnapshotRejectsMissingData renamed to TestNormalizeSnapshotDiscardsMissingData and now expects the bad item to be skipped.
- Added TestNormalizeSnapshotDiscardsInvalidItemsAndKeepsValidOnes to verify a mixed snapshot retains only valid subscriptions.