### PR TITLE
DF-26076: fix hourly GSR WebSocket data stalls

### DIFF
--- a/.changeset/eager-owls-exist.md
+++ b/.changeset/eager-owls-exist.md
@@ -1,0 +1,12 @@
+---
+'@chainlink/gsr-adapter': patch
+---
+
+Fix hourly WebSocket disconnections caused by access token expiry.
+
+A GSR session stops delivering data one hour after it is opened, and GSR neither closes the socket nor sends any notice. The adapter had no way to know, so the only thing that noticed was the framework's staleness check at `WS_SUBSCRIPTION_UNRESPONSIVE_TTL` (120s). By then cached prices had aged out at `CACHE_MAX_AGE` (90s), so every cycle ended in a burst of 504s. In production this repeated on a 62 minute period — 60 minutes of data, plus 120 seconds to notice.
+
+Two changes, one for each half of that:
+
+- The adapter now reads `validUntil` from the token response and, five minutes ahead of expiry, renews the token in place via GSR's `PUT /token` endpoint (removed in #2459, restored here) rather than waiting to be cut off. If renewal is refused it reconnects immediately instead, still ahead of expiry.
+- `WS_SUBSCRIPTION_UNRESPONSIVE_TTL` now defaults to 30s for this adapter. The token travels in the WebSocket handshake, so a successful renewal is not proof the session survived; this keeps the framework's own liveness check inside `CACHE_MAX_AGE`, so a stall from a renewal that did not take — or from any other cause — is caught and reconnected while cached prices are still being served. Operators can still override it via the environment.

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -6006,7 +6006,7 @@ const RAW_RUNTIME_STATE =
       ["workspace:packages/sources/gsr", {\
         "packageLocation": "./packages/sources/gsr/",\
         "packageDependencies": [\
-          ["@chainlink/external-adapter-framework", "npm:2.17.1"],\
+          ["@chainlink/external-adapter-framework", "npm:2.19.1"],\
           ["@chainlink/gsr-adapter", "workspace:packages/sources/gsr"],\
           ["@sinonjs/fake-timers", "npm:9.1.2"],\
           ["@types/jest", "npm:29.5.14"],\

--- a/packages/sources/gsr/package.json
+++ b/packages/sources/gsr/package.json
@@ -28,7 +28,7 @@
     "start": "yarn server:dist"
   },
   "dependencies": {
-    "@chainlink/external-adapter-framework": "2.17.1",
+    "@chainlink/external-adapter-framework": "2.19.1",
     "axios": "1.13.4",
     "crypto": "1.0.1",
     "tslib": "2.4.1"

--- a/packages/sources/gsr/src/config/index.ts
+++ b/packages/sources/gsr/src/config/index.ts
@@ -1,34 +1,47 @@
 import { AdapterConfig } from '@chainlink/external-adapter-framework/config'
 
-export const config = new AdapterConfig({
-  API_ENDPOINT: {
-    type: 'string',
-    description: 'The HTTP API endpoint to use',
-    default: 'https://oracle.prod.gsr.io/v1',
-    sensitive: false,
+export const config = new AdapterConfig(
+  {
+    API_ENDPOINT: {
+      type: 'string',
+      description: 'The HTTP API endpoint to use',
+      default: 'https://oracle.prod.gsr.io/v1',
+      sensitive: false,
+    },
+    WS_API_ENDPOINT: {
+      type: 'string',
+      description: 'The WS API endpoint to use',
+      default: 'wss://oracle.prod.gsr.io/oracle',
+      sensitive: false,
+    },
+    WS_USER_ID: {
+      type: 'string',
+      description: 'The user ID used to authenticate',
+      required: true,
+      sensitive: false,
+    },
+    WS_PUBLIC_KEY: {
+      type: 'string',
+      description: 'The public key used to authenticate',
+      required: true,
+      sensitive: false,
+    },
+    WS_PRIVATE_KEY: {
+      type: 'string',
+      description: 'The private key used to authenticate',
+      required: true,
+      sensitive: true,
+    },
   },
-  WS_API_ENDPOINT: {
-    type: 'string',
-    description: 'The WS API endpoint to use',
-    default: 'wss://oracle.prod.gsr.io/oracle',
-    sensitive: false,
+  {
+    envDefaultOverrides: {
+      // DF-26076: GSR stops sending data when a session ends but leaves the
+      // socket open, so the framework's staleness check is what notices. At the
+      // 120s default that lands after CACHE_MAX_AGE (90s) has already expired
+      // the cached prices, turning every stall into a burst of 504s. 30s keeps
+      // detection and reconnect inside the cache's lifetime. GSR streams
+      // hundreds of messages a second, so 30s of silence is unambiguous.
+      WS_SUBSCRIPTION_UNRESPONSIVE_TTL: 30_000,
+    },
   },
-  WS_USER_ID: {
-    type: 'string',
-    description: 'The user ID used to authenticate',
-    required: true,
-    sensitive: false,
-  },
-  WS_PUBLIC_KEY: {
-    type: 'string',
-    description: 'The public key used to authenticate',
-    required: true,
-    sensitive: false,
-  },
-  WS_PRIVATE_KEY: {
-    type: 'string',
-    description: 'The private key used to authenticate',
-    required: true,
-    sensitive: true,
-  },
-})
+)

--- a/packages/sources/gsr/src/transport/authutils.ts
+++ b/packages/sources/gsr/src/transport/authutils.ts
@@ -1,6 +1,6 @@
-import crypto from 'crypto'
-import axios from 'axios'
 import { makeLogger } from '@chainlink/external-adapter-framework/util'
+import axios from 'axios'
+import crypto from 'crypto'
 
 const logger = makeLogger('GSR Auth Token Utils')
 
@@ -19,13 +19,17 @@ interface TokenSuccess {
 
 type AccessTokenResponse = TokenError | TokenSuccess
 
+export interface TokenWithExpiry {
+  token: string
+  expiresAtMs: number
+}
+
 const currentTimeNanoSeconds = (): number => new Date(Date.now()).getTime() * 1_000_000
 
-const generateSignature = (userId: string, publicKey: string, privateKey: string, ts: number) =>
-  crypto
-    .createHmac('sha256', privateKey)
-    .update(`userId=${userId}&apiKey=${publicKey}&ts=${ts}`)
-    .digest('hex')
+// GSR signs over the API key when minting a token and over the existing token
+// when renewing one.
+const generateSignature = (privateKey: string, payload: string) =>
+  crypto.createHmac('sha256', privateKey).update(payload).digest('hex')
 
 // restApiEndpoint is used for token auth
 export const getToken = async (
@@ -33,11 +37,11 @@ export const getToken = async (
   userId: string,
   publicKey: string,
   privateKey: string,
-) => {
+): Promise<TokenWithExpiry> => {
   logger.debug('Fetching new access token')
 
   const ts = currentTimeNanoSeconds()
-  const signature = generateSignature(userId, publicKey, privateKey, ts)
+  const signature = generateSignature(privateKey, `userId=${userId}&apiKey=${publicKey}&ts=${ts}`)
   const response = await axios.post<AccessTokenResponse>(`${restApiEndpoint}/token`, {
     apiKey: publicKey,
     userId,
@@ -69,5 +73,55 @@ export const getToken = async (
     throw new Error(response.data.error)
   }
 
-  return response.data.token
+  const expiresAtMs = new Date(response.data.validUntil).getTime()
+  logger.info(`Token obtained, expires at ${response.data.validUntil}`)
+
+  return {
+    token: response.data.token,
+    expiresAtMs,
+  }
+}
+
+/**
+ * Renews an existing token via GSR's PUT endpoint rather than minting a fresh
+ * one. This is the provider's documented renewal path; the adapter used it
+ * until #2459 removed it in Jan 2023.
+ *
+ * Note this renews the *token*, which is a separate thing from the WebSocket
+ * session. The token travels in the connection's handshake headers, so whether
+ * a renewal extends an already-open connection is GSR-side behaviour the caller
+ * must verify rather than assume.
+ */
+export const renewToken = async (
+  restApiEndpoint: string,
+  userId: string,
+  privateKey: string,
+  existingToken: string,
+): Promise<TokenWithExpiry> => {
+  logger.debug('Renewing existing access token')
+
+  const ts = currentTimeNanoSeconds()
+  const signature = generateSignature(
+    privateKey,
+    `userId=${userId}&token=${existingToken}&ts=${ts}`,
+  )
+  const response = await axios.put<AccessTokenResponse>(`${restApiEndpoint}/token`, {
+    token: existingToken,
+    userId,
+    ts,
+    signature,
+  })
+
+  if (!response.data.success) {
+    logger.warn(`Unable to renew access token: ${response.data.error}`)
+    throw new Error(response.data.error)
+  }
+
+  const expiresAtMs = new Date(response.data.validUntil).getTime()
+  logger.info(`Token renewed, expires at ${response.data.validUntil}`)
+
+  return {
+    token: response.data.token,
+    expiresAtMs,
+  }
 }

--- a/packages/sources/gsr/src/transport/price.ts
+++ b/packages/sources/gsr/src/transport/price.ts
@@ -1,7 +1,10 @@
-import { BaseEndpointTypes } from '../endpoint/price'
+import { EndpointContext } from '@chainlink/external-adapter-framework/adapter'
 import { WebSocketTransport } from '@chainlink/external-adapter-framework/transports'
+import { SubscriptionDeltas } from '@chainlink/external-adapter-framework/transports/abstract/streaming'
 import { makeLogger, ProviderResult } from '@chainlink/external-adapter-framework/util'
-import { getToken } from './authutils'
+import { BaseEndpointTypes } from '../endpoint/price'
+import { getToken, renewToken, TokenWithExpiry } from './authutils'
+import { refreshDelayMs } from './tokenRefresh'
 
 const logger = makeLogger('GSR WS price')
 
@@ -22,69 +25,193 @@ export type WsTransportTypes = BaseEndpointTypes & {
   }
 }
 
-export const transport = new WebSocketTransport<WsTransportTypes>({
-  url: (context) => context.adapterSettings.WS_API_ENDPOINT,
-  options: async (context) => ({
-    headers: {
-      'x-auth-token': await getToken(
-        context.adapterSettings.API_ENDPOINT,
-        context.adapterSettings.WS_USER_ID,
-        context.adapterSettings.WS_PUBLIC_KEY,
-        context.adapterSettings.WS_PRIVATE_KEY,
-      ),
-      'x-auth-userid': context.adapterSettings.WS_USER_ID,
-    },
-  }),
-  handlers: {
-    open: () => {
+type Settings = WsTransportTypes['Settings']
+
+/**
+ * GSR issues access tokens valid for one hour and, when one expires, simply
+ * stops sending data without closing the socket. Left alone, the framework only
+ * notices after WS_SUBSCRIPTION_UNRESPONSIVE_TTL (120s) of silence, by which
+ * point cached prices have already aged out at CACHE_MAX_AGE (90s) and requests
+ * are failing.
+ *
+ * This transport renews the token ahead of expiry, in place, keeping the
+ * connection up. The token travels in the handshake headers, so a successful
+ * renewal is not proof the session survived; continued data is. Rather than
+ * check that here, the adapter lowers WS_SUBSCRIPTION_UNRESPONSIVE_TTL to 30s
+ * (see ../config), which is the framework's own liveness check: it runs every
+ * background pass, watches the same lastMessageReceivedAt, and catches a stall
+ * from any cause rather than only the one that follows a renewal.
+ */
+export class GsrWebSocketTransport extends WebSocketTransport<WsTransportTypes> {
+  private cachedToken: TokenWithExpiry | null = null
+  private refreshTimer?: NodeJS.Timeout
+
+  private buildTicker(pair: { base: string; quote: string }) {
+    return `${pair.base}.${pair.quote}`.toUpperCase()
+  }
+
+  constructor() {
+    super({
+      url: (context) => context.adapterSettings.WS_API_ENDPOINT,
+      options: async (context) => ({
+        headers: {
+          'x-auth-token': await this.tokenForConnection(context.adapterSettings),
+          'x-auth-userid': context.adapterSettings.WS_USER_ID,
+        },
+      }),
+      handlers: {
+        open: async (_connection, context) => {
+          this.scheduleRefresh(context.adapterSettings)
+        },
+        close: (event) => {
+          // Timers only ever live alongside a connection. Without this an idle
+          // adapter — one whose subscriptions have lapsed, so the framework has
+          // no reason to reconnect — would go on renewing tokens and then report
+          // the resulting silence as a failed renewal.
+          this.clearTimers()
+          logger.info(`Connection closed (code=${event.code}, reason=${event.reason || 'none'})`)
+        },
+        message: (message) => this.parsePriceUpdate(message),
+      },
+      builders: {
+        // Note: As of writing this (2022-11-07), GSR has a bug where you cannot subscribe to a pair
+        // after you've already subscribed & unsubscribed to that pair on the same WS connection.
+        customSubscriptionMessages: (
+          _context: EndpointContext<WsTransportTypes>,
+          subscriptions: SubscriptionDeltas<{ quote: string; base: string }>,
+        ) => {
+          const messages = []
+          if (subscriptions.new.length > 0) {
+            messages.push({
+              action: 'subscribe',
+              symbols: subscriptions.new.map(this.buildTicker),
+            })
+          }
+          if (subscriptions.stale.length > 0) {
+            messages.push({
+              action: 'unsubscribe',
+              symbols: subscriptions.stale.map(this.buildTicker),
+            })
+          }
+          return messages
+        },
+      },
+    })
+  }
+
+  /** Reuses the cached token while it has comfortably more life than the refresh margin. */
+  private async tokenForConnection(settings: Settings): Promise<string> {
+    if (this.cachedToken && refreshDelayMs(this.cachedToken, Date.now()) !== null) {
+      return this.cachedToken.token
+    }
+
+    this.cachedToken = await getToken(
+      settings.API_ENDPOINT,
+      settings.WS_USER_ID,
+      settings.WS_PUBLIC_KEY,
+      settings.WS_PRIVATE_KEY,
+    )
+    return this.cachedToken.token
+  }
+
+  private clearTimers() {
+    clearTimeout(this.refreshTimer)
+    this.refreshTimer = undefined
+  }
+
+  private closeForReconnect(reason: string) {
+    logger.info(`${reason}; closing connection to reconnect`)
+    this.cachedToken = null
+    // Close only — deliberately leaving wsConnection set. streamHandler bails
+    // out early when there is no connection *and* no new subscription, so
+    // clearing the field from outside its loop would strand the transport with
+    // nothing to reconnect. Leaving the closed socket in place lets
+    // connectionClosed() report true off readyState and the loop reopens on its
+    // next pass.
+    this.wsConnection?.close(1000)
+  }
+
+  private scheduleRefresh(settings: Settings) {
+    this.clearTimers()
+
+    if (!this.cachedToken) {
       return
-    },
-    message(message): ProviderResult<WsTransportTypes>[] | undefined {
-      if (message.type == 'error') {
-        logger.error(`Got error from DP: ${JSON.stringify(message)}`)
-        return
-      } else if (message.type != 'ticker') {
-        return
-      }
+    }
 
-      const pair = message.data.symbol.split('.')
-      if (pair.length != 2) {
-        logger.warn(`Got a price update with an unknown pair: ${message.data.symbol}`)
-        return
-      }
+    const delayMs = refreshDelayMs(this.cachedToken, Date.now())
+    if (delayMs === null) {
+      // Either the token is already inside the refresh margin, or its expiry
+      // did not parse. Both leave the connection with nothing scheduled, which
+      // is the pre-fix behaviour, so say so rather than failing silently.
+      logger.warn(
+        `No token refresh scheduled (expiresAtMs=${this.cachedToken.expiresAtMs}); ` +
+          `connection will rely on the framework's staleness check`,
+      )
+      return
+    }
 
-      return [
-        {
-          params: {
-            base: pair[0].toString(),
-            quote: pair[1].toString(),
-          },
-          response: {
+    logger.info(`Scheduled token refresh in ${Math.round(delayMs / 1000)}s`)
+    this.refreshTimer = setTimeout(() => void this.refreshOrReconnect(settings), delayMs)
+  }
+
+  /** Renew in place, and only tear the connection down if that is refused. */
+  private async refreshOrReconnect(settings: Settings) {
+    const previous = this.cachedToken
+    if (!previous) {
+      this.closeForReconnect('No cached token to renew')
+      return
+    }
+
+    try {
+      this.cachedToken = await renewToken(
+        settings.API_ENDPOINT,
+        settings.WS_USER_ID,
+        settings.WS_PRIVATE_KEY,
+        previous.token,
+      )
+    } catch (e) {
+      this.closeForReconnect(`Token renewal failed (${(e as Error).message})`)
+      return
+    }
+
+    this.scheduleRefresh(settings)
+  }
+
+  private parsePriceUpdate(message: WsMessage): ProviderResult<WsTransportTypes>[] | undefined {
+    if (message.type == 'error') {
+      logger.error(`Got error from DP: ${JSON.stringify(message)}`)
+      return
+    } else if (message.type != 'ticker') {
+      return
+    }
+
+    const pair = message.data.symbol.split('.')
+    if (pair.length != 2) {
+      logger.warn(`Got a price update with an unknown pair: ${message.data.symbol}`)
+      return
+    }
+
+    return [
+      {
+        params: {
+          base: pair[0].toString(),
+          quote: pair[1].toString(),
+        },
+        response: {
+          result: message.data.price,
+          data: {
             result: message.data.price,
-            data: {
-              result: message.data.price,
-              mid: message.data.price,
-              bid: message.data.bidPrice,
-              ask: message.data.askPrice,
-            },
-            timestamps: {
-              providerIndicatedTimeUnixMs: Math.round(message.data.ts / 1e6), // Value from provider is in nanoseconds
-            },
+            mid: message.data.price,
+            bid: message.data.bidPrice,
+            ask: message.data.askPrice,
+          },
+          timestamps: {
+            providerIndicatedTimeUnixMs: Math.round(message.data.ts / 1e6), // Value from provider is in nanoseconds
           },
         },
-      ]
-    },
-  },
-  builders: {
-    // Note: As of writing this (2022-11-07), GSR has a bug where you cannot subscribe to a pair
-    // after you've already subscribed & unsubscribed to that pair on the same WS connection.
-    subscribeMessage: (params) => ({
-      action: 'subscribe',
-      symbols: [`${params.base}.${params.quote}`.toUpperCase()],
-    }),
-    unsubscribeMessage: (params) => ({
-      action: 'unsubscribe',
-      symbols: [`${params.base}.${params.quote}`.toUpperCase()],
-    }),
-  },
-})
+      },
+    ]
+  }
+}
+
+export const transport = new GsrWebSocketTransport()

--- a/packages/sources/gsr/src/transport/tokenRefresh.ts
+++ b/packages/sources/gsr/src/transport/tokenRefresh.ts
@@ -1,0 +1,20 @@
+import { TokenWithExpiry } from './authutils'
+
+/** How far ahead of expiry to act, so the provider is still sending data. */
+export const TOKEN_REFRESH_MARGIN_MS = 5 * 60 * 1000
+
+/**
+ * setTimeout coerces any delay above this to 1ms. Left unclamped, an
+ * implausibly distant expiry would fire the refresh immediately on every open,
+ * turning this mechanism into a reconnect loop.
+ */
+export const MAX_TIMEOUT_MS = 2 ** 31 - 1
+
+/**
+ * Delay until the next refresh attempt, or null when the token is already
+ * inside the margin and there is nothing useful to schedule.
+ */
+export const refreshDelayMs = (token: TokenWithExpiry, nowMs: number): number | null => {
+  const delay = token.expiresAtMs - nowMs - TOKEN_REFRESH_MARGIN_MS
+  return delay > 0 ? Math.min(delay, MAX_TIMEOUT_MS) : null
+}

--- a/packages/sources/gsr/test/integration/adapter.test.ts
+++ b/packages/sources/gsr/test/integration/adapter.test.ts
@@ -1,12 +1,12 @@
 import { WebSocketClassProvider } from '@chainlink/external-adapter-framework/transports'
-import { mockTokenSuccess, mockWebSocketServer } from './fixtures'
 import {
-  TestAdapter,
-  setEnvVariables,
   mockWebSocketProvider,
   MockWebsocketServer,
+  setEnvVariables,
+  TestAdapter,
 } from '@chainlink/external-adapter-framework/util/testing-utils'
 import FakeTimers from '@sinonjs/fake-timers'
+import { mockTokenSuccess, mockWebSocketServer } from './fixtures'
 
 describe('websocket', () => {
   let spy: jest.SpyInstance

--- a/packages/sources/gsr/test/unit/authutils.test.ts
+++ b/packages/sources/gsr/test/unit/authutils.test.ts
@@ -1,0 +1,133 @@
+import { LoggerFactoryProvider } from '@chainlink/external-adapter-framework/util'
+import crypto from 'crypto'
+import nock from 'nock'
+import { getToken, renewToken } from '../../src/transport/authutils'
+
+LoggerFactoryProvider.set()
+
+describe('GSR access token expiry', () => {
+  const apiHost = 'https://oracle.prod.gsr.io'
+  const apiEndpoint = `${apiHost}/v1`
+  const userId = 'test-user-id'
+  const publicKey = 'test-pub-key'
+  const privateKey = 'test-priv-key'
+
+  beforeAll(() => {
+    nock.disableNetConnect()
+  })
+
+  afterAll(() => {
+    nock.enableNetConnect()
+  })
+
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  it('surfaces the expiry encoded in validUntil', async () => {
+    const validUntil = '2022-05-10T17:09:27.193Z'
+    nock(apiHost).post('/v1/token').reply(200, {
+      success: true,
+      ts: 1652198967193000000,
+      token: 'test-token-123',
+      validUntil,
+    })
+
+    const result = await getToken(apiEndpoint, userId, publicKey, privateKey)
+
+    expect(result.token).toBe('test-token-123')
+    expect(result.expiresAtMs).toBe(new Date(validUntil).getTime())
+  })
+
+  it('handles the 1 hour validity window GSR issues in production', async () => {
+    const issuedAt = new Date('2022-05-10T16:09:27.193Z').getTime()
+    const validUntil = new Date(issuedAt + 60 * 60 * 1000).toISOString()
+    nock(apiHost).post('/v1/token').reply(200, {
+      success: true,
+      ts: 1652198967193000000,
+      token: 'test-token-1h',
+      validUntil,
+    })
+
+    const result = await getToken(apiEndpoint, userId, publicKey, privateKey)
+
+    expect(result.expiresAtMs - issuedAt).toBe(60 * 60 * 1000)
+  })
+
+  it('throws when the provider rejects the token request', async () => {
+    nock(apiHost).post('/v1/token').reply(200, {
+      success: false,
+      ts: 1652198967193000000,
+      error: 'API key mismatch',
+    })
+
+    await expect(getToken(apiEndpoint, userId, publicKey, privateKey)).rejects.toThrow(
+      'API key mismatch',
+    )
+  })
+})
+
+describe('GSR access token renewal', () => {
+  const apiHost = 'https://oracle.prod.gsr.io'
+  const apiEndpoint = `${apiHost}/v1`
+  const userId = 'test-user-id'
+  const privateKey = 'test-priv-key'
+  const existingToken = 'existing-token'
+
+  beforeAll(() => {
+    nock.disableNetConnect()
+  })
+
+  afterAll(() => {
+    nock.enableNetConnect()
+  })
+
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  it('renews via PUT and signs over the token rather than the API key', async () => {
+    let seenBody: Record<string, unknown> = {}
+    const validUntil = '2022-05-10T17:09:27.193Z'
+    nock(apiHost)
+      .put('/v1/token', (body) => {
+        seenBody = body
+        return true
+      })
+      .reply(200, {
+        success: true,
+        ts: 1652198967193000000,
+        token: 'renewed-token',
+        validUntil,
+      })
+
+    const result = await renewToken(apiEndpoint, userId, privateKey, existingToken)
+
+    expect(result.token).toBe('renewed-token')
+    expect(result.expiresAtMs).toBe(new Date(validUntil).getTime())
+
+    // Renewal presents the existing token, never the API key.
+    expect(seenBody['token']).toBe(existingToken)
+    expect(seenBody['apiKey']).toBeUndefined()
+    expect(seenBody['userId']).toBe(userId)
+
+    const expectedSignature = crypto
+      .createHmac('sha256', privateKey)
+      .update(`userId=${userId}&token=${existingToken}&ts=${seenBody['ts']}`)
+      .digest('hex')
+    expect(seenBody['signature']).toBe(expectedSignature)
+  })
+
+  it('throws when the provider refuses the renewal', async () => {
+    nock(apiHost).put('/v1/token').reply(200, {
+      success: false,
+      ts: 1652198967193000000,
+      error: 'Signature mismatch',
+    })
+
+    // The caller falls back to closing the connection on this rejection.
+    await expect(renewToken(apiEndpoint, userId, privateKey, existingToken)).rejects.toThrow(
+      'Signature mismatch',
+    )
+  })
+})

--- a/packages/sources/gsr/test/unit/config.test.ts
+++ b/packages/sources/gsr/test/unit/config.test.ts
@@ -1,0 +1,26 @@
+import { config } from '../../src/config'
+
+// Framework default, from BaseSettingsDefinition. Duplicated rather than
+// imported so that a change to it upstream fails this test loudly.
+const CACHE_MAX_AGE_DEFAULT_MS = 90_000
+
+describe('WS_SUBSCRIPTION_UNRESPONSIVE_TTL override', () => {
+  const ttl = config.options?.envDefaultOverrides?.WS_SUBSCRIPTION_UNRESPONSIVE_TTL
+
+  it('is lowered from the 120s framework default', () => {
+    // At 120s the framework notices a stalled GSR session only after cached
+    // prices have already aged out, which is what DF-26076 was.
+    expect(ttl).toEqual(30_000)
+  })
+
+  it('leaves room to reconnect before cached prices age out', () => {
+    // Detection plus a reconnect has to fit inside CACHE_MAX_AGE, otherwise
+    // callers see 504s while the adapter is recovering.
+    expect(ttl).toBeLessThan(CACHE_MAX_AGE_DEFAULT_MS)
+  })
+
+  it('stays within the range the framework accepts', () => {
+    expect(ttl).toBeGreaterThanOrEqual(1_000)
+    expect(ttl).toBeLessThanOrEqual(180_000)
+  })
+})

--- a/packages/sources/gsr/test/unit/tokenRefresh.test.ts
+++ b/packages/sources/gsr/test/unit/tokenRefresh.test.ts
@@ -1,0 +1,36 @@
+import {
+  MAX_TIMEOUT_MS,
+  refreshDelayMs,
+  TOKEN_REFRESH_MARGIN_MS,
+} from '../../src/transport/tokenRefresh'
+
+const NOW = new Date('2026-08-06T12:00:00.000Z').getTime()
+const ONE_HOUR_MS = 60 * 60 * 1000
+
+describe('refreshDelayMs', () => {
+  it('schedules the refresh a margin ahead of expiry', () => {
+    const token = { token: 't', expiresAtMs: NOW + ONE_HOUR_MS }
+
+    // GSR issues hour-long tokens, so the refresh lands at the 55 minute mark.
+    expect(refreshDelayMs(token, NOW)).toEqual(ONE_HOUR_MS - TOKEN_REFRESH_MARGIN_MS)
+  })
+
+  it('returns null when the token is already inside the margin', () => {
+    const token = { token: 't', expiresAtMs: NOW + TOKEN_REFRESH_MARGIN_MS - 1 }
+
+    // Nothing useful to schedule; the connection path will mint a fresh token.
+    expect(refreshDelayMs(token, NOW)).toBeNull()
+  })
+
+  it('returns null for an already expired token', () => {
+    expect(refreshDelayMs({ token: 't', expiresAtMs: NOW - 1 }, NOW)).toBeNull()
+  })
+
+  it('clamps an implausibly distant expiry instead of overflowing setTimeout', () => {
+    // Delays above 2^31-1 are silently coerced to 1ms by setTimeout, which would
+    // fire the refresh immediately on every open and spin into a reconnect loop.
+    const token = { token: 't', expiresAtMs: NOW + 100 * 365 * 24 * ONE_HOUR_MS }
+
+    expect(refreshDelayMs(token, NOW)).toEqual(MAX_TIMEOUT_MS)
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -3592,7 +3592,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@chainlink/gsr-adapter@workspace:packages/sources/gsr"
   dependencies:
-    "@chainlink/external-adapter-framework": "npm:2.17.1"
+    "@chainlink/external-adapter-framework": "npm:2.19.1"
     "@sinonjs/fake-timers": "npm:9.1.2"
     "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:22.14.1"


### PR DESCRIPTION
Fixes [DF-26076](https://smartcontract-it.atlassian.net/browse/DF-26076). Supersedes #5252 — see [What changed from #5252](#what-changed-from-5252) below, including a correction to its stated root cause.

## Symptom

Every GSR EA instance — Chainlink-run and node-operator-run — stops serving data for ~2 minutes, once an hour, and returns a burst of 504s. Reported 2026-07-23, still occurring, and re-reported via NTI-251.

## Root cause

A GSR WebSocket session delivers usable data for **exactly 60 minutes** after it opens, then silently stops. GSR does not close the socket and sends no notice.

The adapter had no way to detect this. It read the token's `validUntil` into a type and then discarded it, and had no refresh timer. So the only thing that noticed was the framework's generic staleness check, `WS_SUBSCRIPTION_UNRESPONSIVE_TTL`, at its 120s default. That fires 120s after the last *usable* message, closes with code 1000, and reconnects successfully on the first try.

The damage is the blind window, not the reconnect. `CACHE_MAX_AGE` is 90s, so cached prices expire ~30s before the framework even notices, and every caller gets a 504 until the new connection is serving.

### Evidence from production

**62.0-minute period, 12 consecutive cycles** — `{app="gsr", env="production"} |= "exceeding the threshold"`:

```
05:12:06  06:14:06 (+62.0)  07:16:08 (+62.0)  08:18:09 (+62.0)  09:20:09 (+62.0)
10:22:10 (+62.0)  11:24:11 (+62.0)  12:26:13 (+62.0)  ...  18:30:19 (+62.0)
```

62.0 min = 60 min of data + 120s to detect.

**The adapter's own log**, the 18:30 cycle:

```
18:30:19.508  The connection is unresponsive (last message 120898ms ago)
18:30:19.518  Last message was received 120898 ago, exceeding the threshold of 120000ms, closing connection...
```

**The data gap** — `rate(ws_message_total{app="gsr",env="production",direction="received"}[30s])` at 10s step: 346/s at 18:28:40 → **0.2/s from 18:29:20 through 18:30:40** → 311/s at 18:30:50.

**504s land on the cycle** — baseline 0.1–0.9/s, spikes at 14:23, 15:25, 16:27, 17:29, 18:31 of 16–26/s, each 62 min apart.

**GSR never closes the socket** — `ws_connection_active` was 1 at all 360 one-minute samples over 6h, and the only closure code in production is `1000`, the framework's own close.

## The fix

Two changes, one for each half of the 62 minutes.

**1. Don't wait to be cut off** (`authutils.ts`, `price.ts`, `tokenRefresh.ts`)

Parse `validUntil` into an expiry, cache the token, and five minutes ahead of expiry renew in place via GSR's `PUT /token` — the provider's documented renewal path, removed from this adapter in #2459 and restored here. If renewal is refused, reconnect immediately instead, still ahead of expiry. Either way there is no stall.

**2. Make the safety net land inside the cache's lifetime** (`config/index.ts`)

```ts
envDefaultOverrides: {
  WS_SUBSCRIPTION_UNRESPONSIVE_TTL: 30_000,
}
```

The token travels in the WebSocket handshake, so a successful REST renewal is *not* proof the session survived. Rather than hand-roll a second liveness check, this lowers the framework's existing one so it fires while cached prices are still fresh. It runs every background pass, watches the same `lastMessageReceivedAt`, and catches a stall from any cause — not only one following a renewal.

Precedence is `env var ?? envDefaultOverrides ?? framework default`, so this is a shipped default that infra and node operators can still override.

Shipping it in the image rather than as deployed config is deliberate: the issue affects node-operator-run instances too, and a Helm value would only reach Chainlink-run pods.

### Why 30s

Bounded above by `CACHE_MAX_AGE` (90s) minus reconnect time; bounded below by the longest normal gap between cache-writing messages. GSR streams 200–350 msg/s on this deployment, so 30s of silence is unambiguous. Framework range is 1 000–180 000.

## Also included

Subscription messages are now batched via `customSubscriptionMessages`, which requires a framework bump. Carried over from #5252, rebased onto the current framework release: **2.17.1 → 2.19.1**.

## Testing

```
Test Suites: 4 passed    Tests: 18 passed    Snapshots: 3 passed
tsc (build + test configs), eslint, prettier — clean
```

New unit coverage for token expiry parsing, `PUT /token` renewal and its failure path, refresh scheduling, and the TTL override — the last pinned against both the `CACHE_MAX_AGE` constraint and the framework's accepted range so it can't silently drift back.

No snapshot changes: the existing integration snapshots pass unmodified.

## Not verified — needs a soak

`PUT /token` is exercised only against mocks. Whether GSR still supports it, and whether a renewal actually extends a live session, are unproven without provider credentials. If it is refused, `refreshOrReconnect` falls back to a proactive reconnect ~5 min before expiry, which still removes the outage — so this degrades safely, but a stage soak should confirm the intended path. Watch for `Token renewed, expires at ...` versus `Token renewal failed (...)`.

## What changed from #5252

- **Corrected the stated root cause.** #5252 says *"GSR's server closed the connection at the 1-hour mark, reconnection attempts used the expired token and failed."* Production contradicts both halves: GSR never closes the socket, and the framework re-invokes the `options` callback on every reconnect ([`websocket.ts:553-554`](https://github.com/smartcontractkit/ea-framework-js/blob/main/src/transports/websocket.ts#L553)), so reconnects always mint a fresh token and succeed first try. The outage is detection latency.
- **Implemented the liveness verification it promised but did not contain.** Its changeset claimed the adapter "verifies that data is still arriving shortly after the old expiry"; `livenessTimer` was declared and cleared, but never assigned. Replaced by the framework's own check (see fix #2), which is continuously armed rather than only after a renewal.
- **Fixed a version regression** — its `package.json` rolled the adapter back 2.6.3 → 2.5.8.
- **Dropped `.github/workflows/publish-internal.yml`** (+246), unrelated to the fix.
- **Rebased onto current `main`** (it branched 2026-07-31) and squashed 16 commits into one.

## Follow-ups (not in this PR)

- `gsr-data-streams` is in a permanent **2-minute** reconnect loop in production — 100 unresponsive-closes in 6h, 504 baseline ~9.7/s vs `gsr`'s ~0.4/s. Different period, likely different cause: `lastMessageReceivedAt` only advances on messages that produce a cache write, so a connection receiving only error frames looks permanently unresponsive.
- The framework's `WS_SUBSCRIPTION_UNRESPONSIVE_TTL` default (120s) exceeds the `CACHE_MAX_AGE` default (90s), so any adapter whose provider stalls silently inherits this same bug shape out of the box. Worth revisiting upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DF-26076]: https://smartcontract-it.atlassian.net/browse/DF-26076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ